### PR TITLE
claude/review-project-status-UfE9C

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       onsager-spine: ${{ steps.filter.outputs.onsager-spine }}
+      forge: ${{ steps.filter.outputs.forge }}
+      ising: ${{ steps.filter.outputs.ising }}
       stiglab: ${{ steps.filter.outputs.stiglab }}
       synodic: ${{ steps.filter.outputs.synodic }}
       onsager: ${{ steps.filter.outputs.onsager }}
@@ -30,6 +32,12 @@ jobs:
               - 'rust-toolchain.toml'
             onsager-spine:
               - 'crates/onsager-spine/**'
+            forge:
+              - 'crates/forge/**'
+              - 'crates/onsager-spine/**'
+            ising:
+              - 'crates/ising/**'
+              - 'crates/onsager-spine/**'
             stiglab:
               - 'crates/stiglab/**'
               - 'crates/onsager-spine/**'
@@ -44,6 +52,8 @@ jobs:
     if: |
       needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.onsager-spine == 'true' ||
+      needs.changes.outputs.forge == 'true' ||
+      needs.changes.outputs.ising == 'true' ||
       needs.changes.outputs.stiglab == 'true' ||
       needs.changes.outputs.synodic == 'true' ||
       needs.changes.outputs.onsager == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,14 @@ direct calls.
 
 ```
          onsager-spine (event bus lib)
-        /              \
-   stiglab           synodic        <- do NOT depend on each other
+        /       |        |        \
+   forge    stiglab   synodic    ising    <- do NOT depend on each other
 ```
 
-**Architectural invariant**: `stiglab` and `synodic` must NOT import each other,
-and must NOT be statically linked into the same binary. The `onsager` dispatcher
-has zero business dependencies -- it discovers subsystem binaries on PATH.
+**Architectural invariant**: subsystems (`forge`, `stiglab`, `synodic`, `ising`)
+must NOT import each other, and must NOT be statically linked into the same
+binary. The `onsager` dispatcher has zero business dependencies -- it discovers
+subsystem binaries on PATH.
 
 ## Workspace layout
 
@@ -25,6 +26,8 @@ has zero business dependencies -- it discovers subsystem binaries on PATH.
 crates/
   onsager-spine/   <- event bus client library
   onsager/         <- dispatcher CLI (~100 LOC, no business deps)
+  forge/           <- production line — drives artifacts through their lifecycle (lib + bin)
+  ising/           <- continuous improvement engine — observes and surfaces insights (lib + bin)
   stiglab/         <- distributed AI agent session orchestration (lib + bin)
   synodic/         <- AI agent governance (lib + bin)
 apps/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/onsager-spine",
     "crates/onsager",
+    "crates/forge",
+    "crates/ising",
     "crates/stiglab",
     "crates/synodic",
 ]

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "forge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Production line subsystem — drives artifacts through their lifecycle"
+
+[lib]
+name = "forge"
+path = "src/lib.rs"
+
+[[bin]]
+name = "forge"
+path = "src/main.rs"
+
+[dependencies]
+onsager-spine = { path = "../onsager-spine" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+ulid = { version = "1", features = ["serde"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/forge/src/cmd/mod.rs
+++ b/crates/forge/src/cmd/mod.rs
@@ -1,0 +1,3 @@
+//! CLI subcommands for the Forge binary.
+
+pub mod serve;

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -5,18 +5,14 @@
 /// In production, this connects to the event spine, instantiates the scheduling
 /// kernel, and runs the core tick loop. For v0.1, this is a skeleton that
 /// demonstrates the structure.
-pub fn run(database_url: &str, tick_ms: u64) {
+pub fn run(_database_url: &str, tick_ms: u64) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async move {
         tracing_subscriber::fmt()
             .with_env_filter("forge=info")
             .init();
 
-        tracing::info!(
-            database_url = database_url,
-            tick_ms = tick_ms,
-            "forge: starting scheduling loop"
-        );
+        tracing::info!(tick_ms = tick_ms, "forge: starting scheduling loop");
 
         // In production this would:
         // 1. Connect to the event spine (EventStore)

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -1,0 +1,30 @@
+//! `forge serve` — start the Forge scheduling loop.
+
+/// Start the Forge scheduling loop.
+///
+/// In production, this connects to the event spine, instantiates the scheduling
+/// kernel, and runs the core tick loop. For v0.1, this is a skeleton that
+/// demonstrates the structure.
+pub fn run(database_url: &str, tick_ms: u64) {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async move {
+        tracing_subscriber::fmt()
+            .with_env_filter("forge=info")
+            .init();
+
+        tracing::info!(
+            database_url = database_url,
+            tick_ms = tick_ms,
+            "forge: starting scheduling loop"
+        );
+
+        // In production this would:
+        // 1. Connect to the event spine (EventStore)
+        // 2. Load artifact state from the spine
+        // 3. Instantiate the scheduling kernel
+        // 4. Run the tick loop with Stiglab dispatch + Synodic gate calls
+        //
+        // For now, log and exit.
+        tracing::info!("forge: v0.1 scaffold — scheduling loop not yet connected to spine");
+    });
+}

--- a/crates/forge/src/core/artifact_store.rs
+++ b/crates/forge/src/core/artifact_store.rs
@@ -1,0 +1,282 @@
+//! In-memory artifact store — the single-writer for artifact state (forge-v0.1 §10 invariant #1).
+//!
+//! Only Forge mutates artifact state. This store enforces:
+//! - Valid state transitions (via `ArtifactState::can_transition_to`)
+//! - Atomic version creation with lineage
+//! - Quality signal append-only semantics
+
+use std::collections::HashMap;
+
+use chrono::Utc;
+
+use onsager_spine::artifact::{
+    Artifact, ArtifactId, ArtifactState, ArtifactVersion, ContentRef, Kind, VerticalLineage,
+};
+use onsager_spine::factory_event::ShapingOutcome;
+use onsager_spine::protocol::ShapingResult;
+
+/// In-memory artifact store. Production implementations would back this
+/// with PostgreSQL; this provides the domain logic and invariant enforcement.
+#[derive(Debug, Default)]
+pub struct ArtifactStore {
+    artifacts: HashMap<String, Artifact>,
+}
+
+impl ArtifactStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new artifact in `Draft` state.
+    pub fn register(
+        &mut self,
+        kind: Kind,
+        name: impl Into<String>,
+        owner: impl Into<String>,
+    ) -> ArtifactId {
+        let artifact = Artifact::new(kind, name, owner, "forge", vec![]);
+        let id = artifact.artifact_id.clone();
+        self.artifacts.insert(id.as_str().to_owned(), artifact);
+        id
+    }
+
+    /// Get an artifact by ID.
+    pub fn get(&self, id: &ArtifactId) -> Option<&Artifact> {
+        self.artifacts.get(id.as_str())
+    }
+
+    /// List all artifacts in non-terminal states.
+    pub fn active_artifacts(&self) -> Vec<&Artifact> {
+        self.artifacts
+            .values()
+            .filter(|a| !matches!(a.state, ArtifactState::Archived))
+            .collect()
+    }
+
+    /// Advance an artifact's state after a successful shaping + gate approval.
+    ///
+    /// This enforces the state machine and creates a new version atomically
+    /// (forge invariant #2).
+    pub fn advance(
+        &mut self,
+        id: &ArtifactId,
+        target_state: ArtifactState,
+        result: &ShapingResult,
+    ) -> Result<(), ArtifactStoreError> {
+        let artifact = self
+            .artifacts
+            .get_mut(id.as_str())
+            .ok_or_else(|| ArtifactStoreError::NotFound(id.clone()))?;
+
+        if !artifact.state.can_transition_to(target_state) {
+            return Err(ArtifactStoreError::InvalidTransition {
+                artifact_id: id.clone(),
+                from: artifact.state,
+                to: target_state,
+            });
+        }
+
+        // Only create a new version for successful outcomes.
+        if result.outcome == ShapingOutcome::Completed {
+            let version = ArtifactVersion {
+                version: artifact.current_version + 1,
+                created_at: Utc::now(),
+                created_by_session: result.session_id.clone(),
+                content_ref: result.content_ref.clone().unwrap_or(ContentRef {
+                    uri: format!("pending://{}", result.request_id),
+                    checksum: None,
+                }),
+                change_summary: result.change_summary.clone(),
+                parent_version: if artifact.current_version > 0 {
+                    Some(artifact.current_version)
+                } else {
+                    None
+                },
+            };
+
+            artifact.current_version = version.version;
+            artifact.vertical_lineage.push(VerticalLineage {
+                session_id: result.session_id.clone(),
+                version: version.version,
+                recorded_at: Utc::now(),
+            });
+            artifact.versions.push(version);
+        }
+
+        // Append quality signals from the result.
+        artifact
+            .quality_signals
+            .extend(result.quality_signals.clone());
+
+        // Transition state.
+        artifact.state = target_state;
+
+        Ok(())
+    }
+
+    /// Archive an artifact (any state -> Archived).
+    pub fn archive(&mut self, id: &ArtifactId, _reason: &str) -> Result<(), ArtifactStoreError> {
+        let artifact = self
+            .artifacts
+            .get_mut(id.as_str())
+            .ok_or_else(|| ArtifactStoreError::NotFound(id.clone()))?;
+
+        if artifact.state == ArtifactState::Archived {
+            return Err(ArtifactStoreError::AlreadyArchived(id.clone()));
+        }
+
+        artifact.state = ArtifactState::Archived;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArtifactStoreError {
+    #[error("artifact not found: {0}")]
+    NotFound(ArtifactId),
+    #[error("invalid transition for {artifact_id}: {from} -> {to}")]
+    InvalidTransition {
+        artifact_id: ArtifactId,
+        from: ArtifactState,
+        to: ArtifactState,
+    },
+    #[error("artifact already archived: {0}")]
+    AlreadyArchived(ArtifactId),
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::artifact::Kind;
+
+    fn make_result(outcome: ShapingOutcome) -> ShapingResult {
+        ShapingResult {
+            request_id: "req_001".into(),
+            outcome,
+            content_ref: Some(ContentRef {
+                uri: "git://repo@abc123".into(),
+                checksum: None,
+            }),
+            change_summary: "implemented feature X".into(),
+            quality_signals: vec![],
+            session_id: "sess_001".into(),
+            duration_ms: 5000,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn register_and_get() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+        let art = store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::Draft);
+        assert_eq!(art.current_version, 0);
+    }
+
+    #[test]
+    fn advance_through_lifecycle() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+
+        let result = make_result(ShapingOutcome::Completed);
+
+        // Draft -> InProgress
+        store
+            .advance(&id, ArtifactState::InProgress, &result)
+            .unwrap();
+        let art = store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::InProgress);
+        assert_eq!(art.current_version, 1);
+        assert_eq!(art.versions.len(), 1);
+
+        // InProgress -> UnderReview
+        store
+            .advance(&id, ArtifactState::UnderReview, &result)
+            .unwrap();
+        let art = store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::UnderReview);
+        assert_eq!(art.current_version, 2);
+
+        // UnderReview -> Released
+        store
+            .advance(&id, ArtifactState::Released, &result)
+            .unwrap();
+        assert_eq!(store.get(&id).unwrap().state, ArtifactState::Released);
+    }
+
+    #[test]
+    fn advance_invalid_transition() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+        let result = make_result(ShapingOutcome::Completed);
+
+        // Draft -> Released is invalid
+        let err = store.advance(&id, ArtifactState::Released, &result);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn advance_partial_does_not_create_version() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+
+        let result = make_result(ShapingOutcome::Partial);
+        store
+            .advance(&id, ArtifactState::InProgress, &result)
+            .unwrap();
+
+        let art = store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::InProgress);
+        assert_eq!(art.current_version, 0); // No version bump
+        assert!(art.versions.is_empty());
+    }
+
+    #[test]
+    fn archive_from_any_state() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+        store.archive(&id, "cancelled").unwrap();
+        assert_eq!(store.get(&id).unwrap().state, ArtifactState::Archived);
+    }
+
+    #[test]
+    fn archive_already_archived() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+        store.archive(&id, "cancelled").unwrap();
+        assert!(store.archive(&id, "again").is_err());
+    }
+
+    #[test]
+    fn active_artifacts_excludes_archived() {
+        let mut store = ArtifactStore::new();
+        let id1 = store.register(Kind::Code, "active", "marvin");
+        let id2 = store.register(Kind::Code, "archived", "marvin");
+        store.archive(&id2, "done").unwrap();
+
+        let active = store.active_artifacts();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].artifact_id, id1);
+    }
+
+    #[test]
+    fn advance_records_vertical_lineage() {
+        let mut store = ArtifactStore::new();
+        let id = store.register(Kind::Code, "my-service", "marvin");
+
+        let result = make_result(ShapingOutcome::Completed);
+        store
+            .advance(&id, ArtifactState::InProgress, &result)
+            .unwrap();
+
+        let art = store.get(&id).unwrap();
+        assert_eq!(art.vertical_lineage.len(), 1);
+        assert_eq!(art.vertical_lineage[0].session_id, "sess_001");
+        assert_eq!(art.vertical_lineage[0].version, 1);
+    }
+}

--- a/crates/forge/src/core/kernel.rs
+++ b/crates/forge/src/core/kernel.rs
@@ -1,0 +1,307 @@
+//! Scheduling kernel — the pluggable decision engine (forge-v0.1 §4).
+//!
+//! The kernel answers one question each tick:
+//!   "Given the current world state, what is the next artifact to shape, and how?"
+//!
+//! v0.1 ships a baseline FIFO + priority kernel. The trait is the contract;
+//! implementations are replaceable.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use onsager_spine::artifact::{Artifact, ArtifactState};
+use onsager_spine::factory_event::FactoryEvent;
+use onsager_spine::protocol::{Insight, ShapingDecision};
+
+/// The world state visible to the scheduling kernel (forge-v0.1 §4.2).
+#[derive(Debug, Default)]
+pub struct WorldState {
+    /// All artifacts in non-terminal states.
+    pub artifacts: Vec<Artifact>,
+    /// Recent insights from Ising (advisory).
+    pub insights: Vec<Insight>,
+    /// Number of in-flight shaping requests.
+    pub in_flight_count: usize,
+    /// Maximum concurrent in-flight requests.
+    pub max_in_flight: usize,
+}
+
+/// The scheduling kernel contract (forge-v0.1 §4.3).
+///
+/// Any implementation that honors this interface is valid.
+pub trait SchedulingKernel: Send + Sync {
+    /// Produce the next shaping decision, or `None` if there is no work.
+    fn decide(&self, world: &WorldState) -> Option<ShapingDecision>;
+
+    /// Observe a factory event (for updating internal state).
+    fn observe(&mut self, event: &FactoryEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Baseline kernel: priority queue + FIFO within same priority
+// ---------------------------------------------------------------------------
+
+/// A schedulable artifact with its priority.
+#[derive(Debug, Clone)]
+struct SchedulableArtifact {
+    artifact: Artifact,
+    priority: i32,
+    /// Tie-breaker: earlier creation time goes first (FIFO).
+    created_at_ms: i64,
+}
+
+impl PartialEq for SchedulableArtifact {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority && self.created_at_ms == other.created_at_ms
+    }
+}
+impl Eq for SchedulableArtifact {}
+
+impl PartialOrd for SchedulableArtifact {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SchedulableArtifact {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Higher priority first, then earlier creation (FIFO).
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| other.created_at_ms.cmp(&self.created_at_ms))
+    }
+}
+
+/// Baseline scheduling kernel: priority queue with FIFO tie-breaking.
+///
+/// - Picks the highest-priority artifact in `Draft` or `InProgress` state
+/// - Skips artifacts that are `UnderReview`, `Released`, or `Archived`
+/// - Respects `max_in_flight` concurrency limit
+#[derive(Debug, Default)]
+pub struct BaselineKernel {
+    /// Failure counts per artifact (from Ising insights).
+    failure_counts: std::collections::HashMap<String, u32>,
+}
+
+impl BaselineKernel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Compute priority for an artifact. Higher = more urgent.
+    fn compute_priority(&self, artifact: &Artifact) -> i32 {
+        let base = match artifact.state {
+            ArtifactState::Draft => 10,
+            ArtifactState::InProgress => 20,
+            _ => 0,
+        };
+
+        // Deprioritize artifacts with known failure patterns (Ising advisory).
+        let failure_penalty = self
+            .failure_counts
+            .get(artifact.artifact_id.as_str())
+            .copied()
+            .unwrap_or(0) as i32;
+
+        base - failure_penalty.min(base)
+    }
+}
+
+impl SchedulingKernel for BaselineKernel {
+    fn decide(&self, world: &WorldState) -> Option<ShapingDecision> {
+        if world.in_flight_count >= world.max_in_flight {
+            return None;
+        }
+
+        let mut heap = BinaryHeap::new();
+
+        for artifact in &world.artifacts {
+            // Only schedule artifacts that need shaping.
+            if !matches!(
+                artifact.state,
+                ArtifactState::Draft | ArtifactState::InProgress
+            ) {
+                continue;
+            }
+
+            let priority = self.compute_priority(artifact);
+            if priority <= 0 {
+                continue;
+            }
+
+            heap.push(SchedulableArtifact {
+                artifact: artifact.clone(),
+                priority,
+                created_at_ms: artifact.created_at.timestamp_millis(),
+            });
+        }
+
+        let top = heap.pop()?;
+        let target_version = top.artifact.current_version + 1;
+        let target_state = match top.artifact.state {
+            ArtifactState::Draft => ArtifactState::InProgress,
+            ArtifactState::InProgress => ArtifactState::UnderReview,
+            _ => return None,
+        };
+
+        Some(ShapingDecision {
+            artifact_id: top.artifact.artifact_id.clone(),
+            target_version,
+            target_state,
+            shaping_intent: serde_json::json!({
+                "action": "shape",
+                "kind": top.artifact.kind.to_string(),
+            }),
+            inputs: vec![],
+            constraints: vec![],
+            priority: top.priority,
+            deadline: None,
+        })
+    }
+
+    fn observe(&mut self, event: &FactoryEvent) {
+        use onsager_spine::factory_event::FactoryEventKind;
+
+        if let FactoryEventKind::ForgeInsightObserved {
+            insight_id: _,
+            insight_kind,
+            scope,
+        } = &event.event
+        {
+            if *insight_kind == onsager_spine::factory_event::InsightKind::Failure {
+                if let onsager_spine::factory_event::InsightScope::SpecificArtifact(id) = scope {
+                    *self
+                        .failure_counts
+                        .entry(id.as_str().to_owned())
+                        .or_default() += 1;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::artifact::{Artifact, Kind};
+
+    fn make_artifact(name: &str, state: ArtifactState, version: u32) -> Artifact {
+        let mut art = Artifact::new(Kind::Code, name, "test-owner", "system", vec![]);
+        art.state = state;
+        art.current_version = version;
+        art
+    }
+
+    #[test]
+    fn decide_picks_highest_priority() {
+        let kernel = BaselineKernel::new();
+
+        let draft = make_artifact("draft-art", ArtifactState::Draft, 0);
+        let in_progress = make_artifact("ip-art", ArtifactState::InProgress, 1);
+
+        let world = WorldState {
+            artifacts: vec![draft, in_progress.clone()],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+
+        let decision = kernel.decide(&world).unwrap();
+        // InProgress has higher base priority (20) than Draft (10)
+        assert_eq!(decision.artifact_id, in_progress.artifact_id);
+        assert_eq!(decision.target_state, ArtifactState::UnderReview);
+    }
+
+    #[test]
+    fn decide_returns_none_when_at_capacity() {
+        let kernel = BaselineKernel::new();
+        let art = make_artifact("art", ArtifactState::Draft, 0);
+        let world = WorldState {
+            artifacts: vec![art],
+            insights: vec![],
+            in_flight_count: 5,
+            max_in_flight: 5,
+        };
+        assert!(kernel.decide(&world).is_none());
+    }
+
+    #[test]
+    fn decide_skips_terminal_states() {
+        let kernel = BaselineKernel::new();
+        let released = make_artifact("rel", ArtifactState::Released, 3);
+        let archived = make_artifact("arch", ArtifactState::Archived, 2);
+        let review = make_artifact("rev", ArtifactState::UnderReview, 1);
+
+        let world = WorldState {
+            artifacts: vec![released, archived, review],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+        assert!(kernel.decide(&world).is_none());
+    }
+
+    #[test]
+    fn decide_returns_none_for_empty_world() {
+        let kernel = BaselineKernel::new();
+        let world = WorldState::default();
+        assert!(kernel.decide(&world).is_none());
+    }
+
+    #[test]
+    fn decide_increments_version() {
+        let kernel = BaselineKernel::new();
+        let art = make_artifact("art", ArtifactState::Draft, 3);
+        let world = WorldState {
+            artifacts: vec![art],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+
+        let decision = kernel.decide(&world).unwrap();
+        assert_eq!(decision.target_version, 4);
+    }
+
+    #[test]
+    fn observe_deprioritizes_failing_artifacts() {
+        use chrono::Utc;
+        use onsager_spine::factory_event::{
+            FactoryEvent, FactoryEventKind, InsightKind, InsightScope,
+        };
+        let mut kernel = BaselineKernel::new();
+
+        let failing_art = make_artifact("failing", ArtifactState::Draft, 0);
+        let good_art = make_artifact("good", ArtifactState::Draft, 0);
+
+        // Simulate repeated failure insights for the failing artifact
+        for _ in 0..15 {
+            kernel.observe(&FactoryEvent {
+                event: FactoryEventKind::ForgeInsightObserved {
+                    insight_id: "ins_1".into(),
+                    insight_kind: InsightKind::Failure,
+                    scope: InsightScope::SpecificArtifact(failing_art.artifact_id.clone()),
+                },
+                correlation_id: None,
+                causation_id: None,
+                actor: "ising".into(),
+                timestamp: Utc::now(),
+            });
+        }
+
+        let world = WorldState {
+            artifacts: vec![failing_art, good_art.clone()],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+
+        let decision = kernel.decide(&world).unwrap();
+        // Good artifact should be picked over the penalized one
+        assert_eq!(decision.artifact_id, good_art.artifact_id);
+    }
+}

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -1,0 +1,11 @@
+//! Core Forge logic — scheduling kernel, artifact store, pipeline, and state machine.
+
+pub mod artifact_store;
+pub mod kernel;
+pub mod pipeline;
+pub mod state;
+
+pub use artifact_store::ArtifactStore;
+pub use kernel::{BaselineKernel, SchedulingKernel, WorldState};
+pub use pipeline::ForgePipeline;
+pub use state::ForgeState;

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use onsager_spine::artifact::ArtifactState;
-use onsager_spine::factory_event::{GatePoint, VerdictSummary};
+use onsager_spine::factory_event::{GatePoint, ShapingOutcome, VerdictSummary};
 use onsager_spine::protocol::{
     GateContext, GateRequest, GateVerdict, ProposedAction, ShapingDecision, ShapingRequest,
     ShapingResult,
@@ -84,7 +84,6 @@ pub struct ForgePipeline<S: StiglabDispatcher, G: SynodicGate> {
     pub state: ForgeState,
     stiglab: S,
     synodic: G,
-    request_counter: u64,
 }
 
 impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
@@ -94,7 +93,6 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             state: ForgeState::new(),
             stiglab,
             synodic,
-            request_counter: 0,
         }
     }
 
@@ -190,8 +188,7 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
         }
 
         // Dispatch to Stiglab.
-        self.request_counter += 1;
-        let request_id = format!("req_{:08x}", self.request_counter);
+        let request_id = ulid::Ulid::new().to_string();
         let shaping_request = ShapingRequest {
             request_id: request_id.clone(),
             artifact_id: decision.artifact_id.clone(),
@@ -216,6 +213,19 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             outcome: format!("{:?}", result.outcome),
         });
 
+        // Short-circuit on unsuccessful outcomes — don't advance state
+        // (forge-v0.1 §5.4: Failed/Aborted → artifact stays in previous state).
+        if matches!(
+            result.outcome,
+            ShapingOutcome::Failed | ShapingOutcome::Aborted
+        ) {
+            output.events.push(PipelineEvent::Error(format!(
+                "shaping {:?} for {}: not advancing state",
+                result.outcome, decision.artifact_id
+            )));
+            return output;
+        }
+
         // Gate check: state transition.
         let transition_gate = GateRequest {
             context: GateContext {
@@ -231,7 +241,7 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
                     "advance {} from {} to {}",
                     decision.artifact_id, artifact.state, decision.target_state
                 ),
-                payload: serde_json::to_value(&result).unwrap_or_default(),
+                payload: serde_json::to_value(&result).expect("ShapingResult must be serializable"),
             },
         };
 
@@ -433,5 +443,40 @@ mod tests {
             .events
             .iter()
             .any(|e| matches!(e, PipelineEvent::IdleTick)));
+    }
+
+    #[test]
+    fn tick_does_not_advance_on_failed_shaping() {
+        /// Mock Stiglab that always fails.
+        struct MockStiglabFail;
+        impl StiglabDispatcher for MockStiglabFail {
+            fn dispatch(&self, req: &ShapingRequest) -> ShapingResult {
+                ShapingResult {
+                    request_id: req.request_id.clone(),
+                    outcome: ShapingOutcome::Failed,
+                    content_ref: None,
+                    change_summary: "shaping failed".into(),
+                    quality_signals: vec![],
+                    session_id: "mock_session".into(),
+                    duration_ms: 100,
+                    error: Some(onsager_spine::protocol::ErrorDetail {
+                        code: "test_failure".into(),
+                        message: "mock failure".into(),
+                        retriable: Some(true),
+                    }),
+                }
+            }
+        }
+
+        let mut pipeline = ForgePipeline::new(MockStiglabFail, MockSynodicAllow);
+        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let kernel = BaselineKernel::new();
+        pipeline.tick(&kernel);
+
+        // Artifact should remain in Draft — not advanced
+        let art = pipeline.store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::Draft);
+        assert_eq!(art.current_version, 0);
     }
 }

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -1,0 +1,437 @@
+//! Forge pipeline — the core loop that drives the factory (forge-v0.1 §3).
+//!
+//! ```text
+//! loop:
+//!     decision = scheduling_kernel.decide(world_state)
+//!     shaping_result = stiglab.dispatch(decision)
+//!     verdict = synodic.gate(shaping_result, target_state)
+//!     if verdict.allow:
+//!         forge.advance(artifact, shaping_result, target_state)
+//!         if target_state == RELEASED:
+//!             forge.route(artifact, consumers)
+//!     emit_factory_events()
+//! ```
+
+use onsager_spine::artifact::ArtifactState;
+use onsager_spine::factory_event::{GatePoint, VerdictSummary};
+use onsager_spine::protocol::{
+    GateContext, GateRequest, GateVerdict, ProposedAction, ShapingDecision, ShapingRequest,
+    ShapingResult,
+};
+
+use super::artifact_store::ArtifactStore;
+use super::kernel::{SchedulingKernel, WorldState};
+use super::state::ForgeState;
+
+/// Events emitted by a single pipeline tick.
+#[derive(Debug, Default)]
+pub struct TickOutput {
+    /// Factory events produced during this tick.
+    pub events: Vec<PipelineEvent>,
+}
+
+/// Pipeline-level events (these get translated into FactoryEventKind for the spine).
+#[derive(Debug)]
+pub enum PipelineEvent {
+    DecisionMade(ShapingDecision),
+    ShapingDispatched {
+        request_id: String,
+        artifact_id: String,
+        target_version: u32,
+    },
+    ShapingReturned {
+        request_id: String,
+        artifact_id: String,
+        outcome: String,
+    },
+    GateRequested {
+        artifact_id: String,
+        gate_point: GatePoint,
+    },
+    GateVerdictReceived {
+        artifact_id: String,
+        gate_point: GatePoint,
+        verdict: VerdictSummary,
+    },
+    ArtifactAdvanced {
+        artifact_id: String,
+        from_state: ArtifactState,
+        to_state: ArtifactState,
+    },
+    IdleTick,
+    Error(String),
+}
+
+/// Trait for dispatching shaping work to Stiglab.
+///
+/// Production implementations call Stiglab's HTTP API.
+/// Tests use mock implementations.
+pub trait StiglabDispatcher: Send + Sync {
+    fn dispatch(&self, request: &ShapingRequest) -> ShapingResult;
+}
+
+/// Trait for consulting Synodic at gate points.
+///
+/// Production implementations call Synodic's gate API.
+/// Tests use mock implementations.
+pub trait SynodicGate: Send + Sync {
+    fn evaluate(&self, request: &GateRequest) -> GateVerdict;
+}
+
+/// The Forge pipeline — orchestrates one tick of the factory loop.
+pub struct ForgePipeline<S: StiglabDispatcher, G: SynodicGate> {
+    pub store: ArtifactStore,
+    pub state: ForgeState,
+    stiglab: S,
+    synodic: G,
+    request_counter: u64,
+}
+
+impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
+    pub fn new(stiglab: S, synodic: G) -> Self {
+        Self {
+            store: ArtifactStore::new(),
+            state: ForgeState::new(),
+            stiglab,
+            synodic,
+            request_counter: 0,
+        }
+    }
+
+    /// Execute one tick of the scheduling loop.
+    pub fn tick(&mut self, kernel: &dyn SchedulingKernel) -> TickOutput {
+        let mut output = TickOutput::default();
+
+        if !self.state.should_decide() {
+            output.events.push(PipelineEvent::IdleTick);
+            return output;
+        }
+
+        // Build world state.
+        let world = WorldState {
+            artifacts: self.store.active_artifacts().into_iter().cloned().collect(),
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+
+        // Ask the kernel for a decision.
+        let decision = match kernel.decide(&world) {
+            Some(d) => d,
+            None => {
+                output.events.push(PipelineEvent::IdleTick);
+                return output;
+            }
+        };
+
+        output
+            .events
+            .push(PipelineEvent::DecisionMade(decision.clone()));
+
+        // Gate check: pre-dispatch.
+        let artifact = match self.store.get(&decision.artifact_id) {
+            Some(a) => a.clone(),
+            None => {
+                output.events.push(PipelineEvent::Error(format!(
+                    "artifact {} not found",
+                    decision.artifact_id
+                )));
+                return output;
+            }
+        };
+
+        let pre_dispatch_gate = GateRequest {
+            context: GateContext {
+                gate_point: GatePoint::PreDispatch,
+                artifact_id: decision.artifact_id.clone(),
+                artifact_kind: artifact.kind.clone(),
+                current_state: artifact.state,
+                target_state: Some(decision.target_state),
+                extra: None,
+            },
+            proposed_action: ProposedAction {
+                description: format!("dispatch shaping for {}", decision.artifact_id),
+                payload: decision.shaping_intent.clone(),
+            },
+        };
+
+        output.events.push(PipelineEvent::GateRequested {
+            artifact_id: decision.artifact_id.to_string(),
+            gate_point: GatePoint::PreDispatch,
+        });
+
+        let verdict = self.synodic.evaluate(&pre_dispatch_gate);
+        let verdict_summary = match &verdict {
+            GateVerdict::Allow => VerdictSummary::Allow,
+            GateVerdict::Deny { .. } => VerdictSummary::Deny,
+            GateVerdict::Modify { .. } => VerdictSummary::Modify,
+            GateVerdict::Escalate { .. } => VerdictSummary::Escalate,
+        };
+
+        output.events.push(PipelineEvent::GateVerdictReceived {
+            artifact_id: decision.artifact_id.to_string(),
+            gate_point: GatePoint::PreDispatch,
+            verdict: verdict_summary,
+        });
+
+        match verdict {
+            GateVerdict::Deny { reason } => {
+                output.events.push(PipelineEvent::Error(format!(
+                    "pre-dispatch gate denied for {}: {}",
+                    decision.artifact_id, reason
+                )));
+                return output;
+            }
+            GateVerdict::Escalate { .. } => {
+                // Park the decision (non-blocking — forge invariant #5).
+                return output;
+            }
+            GateVerdict::Allow | GateVerdict::Modify { .. } => {}
+        }
+
+        // Dispatch to Stiglab.
+        self.request_counter += 1;
+        let request_id = format!("req_{:08x}", self.request_counter);
+        let shaping_request = ShapingRequest {
+            request_id: request_id.clone(),
+            artifact_id: decision.artifact_id.clone(),
+            target_version: decision.target_version,
+            shaping_intent: decision.shaping_intent.clone(),
+            inputs: decision.inputs.clone(),
+            constraints: decision.constraints.clone(),
+            deadline: decision.deadline,
+        };
+
+        output.events.push(PipelineEvent::ShapingDispatched {
+            request_id: request_id.clone(),
+            artifact_id: decision.artifact_id.to_string(),
+            target_version: decision.target_version,
+        });
+
+        let result = self.stiglab.dispatch(&shaping_request);
+
+        output.events.push(PipelineEvent::ShapingReturned {
+            request_id: request_id.clone(),
+            artifact_id: decision.artifact_id.to_string(),
+            outcome: format!("{:?}", result.outcome),
+        });
+
+        // Gate check: state transition.
+        let transition_gate = GateRequest {
+            context: GateContext {
+                gate_point: GatePoint::StateTransition,
+                artifact_id: decision.artifact_id.clone(),
+                artifact_kind: artifact.kind.clone(),
+                current_state: artifact.state,
+                target_state: Some(decision.target_state),
+                extra: None,
+            },
+            proposed_action: ProposedAction {
+                description: format!(
+                    "advance {} from {} to {}",
+                    decision.artifact_id, artifact.state, decision.target_state
+                ),
+                payload: serde_json::to_value(&result).unwrap_or_default(),
+            },
+        };
+
+        output.events.push(PipelineEvent::GateRequested {
+            artifact_id: decision.artifact_id.to_string(),
+            gate_point: GatePoint::StateTransition,
+        });
+
+        let transition_verdict = self.synodic.evaluate(&transition_gate);
+        let transition_verdict_summary = match &transition_verdict {
+            GateVerdict::Allow => VerdictSummary::Allow,
+            GateVerdict::Deny { .. } => VerdictSummary::Deny,
+            GateVerdict::Modify { .. } => VerdictSummary::Modify,
+            GateVerdict::Escalate { .. } => VerdictSummary::Escalate,
+        };
+
+        output.events.push(PipelineEvent::GateVerdictReceived {
+            artifact_id: decision.artifact_id.to_string(),
+            gate_point: GatePoint::StateTransition,
+            verdict: transition_verdict_summary,
+        });
+
+        match transition_verdict {
+            GateVerdict::Allow | GateVerdict::Modify { .. } => {
+                let from_state = artifact.state;
+                match self
+                    .store
+                    .advance(&decision.artifact_id, decision.target_state, &result)
+                {
+                    Ok(()) => {
+                        output.events.push(PipelineEvent::ArtifactAdvanced {
+                            artifact_id: decision.artifact_id.to_string(),
+                            from_state,
+                            to_state: decision.target_state,
+                        });
+                    }
+                    Err(e) => {
+                        output.events.push(PipelineEvent::Error(format!(
+                            "failed to advance {}: {}",
+                            decision.artifact_id, e
+                        )));
+                    }
+                }
+            }
+            GateVerdict::Deny { reason } => {
+                output.events.push(PipelineEvent::Error(format!(
+                    "state transition gate denied for {}: {}",
+                    decision.artifact_id, reason
+                )));
+            }
+            GateVerdict::Escalate { .. } => {
+                // Park — non-blocking.
+            }
+        }
+
+        output
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::kernel::BaselineKernel;
+    use onsager_spine::artifact::ContentRef;
+    use onsager_spine::artifact::Kind;
+    use onsager_spine::factory_event::ShapingOutcome;
+
+    /// Mock Stiglab dispatcher that always succeeds.
+    struct MockStiglab;
+    impl StiglabDispatcher for MockStiglab {
+        fn dispatch(&self, req: &ShapingRequest) -> ShapingResult {
+            ShapingResult {
+                request_id: req.request_id.clone(),
+                outcome: ShapingOutcome::Completed,
+                content_ref: Some(ContentRef {
+                    uri: "git://test@abc".into(),
+                    checksum: None,
+                }),
+                change_summary: "mock shaping completed".into(),
+                quality_signals: vec![],
+                session_id: "mock_session".into(),
+                duration_ms: 100,
+                error: None,
+            }
+        }
+    }
+
+    /// Mock Synodic gate that always allows.
+    struct MockSynodicAllow;
+    impl SynodicGate for MockSynodicAllow {
+        fn evaluate(&self, _req: &GateRequest) -> GateVerdict {
+            GateVerdict::Allow
+        }
+    }
+
+    /// Mock Synodic gate that always denies.
+    struct MockSynodicDeny;
+    impl SynodicGate for MockSynodicDeny {
+        fn evaluate(&self, _req: &GateRequest) -> GateVerdict {
+            GateVerdict::Deny {
+                reason: "policy violation".into(),
+            }
+        }
+    }
+
+    #[test]
+    fn tick_advances_artifact_when_allowed() {
+        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let kernel = BaselineKernel::new();
+        let output = pipeline.tick(&kernel);
+
+        // Should have: decision, pre-dispatch gate+verdict, dispatch, return,
+        // transition gate+verdict, advance
+        assert!(output.events.len() >= 7);
+
+        let art = pipeline.store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::InProgress);
+        assert_eq!(art.current_version, 1);
+    }
+
+    #[test]
+    fn tick_blocks_when_gate_denies() {
+        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicDeny);
+        pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let kernel = BaselineKernel::new();
+        let output = pipeline.tick(&kernel);
+
+        // Should have error event from denied pre-dispatch gate
+        let has_error = output
+            .events
+            .iter()
+            .any(|e| matches!(e, PipelineEvent::Error(_)));
+        assert!(has_error);
+    }
+
+    #[test]
+    fn tick_idles_when_no_work() {
+        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+        // No artifacts registered
+        let kernel = BaselineKernel::new();
+        let output = pipeline.tick(&kernel);
+
+        assert!(output
+            .events
+            .iter()
+            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+    }
+
+    #[test]
+    fn tick_idles_when_paused() {
+        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+        pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        pipeline
+            .state
+            .transition(onsager_spine::factory_event::ForgeProcessState::Paused)
+            .unwrap();
+
+        let kernel = BaselineKernel::new();
+        let output = pipeline.tick(&kernel);
+
+        assert!(output
+            .events
+            .iter()
+            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+    }
+
+    #[test]
+    fn full_lifecycle_three_ticks() {
+        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let kernel = BaselineKernel::new();
+
+        // Tick 1: Draft -> InProgress
+        pipeline.tick(&kernel);
+        assert_eq!(
+            pipeline.store.get(&id).unwrap().state,
+            ArtifactState::InProgress
+        );
+
+        // Tick 2: InProgress -> UnderReview
+        pipeline.tick(&kernel);
+        assert_eq!(
+            pipeline.store.get(&id).unwrap().state,
+            ArtifactState::UnderReview
+        );
+
+        // Tick 3: UnderReview is not schedulable, so idle
+        let output = pipeline.tick(&kernel);
+        assert!(output
+            .events
+            .iter()
+            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+    }
+}

--- a/crates/forge/src/core/state.rs
+++ b/crates/forge/src/core/state.rs
@@ -1,0 +1,149 @@
+//! Forge process state machine (forge-v0.1 §8).
+//!
+//! ```text
+//! running ──pause──► paused
+//!    ▲                  │
+//!    └────── resume ────┘
+//!    │
+//!    ▼
+//! draining ──drained──► stopped
+//! ```
+
+use onsager_spine::factory_event::ForgeProcessState;
+
+/// Forge process state machine.
+///
+/// Invariant: pausing never loses in-flight work (forge invariant #9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForgeState {
+    current: ForgeProcessState,
+}
+
+impl ForgeState {
+    pub fn new() -> Self {
+        Self {
+            current: ForgeProcessState::Running,
+        }
+    }
+
+    pub fn current(&self) -> ForgeProcessState {
+        self.current
+    }
+
+    /// Attempt a state transition. Returns the previous state on success,
+    /// or an error if the transition is invalid.
+    pub fn transition(
+        &mut self,
+        target: ForgeProcessState,
+    ) -> Result<ForgeProcessState, ForgeStateError> {
+        use ForgeProcessState::*;
+        let valid = matches!(
+            (self.current, target),
+            (Running, Paused) | (Paused, Running) | (Running, Draining) | (Draining, Stopped)
+        );
+        if valid {
+            let prev = self.current;
+            self.current = target;
+            Ok(prev)
+        } else {
+            Err(ForgeStateError::InvalidTransition {
+                from: self.current,
+                to: target,
+            })
+        }
+    }
+
+    /// Whether the kernel should produce decisions in this state.
+    pub fn should_decide(&self) -> bool {
+        self.current == ForgeProcessState::Running
+    }
+
+    /// Whether in-flight work should still be processed.
+    pub fn should_process_results(&self) -> bool {
+        matches!(
+            self.current,
+            ForgeProcessState::Running | ForgeProcessState::Paused | ForgeProcessState::Draining
+        )
+    }
+}
+
+impl Default for ForgeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ForgeStateError {
+    #[error("invalid forge state transition: {from:?} -> {to:?}")]
+    InvalidTransition {
+        from: ForgeProcessState,
+        to: ForgeProcessState,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::factory_event::ForgeProcessState::*;
+
+    #[test]
+    fn initial_state_is_running() {
+        let state = ForgeState::new();
+        assert_eq!(state.current(), Running);
+        assert!(state.should_decide());
+    }
+
+    #[test]
+    fn pause_and_resume() {
+        let mut state = ForgeState::new();
+        assert!(state.transition(Paused).is_ok());
+        assert_eq!(state.current(), Paused);
+        assert!(!state.should_decide());
+        assert!(state.should_process_results());
+
+        assert!(state.transition(Running).is_ok());
+        assert_eq!(state.current(), Running);
+    }
+
+    #[test]
+    fn drain_and_stop() {
+        let mut state = ForgeState::new();
+        assert!(state.transition(Draining).is_ok());
+        assert!(!state.should_decide());
+        assert!(state.should_process_results());
+
+        assert!(state.transition(Stopped).is_ok());
+        assert!(!state.should_decide());
+        assert!(!state.should_process_results());
+    }
+
+    #[test]
+    fn invalid_transitions() {
+        let mut state = ForgeState::new();
+        // Can't go directly to Stopped
+        assert!(state.transition(Stopped).is_err());
+
+        // Can't go from Paused to Draining
+        state.transition(Paused).unwrap();
+        assert!(state.transition(Draining).is_err());
+
+        // Can't go from Stopped to anything
+        let mut state = ForgeState::new();
+        state.transition(Draining).unwrap();
+        state.transition(Stopped).unwrap();
+        assert!(state.transition(Running).is_err());
+        assert!(state.transition(Paused).is_err());
+    }
+
+    #[test]
+    fn transition_returns_previous_state() {
+        let mut state = ForgeState::new();
+        let prev = state.transition(Paused).unwrap();
+        assert_eq!(prev, Running);
+    }
+}

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -1,0 +1,10 @@
+//! Forge — production line subsystem of the Onsager factory.
+//!
+//! Forge drives artifacts through their lifecycle: deciding what to shape next,
+//! dispatching shaping work to Stiglab, consulting Synodic at every gate point,
+//! advancing artifact state, and routing released artifacts to consumers.
+//!
+//! See `specs/forge-v0.1.md` for the full specification.
+
+pub mod cmd;
+pub mod core;

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -1,0 +1,43 @@
+//! forge — CLI entry point for the Forge production line subsystem.
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "forge", about = "Onsager Forge — production line subsystem")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start the Forge scheduling loop
+    Serve {
+        /// Database URL for the event spine
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+
+        /// Tick interval in milliseconds
+        #[arg(long, default_value = "1000")]
+        tick_ms: u64,
+    },
+
+    /// Show current Forge status
+    Status,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve {
+            database_url,
+            tick_ms,
+        } => {
+            forge::cmd::serve::run(&database_url, tick_ms);
+        }
+        Commands::Status => {
+            println!("forge: not running (status check requires a running instance)");
+        }
+    }
+}

--- a/crates/ising/Cargo.toml
+++ b/crates/ising/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ising"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Continuous improvement engine — observes the factory and surfaces insights"
+
+[lib]
+name = "ising"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ising"
+path = "src/main.rs"
+
+[dependencies]
+onsager-spine = { path = "../onsager-spine" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }

--- a/crates/ising/src/analyzers/mod.rs
+++ b/crates/ising/src/analyzers/mod.rs
@@ -1,0 +1,17 @@
+//! Built-in heuristic analyzers for Ising v0.1.
+//!
+//! v0.1 ships with heuristic analyzers, not learned models (ising-v0.1 §6).
+
+pub mod repeated_failures;
+pub mod stuck_artifacts;
+
+pub use repeated_failures::RepeatedFailuresAnalyzer;
+pub use stuck_artifacts::StuckArtifactsAnalyzer;
+
+use crate::core::AnalyzerRegistry;
+
+/// Register all v0.1 built-in analyzers.
+pub fn register_defaults(registry: &mut AnalyzerRegistry) {
+    registry.register(Box::new(RepeatedFailuresAnalyzer::default()));
+    registry.register(Box::new(StuckArtifactsAnalyzer::default()));
+}

--- a/crates/ising/src/analyzers/repeated_failures.rs
+++ b/crates/ising/src/analyzers/repeated_failures.rs
@@ -1,0 +1,198 @@
+//! Repeated shaping failures analyzer (ising-v0.1 §6.1).
+//!
+//! Looks for artifacts or artifact kinds where shaping requests consistently
+//! return Failed or Aborted outcomes.
+//!
+//! Signal: if more than N of the last M shaping requests for a given scope
+//! have failed, emit a Failure insight. Default: N=3, M=5.
+
+use onsager_spine::factory_event::{InsightKind, InsightScope};
+use onsager_spine::protocol::{FactoryEventRef, Insight};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+/// Configuration for the repeated failures analyzer.
+#[derive(Debug, Clone)]
+pub struct RepeatedFailuresConfig {
+    /// Minimum failures in the window to trigger an insight.
+    pub min_failures: usize,
+    /// Window size (last M shaping attempts).
+    pub window_size: usize,
+}
+
+impl Default for RepeatedFailuresConfig {
+    fn default() -> Self {
+        Self {
+            min_failures: 3,
+            window_size: 5,
+        }
+    }
+}
+
+/// Detects artifacts with repeated shaping failures.
+pub struct RepeatedFailuresAnalyzer {
+    config: RepeatedFailuresConfig,
+}
+
+impl RepeatedFailuresAnalyzer {
+    pub fn new(config: RepeatedFailuresConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for RepeatedFailuresAnalyzer {
+    fn default() -> Self {
+        Self::new(RepeatedFailuresConfig::default())
+    }
+}
+
+impl Analyzer for RepeatedFailuresAnalyzer {
+    fn name(&self) -> &str {
+        "repeated_failures"
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let mut insights = Vec::new();
+
+        for tracked in model.artifacts.values() {
+            let failure_rate = model.failure_rate(&tracked.artifact_id, self.config.window_size);
+            let threshold = self.config.min_failures as f64 / self.config.window_size as f64;
+
+            if failure_rate >= threshold {
+                let history = model.shaping_history(&tracked.artifact_id);
+                let evidence: Vec<FactoryEventRef> = history
+                    .iter()
+                    .rev()
+                    .take(self.config.window_size)
+                    .enumerate()
+                    .map(|(i, _)| FactoryEventRef {
+                        event_id: (i + 1) as i64,
+                        event_type: "forge.shaping_returned".into(),
+                    })
+                    .collect();
+
+                if evidence.is_empty() {
+                    continue;
+                }
+
+                // Confidence scales with failure rate.
+                let confidence = (failure_rate * 0.9).min(0.95);
+
+                insights.push(Insight {
+                    insight_id: format!(
+                        "ins_rf_{}_{}",
+                        tracked.artifact_id, model.events_processed
+                    ),
+                    kind: InsightKind::Failure,
+                    scope: InsightScope::SpecificArtifact(tracked.artifact_id.clone()),
+                    observation: format!(
+                        "artifact {} has {:.0}% failure rate over last {} shaping attempts",
+                        tracked.artifact_id,
+                        failure_rate * 100.0,
+                        self.config.window_size,
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                });
+            }
+        }
+
+        insights
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::artifact::{ArtifactId, Kind};
+    use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
+
+    fn build_model_with_failures(completed: u32, failed: u32) -> FactoryModel {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_test1");
+
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "test".into(),
+                owner: "marvin".into(),
+            },
+        );
+
+        let mut seq = 2i64;
+        for _ in 0..completed {
+            model.ingest(
+                seq,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_{seq}"),
+                    artifact_id: id.clone(),
+                    outcome: ShapingOutcome::Completed,
+                },
+            );
+            seq += 1;
+        }
+        for _ in 0..failed {
+            model.ingest(
+                seq,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_{seq}"),
+                    artifact_id: id.clone(),
+                    outcome: ShapingOutcome::Failed,
+                },
+            );
+            seq += 1;
+        }
+
+        model
+    }
+
+    #[test]
+    fn detects_repeated_failures() {
+        // 1 completed + 4 failed = 80% failure in last 5
+        let model = build_model_with_failures(1, 4);
+        let analyzer = RepeatedFailuresAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert_eq!(insights.len(), 1);
+        assert_eq!(insights[0].kind, InsightKind::Failure);
+        assert!(insights[0].confidence > 0.5);
+    }
+
+    #[test]
+    fn no_insight_for_healthy_artifact() {
+        // 5 completed + 0 failed
+        let model = build_model_with_failures(5, 0);
+        let analyzer = RepeatedFailuresAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert!(insights.is_empty());
+    }
+
+    #[test]
+    fn threshold_boundary() {
+        // 2 completed + 3 failed = 60% failure (exactly at 3/5 threshold)
+        let model = build_model_with_failures(2, 3);
+        let analyzer = RepeatedFailuresAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert_eq!(insights.len(), 1);
+    }
+
+    #[test]
+    fn below_threshold() {
+        // 3 completed + 2 failed = 40% failure (below 3/5 threshold)
+        let model = build_model_with_failures(3, 2);
+        let analyzer = RepeatedFailuresAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert!(insights.is_empty());
+    }
+}

--- a/crates/ising/src/analyzers/repeated_failures.rs
+++ b/crates/ising/src/analyzers/repeated_failures.rs
@@ -53,6 +53,10 @@ impl Analyzer for RepeatedFailuresAnalyzer {
     }
 
     fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        if self.config.window_size == 0 {
+            return Vec::new();
+        }
+
         let mut insights = Vec::new();
 
         for tracked in model.artifacts.values() {
@@ -65,9 +69,8 @@ impl Analyzer for RepeatedFailuresAnalyzer {
                     .iter()
                     .rev()
                     .take(self.config.window_size)
-                    .enumerate()
-                    .map(|(i, _)| FactoryEventRef {
-                        event_id: (i + 1) as i64,
+                    .map(|record| FactoryEventRef {
+                        event_id: record.event_id,
                         event_type: "forge.shaping_returned".into(),
                     })
                     .collect();

--- a/crates/ising/src/analyzers/stuck_artifacts.rs
+++ b/crates/ising/src/analyzers/stuck_artifacts.rs
@@ -49,6 +49,10 @@ impl Analyzer for StuckArtifactsAnalyzer {
     }
 
     fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        if self.config.max_shapings == 0 {
+            return Vec::new();
+        }
+
         let mut insights = Vec::new();
 
         for tracked in model.artifacts.values() {
@@ -61,10 +65,21 @@ impl Analyzer for StuckArtifactsAnalyzer {
             }
 
             if tracked.shaping_count > self.config.max_shapings {
-                let evidence = vec![FactoryEventRef {
-                    event_id: model.last_event_id.unwrap_or(0),
-                    event_type: "forge.shaping_returned".into(),
-                }];
+                // Use real event IDs from shaping history for traceable evidence.
+                let history = model.shaping_history(&tracked.artifact_id);
+                let evidence: Vec<FactoryEventRef> = history
+                    .iter()
+                    .rev()
+                    .take(3)
+                    .map(|record| FactoryEventRef {
+                        event_id: record.event_id,
+                        event_type: "forge.shaping_returned".into(),
+                    })
+                    .collect();
+
+                if evidence.is_empty() {
+                    continue;
+                }
 
                 // Confidence increases with how far over the threshold we are.
                 let over_ratio = tracked.shaping_count as f64 / self.config.max_shapings as f64;

--- a/crates/ising/src/analyzers/stuck_artifacts.rs
+++ b/crates/ising/src/analyzers/stuck_artifacts.rs
@@ -1,0 +1,192 @@
+//! Stuck artifacts analyzer (ising-v0.1 §6.2).
+//!
+//! Looks for artifacts that remain in `in_progress` or `under_review` for too
+//! long, or that have been shaped many times without advancing state.
+//!
+//! Signal: if an artifact has accumulated more than `max_shapings` shaping
+//! attempts without reaching a terminal or release state, emit a Waste insight.
+
+use onsager_spine::artifact::ArtifactState;
+use onsager_spine::factory_event::{InsightKind, InsightScope};
+use onsager_spine::protocol::{FactoryEventRef, Insight};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+/// Configuration for the stuck artifacts analyzer.
+#[derive(Debug, Clone)]
+pub struct StuckArtifactsConfig {
+    /// Maximum shaping attempts before an artifact is considered stuck.
+    pub max_shapings: u32,
+}
+
+impl Default for StuckArtifactsConfig {
+    fn default() -> Self {
+        Self { max_shapings: 10 }
+    }
+}
+
+/// Detects artifacts stuck in non-terminal states with excessive shaping attempts.
+pub struct StuckArtifactsAnalyzer {
+    config: StuckArtifactsConfig,
+}
+
+impl StuckArtifactsAnalyzer {
+    pub fn new(config: StuckArtifactsConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for StuckArtifactsAnalyzer {
+    fn default() -> Self {
+        Self::new(StuckArtifactsConfig::default())
+    }
+}
+
+impl Analyzer for StuckArtifactsAnalyzer {
+    fn name(&self) -> &str {
+        "stuck_artifacts"
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let mut insights = Vec::new();
+
+        for tracked in model.artifacts.values() {
+            // Only check non-terminal, non-released artifacts.
+            if matches!(
+                tracked.current_state,
+                ArtifactState::Released | ArtifactState::Archived
+            ) {
+                continue;
+            }
+
+            if tracked.shaping_count > self.config.max_shapings {
+                let evidence = vec![FactoryEventRef {
+                    event_id: model.last_event_id.unwrap_or(0),
+                    event_type: "forge.shaping_returned".into(),
+                }];
+
+                // Confidence increases with how far over the threshold we are.
+                let over_ratio = tracked.shaping_count as f64 / self.config.max_shapings as f64;
+                let confidence = (0.5 + (over_ratio - 1.0) * 0.3).min(0.95);
+
+                insights.push(Insight {
+                    insight_id: format!(
+                        "ins_sa_{}_{}",
+                        tracked.artifact_id, model.events_processed
+                    ),
+                    kind: InsightKind::Waste,
+                    scope: InsightScope::SpecificArtifact(tracked.artifact_id.clone()),
+                    observation: format!(
+                        "artifact {} has been shaped {} times without advancing past {} state",
+                        tracked.artifact_id, tracked.shaping_count, tracked.current_state,
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                });
+            }
+        }
+
+        insights
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::artifact::{ArtifactId, Kind};
+    use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
+
+    fn build_model_with_shapings(count: u32) -> FactoryModel {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_stuck");
+
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "stuck-service".into(),
+                owner: "marvin".into(),
+            },
+        );
+        model.ingest(
+            2,
+            &FactoryEventKind::ArtifactStateChanged {
+                artifact_id: id.clone(),
+                from_state: ArtifactState::Draft,
+                to_state: ArtifactState::InProgress,
+            },
+        );
+
+        for i in 0..count {
+            model.ingest(
+                i as i64 + 3,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_{i}"),
+                    artifact_id: id.clone(),
+                    outcome: ShapingOutcome::Partial,
+                },
+            );
+        }
+
+        model
+    }
+
+    #[test]
+    fn detects_stuck_artifact() {
+        let model = build_model_with_shapings(15);
+        let analyzer = StuckArtifactsAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert_eq!(insights.len(), 1);
+        assert_eq!(insights[0].kind, InsightKind::Waste);
+        assert!(insights[0].observation.contains("15 times"));
+    }
+
+    #[test]
+    fn no_insight_below_threshold() {
+        let model = build_model_with_shapings(5);
+        let analyzer = StuckArtifactsAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert!(insights.is_empty());
+    }
+
+    #[test]
+    fn skips_released_artifacts() {
+        let mut model = build_model_with_shapings(15);
+        // Advance to released
+        let id = ArtifactId::new("art_stuck");
+        model.ingest(
+            100,
+            &FactoryEventKind::ArtifactStateChanged {
+                artifact_id: id,
+                from_state: ArtifactState::InProgress,
+                to_state: ArtifactState::Released,
+            },
+        );
+
+        let analyzer = StuckArtifactsAnalyzer::default();
+        let insights = analyzer.run(&model);
+
+        assert!(insights.is_empty());
+    }
+
+    #[test]
+    fn confidence_scales_with_excess() {
+        let model_11 = build_model_with_shapings(11);
+        let model_20 = build_model_with_shapings(20);
+        let analyzer = StuckArtifactsAnalyzer::default();
+
+        let insights_11 = analyzer.run(&model_11);
+        let insights_20 = analyzer.run(&model_20);
+
+        assert!(insights_20[0].confidence > insights_11[0].confidence);
+    }
+}

--- a/crates/ising/src/cmd/mod.rs
+++ b/crates/ising/src/cmd/mod.rs
@@ -1,0 +1,3 @@
+//! CLI subcommands for the Ising binary.
+
+pub mod serve;

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -1,0 +1,30 @@
+//! `ising serve` — start the Ising observation loop.
+
+/// Start the Ising observation loop.
+///
+/// In production, this connects to the event spine, instantiates the analyzer
+/// registry, and runs the core observation loop. For v0.1, this is a skeleton.
+pub fn run(database_url: &str, tick_ms: u64) {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async move {
+        tracing_subscriber::fmt()
+            .with_env_filter("ising=info")
+            .init();
+
+        tracing::info!(
+            database_url = database_url,
+            tick_ms = tick_ms,
+            "ising: starting observation loop"
+        );
+
+        // In production this would:
+        // 1. Connect to the event spine (EventStore)
+        // 2. Register all analyzers (register_defaults)
+        // 3. Subscribe to pg_notify and consume events
+        // 4. Run analyzers on each tick
+        // 5. Emit insights back to the spine
+        //
+        // For now, log and exit.
+        tracing::info!("ising: v0.1 scaffold — observation loop not yet connected to spine");
+    });
+}

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -4,18 +4,14 @@
 ///
 /// In production, this connects to the event spine, instantiates the analyzer
 /// registry, and runs the core observation loop. For v0.1, this is a skeleton.
-pub fn run(database_url: &str, tick_ms: u64) {
+pub fn run(_database_url: &str, tick_ms: u64) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async move {
         tracing_subscriber::fmt()
             .with_env_filter("ising=info")
             .init();
 
-        tracing::info!(
-            database_url = database_url,
-            tick_ms = tick_ms,
-            "ising: starting observation loop"
-        );
+        tracing::info!(tick_ms = tick_ms, "ising: starting observation loop");
 
         // In production this would:
         // 1. Connect to the event spine (EventStore)

--- a/crates/ising/src/core/analyzer.rs
+++ b/crates/ising/src/core/analyzer.rs
@@ -1,0 +1,114 @@
+//! Analyzer trait and registry (ising-v0.1 §6.8).
+//!
+//! The analyzer contract:
+//! ```text
+//! trait Analyzer:
+//!     fn name(&self) -> &str
+//!     fn run(&self, model: &FactoryModel) -> Vec<Insight>
+//! ```
+//!
+//! Any implementation that produces well-formed insights (with evidence,
+//! valid confidence, correct scope) is valid.
+
+use onsager_spine::protocol::Insight;
+
+use super::model::FactoryModel;
+
+/// Pluggable analyzer contract (ising-v0.1 §6.8).
+pub trait Analyzer: Send + Sync {
+    /// Human-readable analyzer name.
+    fn name(&self) -> &str;
+
+    /// Run analysis over the accumulated factory model and produce insights.
+    fn run(&self, model: &FactoryModel) -> Vec<Insight>;
+}
+
+/// Registry of active analyzers.
+#[derive(Default)]
+pub struct AnalyzerRegistry {
+    analyzers: Vec<Box<dyn Analyzer>>,
+}
+
+impl AnalyzerRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new analyzer.
+    pub fn register(&mut self, analyzer: Box<dyn Analyzer>) {
+        self.analyzers.push(analyzer);
+    }
+
+    /// Run all registered analyzers and collect their insights.
+    pub fn run_all(&self, model: &FactoryModel) -> Vec<(String, Vec<Insight>)> {
+        self.analyzers
+            .iter()
+            .map(|a| {
+                let insights = a.run(model);
+                (a.name().to_owned(), insights)
+            })
+            .collect()
+    }
+
+    /// Number of registered analyzers.
+    pub fn len(&self) -> usize {
+        self.analyzers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.analyzers.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::factory_event::{InsightKind, InsightScope};
+    use onsager_spine::protocol::FactoryEventRef;
+
+    struct DummyAnalyzer;
+    impl Analyzer for DummyAnalyzer {
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn run(&self, _model: &FactoryModel) -> Vec<Insight> {
+            vec![Insight {
+                insight_id: "ins_dummy".into(),
+                kind: InsightKind::Win,
+                scope: InsightScope::Global,
+                observation: "everything is great".into(),
+                evidence: vec![FactoryEventRef {
+                    event_id: 1,
+                    event_type: "forge.idle_tick".into(),
+                }],
+                suggested_action: None,
+                confidence: 0.5,
+            }]
+        }
+    }
+
+    #[test]
+    fn registry_runs_all_analyzers() {
+        let mut registry = AnalyzerRegistry::new();
+        registry.register(Box::new(DummyAnalyzer));
+        assert_eq!(registry.len(), 1);
+
+        let model = FactoryModel::new();
+        let results = registry.run_all(&model);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "dummy");
+        assert_eq!(results[0].1.len(), 1);
+    }
+
+    #[test]
+    fn empty_registry() {
+        let registry = AnalyzerRegistry::new();
+        assert!(registry.is_empty());
+        let results = registry.run_all(&FactoryModel::new());
+        assert!(results.is_empty());
+    }
+}

--- a/crates/ising/src/core/emitter.rs
+++ b/crates/ising/src/core/emitter.rs
@@ -1,0 +1,231 @@
+//! Insight emitter — validates, deduplicates, and emits insights (ising-v0.1 §7).
+//!
+//! Insight lifecycle: detected → validated → forwarded → [crystallized]
+//!
+//! Invariants enforced:
+//! - Evidence-backed (invariant #2): insights with empty evidence are rejected
+//! - Non-flooding (invariant #8): deduplication within configurable window
+//! - Idempotent (invariant #4): same event reprocessed does not produce duplicates
+
+use std::collections::HashSet;
+
+use onsager_spine::protocol::Insight;
+
+/// Configuration for the insight emitter.
+#[derive(Debug, Clone)]
+pub struct EmitterConfig {
+    /// Minimum confidence to record an insight on the spine.
+    pub min_confidence: f64,
+    /// Confidence threshold for forwarding to Forge as advisory.
+    pub advisory_threshold: f64,
+    /// Confidence threshold for rule proposal to Synodic.
+    pub crystallization_threshold: f64,
+}
+
+impl Default for EmitterConfig {
+    fn default() -> Self {
+        Self {
+            min_confidence: 0.3,
+            advisory_threshold: 0.3,
+            crystallization_threshold: 0.7,
+        }
+    }
+}
+
+/// What should happen with a validated insight.
+#[derive(Debug, PartialEq, Eq)]
+pub enum InsightDisposition {
+    /// Record on spine only (below advisory threshold).
+    RecordOnly,
+    /// Forward to Forge as advisory.
+    ForwardToForge,
+    /// Forward to Forge AND propose as rule to Synodic.
+    ProposeRule,
+}
+
+/// Result of attempting to emit an insight.
+#[derive(Debug)]
+pub enum EmitResult {
+    /// Insight was accepted and should be emitted.
+    Accepted {
+        insight: Insight,
+        disposition: InsightDisposition,
+    },
+    /// Insight was suppressed (dedup or below threshold).
+    Suppressed { insight_id: String, reason: String },
+    /// Insight was rejected (malformed).
+    Rejected { reason: String },
+}
+
+/// Validates, deduplicates, and routes insights.
+pub struct InsightEmitter {
+    config: EmitterConfig,
+    /// Recently emitted insight fingerprints for deduplication.
+    recent_fingerprints: HashSet<String>,
+}
+
+impl InsightEmitter {
+    pub fn new(config: EmitterConfig) -> Self {
+        Self {
+            config,
+            recent_fingerprints: HashSet::new(),
+        }
+    }
+
+    /// Attempt to emit an insight. Returns the disposition.
+    pub fn emit(&mut self, insight: Insight) -> EmitResult {
+        // Invariant #2: evidence-backed.
+        if insight.evidence.is_empty() {
+            return EmitResult::Rejected {
+                reason: "insight has no evidence (invariant #2 violation)".into(),
+            };
+        }
+
+        // Minimum confidence check.
+        if insight.confidence < self.config.min_confidence {
+            return EmitResult::Suppressed {
+                insight_id: insight.insight_id,
+                reason: format!(
+                    "confidence {:.2} below minimum {:.2}",
+                    insight.confidence, self.config.min_confidence
+                ),
+            };
+        }
+
+        // Deduplication: fingerprint = kind + scope + observation.
+        let fingerprint = format!(
+            "{:?}:{:?}:{}",
+            insight.kind, insight.scope, insight.observation
+        );
+        if self.recent_fingerprints.contains(&fingerprint) {
+            return EmitResult::Suppressed {
+                insight_id: insight.insight_id,
+                reason: "duplicate insight within deduplication window".into(),
+            };
+        }
+        self.recent_fingerprints.insert(fingerprint);
+
+        // Route based on confidence.
+        let disposition = if insight.confidence >= self.config.crystallization_threshold {
+            InsightDisposition::ProposeRule
+        } else if insight.confidence >= self.config.advisory_threshold {
+            InsightDisposition::ForwardToForge
+        } else {
+            InsightDisposition::RecordOnly
+        };
+
+        EmitResult::Accepted {
+            insight,
+            disposition,
+        }
+    }
+
+    /// Clear the deduplication window (e.g., on a new analysis tick).
+    pub fn clear_dedup_window(&mut self) {
+        self.recent_fingerprints.clear();
+    }
+
+    /// Number of fingerprints in the dedup window.
+    pub fn dedup_window_size(&self) -> usize {
+        self.recent_fingerprints.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::factory_event::{InsightKind, InsightScope};
+    use onsager_spine::protocol::FactoryEventRef;
+
+    fn make_insight(id: &str, confidence: f64) -> Insight {
+        Insight {
+            insight_id: id.into(),
+            kind: InsightKind::Failure,
+            scope: InsightScope::Global,
+            observation: "test pattern detected".into(),
+            evidence: vec![FactoryEventRef {
+                event_id: 1,
+                event_type: "forge.shaping_returned".into(),
+            }],
+            suggested_action: None,
+            confidence,
+        }
+    }
+
+    fn make_insight_no_evidence(id: &str) -> Insight {
+        Insight {
+            insight_id: id.into(),
+            kind: InsightKind::Failure,
+            scope: InsightScope::Global,
+            observation: "no evidence".into(),
+            evidence: vec![],
+            suggested_action: None,
+            confidence: 0.9,
+        }
+    }
+
+    #[test]
+    fn rejects_evidenceless_insight() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+        let result = emitter.emit(make_insight_no_evidence("ins_1"));
+        assert!(matches!(result, EmitResult::Rejected { .. }));
+    }
+
+    #[test]
+    fn suppresses_low_confidence() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+        let result = emitter.emit(make_insight("ins_1", 0.1));
+        assert!(matches!(result, EmitResult::Suppressed { .. }));
+    }
+
+    #[test]
+    fn accepts_and_routes_to_forge() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+        let result = emitter.emit(make_insight("ins_1", 0.5));
+        match result {
+            EmitResult::Accepted { disposition, .. } => {
+                assert_eq!(disposition, InsightDisposition::ForwardToForge);
+            }
+            _ => panic!("expected Accepted"),
+        }
+    }
+
+    #[test]
+    fn high_confidence_proposes_rule() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+        let result = emitter.emit(make_insight("ins_1", 0.85));
+        match result {
+            EmitResult::Accepted { disposition, .. } => {
+                assert_eq!(disposition, InsightDisposition::ProposeRule);
+            }
+            _ => panic!("expected Accepted"),
+        }
+    }
+
+    #[test]
+    fn deduplicates_identical_insights() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+
+        let result1 = emitter.emit(make_insight("ins_1", 0.5));
+        assert!(matches!(result1, EmitResult::Accepted { .. }));
+
+        // Same observation, kind, scope — should be suppressed.
+        let result2 = emitter.emit(make_insight("ins_2", 0.5));
+        assert!(matches!(result2, EmitResult::Suppressed { .. }));
+    }
+
+    #[test]
+    fn clear_dedup_allows_re_emit() {
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+
+        emitter.emit(make_insight("ins_1", 0.5));
+        emitter.clear_dedup_window();
+
+        let result = emitter.emit(make_insight("ins_2", 0.5));
+        assert!(matches!(result, EmitResult::Accepted { .. }));
+    }
+}

--- a/crates/ising/src/core/mod.rs
+++ b/crates/ising/src/core/mod.rs
@@ -1,0 +1,9 @@
+//! Core Ising logic — analyzer trait, factory model, insight pipeline.
+
+pub mod analyzer;
+pub mod emitter;
+pub mod model;
+
+pub use analyzer::{Analyzer, AnalyzerRegistry};
+pub use emitter::InsightEmitter;
+pub use model::FactoryModel;

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -1,0 +1,315 @@
+//! Factory model — accumulated internal representation of factory behavior
+//! (ising-v0.1 §4.2).
+//!
+//! This is not a raw event log — it tracks:
+//! - Artifact state transition histories
+//! - Shaping request/result pairs with timing
+//! - Gate verdict patterns per artifact kind
+//! - Session duration and outcome distributions
+//! - Insight history (own previous outputs)
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use onsager_spine::artifact::{ArtifactId, ArtifactState, Kind};
+use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
+
+/// A tracked shaping attempt.
+#[derive(Debug, Clone)]
+pub struct ShapingRecord {
+    pub request_id: String,
+    pub artifact_id: ArtifactId,
+    pub outcome: ShapingOutcome,
+    pub duration_ms: Option<u64>,
+    pub recorded_at: DateTime<Utc>,
+}
+
+/// A tracked artifact state.
+#[derive(Debug, Clone)]
+pub struct TrackedArtifact {
+    pub artifact_id: ArtifactId,
+    pub kind: Kind,
+    pub current_state: ArtifactState,
+    pub version: u32,
+    pub shaping_count: u32,
+    pub first_seen: DateTime<Utc>,
+    pub last_updated: DateTime<Utc>,
+}
+
+/// Accumulated factory model — the internal state Ising maintains.
+#[derive(Debug)]
+pub struct FactoryModel {
+    /// Tracked artifacts by ID.
+    pub artifacts: HashMap<String, TrackedArtifact>,
+    /// Recent shaping records (bounded by retention window).
+    pub shaping_records: Vec<ShapingRecord>,
+    /// Total events processed.
+    pub events_processed: u64,
+    /// Last processed event ID (for catch-up).
+    pub last_event_id: Option<i64>,
+}
+
+impl FactoryModel {
+    pub fn new() -> Self {
+        Self {
+            artifacts: HashMap::new(),
+            shaping_records: Vec::new(),
+            events_processed: 0,
+            last_event_id: None,
+        }
+    }
+
+    /// Ingest a factory event into the model.
+    pub fn ingest(&mut self, event_id: i64, event: &FactoryEventKind) {
+        self.events_processed += 1;
+        self.last_event_id = Some(event_id);
+
+        match event {
+            FactoryEventKind::ArtifactRegistered {
+                artifact_id,
+                kind,
+                name: _,
+                owner: _,
+            } => {
+                self.artifacts.insert(
+                    artifact_id.as_str().to_owned(),
+                    TrackedArtifact {
+                        artifact_id: artifact_id.clone(),
+                        kind: kind.clone(),
+                        current_state: ArtifactState::Draft,
+                        version: 0,
+                        shaping_count: 0,
+                        first_seen: Utc::now(),
+                        last_updated: Utc::now(),
+                    },
+                );
+            }
+
+            FactoryEventKind::ArtifactStateChanged {
+                artifact_id,
+                to_state,
+                ..
+            } => {
+                if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
+                    tracked.current_state = *to_state;
+                    tracked.last_updated = Utc::now();
+                }
+            }
+
+            FactoryEventKind::ArtifactVersionCreated {
+                artifact_id,
+                version,
+                ..
+            } => {
+                if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
+                    tracked.version = *version;
+                    tracked.last_updated = Utc::now();
+                }
+            }
+
+            FactoryEventKind::ForgeShapingReturned {
+                request_id,
+                artifact_id,
+                outcome,
+            } => {
+                if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
+                    tracked.shaping_count += 1;
+                    tracked.last_updated = Utc::now();
+                }
+
+                self.shaping_records.push(ShapingRecord {
+                    request_id: request_id.clone(),
+                    artifact_id: artifact_id.clone(),
+                    outcome: *outcome,
+                    duration_ms: None,
+                    recorded_at: Utc::now(),
+                });
+            }
+
+            _ => {}
+        }
+    }
+
+    /// Get shaping records for a specific artifact.
+    pub fn shaping_history(&self, artifact_id: &ArtifactId) -> Vec<&ShapingRecord> {
+        self.shaping_records
+            .iter()
+            .filter(|r| r.artifact_id.as_str() == artifact_id.as_str())
+            .collect()
+    }
+
+    /// Get shaping records for a specific artifact kind.
+    pub fn shaping_history_by_kind(
+        &self,
+        kind: &Kind,
+    ) -> Vec<(&TrackedArtifact, Vec<&ShapingRecord>)> {
+        self.artifacts
+            .values()
+            .filter(|a| &a.kind == kind)
+            .map(|a| {
+                let records = self.shaping_history(&a.artifact_id);
+                (a, records)
+            })
+            .collect()
+    }
+
+    /// Count failure rate for a given artifact over last N shaping attempts.
+    pub fn failure_rate(&self, artifact_id: &ArtifactId, last_n: usize) -> f64 {
+        let history = self.shaping_history(artifact_id);
+        let recent: Vec<_> = history.iter().rev().take(last_n).collect();
+        if recent.is_empty() {
+            return 0.0;
+        }
+        let failures = recent
+            .iter()
+            .filter(|r| matches!(r.outcome, ShapingOutcome::Failed | ShapingOutcome::Aborted))
+            .count();
+        failures as f64 / recent.len() as f64
+    }
+}
+
+impl Default for FactoryModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::artifact::Kind;
+
+    #[test]
+    fn ingest_artifact_registered() {
+        let mut model = FactoryModel::new();
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: ArtifactId::new("art_test1"),
+                kind: Kind::Code,
+                name: "test".into(),
+                owner: "marvin".into(),
+            },
+        );
+        assert_eq!(model.artifacts.len(), 1);
+        assert_eq!(model.events_processed, 1);
+    }
+
+    #[test]
+    fn ingest_state_change() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_test1");
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "test".into(),
+                owner: "marvin".into(),
+            },
+        );
+        model.ingest(
+            2,
+            &FactoryEventKind::ArtifactStateChanged {
+                artifact_id: id.clone(),
+                from_state: ArtifactState::Draft,
+                to_state: ArtifactState::InProgress,
+            },
+        );
+        assert_eq!(
+            model.artifacts["art_test1"].current_state,
+            ArtifactState::InProgress
+        );
+    }
+
+    #[test]
+    fn shaping_history_tracking() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_test1");
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "test".into(),
+                owner: "marvin".into(),
+            },
+        );
+        model.ingest(
+            2,
+            &FactoryEventKind::ForgeShapingReturned {
+                request_id: "req_1".into(),
+                artifact_id: id.clone(),
+                outcome: ShapingOutcome::Completed,
+            },
+        );
+        model.ingest(
+            3,
+            &FactoryEventKind::ForgeShapingReturned {
+                request_id: "req_2".into(),
+                artifact_id: id.clone(),
+                outcome: ShapingOutcome::Failed,
+            },
+        );
+
+        let history = model.shaping_history(&id);
+        assert_eq!(history.len(), 2);
+        assert_eq!(model.artifacts["art_test1"].shaping_count, 2);
+    }
+
+    #[test]
+    fn failure_rate_calculation() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_test1");
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "test".into(),
+                owner: "marvin".into(),
+            },
+        );
+
+        // 3 completed, 2 failed = 40% failure rate
+        for i in 0..3 {
+            model.ingest(
+                i + 2,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_{i}"),
+                    artifact_id: id.clone(),
+                    outcome: ShapingOutcome::Completed,
+                },
+            );
+        }
+        for i in 0..2 {
+            model.ingest(
+                i + 5,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_fail_{i}"),
+                    artifact_id: id.clone(),
+                    outcome: ShapingOutcome::Failed,
+                },
+            );
+        }
+
+        let rate = model.failure_rate(&id, 5);
+        assert!((rate - 0.4).abs() < f64::EPSILON);
+
+        // Last 2 are both failures
+        let rate_last2 = model.failure_rate(&id, 2);
+        assert!((rate_last2 - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn failure_rate_empty() {
+        let model = FactoryModel::new();
+        let id = ArtifactId::new("art_nonexistent");
+        assert!((model.failure_rate(&id, 5)).abs() < f64::EPSILON);
+    }
+}

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -18,6 +18,8 @@ use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
 /// A tracked shaping attempt.
 #[derive(Debug, Clone)]
 pub struct ShapingRecord {
+    /// The spine event ID that produced this record (for traceable evidence).
+    pub event_id: i64,
     pub request_id: String,
     pub artifact_id: ArtifactId,
     pub outcome: ShapingOutcome,
@@ -119,6 +121,7 @@ impl FactoryModel {
                 }
 
                 self.shaping_records.push(ShapingRecord {
+                    event_id,
                     request_id: request_id.clone(),
                     artifact_id: artifact_id.clone(),
                     outcome: *outcome,

--- a/crates/ising/src/lib.rs
+++ b/crates/ising/src/lib.rs
@@ -1,0 +1,15 @@
+//! Ising — continuous improvement engine of the Onsager factory.
+//!
+//! Ising observes the entire factory event spine and surfaces insights that make
+//! the factory smarter over time. It detects patterns (failures, waste, wins,
+//! anomalies) and emits structured insights back to the spine.
+//!
+//! Ising is **advisory-only** — it cannot block production, deny gate requests,
+//! or force scheduling decisions. Its path to influencing the factory is through
+//! advisory forwarding to Forge and rule proposals to Synodic.
+//!
+//! See `specs/ising-v0.1.md` for the full specification.
+
+pub mod analyzers;
+pub mod cmd;
+pub mod core;

--- a/crates/ising/src/main.rs
+++ b/crates/ising/src/main.rs
@@ -1,0 +1,46 @@
+//! ising — CLI entry point for the Ising continuous improvement engine.
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "ising",
+    about = "Onsager Ising — continuous improvement engine"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start the Ising observation loop
+    Serve {
+        /// Database URL for the event spine
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+
+        /// Analyzer tick interval in milliseconds
+        #[arg(long, default_value = "5000")]
+        tick_ms: u64,
+    },
+
+    /// Show current Ising status
+    Status,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve {
+            database_url,
+            tick_ms,
+        } => {
+            ising::cmd::serve::run(&database_url, tick_ms);
+        }
+        Commands::Status => {
+            println!("ising: not running (status check requires a running instance)");
+        }
+    }
+}

--- a/crates/onsager-spine/CLAUDE.md
+++ b/crates/onsager-spine/CLAUDE.md
@@ -12,19 +12,17 @@ This is a **library crate** (no binaries). The public surface is:
 
 The library does **not** manage schema. The SQL contract lives in `migrations/001_initial.sql`; downstream services apply it themselves.
 
-## Polyrepo
+## Monorepo
 
-**Subsystem repos** (each has a spec in `specs/`) under `onsager-ai/`:
+All subsystems live under `crates/` in the workspace root:
 
-- `stiglab` — AI agent orchestration
-- `synodic` — policy enforcement
-- `ising` — evaluation framework
+- `forge` — production line (artifact lifecycle, scheduling kernel)
+- `stiglab` — AI agent session orchestration
+- `synodic` — AI agent governance
+- `ising` — continuous improvement engine (factory observation)
 
-**Adapter repos** (no subsystem spec; hold a reserved namespace in `events_ext`):
-
-- `telegramable` — Telegram-first human interface
-
-Each lives in its own repo with its own CI and codebase.
+Each depends on `onsager-spine` via `path = "../onsager-spine"`.
+Subsystems must NOT import each other.
 
 ## Build & Test
 

--- a/crates/onsager-spine/src/namespace.rs
+++ b/crates/onsager-spine/src/namespace.rs
@@ -1,6 +1,6 @@
 //! Namespace partitioning for the `events_ext` table.
 //!
-//! Each component in the onsager-ai polyrepo owns a namespace that scopes its
+//! Each subsystem in the Onsager monorepo owns a namespace that scopes its
 //! extension events. Adding a new component means adding a well-known constant
 //! to [`Namespace`].
 
@@ -59,8 +59,13 @@ impl Namespace {
     }
 
     // -- Well-known constants ---------------------------------------------------
-    // These are the soft contract for namespace ownership across the polyrepo.
+    // These are the soft contract for namespace ownership across the monorepo.
     // Adding a new component means adding a constant here.
+
+    /// Namespace for the forge component.
+    pub fn forge() -> Self {
+        Self::new("forge").unwrap()
+    }
 
     /// Namespace for the stiglab component.
     pub fn stiglab() -> Self {
@@ -148,6 +153,7 @@ mod tests {
 
     #[test]
     fn well_known_constants() {
+        assert_eq!(Namespace::forge().as_str(), "forge");
         assert_eq!(Namespace::stiglab().as_str(), "stiglab");
         assert_eq!(Namespace::synodic().as_str(), "synodic");
         assert_eq!(Namespace::ising().as_str(), "ising");

--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -25,11 +25,13 @@ Subcommands are discovered on PATH. Any executable named `onsager-<name>`
 or `<name>` (for known subsystems) is a valid subcommand.
 
 KNOWN SUBCOMMANDS:
+    forge       Production line — drives artifacts through their lifecycle
+    ising       Continuous improvement engine — observes and surfaces insights
     stiglab     Distributed AI agent session orchestration
     synodic     AI agent governance
 ";
 
-const KNOWN: &[&str] = &["stiglab", "synodic"];
+const KNOWN: &[&str] = &["forge", "ising", "stiglab", "synodic"];
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/crates/stiglab/src/core/adapter.rs
+++ b/crates/stiglab/src/core/adapter.rs
@@ -217,6 +217,57 @@ mod tests {
     }
 
     #[test]
+    fn test_task_to_session() {
+        let task = Task {
+            id: "task_001".to_string(),
+            prompt: "Implement feature X".to_string(),
+            node_id: None,
+            working_dir: Some("/home/user/project".to_string()),
+            allowed_tools: None,
+            max_turns: Some(10),
+            model: Some("claude-sonnet-4-20250514".to_string()),
+            system_prompt: None,
+            permission_mode: None,
+            created_at: Utc::now(),
+        };
+
+        let session = task_to_session(&task, "node_42");
+
+        assert_eq!(session.task_id, "task_001");
+        assert_eq!(session.node_id, "node_42");
+        assert_eq!(session.state, SessionState::Pending);
+        assert_eq!(session.prompt, "Implement feature X");
+        assert_eq!(session.working_dir.as_deref(), Some("/home/user/project"));
+        assert!(session.output.is_none());
+        // Session ID should be a valid UUID
+        assert!(uuid::Uuid::parse_str(&session.id).is_ok());
+    }
+
+    #[test]
+    fn test_session_to_shaping_result_partial() {
+        let req = sample_request();
+        let session = Session {
+            id: "sess_003".to_string(),
+            task_id: "req_001".to_string(),
+            node_id: "node_1".to_string(),
+            state: SessionState::Running,
+            prompt: "Fix the login bug".to_string(),
+            output: Some("Partial progress".to_string()),
+            working_dir: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let result = session_to_shaping_result(&req, &session, 10000);
+
+        assert_eq!(
+            result.outcome,
+            onsager_spine::factory_event::ShapingOutcome::Partial
+        );
+        assert!(result.error.is_none());
+    }
+
+    #[test]
     fn test_session_to_shaping_result_failed() {
         let req = sample_request();
         let session = Session {

--- a/crates/stiglab/src/server/auth.rs
+++ b/crates/stiglab/src/server/auth.rs
@@ -267,4 +267,81 @@ mod tests {
         );
         assert_eq!(parse_cookie("theme=dark", "stiglab_session"), None);
     }
+
+    #[test]
+    fn test_parse_cookie_empty() {
+        assert_eq!(parse_cookie("", "stiglab_session"), None);
+    }
+
+    #[test]
+    fn test_parse_cookie_no_value() {
+        assert_eq!(
+            parse_cookie("stiglab_session; theme=dark", "stiglab_session"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_cookie_whitespace() {
+        assert_eq!(
+            parse_cookie("  stiglab_session = abc123 ; theme=dark", "stiglab_session"),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn test_generate_session_token_uniqueness() {
+        let t1 = generate_session_token();
+        let t2 = generate_session_token();
+        assert_ne!(t1, t2);
+        assert_eq!(t1.len(), 64); // 32 bytes hex-encoded
+    }
+
+    #[test]
+    fn test_generate_state_uniqueness() {
+        let s1 = generate_state();
+        let s2 = generate_state();
+        assert_ne!(s1, s2);
+        assert_eq!(s1.len(), 32); // 16 bytes hex-encoded
+    }
+
+    #[test]
+    fn test_generate_credential_key_length() {
+        let key = generate_credential_key();
+        assert_eq!(key.len(), 64); // 32 bytes hex-encoded
+                                   // Should be valid hex
+        assert!(hex::decode(&key).is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_key_fails() {
+        let key1 = generate_credential_key();
+        let key2 = generate_credential_key();
+        let encrypted = encrypt_credential(&key1, "secret").unwrap();
+        assert!(decrypt_credential(&key2, &encrypted).is_err());
+    }
+
+    #[test]
+    fn test_decrypt_invalid_data() {
+        let key = generate_credential_key();
+        assert!(decrypt_credential(&key, "tooshort").is_err());
+        assert!(decrypt_credential(&key, "not-hex!").is_err());
+    }
+
+    #[test]
+    fn test_github_authorize_url() {
+        let url = github_authorize_url("client123", "https://example.com/callback", "state456");
+        assert!(url.contains("client_id=client123"));
+        assert!(url.contains("state=state456"));
+        assert!(url.contains("scope=read%3Auser"));
+        assert!(url.starts_with("https://github.com/login/oauth/authorize"));
+    }
+
+    #[test]
+    fn test_auth_user_anonymous() {
+        let user = AuthUser::anonymous();
+        assert_eq!(user.user_id, "anonymous");
+        assert_eq!(user.github_login, "anonymous");
+        assert!(user.github_name.is_none());
+    }
 }

--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -48,3 +48,46 @@ impl ServerConfig {
         self.github_client_id.is_some() && self.github_client_secret.is_some()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(client_id: Option<&str>, client_secret: Option<&str>) -> ServerConfig {
+        ServerConfig {
+            host: "0.0.0.0".to_string(),
+            port: 3000,
+            database_url: "sqlite://test.db".to_string(),
+            static_dir: None,
+            cors_origin: None,
+            github_client_id: client_id.map(|s| s.to_string()),
+            github_client_secret: client_secret.map(|s| s.to_string()),
+            credential_key: None,
+            public_url: None,
+        }
+    }
+
+    #[test]
+    fn auth_enabled_when_both_set() {
+        let config = make_config(Some("id"), Some("secret"));
+        assert!(config.auth_enabled());
+    }
+
+    #[test]
+    fn auth_disabled_when_id_missing() {
+        let config = make_config(None, Some("secret"));
+        assert!(!config.auth_enabled());
+    }
+
+    #[test]
+    fn auth_disabled_when_secret_missing() {
+        let config = make_config(Some("id"), None);
+        assert!(!config.auth_enabled());
+    }
+
+    #[test]
+    fn auth_disabled_when_both_missing() {
+        let config = make_config(None, None);
+        assert!(!config.auth_enabled());
+    }
+}

--- a/justfile
+++ b/justfile
@@ -37,6 +37,12 @@ lint-ui:
 dev-dashboard:
     pnpm --filter dashboard dev
 
+dev-forge:
+    cargo run -p forge -- serve --database-url "${DATABASE_URL}"
+
+dev-ising:
+    cargo run -p ising -- serve --database-url "${DATABASE_URL}"
+
 dev-stiglab:
     cargo run -p stiglab -- serve
 
@@ -51,5 +57,7 @@ db-migrate:
 # ── Install from source ──────────────────────────────────────────────
 install:
     cargo install --path crates/onsager
+    cargo install --path crates/forge
+    cargo install --path crates/ising
     cargo install --path crates/stiglab
     cargo install --path crates/synodic


### PR DESCRIPTION
Add the two missing factory subsystems:

- **forge**: production line — scheduling kernel (pluggable, baseline
  FIFO+priority), artifact store (single-writer invariant), pipeline
  (decide→gate→dispatch→advance loop), process state machine, CLI
  skeleton. 24 tests covering kernel, store, pipeline, and state.

- **ising**: continuous improvement engine — analyzer trait + registry,
  factory model (event accumulation), insight emitter (validation,
  dedup, confidence routing), two built-in analyzers (repeated failures,
  stuck artifacts), CLI skeleton. 21 tests covering model, emitter,
  and both analyzers.

Also:
- Add forge + ising to workspace Cargo.toml and CI path filters
- Register forge + ising in the onsager dispatcher (KNOWN list)
- Add dev-forge / dev-ising commands to justfile
- Add 16 new stiglab tests (adapter, auth, config)

175 tests pass workspace-wide, zero clippy warnings, clean fmt.

https://claude.ai/code/session_011u4328uMCN53KtgAX7TyJo