### PR TITLE
claude/plan-dogfooding-gNRZr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Onsager dev environment.
+# Copy to .env and adjust as needed:  cp .env.example .env
+
+# === Postgres (shared event spine) ===
+POSTGRES_USER=onsager
+POSTGRES_PASSWORD=onsager
+POSTGRES_DB=onsager
+
+# === Spine (used by onsager-spine tests, forge, ising) ===
+DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
+
+# === Stiglab ===
+STIGLAB_HOST=0.0.0.0
+STIGLAB_PORT=3000
+# Stiglab's own DB (SQLite by default — no setup needed)
+# STIGLAB_DATABASE_URL=sqlite://./data/stiglab.db
+# Connect stiglab to the shared event spine:
+ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
+# Path to serve the built dashboard (optional in dev — use vite proxy instead)
+# STIGLAB_STATIC_DIR=apps/dashboard/dist
+# STIGLAB_CORS_ORIGIN=http://localhost:5173
+# STIGLAB_NO_RUNNER=false
+# STIGLAB_MAX_SESSIONS=4
+# STIGLAB_AGENT_COMMAND=claude
+# STIGLAB_NODE_NAME=main
+# GitHub OAuth (optional — auth disabled when unset)
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# STIGLAB_CREDENTIAL_KEY=          # 32-byte hex key for AES-256-GCM credential encryption
+# STIGLAB_PUBLIC_URL=               # Public URL for OAuth callback
+
+# === Synodic ===
+SYNODIC_PORT=3001
+# Synodic uses its own SQLite DB by default (~/.synodic/synodic.db)
+# SYNODIC_DASHBOARD_DIR=
+# ANTHROPIC_API_KEY=                # Required for governance semantic checks

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # === Stiglab ===
 STIGLAB_HOST=0.0.0.0
 STIGLAB_PORT=3000
-# Stiglab's own DB (SQLite by default — no setup needed)
-# STIGLAB_DATABASE_URL=sqlite://./data/stiglab.db
+# Stiglab's own DB (reads DATABASE_URL, defaults to sqlite://./data/stiglab.db)
+# Leave unset here — stiglab uses SQLite by default, which needs no setup.
+# The just dev recipe passes ONSAGER_DATABASE_URL for spine integration.
 # Connect stiglab to the shared event spine:
 ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # Path to serve the built dashboard (optional in dev — use vite proxy instead)
@@ -35,6 +36,7 @@ ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # ANTHROPIC_API_KEY=                # Fallback — direct Anthropic API key
 
 # === Synodic ===
-SYNODIC_PORT=3001
+# Synodic reads PORT (default 3000). Set to 3001 to avoid conflict with stiglab.
+# PORT=3001
 # Synodic uses its own SQLite DB by default (~/.synodic/synodic.db)
 # SYNODIC_DASHBOARD_DIR=

--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,12 @@ ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # STIGLAB_CREDENTIAL_KEY=          # 32-byte hex key for AES-256-GCM credential encryption
 # STIGLAB_PUBLIC_URL=               # Public URL for OAuth callback
 
+# === Agent credentials (set via Dashboard > Settings > Credentials) ===
+# These are encrypted at rest and passed to agent sessions as env vars.
+# CLAUDE_CODE_OAUTH_TOKEN=          # Primary auth — Claude Code CLI OAuth token
+# ANTHROPIC_API_KEY=                # Fallback — direct Anthropic API key
+
 # === Synodic ===
 SYNODIC_PORT=3001
 # Synodic uses its own SQLite DB by default (~/.synodic/synodic.db)
 # SYNODIC_DASHBOARD_DIR=
-# ANTHROPIC_API_KEY=                # Required for governance semantic checks

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.env
 **/*.rs.bak
 /node_modules
 **/node_modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ just dev                        # start stiglab + synodic + dashboard
 just smoke-test                 # verify everything works (in another terminal)
 ```
 
+To run agent sessions, add your `CLAUDE_CODE_OAUTH_TOKEN` via
+Dashboard > Settings > Credentials (encrypted at rest, passed to agents as env vars).
+
 Services:
 - **Dashboard**: http://localhost:5173 (Vite dev server with HMR)
 - **Stiglab API**: http://localhost:3000 (sessions, nodes, WebSocket)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,8 @@ apps/
 Prerequisites: Docker, Rust toolchain (via rustup), pnpm.
 
 ```bash
-cp .env.example .env            # configure environment
-just dev-infra                  # start Postgres + run migrations
-just dev                        # start stiglab + synodic + dashboard
+cp .env.example .env            # configure environment (reference for docker-compose)
+just dev                        # start Postgres, run migrations, and launch services
 just smoke-test                 # verify everything works (in another terminal)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,31 @@ apps/
   dashboard/       <- React UI (sessions, nodes, governance, factory views)
 ```
 
+## Getting Started
+
+Prerequisites: Docker, Rust toolchain (via rustup), pnpm.
+
+```bash
+cp .env.example .env            # configure environment
+just dev-infra                  # start Postgres + run migrations
+just dev                        # start stiglab + synodic + dashboard
+just smoke-test                 # verify everything works (in another terminal)
+```
+
+Services:
+- **Dashboard**: http://localhost:5173 (Vite dev server with HMR)
+- **Stiglab API**: http://localhost:3000 (sessions, nodes, WebSocket)
+- **Synodic API**: http://localhost:3001 (governance)
+- **Postgres**: localhost:5432 (event spine)
+
+To stop: `Ctrl+C` for services, `just dev-down` for Postgres.
+
 ## Build & Test
 
 ```bash
 just build           # Rust workspace + dashboard
 just test            # All tests
+just test-all        # All tests including spine integration tests
 just lint            # fmt + clippy + eslint
 ```
 

--- a/crates/onsager-spine/src/listener.rs
+++ b/crates/onsager-spine/src/listener.rs
@@ -277,8 +277,10 @@ mod tests {
         use std::sync::atomic::{AtomicI64, Ordering};
         use tokio::sync::Semaphore;
 
-        let db_url = std::env::var("DATABASE_URL")
-            .expect("DATABASE_URL must be set to run listener integration tests");
+        let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
 
         let store = EventStore::connect(&db_url).await.unwrap();
         let tag = format!("backfill_test_{}", ulid::Ulid::new());

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -391,9 +391,8 @@ mod tests {
     use crate::artifact::{ArtifactId, Kind};
     use crate::factory_event::{FactoryEvent, FactoryEventKind};
 
-    fn db_url() -> String {
-        std::env::var("DATABASE_URL")
-            .expect("DATABASE_URL must be set to run store integration tests")
+    fn db_url() -> Option<String> {
+        std::env::var("DATABASE_URL").ok()
     }
 
     fn test_event(stream_suffix: &str) -> FactoryEvent {
@@ -421,7 +420,11 @@ mod tests {
     /// Committed transaction: event lands in the database.
     #[tokio::test]
     async fn transaction_commit_persists_event() {
-        let store = EventStore::connect(&db_url()).await.unwrap();
+        let Some(url) = db_url() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let store = EventStore::connect(&url).await.unwrap();
         let event = test_event("commit");
         let stream_id = event.event.stream_id();
         let meta = test_metadata();
@@ -451,7 +454,11 @@ mod tests {
     /// Rolled-back transaction: event is not visible after rollback.
     #[tokio::test]
     async fn transaction_rollback_discards_event() {
-        let store = EventStore::connect(&db_url()).await.unwrap();
+        let Some(url) = db_url() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let store = EventStore::connect(&url).await.unwrap();
         let event = test_event("rollback");
         let stream_id = event.event.stream_id();
         let meta = test_metadata();
@@ -477,7 +484,11 @@ mod tests {
     /// Dropped transaction (simulating panic path): event does not persist.
     #[tokio::test]
     async fn transaction_drop_rolls_back() {
-        let store = EventStore::connect(&db_url()).await.unwrap();
+        let Some(url) = db_url() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let store = EventStore::connect(&url).await.unwrap();
         let event = test_event("drop");
         let stream_id = event.event.stream_id();
         let meta = test_metadata();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       PGPASSWORD: onsager
     entrypoint: >
       sh -c "
-        psql -h db -U onsager -d onsager -f /migrations/001_initial.sql &&
-        psql -h db -U onsager -d onsager -f /migrations/002_artifacts.sql
+        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/001_initial.sql &&
+        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/002_artifacts.sql
       "
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Onsager dev infrastructure.
+# Usage:
+#   just dev-infra          # start Postgres + run migrations
+#   just dev-down           # tear down
+#   docker compose up db -d # Postgres only (manual migration)
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: onsager
+      POSTGRES_PASSWORD: onsager
+      POSTGRES_DB: onsager
+    ports:
+      - "5432:5432"
+    volumes:
+      - onsager-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U onsager"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  migrate:
+    image: postgres:16-alpine
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./crates/onsager-spine/migrations:/migrations:ro
+    environment:
+      PGPASSWORD: onsager
+    entrypoint: >
+      sh -c "
+        psql -h db -U onsager -d onsager -f /migrations/001_initial.sql &&
+        psql -h db -U onsager -d onsager -f /migrations/002_artifacts.sql
+      "
+
+volumes:
+  onsager-db:

--- a/justfile
+++ b/justfile
@@ -33,7 +33,49 @@ lint-rust:
 lint-ui:
     pnpm --filter dashboard lint
 
-# ── Dev ──────────────────────────────────────────────────────────────
+# ── Dev (full stack) ─────────────────────────────────────────────────
+
+# Start the full dev stack: Postgres + migrations + all services
+dev: dev-infra
+    #!/usr/bin/env bash
+    set -euo pipefail
+    trap 'kill $(jobs -p) 2>/dev/null' EXIT
+
+    echo "==> Starting stiglab on :3000..."
+    ONSAGER_DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+        cargo run -p stiglab -- server &
+
+    echo "==> Starting synodic on :3001..."
+    PORT=3001 cargo run -p synodic -- serve &
+
+    echo "==> Starting dashboard on :5173..."
+    pnpm --filter dashboard dev &
+
+    echo ""
+    echo "=== Onsager dev stack running ==="
+    echo "  Dashboard:  http://localhost:5173"
+    echo "  Stiglab:    http://localhost:3000"
+    echo "  Synodic:    http://localhost:3001"
+    echo "  Postgres:   postgres://onsager:onsager@localhost:5432/onsager"
+    echo ""
+    echo "Press Ctrl+C to stop all services."
+    wait
+
+# Start infrastructure only (Postgres + migrations)
+dev-infra:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "==> Starting Postgres..."
+    docker compose up db -d --wait
+    echo "==> Running spine migrations..."
+    docker compose up migrate --exit-code-from migrate
+    echo "==> Infrastructure ready."
+
+# Stop infrastructure
+dev-down:
+    docker compose down
+
+# ── Dev (individual services) ────────────────────────────────────────
 dev-dashboard:
     pnpm --filter dashboard dev
 
@@ -44,15 +86,29 @@ dev-ising:
     cargo run -p ising -- serve --database-url "${DATABASE_URL}"
 
 dev-stiglab:
-    cargo run -p stiglab -- serve
+    cargo run -p stiglab -- server
 
-dev-synodic:
-    cargo run -p synodic -- serve
+dev-synodic port="3001":
+    PORT={{port}} cargo run -p synodic -- serve
 
 # ── DB ───────────────────────────────────────────────────────────────
 db-migrate:
     psql "$DATABASE_URL" -f crates/onsager-spine/migrations/001_initial.sql
     psql "$DATABASE_URL" -f crates/onsager-spine/migrations/002_artifacts.sql
+
+# ── Test (with spine integration) ────────────────────────────────────
+
+# Run onsager-spine integration tests (requires running Postgres via dev-infra)
+test-spine:
+    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+        cargo test -p onsager-spine -- --test-threads=1
+
+# Run all tests including spine integration tests
+test-all: test-spine test-rust test-ui
+
+# Smoke test the running dev stack
+smoke-test:
+    bash scripts/smoke-test.sh
 
 # ── Install from source ──────────────────────────────────────────────
 install:

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ lint-ui:
 dev: dev-infra
     #!/usr/bin/env bash
     set -euo pipefail
-    trap 'kill $(jobs -p) 2>/dev/null' EXIT
+    trap 'pids=$(jobs -p); [ -n "$pids" ] && kill $pids 2>/dev/null || true' EXIT
 
     echo "==> Starting stiglab on :3000..."
     ONSAGER_DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
@@ -68,7 +68,7 @@ dev-infra:
     echo "==> Starting Postgres..."
     docker compose up db -d --wait
     echo "==> Running spine migrations..."
-    docker compose up migrate --exit-code-from migrate
+    docker compose run --rm migrate
     echo "==> Infrastructure ready."
 
 # Stop infrastructure

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -45,12 +45,24 @@ check "html"     "$DASHBOARD_URL"             '<'
 
 echo ""
 echo "-- Spine (Postgres) --"
-if psql "$SPINE_URL" -c "SELECT 1 FROM events LIMIT 0;" > /dev/null 2>&1; then
-    echo "  PASS  events table accessible"
-    PASS=$((PASS + 1))
+if command -v psql > /dev/null 2>&1; then
+    if psql "$SPINE_URL" -c "SELECT 1 FROM events LIMIT 0;" > /dev/null 2>&1; then
+        echo "  PASS  events table accessible"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  events table  (db unreachable via local psql)"
+        FAIL=$((FAIL + 1))
+    fi
+elif command -v docker > /dev/null 2>&1 && docker compose version > /dev/null 2>&1; then
+    if docker compose exec -T db psql -U onsager -d onsager -c "SELECT 1 FROM events LIMIT 0;" > /dev/null 2>&1; then
+        echo "  PASS  events table accessible"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  events table  (db unreachable via docker compose)"
+        FAIL=$((FAIL + 1))
+    fi
 else
-    echo "  FAIL  events table  (psql not available or db unreachable)"
-    FAIL=$((FAIL + 1))
+    echo "  SKIP  events table  (no psql or docker compose available)"
 fi
 
 echo ""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Smoke test for the Onsager dev stack.
+# Verifies that all services are running and responding.
+#
+# Usage:
+#   just smoke-test                         # defaults
+#   STIGLAB_URL=http://host:3000 bash scripts/smoke-test.sh
+
+set -euo pipefail
+
+STIGLAB_URL="${STIGLAB_URL:-http://localhost:3000}"
+SYNODIC_URL="${SYNODIC_URL:-http://localhost:3001}"
+DASHBOARD_URL="${DASHBOARD_URL:-http://localhost:5173}"
+SPINE_URL="${SPINE_URL:-postgres://onsager:onsager@localhost:5432/onsager}"
+
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1" url="$2" expect="$3"
+    if curl -sf --max-time 5 "$url" | grep -q "$expect"; then
+        echo "  PASS  $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $name  ($url)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Onsager Smoke Test ==="
+echo ""
+
+echo "-- Stiglab --"
+check "health"   "$STIGLAB_URL/api/health"   '"status"'
+check "nodes"    "$STIGLAB_URL/api/nodes"     'nodes'
+check "sessions" "$STIGLAB_URL/api/sessions"  'sessions'
+
+echo ""
+echo "-- Synodic --"
+check "health"   "$SYNODIC_URL/api/health"    '"status"'
+
+echo ""
+echo "-- Dashboard --"
+check "html"     "$DASHBOARD_URL"             '<'
+
+echo ""
+echo "-- Spine (Postgres) --"
+if psql "$SPINE_URL" -c "SELECT 1 FROM events LIMIT 0;" > /dev/null 2>&1; then
+    echo "  PASS  events table accessible"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  events table  (psql not available or db unreachable)"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
- Skip spine integration tests gracefully when DATABASE_URL is unset
- Add top-level docker-compose.yml (Postgres + migration runner)
- Add .env.example documenting all service env vars
- Add `just dev` to start full stack (stiglab + synodic + dashboard)
- Add `just dev-infra` / `just dev-down` for Postgres lifecycle
- Add `just test-spine` / `just test-all` / `just smoke-test`
- Fix dev-stiglab recipe to use correct `server` subcommand
- Default dev-synodic to port 3001 to avoid conflict with stiglab
- Add smoke test script to verify running stack
- Update CLAUDE.md with Getting Started section

https://claude.ai/code/session_01KDrJeXnyvZ2UsZm4Kx8LW3