### PR TITLE
feat: add unified production deployment setup

### DIFF
--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -36,7 +36,7 @@ RUN npm install -g @anthropic-ai/claude-code
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates libssl3 libsqlite3-0 libgcc-s1 libstdc++6 \
-      curl git \
+      curl git postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Node.js + Claude Code CLI from the glibc-based node image
@@ -59,7 +59,11 @@ RUN printf '#!/bin/sh\necho "username=x-access-token\npassword=${GITHUB_TOKEN}"\
 WORKDIR /app
 COPY --from=rust-builder /app/target/release/stiglab /app/stiglab
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static
+# Spine migrations — applied on startup when ONSAGER_DATABASE_URL is set
+COPY crates/onsager-spine/migrations/ /app/spine-migrations/
+COPY crates/stiglab/deploy/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 ENV STIGLAB_STATIC_DIR=/app/static
 ENV STIGLAB_HOST=0.0.0.0
-ENTRYPOINT ["/app/stiglab"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["server"]

--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -46,6 +46,16 @@ COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
 # Claude Code CLI installed globally via npm
 COPY --from=node-runtime /usr/local/bin/claude /usr/local/bin/claude
 
+# Git credential helper — reads GITHUB_TOKEN from env at push time.
+# Users add GITHUB_TOKEN as a credential in Dashboard > Settings; stiglab
+# injects it as an env var into the claude subprocess, and this helper
+# feeds it to git for HTTPS auth.
+RUN printf '#!/bin/sh\necho "username=x-access-token\npassword=${GITHUB_TOKEN}"\n' \
+      > /usr/local/bin/git-credential-env \
+    && chmod +x /usr/local/bin/git-credential-env \
+    && git config --system credential.helper /usr/local/bin/git-credential-env \
+    && git config --system --add safe.directory '*'
+
 WORKDIR /app
 COPY --from=rust-builder /app/target/release/stiglab /app/stiglab
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static

--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -28,11 +28,24 @@ RUN mkdir -p crates/onsager-spine/src crates/stiglab/src \
 COPY crates/ crates/
 RUN find crates -name "*.rs" | xargs touch && cargo build --release -p stiglab
 
-# ---- Stage 3: Runtime ----
+# ---- Stage 3: Node.js for runtime (glibc-compatible) ----
+FROM node:20-bookworm-slim AS node-runtime
+RUN npm install -g @anthropic-ai/claude-code
+
+# ---- Stage 4: Runtime ----
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates libssl3 libsqlite3-0 libgcc-s1 libstdc++6 \
+      curl git \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy Node.js + Claude Code CLI from the glibc-based node image
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Claude Code CLI installed globally via npm
+COPY --from=node-runtime /usr/local/bin/claude /usr/local/bin/claude
+
 WORKDIR /app
 COPY --from=rust-builder /app/target/release/stiglab /app/stiglab
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static

--- a/crates/stiglab/deploy/entrypoint.sh
+++ b/crates/stiglab/deploy/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Run onsager-spine migrations if ONSAGER_DATABASE_URL is set.
+# The spine is a shared Postgres schema (events, events_ext, artifacts).
+# All migrations are idempotent (IF NOT EXISTS / OR REPLACE).
+if [ -n "$ONSAGER_DATABASE_URL" ] && [ -d /app/spine-migrations ]; then
+    echo "Running onsager-spine migrations..."
+    for f in /app/spine-migrations/*.sql; do
+        echo "  applying $(basename "$f")..."
+        psql -X -v ON_ERROR_STOP=1 "$ONSAGER_DATABASE_URL" -f "$f"
+    done
+    echo "Spine migrations complete."
+fi
+
+exec /app/stiglab "$@"

--- a/crates/stiglab/deploy/railway.toml
+++ b/crates/stiglab/deploy/railway.toml
@@ -1,5 +1,8 @@
+# Stiglab Railway service config.
+# In Railway dashboard, set root directory to "/" (repo root).
+
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "crates/stiglab/deploy/Dockerfile"
 
 [deploy]
 healthcheckPath = "/api/health"

--- a/crates/synodic/deploy/railway.json
+++ b/crates/synodic/deploy/railway.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "dockerfilePath": "../docker/Dockerfile"
+    "dockerfilePath": "deploy/synodic.Dockerfile"
   },
   "deploy": {
     "healthcheckPath": "/api/health",
-    "healthcheckTimeout": 5,
+    "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "numReplicas": 1

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,16 +7,25 @@ POSTGRES_PASSWORD=changeme           # REQUIRED — pick a real password
 POSTGRES_DB=onsager
 POSTGRES_PORT=5432                   # host port (change if 5432 is taken)
 
-# === Stiglab (sessions + dashboard) ===
+# === Stiglab (sessions + dashboard + agent runner) ===
 STIGLAB_PORT=3000                    # host port for the dashboard
 STIGLAB_NODE_NAME=main
 STIGLAB_MAX_SESSIONS=4               # max concurrent agent sessions
+STIGLAB_AGENT_COMMAND=claude         # CLI binary to invoke for each session
+
+# Agent workspace — host directory bind-mounted into the container at /workspace.
+# Agents clone repos and make changes here. Persists across container restarts.
+# Default: ./workspace (relative to deploy/ directory)
+AGENT_WORKSPACE_DIR=./workspace
+
+# Credential encryption key — REQUIRED for storing agent credentials securely.
+# Generate one with:  openssl rand -hex 32
+STIGLAB_CREDENTIAL_KEY=
 
 # GitHub OAuth (optional — auth disabled when unset)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
-# STIGLAB_CREDENTIAL_KEY=            # 32-byte hex key for AES-256-GCM — generate with: openssl rand -hex 32
-# STIGLAB_PUBLIC_URL=                 # e.g. https://onsager.example.com (for OAuth callback)
+# STIGLAB_PUBLIC_URL=                # e.g. https://onsager.example.com (for OAuth callback)
 
 # === Synodic (governance) ===
 SYNODIC_PORT=3001                    # host port for governance API

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,22 @@
+# Onsager production environment.
+# Copy to .env and fill in secrets:  cp .env.example .env
+
+# === Postgres ===
+POSTGRES_USER=onsager
+POSTGRES_PASSWORD=changeme           # REQUIRED — pick a real password
+POSTGRES_DB=onsager
+POSTGRES_PORT=5432                   # host port (change if 5432 is taken)
+
+# === Stiglab (sessions + dashboard) ===
+STIGLAB_PORT=3000                    # host port for the dashboard
+STIGLAB_NODE_NAME=main
+STIGLAB_MAX_SESSIONS=4               # max concurrent agent sessions
+
+# GitHub OAuth (optional — auth disabled when unset)
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# STIGLAB_CREDENTIAL_KEY=            # 32-byte hex key for AES-256-GCM — generate with: openssl rand -hex 32
+# STIGLAB_PUBLIC_URL=                 # e.g. https://onsager.example.com (for OAuth callback)
+
+# === Synodic (governance) ===
+SYNODIC_PORT=3001                    # host port for governance API

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -22,7 +22,22 @@ AGENT_WORKSPACE_DIR=./workspace
 # Generate one with:  openssl rand -hex 32
 STIGLAB_CREDENTIAL_KEY=
 
-# GitHub OAuth (optional — auth disabled when unset)
+# === Agent credentials (added via Dashboard > Settings > Credentials) ===
+# These are NOT set in this file — they're stored encrypted in Postgres and
+# injected as env vars into each claude subprocess at session start.
+#
+# Required credentials to add in the dashboard:
+#   CLAUDE_CODE_OAUTH_TOKEN  — authenticates the claude CLI with Anthropic
+#   GITHUB_TOKEN             — GitHub PAT (repo scope) for git push
+#
+# Optional:
+#   GIT_AUTHOR_NAME          — git commit author (default: agent identity)
+#   GIT_AUTHOR_EMAIL         — git commit email
+#
+# The container has a git credential helper that automatically uses
+# GITHUB_TOKEN for HTTPS pushes — no SSH key setup needed.
+
+# GitHub OAuth for dashboard login (optional — auth disabled when unset)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
 # STIGLAB_PUBLIC_URL=                # e.g. https://onsager.example.com (for OAuth callback)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,119 @@
+# Onsager production stack.
+#
+# Usage:
+#   cp .env.example .env          # fill in secrets
+#   docker compose build           # build images
+#   docker compose up -d           # start everything
+#   docker compose logs -f         # tail logs
+#   docker compose down            # stop
+#
+# The stack:
+#   db       — PostgreSQL 16 (shared event spine + stiglab + synodic)
+#   migrate  — runs spine + synodic Postgres migrations, then exits
+#   stiglab  — sessions, agents, dashboard UI (port 3000)
+#   synodic  — governance API (port 3001)
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-onsager}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-onsager}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - onsager-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-onsager}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  migrate:
+    image: postgres:16-alpine
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ../crates/onsager-spine/migrations:/spine-migrations:ro
+      - ../crates/synodic/migrations/pg:/synodic-migrations:ro
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    entrypoint: >
+      sh -c "
+        echo '==> Running spine migrations...' &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /spine-migrations/001_initial.sql &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /spine-migrations/002_artifacts.sql &&
+        echo '==> Running synodic migrations...' &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /synodic-migrations/001_initial_schema.sql &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /synodic-migrations/002_seed_data.sql &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /synodic-migrations/003_pipeline_runs.sql &&
+        psql -X -v ON_ERROR_STOP=1
+          -h db -U ${POSTGRES_USER:-onsager} -d ${POSTGRES_DB:-onsager}
+          -f /synodic-migrations/004_governance_events.sql &&
+        echo '==> Migrations complete.'
+      "
+
+  stiglab:
+    build:
+      context: ..
+      dockerfile: crates/stiglab/deploy/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${STIGLAB_PORT:-3000}:3000"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      STIGLAB_HOST: "0.0.0.0"
+      STIGLAB_PORT: "3000"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-onsager}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-onsager}"
+      ONSAGER_DATABASE_URL: "postgres://${POSTGRES_USER:-onsager}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-onsager}"
+      STIGLAB_NODE_NAME: "${STIGLAB_NODE_NAME:-main}"
+      STIGLAB_MAX_SESSIONS: "${STIGLAB_MAX_SESSIONS:-4}"
+      # GitHub OAuth (optional — auth disabled when unset)
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      STIGLAB_CREDENTIAL_KEY: "${STIGLAB_CREDENTIAL_KEY:-}"
+      STIGLAB_PUBLIC_URL: "${STIGLAB_PUBLIC_URL:-}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  synodic:
+    build:
+      context: ..
+      dockerfile: deploy/synodic.Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${SYNODIC_PORT:-3001}:3001"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      PORT: "3001"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-onsager}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-onsager}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3001/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  onsager-db:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,8 +10,14 @@
 # The stack:
 #   db       — PostgreSQL 16 (shared event spine + stiglab + synodic)
 #   migrate  — runs spine + synodic Postgres migrations, then exits
-#   stiglab  — sessions, agents, dashboard UI (port 3000)
+#   stiglab  — sessions, agents, dashboard UI + Claude Code CLI (port 3000)
 #   synodic  — governance API (port 3001)
+#
+# Agent sessions:
+#   Stiglab's built-in runner spawns `claude` (Claude Code CLI) as a subprocess.
+#   The AGENT_WORKSPACE_DIR host directory is bind-mounted into the container
+#   so agents can clone repos and make changes that persist across restarts.
+#   Credentials (CLAUDE_CODE_OAUTH_TOKEN) are added via Dashboard > Settings.
 
 services:
   db:
@@ -76,6 +82,8 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+    volumes:
+      - ${AGENT_WORKSPACE_DIR:-./workspace}:/workspace
     environment:
       STIGLAB_HOST: "0.0.0.0"
       STIGLAB_PORT: "3000"
@@ -83,6 +91,7 @@ services:
       ONSAGER_DATABASE_URL: "postgres://${POSTGRES_USER:-onsager}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-onsager}"
       STIGLAB_NODE_NAME: "${STIGLAB_NODE_NAME:-main}"
       STIGLAB_MAX_SESSIONS: "${STIGLAB_MAX_SESSIONS:-4}"
+      STIGLAB_AGENT_COMMAND: "${STIGLAB_AGENT_COMMAND:-claude}"
       # GitHub OAuth (optional — auth disabled when unset)
       GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
       GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"

--- a/deploy/synodic.Dockerfile
+++ b/deploy/synodic.Dockerfile
@@ -1,0 +1,31 @@
+# Synodic — AI agent governance server.
+# Build context: repository root (../ from deploy/).
+
+# ---- Stage 1: Build Rust ----
+FROM rust:1.94-bookworm AS rust-builder
+WORKDIR /app
+# Cache dependencies: copy manifests first
+COPY Cargo.toml Cargo.lock ./
+COPY crates/onsager-spine/Cargo.toml crates/onsager-spine/Cargo.toml
+COPY crates/synodic/Cargo.toml crates/synodic/Cargo.toml
+# Create dummy source files for dependency caching
+RUN mkdir -p crates/onsager-spine/src crates/synodic/src \
+    && echo "fn main() {}" > crates/synodic/src/main.rs \
+    && touch crates/onsager-spine/src/lib.rs \
+    && touch crates/synodic/src/lib.rs \
+    && cargo build --release -p synodic --features postgres 2>/dev/null || true
+# Copy actual source and rebuild.
+# Touch all .rs files so their mtime is newer than the dummy-build artifacts.
+COPY crates/ crates/
+RUN find crates -name "*.rs" | xargs touch \
+    && cargo build --release -p synodic --features postgres
+
+# ---- Stage 2: Runtime ----
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates libssl3 libgcc-s1 libstdc++6 curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=rust-builder /app/target/release/synodic /app/synodic
+ENTRYPOINT ["/app/synodic"]
+CMD ["serve"]

--- a/justfile
+++ b/justfile
@@ -110,6 +110,36 @@ test-all: test-spine test-rust test-ui
 smoke-test:
     bash scripts/smoke-test.sh
 
+# ── Deploy (production) ──────────────────────────────────────────────
+
+# Build production Docker images
+deploy-build:
+    docker compose -f deploy/docker-compose.yml build
+
+# Start the production stack (Postgres + migrations + stiglab + synodic)
+deploy-up:
+    docker compose -f deploy/docker-compose.yml up -d
+
+# Stop the production stack
+deploy-down:
+    docker compose -f deploy/docker-compose.yml down
+
+# Tail production logs
+deploy-logs:
+    docker compose -f deploy/docker-compose.yml logs -f
+
+# Full deploy: build images then start everything
+deploy: deploy-build deploy-up
+    #!/usr/bin/env bash
+    echo ""
+    echo "=== Onsager production stack running ==="
+    echo "  Dashboard:  http://localhost:${STIGLAB_PORT:-3000}"
+    echo "  Stiglab:    http://localhost:${STIGLAB_PORT:-3000}/api/health"
+    echo "  Synodic:    http://localhost:${SYNODIC_PORT:-3001}/api/health"
+    echo ""
+    echo "Logs:  just deploy-logs"
+    echo "Stop:  just deploy-down"
+
 # ── Install from source ──────────────────────────────────────────────
 install:
     cargo install --path crates/onsager


### PR DESCRIPTION
Adds deploy/ directory with a docker-compose stack that brings up
the full Onsager system (Postgres + migrations + stiglab + synodic)
in production mode.

- deploy/docker-compose.yml: unified stack with health checks
- deploy/synodic.Dockerfile: fixed for monorepo (old one had stale paths)
- deploy/.env.example: production env template
- justfile: deploy-build, deploy-up, deploy-down, deploy-logs, deploy targets

Usage: cp deploy/.env.example deploy/.env && just deploy

https://claude.ai/code/session_01UXYBTKjw7NFFEDUJNvGu8j