### PR TITLE
feat: make factory the primary dashboard entry point with artifact registration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,8 @@ jobs:
       - uses: actions/checkout@v4
 
       # ── Rust build ──────────────────────────────────────────
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show active-toolchain
       - uses: Swatinem/rust-cache@v2
 
       - name: Build stiglab + synodic

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,9 +71,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show active-toolchain
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
       - run: cargo build --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,11 +603,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "onsager-spine",
+ "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2337,6 +2340,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "uuid",
 ]
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -3,7 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider } from "@/components/providers/ThemeProvider"
 import { AuthProvider, useAuth } from "@/lib/auth"
 import { AppLayout } from "@/components/layout/AppLayout"
-import { DashboardPage } from "@/pages/DashboardPage"
+import { FactoryOverviewPage } from "@/pages/FactoryOverviewPage"
+import { ArtifactDetailPage } from "@/pages/ArtifactDetailPage"
 import { NodesPage } from "@/pages/NodesPage"
 import { SessionsPage } from "@/pages/SessionsPage"
 import { SessionDetailPage } from "@/pages/SessionDetailPage"
@@ -73,13 +74,14 @@ function AppRoutes() {
           <ProtectedRoute>
             <AppLayout>
               <Routes>
-                <Route path="/" element={<DashboardPage />} />
-                <Route path="/nodes" element={<NodesPage />} />
+                <Route path="/" element={<FactoryOverviewPage />} />
+                <Route path="/artifacts" element={<ArtifactsPage />} />
+                <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
+                <Route path="/spine" element={<SpinePage />} />
+                <Route path="/governance" element={<GovernancePage />} />
                 <Route path="/sessions" element={<SessionsPage />} />
                 <Route path="/sessions/:id" element={<SessionDetailPage />} />
-                <Route path="/governance" element={<GovernancePage />} />
-                <Route path="/artifacts" element={<ArtifactsPage />} />
-                <Route path="/spine" element={<SpinePage />} />
+                <Route path="/nodes" element={<NodesPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Routes>
             </AppLayout>

--- a/apps/dashboard/src/components/factory/CreateArtifactSheet.tsx
+++ b/apps/dashboard/src/components/factory/CreateArtifactSheet.tsx
@@ -1,0 +1,166 @@
+import { type FormEvent, useState, type ReactElement } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { api, type RegisterArtifactRequest } from "@/lib/api"
+import { useIsMobile } from "@/hooks/use-mobile"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+const ARTIFACT_KINDS = [
+  { value: "code", label: "Code" },
+  { value: "document", label: "Document" },
+  { value: "report", label: "Report" },
+  { value: "dataset", label: "Dataset" },
+  { value: "config", label: "Config" },
+  { value: "api_call", label: "API Call" },
+]
+
+interface CreateArtifactSheetProps {
+  children: ReactElement
+}
+
+export function CreateArtifactSheet({ children }: CreateArtifactSheetProps) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState("")
+  const [kind, setKind] = useState("code")
+  const [owner, setOwner] = useState("")
+  const [description, setDescription] = useState("")
+  const [workingDir, setWorkingDir] = useState("")
+  const isMobile = useIsMobile()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (req: RegisterArtifactRequest) => api.registerArtifact(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["artifacts"] })
+      setOpen(false)
+      setName("")
+      setKind("code")
+      setOwner("")
+      setDescription("")
+      setWorkingDir("")
+    },
+  })
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !owner.trim()) return
+    mutation.mutate({
+      name: name.trim(),
+      kind,
+      owner: owner.trim(),
+      ...(description.trim() && { description: description.trim() }),
+      ...(workingDir.trim() && { working_dir: workingDir.trim() }),
+    })
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger render={children} />
+      <SheetContent side={isMobile ? "bottom" : "right"} className={isMobile ? "rounded-t-xl" : ""}>
+        <SheetHeader>
+          <SheetTitle>Register Artifact</SheetTitle>
+          <SheetDescription>
+            Register a new artifact in the factory pipeline. Forge will pick it up and begin shaping.
+          </SheetDescription>
+        </SheetHeader>
+        <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-4 overflow-y-auto px-4">
+          <div className="space-y-1.5">
+            <label htmlFor="artifact-name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input
+              id="artifact-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-service"
+              required
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="artifact-kind" className="text-sm font-medium">
+              Kind
+            </label>
+            <select
+              id="artifact-kind"
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-base outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm dark:bg-input/30"
+            >
+              {ARTIFACT_KINDS.map((k) => (
+                <option key={k.value} value={k.value}>
+                  {k.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="artifact-owner" className="text-sm font-medium">
+              Owner
+            </label>
+            <Input
+              id="artifact-owner"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              placeholder="team-name or username"
+              required
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="artifact-description" className="text-sm font-medium">
+              Description <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="artifact-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What should this artifact accomplish..."
+              rows={3}
+              className="w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm dark:bg-input/30"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="artifact-workdir" className="text-sm font-medium">
+              Working directory <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <Input
+              id="artifact-workdir"
+              value={workingDir}
+              onChange={(e) => setWorkingDir(e.target.value)}
+              placeholder="/path/to/project"
+            />
+          </div>
+
+          {mutation.isError && (
+            <p className="text-sm text-destructive">
+              {mutation.error instanceof Error ? mutation.error.message : "Failed to register artifact"}
+            </p>
+          )}
+
+          <SheetFooter>
+            <Button
+              type="submit"
+              disabled={!name.trim() || !owner.trim() || mutation.isPending}
+              className="w-full"
+              size="lg"
+            >
+              {mutation.isPending ? "Registering..." : "Register Artifact"}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Plus, Server, Terminal, Settings, LogOut, Shield, Package, Activity } from "lucide-react"
+import { Factory, Plus, Server, Terminal, Settings, LogOut, Shield, Package, Activity } from "lucide-react"
 import { OnsagerLogo } from "./OnsagerLogo"
 import { Link, useLocation } from "react-router-dom"
 import {
@@ -15,21 +15,16 @@ import {
 } from "@/components/ui/sidebar"
 import { ThemeToggle } from "./ThemeToggle"
 import { useAuth } from "@/lib/auth"
-import { CreateSessionSheet } from "@/components/sessions/CreateSessionSheet"
+import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
 import { Button } from "@/components/ui/button"
 
 const navSections = [
   {
-    label: "Overview",
+    label: "Factory",
     items: [
-      { title: "Dashboard", icon: LayoutDashboard, path: "/" },
-    ],
-  },
-  {
-    label: "Agents",
-    items: [
-      { title: "Sessions", icon: Terminal, path: "/sessions" },
-      { title: "Nodes", icon: Server, path: "/nodes" },
+      { title: "Overview", icon: Factory, path: "/" },
+      { title: "Artifacts", icon: Package, path: "/artifacts" },
+      { title: "Event Spine", icon: Activity, path: "/spine" },
     ],
   },
   {
@@ -39,10 +34,10 @@ const navSections = [
     ],
   },
   {
-    label: "Factory",
+    label: "Infrastructure",
     items: [
-      { title: "Artifacts", icon: Package, path: "/artifacts" },
-      { title: "Event Spine", icon: Activity, path: "/spine" },
+      { title: "Sessions", icon: Terminal, path: "/sessions" },
+      { title: "Nodes", icon: Server, path: "/nodes" },
     ],
   },
   {
@@ -92,12 +87,12 @@ export function AppSidebar() {
         ))}
         <SidebarGroup>
           <SidebarGroupContent>
-            <CreateSessionSheet>
+            <CreateArtifactSheet>
               <Button variant="outline" className="w-full justify-start gap-2">
                 <Plus className="h-4 w-4" />
-                <span>New Session</span>
+                <span>Register Artifact</span>
               </Button>
-            </CreateSessionSheet>
+            </CreateArtifactSheet>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -117,7 +117,7 @@ export interface SpineArtifact {
   owner: string;
   state: string;
   current_version: number;
-  consumers: string[];
+  consumers?: string[];
   created_at: string;
   updated_at: string;
 }

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -113,11 +113,43 @@ export interface SpineEvent {
 export interface SpineArtifact {
   id: string;
   kind: string;
-  state: string;
+  name: string;
   owner: string;
+  state: string;
   current_version: number;
+  consumers: string[];
   created_at: string;
   updated_at: string;
+}
+
+export interface ArtifactDetail extends SpineArtifact {
+  created_by: string;
+  versions: ArtifactVersion[];
+  vertical_lineage: ArtifactLineageEntry[];
+}
+
+export interface ArtifactVersion {
+  version: number;
+  content_ref_uri: string;
+  content_ref_checksum: string | null;
+  change_summary: string;
+  created_by_session: string;
+  parent_version: number | null;
+  created_at: string;
+}
+
+export interface ArtifactLineageEntry {
+  version: number;
+  session_id: string;
+  recorded_at: string;
+}
+
+export interface RegisterArtifactRequest {
+  kind: string;
+  name: string;
+  owner: string;
+  description?: string;
+  working_dir?: string;
 }
 
 export const api = {
@@ -164,5 +196,10 @@ export const api = {
     return request<{ events: SpineEvent[] }>(`/spine/events${qs}`);
   },
   getArtifacts: () => request<{ artifacts: SpineArtifact[] }>('/spine/artifacts'),
-  getArtifact: (id: string) => request<{ artifact: SpineArtifact }>(`/spine/artifacts/${id}`),
+  getArtifact: (id: string) => request<{ artifact: ArtifactDetail }>(`/spine/artifacts/${id}`),
+  registerArtifact: (req: RegisterArtifactRequest) =>
+    request<{ artifact: SpineArtifact }>('/spine/artifacts', {
+      method: 'POST',
+      body: JSON.stringify(req),
+    }),
 };

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -1,0 +1,193 @@
+import { useParams, Link } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { ArrowLeft } from "lucide-react"
+
+const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  in_progress: "default",
+  under_review: "secondary",
+  released: "default",
+  archived: "secondary",
+}
+
+export function ArtifactDetailPage() {
+  const { id } = useParams<{ id: string }>()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["artifact", id],
+    queryFn: () => api.getArtifact(id!),
+    enabled: !!id,
+    refetchInterval: 5000,
+  })
+
+  const artifact = data?.artifact
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    )
+  }
+
+  if (error || !artifact) {
+    return (
+      <div className="space-y-4">
+        <Link to="/artifacts" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-4 w-4" /> Back to Artifacts
+        </Link>
+        <p className="text-destructive">Artifact not found.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <Link to="/artifacts" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Back to Artifacts
+      </Link>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">{artifact.name}</h1>
+          <p className="text-sm text-muted-foreground font-mono">{artifact.id}</p>
+        </div>
+        <Badge variant={STATE_VARIANT[artifact.state] || "secondary"} className="text-sm">
+          {artifact.state.replace("_", " ")}
+        </Badge>
+      </div>
+
+      {/* Metadata */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Card>
+          <CardContent className="px-3 py-3">
+            <div className="text-xs text-muted-foreground">Kind</div>
+            <div className="font-medium">{artifact.kind}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="px-3 py-3">
+            <div className="text-xs text-muted-foreground">Owner</div>
+            <div className="font-medium">{artifact.owner}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="px-3 py-3">
+            <div className="text-xs text-muted-foreground">Version</div>
+            <div className="font-mono font-medium">v{artifact.current_version}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="px-3 py-3">
+            <div className="text-xs text-muted-foreground">Created</div>
+            <div className="text-sm">{new Date(artifact.created_at).toLocaleDateString()}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Version History */}
+      <Card>
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-lg">
+            Version History
+            {artifact.versions && artifact.versions.length > 0 && (
+              <span className="ml-2 text-muted-foreground font-normal">
+                ({artifact.versions.length})
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          {!artifact.versions || artifact.versions.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No versions yet. Versions are created as Forge shapes this artifact.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Summary</TableHead>
+                  <TableHead>Session</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {artifact.versions
+                  .sort((a, b) => b.version - a.version)
+                  .map((v) => (
+                    <TableRow key={v.version}>
+                      <TableCell className="font-mono">v{v.version}</TableCell>
+                      <TableCell className="max-w-[300px] truncate">
+                        {v.change_summary || "-"}
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          to={`/sessions/${v.created_by_session}`}
+                          className="font-mono text-xs hover:underline"
+                        >
+                          {v.created_by_session.slice(0, 8)}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {new Date(v.created_at).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Lineage */}
+      {artifact.vertical_lineage && artifact.vertical_lineage.length > 0 && (
+        <Card>
+          <CardHeader className="px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Vertical Lineage</CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 md:px-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Session</TableHead>
+                  <TableHead>Recorded</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {artifact.vertical_lineage.map((entry, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="font-mono">v{entry.version}</TableCell>
+                    <TableCell>
+                      <Link
+                        to={`/sessions/${entry.session_id}`}
+                        className="font-mono text-xs hover:underline"
+                      >
+                        {entry.session_id.slice(0, 8)}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {new Date(entry.recorded_at).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -124,7 +124,7 @@ export function ArtifactDetailPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {artifact.versions
+                {[...artifact.versions]
                   .sort((a, b) => b.version - a.version)
                   .map((v) => (
                     <TableRow key={v.version}>

--- a/apps/dashboard/src/pages/ArtifactsPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactsPage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Table,
   TableBody,
@@ -10,6 +11,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Plus } from "lucide-react"
+import { Link } from "react-router-dom"
+import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
 
 const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -30,11 +34,19 @@ export function ArtifactsPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div>
-        <h1 className="text-xl font-bold tracking-tight md:text-2xl">Artifacts</h1>
-        <p className="text-sm text-muted-foreground">
-          Production artifacts managed by Forge.
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">Artifacts</h1>
+          <p className="text-sm text-muted-foreground">
+            Production artifacts managed by Forge.
+          </p>
+        </div>
+        <CreateArtifactSheet>
+          <Button size="sm">
+            <Plus className="mr-1.5 h-4 w-4" />
+            Register Artifact
+          </Button>
+        </CreateArtifactSheet>
       </div>
 
       <Card>
@@ -47,14 +59,22 @@ export function ArtifactsPage() {
           {isLoading ? (
             <p className="py-8 text-center text-muted-foreground">Loading...</p>
           ) : artifacts.length === 0 ? (
-            <p className="py-8 text-center text-muted-foreground">
-              No artifacts yet. Artifacts appear when Forge processes work through the pipeline.
-            </p>
+            <div className="py-8 text-center">
+              <p className="text-muted-foreground">
+                No artifacts yet. Register one to start the factory pipeline.
+              </p>
+              <CreateArtifactSheet>
+                <Button variant="outline" className="mt-4">
+                  <Plus className="mr-1.5 h-4 w-4" />
+                  Register your first artifact
+                </Button>
+              </CreateArtifactSheet>
+            </div>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>ID</TableHead>
+                  <TableHead>Name</TableHead>
                   <TableHead>Kind</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead>Owner</TableHead>
@@ -65,13 +85,17 @@ export function ArtifactsPage() {
               <TableBody>
                 {artifacts.map((a) => (
                   <TableRow key={a.id}>
-                    <TableCell className="font-mono text-sm">{a.id}</TableCell>
+                    <TableCell>
+                      <Link to={`/artifacts/${a.id}`} className="font-medium hover:underline">
+                        {a.name ?? a.id}
+                      </Link>
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline">{a.kind}</Badge>
                     </TableCell>
                     <TableCell>
                       <Badge variant={STATE_VARIANT[a.state] || "secondary"}>
-                        {a.state}
+                        {a.state.replace("_", " ")}
                       </Badge>
                     </TableCell>
                     <TableCell className="text-muted-foreground">{a.owner}</TableCell>

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -1,0 +1,251 @@
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Package, Activity, Shield, Server, ArrowRight } from "lucide-react"
+import { Link } from "react-router-dom"
+import type { SpineArtifact, SpineEvent } from "@/lib/api"
+
+const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  in_progress: "default",
+  under_review: "secondary",
+  released: "default",
+  archived: "secondary",
+}
+
+const STREAM_TYPE_COLORS: Record<string, string> = {
+  stiglab: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+  synodic: "bg-purple-500/10 text-purple-500 border-purple-500/20",
+  forge: "bg-orange-500/10 text-orange-500 border-orange-500/20",
+  ising: "bg-green-500/10 text-green-500 border-green-500/20",
+}
+
+function PipelineStats({ artifacts }: { artifacts: SpineArtifact[] }) {
+  const byState = {
+    draft: artifacts.filter((a) => a.state === "draft").length,
+    in_progress: artifacts.filter((a) => a.state === "in_progress").length,
+    under_review: artifacts.filter((a) => a.state === "under_review").length,
+    released: artifacts.filter((a) => a.state === "released").length,
+    archived: artifacts.filter((a) => a.state === "archived").length,
+  }
+
+  const stages = [
+    { label: "Draft", count: byState.draft, color: "text-muted-foreground" },
+    { label: "In Progress", count: byState.in_progress, color: "text-blue-500" },
+    { label: "Under Review", count: byState.under_review, color: "text-yellow-500" },
+    { label: "Released", count: byState.released, color: "text-green-500" },
+  ]
+
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base md:text-lg">Artifact Pipeline</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 md:px-6">
+        <div className="flex items-center justify-between gap-2">
+          {stages.map((stage, i) => (
+            <div key={stage.label} className="flex items-center gap-2">
+              <div className="text-center">
+                <div className={`text-2xl font-bold md:text-3xl ${stage.color}`}>
+                  {stage.count}
+                </div>
+                <div className="text-xs text-muted-foreground">{stage.label}</div>
+              </div>
+              {i < stages.length - 1 && (
+                <ArrowRight className="h-4 w-4 text-muted-foreground/50" />
+              )}
+            </div>
+          ))}
+        </div>
+        {byState.archived > 0 && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {byState.archived} archived
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function FactoryOverviewPage() {
+  const { data: artifactsData } = useQuery({
+    queryKey: ["artifacts"],
+    queryFn: api.getArtifacts,
+    refetchInterval: 5000,
+  })
+  const { data: govStats } = useQuery({
+    queryKey: ["governance-stats"],
+    queryFn: api.getGovernanceStats,
+    refetchInterval: 10000,
+  })
+  const { data: spineData } = useQuery({
+    queryKey: ["spine-events-overview"],
+    queryFn: () => api.getSpineEvents({ limit: 20 }),
+    refetchInterval: 5000,
+  })
+  const { data: nodesData } = useQuery({
+    queryKey: ["nodes"],
+    queryFn: api.getNodes,
+    refetchInterval: 10000,
+  })
+
+  const artifacts = artifactsData?.artifacts ?? []
+  const events = spineData?.events ?? []
+  const nodes = nodesData?.nodes ?? []
+  const onlineNodes = nodes.filter((n) => n.status === "online").length
+
+  const stats = [
+    {
+      title: "Total Artifacts",
+      value: artifacts.length,
+      icon: Package,
+      description: `${artifacts.filter((a) => a.state !== "archived").length} active`,
+    },
+    {
+      title: "Factory Events",
+      value: events.length > 0 ? `${events.length}` : "0",
+      icon: Activity,
+      description: "Last 20 events",
+    },
+    {
+      title: "Gov. Issues",
+      value: govStats?.unresolved ?? 0,
+      icon: Shield,
+      description: `${govStats?.total ?? 0} total`,
+      highlight: (govStats?.unresolved ?? 0) > 0,
+    },
+    {
+      title: "Nodes Online",
+      value: `${onlineNodes}/${nodes.length}`,
+      icon: Server,
+      description: `${nodes.length - onlineNodes} offline`,
+    },
+  ]
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <div>
+        <h1 className="text-xl font-bold tracking-tight md:text-2xl">Factory</h1>
+        <p className="text-sm text-muted-foreground">
+          Production pipeline overview — artifacts, events, and factory health.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <Card key={stat.title} className={stat.highlight ? "border-yellow-500/50" : ""}>
+            <CardHeader className="flex flex-row items-center justify-between px-3 pb-1 pt-3 md:px-6 md:pb-2 md:pt-6">
+              <CardTitle className="text-xs font-medium text-muted-foreground md:text-sm">
+                {stat.title}
+              </CardTitle>
+              <stat.icon className={`h-4 w-4 ${stat.highlight ? "text-yellow-500" : "text-muted-foreground"}`} />
+            </CardHeader>
+            <CardContent className="px-3 pb-3 md:px-6 md:pb-6">
+              <div className={`text-xl font-bold md:text-2xl ${stat.highlight ? "text-yellow-500" : ""}`}>
+                {stat.value}
+              </div>
+              <p className="text-[10px] text-muted-foreground md:text-xs">{stat.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <PipelineStats artifacts={artifacts} />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* Active Artifacts */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Active Artifacts</CardTitle>
+            <Link to="/artifacts" className="text-sm text-muted-foreground hover:text-foreground">
+              View all
+            </Link>
+          </CardHeader>
+          <CardContent className="px-4 md:px-6">
+            {artifacts.filter((a) => a.state !== "archived").length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                No active artifacts. Register one to start the pipeline.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>State</TableHead>
+                    <TableHead>Version</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {artifacts
+                    .filter((a) => a.state !== "archived")
+                    .slice(0, 8)
+                    .map((a) => (
+                      <TableRow key={a.id}>
+                        <TableCell>
+                          <Link to={`/artifacts/${a.id}`} className="font-medium hover:underline">
+                            {a.name ?? a.id}
+                          </Link>
+                          <div className="text-xs text-muted-foreground">{a.kind}</div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={STATE_VARIANT[a.state] || "secondary"}>
+                            {a.state.replace("_", " ")}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="font-mono text-sm">v{a.current_version}</TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Recent Events */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Recent Events</CardTitle>
+            <Link to="/spine" className="text-sm text-muted-foreground hover:text-foreground">
+              View all
+            </Link>
+          </CardHeader>
+          <CardContent className="px-4 md:px-6">
+            {events.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                No events yet. Events appear as the factory processes work.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {events.slice(0, 10).map((e: SpineEvent) => (
+                  <div key={e.id} className="flex items-center justify-between gap-2 py-1">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Badge
+                        variant="outline"
+                        className={`shrink-0 text-[10px] ${STREAM_TYPE_COLORS[e.stream_type] || ""}`}
+                      >
+                        {e.stream_type}
+                      </Badge>
+                      <span className="truncate text-sm font-mono">{e.event_type}</span>
+                    </div>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {new Date(e.created_at).toLocaleTimeString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/tests/e2e/regression.test.ts
+++ b/apps/dashboard/tests/e2e/regression.test.ts
@@ -26,7 +26,7 @@ afterAll(() => {
   }
 });
 
-describe("E2E Regression: Dashboard Data", () => {
+describe("E2E Regression: Factory Overview Data", () => {
   it("renders stat cards with numeric values", () => {
     browser.open("/");
     const snapshot = browser.snapshot();
@@ -34,21 +34,20 @@ describe("E2E Regression: Dashboard Data", () => {
     // Stat card titles must be present
     const requiredLabels = [
       "Nodes Online",
-      "Active Sessions",
-      "Waiting Input",
-      "Completed",
+      "Total Artifacts",
+      "Factory Events",
+      "Gov. Issues",
     ];
     for (const label of requiredLabels) {
       expect(snapshot).toContain(label);
     }
   });
 
-  it("renders stat card descriptions", () => {
+  it("renders pipeline stats section", () => {
     browser.open("/");
     const snapshot = browser.snapshot();
 
-    expect(snapshot).toContain("Currently running");
-    expect(snapshot).toContain("Successfully done");
+    expect(snapshot).toContain("Artifact Pipeline");
   });
 });
 
@@ -58,7 +57,7 @@ describe("E2E Regression: Sidebar Navigation", () => {
     const interactive = browser.interactiveSnapshot();
 
     // Sidebar should have navigation links
-    expect(interactive).toContain("Dashboard");
+    expect(interactive).toContain("Overview");
     expect(interactive).toContain("Sessions");
     expect(interactive).toContain("Nodes");
   });

--- a/apps/dashboard/tests/e2e/smoke.test.ts
+++ b/apps/dashboard/tests/e2e/smoke.test.ts
@@ -27,12 +27,12 @@ afterAll(() => {
 });
 
 describe("E2E Smoke: Navigation", () => {
-  it("loads the dashboard page", () => {
+  it("loads the factory overview page", () => {
     const output = browser.open("/");
     expect(output).toBeDefined();
 
     const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Dashboard");
+    expect(snapshot).toContain("Factory");
   });
 
   it("navigates to Sessions page", () => {
@@ -48,20 +48,20 @@ describe("E2E Smoke: Navigation", () => {
   });
 });
 
-describe("E2E Smoke: Dashboard", () => {
+describe("E2E Smoke: Factory Overview", () => {
   it("displays overview stat cards", () => {
     browser.open("/");
     const snapshot = browser.snapshot();
 
     expect(snapshot).toContain("Nodes Online");
-    expect(snapshot).toContain("Active Sessions");
-    expect(snapshot).toContain("Completed");
+    expect(snapshot).toContain("Total Artifacts");
+    expect(snapshot).toContain("Factory Events");
   });
 
-  it("displays recent sessions section", () => {
+  it("displays active artifacts section", () => {
     browser.open("/");
     const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Recent Sessions");
+    expect(snapshot).toContain("Active Artifacts");
   });
 });
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -28,3 +28,6 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
+axum = { workspace = true }
+reqwest = { workspace = true }
+sqlx = { workspace = true }

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use tokio::sync::RwLock;
 
-use onsager_spine::artifact::Kind;
+use onsager_spine::artifact::{ArtifactState, Kind};
 use onsager_spine::factory_event::ShapingOutcome;
 use onsager_spine::protocol::ShapingResult;
 use onsager_spine::EventStore;
@@ -24,20 +24,22 @@ struct HttpStiglabDispatcher {
 
 impl StiglabDispatcher for HttpStiglabDispatcher {
     fn dispatch(&self, request: &ShapingRequest) -> ShapingResult {
-        // Use a blocking approach since the pipeline tick is synchronous.
-        // In a fully async pipeline, this would be async.
-        let rt = tokio::runtime::Handle::current();
+        // The pipeline tick is synchronous, so use block_in_place to allow
+        // blocking on async HTTP calls without panicking inside the Tokio runtime.
         let url = format!("{}/api/shaping", self.stiglab_url);
         let body = serde_json::to_value(request).unwrap_or_default();
+        let client = self.client.clone();
 
-        match rt.block_on(async {
-            self.client
-                .post(&url)
-                .json(&body)
-                .send()
-                .await?
-                .json::<ShapingResult>()
-                .await
+        match tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                client
+                    .post(&url)
+                    .json(&body)
+                    .send()
+                    .await?
+                    .json::<ShapingResult>()
+                    .await
+            })
         }) {
             Ok(result) => result,
             Err(e) => {
@@ -69,35 +71,38 @@ struct HttpSynodicGate {
 
 impl SynodicGate for HttpSynodicGate {
     fn evaluate(&self, request: &GateRequest) -> GateVerdict {
-        let rt = tokio::runtime::Handle::current();
         let url = format!("{}/api/gate", self.synodic_url);
         let body = serde_json::to_value(request).unwrap_or_default();
+        let client = self.client.clone();
 
-        match rt.block_on(async { self.client.post(&url).json(&body).send().await }) {
-            Ok(resp) => {
-                if resp.status().is_success() {
-                    match rt.block_on(resp.json::<GateVerdict>()) {
-                        Ok(verdict) => verdict,
-                        Err(e) => {
-                            tracing::warn!(
-                                "synodic gate response parse error: {e}, defaulting to Allow"
-                            );
-                            GateVerdict::Allow
+        tokio::task::block_in_place(|| {
+            let rt = tokio::runtime::Handle::current();
+            match rt.block_on(async { client.post(&url).json(&body).send().await }) {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        match rt.block_on(resp.json::<GateVerdict>()) {
+                            Ok(verdict) => verdict,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "synodic gate response parse error: {e}, defaulting to Allow"
+                                );
+                                GateVerdict::Allow
+                            }
                         }
+                    } else {
+                        tracing::warn!(
+                            "synodic gate returned {}, defaulting to Allow",
+                            resp.status()
+                        );
+                        GateVerdict::Allow
                     }
-                } else {
-                    tracing::warn!(
-                        "synodic gate returned {}, defaulting to Allow",
-                        resp.status()
-                    );
+                }
+                Err(e) => {
+                    tracing::warn!("synodic gate unavailable: {e}, defaulting to Allow");
                     GateVerdict::Allow
                 }
             }
-            Err(e) => {
-                tracing::warn!("synodic gate unavailable: {e}, defaulting to Allow");
-                GateVerdict::Allow
-            }
-        }
+        })
     }
 }
 
@@ -135,13 +140,14 @@ pub fn run(database_url: &str, tick_ms: u64) {
         // Load existing artifacts from the spine database.
         let mut artifact_store = ArtifactStore::new();
         if let Some(ref spine) = spine {
-            if let Ok(rows) = sqlx::query_as::<_, (String, String, String, String, i32)>(
-                "SELECT artifact_id, kind, name, owner, current_version FROM artifacts WHERE state != 'archived'"
+            if let Ok(rows) = sqlx::query_as::<_, (String, String, String, String, String, i32)>(
+                "SELECT artifact_id, kind, name, owner, state, current_version \
+                 FROM artifacts WHERE state != 'archived'",
             )
             .fetch_all(spine.pool())
             .await
             {
-                for (id, kind, name, owner, _version) in &rows {
+                for (id, kind, name, owner, state_str, version) in &rows {
                     let kind_enum = match kind.as_str() {
                         "code" => Kind::Code,
                         "document" => Kind::Document,
@@ -151,18 +157,32 @@ pub fn run(database_url: &str, tick_ms: u64) {
                         "api_call" => Kind::ApiCall,
                         other => Kind::Custom(other.to_string()),
                     };
-                    artifact_store.register_with_id(id.clone(), kind_enum, name.clone(), owner.clone());
+                    let state = match state_str.as_str() {
+                        "in_progress" => ArtifactState::InProgress,
+                        "under_review" => ArtifactState::UnderReview,
+                        "released" => ArtifactState::Released,
+                        "archived" => ArtifactState::Archived,
+                        _ => ArtifactState::Draft,
+                    };
+                    artifact_store.register_with_id(
+                        id.clone(),
+                        kind_enum,
+                        name.clone(),
+                        owner.clone(),
+                        state,
+                        *version as u32,
+                    );
                 }
                 tracing::info!("forge: loaded {} active artifacts from spine", rows.len());
             }
         }
 
         let stiglab_port = std::env::var("STIGLAB_PORT").unwrap_or_else(|_| "3000".to_string());
-        let stiglab_url =
-            std::env::var("STIGLAB_URL").unwrap_or_else(|_| format!("http://localhost:{stiglab_port}"));
+        let stiglab_url = std::env::var("STIGLAB_URL")
+            .unwrap_or_else(|_| format!("http://localhost:{stiglab_port}"));
         let synodic_port = std::env::var("SYNODIC_PORT").unwrap_or_else(|_| "3001".to_string());
-        let synodic_url =
-            std::env::var("SYNODIC_URL").unwrap_or_else(|_| format!("http://localhost:{synodic_port}"));
+        let synodic_url = std::env::var("SYNODIC_URL")
+            .unwrap_or_else(|_| format!("http://localhost:{synodic_port}"));
 
         let client = reqwest::Client::new();
 
@@ -202,14 +222,20 @@ pub fn run(database_url: &str, tick_ms: u64) {
             let mut interval = tokio::time::interval(std::time::Duration::from_millis(tick_ms));
             loop {
                 interval.tick().await;
-                let mut state = tick_shared.write().await;
-                // Clone kernel snapshot to avoid borrowing state immutably and mutably.
-                let kernel = state.kernel.clone();
-                let output = state.pipeline.tick(&kernel);
 
-                // Emit pipeline events to the spine.
+                // Run the pipeline tick under the write lock, then release it
+                // before emitting spine events so HTTP reads aren't starved.
+                let (output, spine) = {
+                    let mut state = tick_shared.write().await;
+                    let kernel = state.kernel.clone();
+                    let output = state.pipeline.tick(&kernel);
+                    let spine = state.spine.clone();
+                    (output, spine)
+                };
+
+                // Emit pipeline events to the spine (lock released).
                 for event in &output.events {
-                    if let Some(ref spine) = state.spine {
+                    if let Some(ref spine) = spine {
                         emit_pipeline_event(spine, event).await;
                     }
                     match event {

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -1,26 +1,467 @@
-//! `forge serve` — start the Forge scheduling loop.
+//! `forge serve` — start the Forge scheduling loop with HTTP API.
 
-/// Start the Forge scheduling loop.
-///
-/// In production, this connects to the event spine, instantiates the scheduling
-/// kernel, and runs the core tick loop. For v0.1, this is a skeleton that
-/// demonstrates the structure.
-pub fn run(_database_url: &str, tick_ms: u64) {
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use tokio::sync::RwLock;
+
+use onsager_spine::artifact::Kind;
+use onsager_spine::factory_event::ShapingOutcome;
+use onsager_spine::protocol::ShapingResult;
+use onsager_spine::EventStore;
+
+use crate::core::artifact_store::ArtifactStore;
+use crate::core::kernel::BaselineKernel;
+use crate::core::pipeline::{ForgePipeline, PipelineEvent, StiglabDispatcher, SynodicGate};
+
+use onsager_spine::protocol::{GateRequest, GateVerdict, ShapingRequest};
+
+/// HTTP Stiglab dispatcher — calls Stiglab's shaping endpoint.
+struct HttpStiglabDispatcher {
+    client: reqwest::Client,
+    stiglab_url: String,
+}
+
+impl StiglabDispatcher for HttpStiglabDispatcher {
+    fn dispatch(&self, request: &ShapingRequest) -> ShapingResult {
+        // Use a blocking approach since the pipeline tick is synchronous.
+        // In a fully async pipeline, this would be async.
+        let rt = tokio::runtime::Handle::current();
+        let url = format!("{}/api/shaping", self.stiglab_url);
+        let body = serde_json::to_value(request).unwrap_or_default();
+
+        match rt.block_on(async {
+            self.client
+                .post(&url)
+                .json(&body)
+                .send()
+                .await?
+                .json::<ShapingResult>()
+                .await
+        }) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("stiglab dispatch failed: {e}");
+                ShapingResult {
+                    request_id: request.request_id.clone(),
+                    outcome: ShapingOutcome::Failed,
+                    content_ref: None,
+                    change_summary: String::new(),
+                    quality_signals: vec![],
+                    session_id: String::new(),
+                    duration_ms: 0,
+                    error: Some(onsager_spine::protocol::ErrorDetail {
+                        code: "dispatch_error".into(),
+                        message: e.to_string(),
+                        retriable: Some(true),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+/// HTTP Synodic gate — calls Synodic's gate endpoint.
+struct HttpSynodicGate {
+    client: reqwest::Client,
+    synodic_url: String,
+}
+
+impl SynodicGate for HttpSynodicGate {
+    fn evaluate(&self, request: &GateRequest) -> GateVerdict {
+        let rt = tokio::runtime::Handle::current();
+        let url = format!("{}/api/gate", self.synodic_url);
+        let body = serde_json::to_value(request).unwrap_or_default();
+
+        match rt.block_on(async { self.client.post(&url).json(&body).send().await }) {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    match rt.block_on(resp.json::<GateVerdict>()) {
+                        Ok(verdict) => verdict,
+                        Err(e) => {
+                            tracing::warn!(
+                                "synodic gate response parse error: {e}, defaulting to Allow"
+                            );
+                            GateVerdict::Allow
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        "synodic gate returned {}, defaulting to Allow",
+                        resp.status()
+                    );
+                    GateVerdict::Allow
+                }
+            }
+            Err(e) => {
+                tracing::warn!("synodic gate unavailable: {e}, defaulting to Allow");
+                GateVerdict::Allow
+            }
+        }
+    }
+}
+
+/// Shared Forge state accessible from both the HTTP API and the tick loop.
+struct ForgeSharedState {
+    pipeline: ForgePipeline<HttpStiglabDispatcher, HttpSynodicGate>,
+    kernel: BaselineKernel,
+    spine: Option<EventStore>,
+}
+
+type SharedForge = Arc<RwLock<ForgeSharedState>>;
+
+/// Start the Forge scheduling loop with an HTTP API.
+pub fn run(database_url: &str, tick_ms: u64) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async move {
         tracing_subscriber::fmt()
             .with_env_filter("forge=info")
             .init();
 
-        tracing::info!(tick_ms = tick_ms, "forge: starting scheduling loop");
+        tracing::info!(tick_ms, "forge: starting");
 
-        // In production this would:
-        // 1. Connect to the event spine (EventStore)
-        // 2. Load artifact state from the spine
-        // 3. Instantiate the scheduling kernel
-        // 4. Run the tick loop with Stiglab dispatch + Synodic gate calls
-        //
-        // For now, log and exit.
-        tracing::info!("forge: v0.1 scaffold — scheduling loop not yet connected to spine");
+        // Connect to event spine.
+        let spine = match EventStore::connect(database_url).await {
+            Ok(s) => {
+                tracing::info!("forge: connected to event spine");
+                Some(s)
+            }
+            Err(e) => {
+                tracing::warn!("forge: spine connection failed ({e}), running without persistence");
+                None
+            }
+        };
+
+        // Load existing artifacts from the spine database.
+        let mut artifact_store = ArtifactStore::new();
+        if let Some(ref spine) = spine {
+            if let Ok(rows) = sqlx::query_as::<_, (String, String, String, String, i32)>(
+                "SELECT artifact_id, kind, name, owner, current_version FROM artifacts WHERE state != 'archived'"
+            )
+            .fetch_all(spine.pool())
+            .await
+            {
+                for (id, kind, name, owner, _version) in &rows {
+                    let kind_enum = match kind.as_str() {
+                        "code" => Kind::Code,
+                        "document" => Kind::Document,
+                        "report" => Kind::Report,
+                        "dataset" => Kind::Dataset,
+                        "config" => Kind::Config,
+                        "api_call" => Kind::ApiCall,
+                        other => Kind::Custom(other.to_string()),
+                    };
+                    artifact_store.register_with_id(id.clone(), kind_enum, name.clone(), owner.clone());
+                }
+                tracing::info!("forge: loaded {} active artifacts from spine", rows.len());
+            }
+        }
+
+        let stiglab_port = std::env::var("STIGLAB_PORT").unwrap_or_else(|_| "3000".to_string());
+        let stiglab_url =
+            std::env::var("STIGLAB_URL").unwrap_or_else(|_| format!("http://localhost:{stiglab_port}"));
+        let synodic_port = std::env::var("SYNODIC_PORT").unwrap_or_else(|_| "3001".to_string());
+        let synodic_url =
+            std::env::var("SYNODIC_URL").unwrap_or_else(|_| format!("http://localhost:{synodic_port}"));
+
+        let client = reqwest::Client::new();
+
+        let stiglab = HttpStiglabDispatcher {
+            client: client.clone(),
+            stiglab_url: stiglab_url.clone(),
+        };
+        let synodic = HttpSynodicGate {
+            client,
+            synodic_url: synodic_url.clone(),
+        };
+
+        let mut pipeline = ForgePipeline::new(stiglab, synodic);
+        pipeline.store = artifact_store;
+
+        let shared = Arc::new(RwLock::new(ForgeSharedState {
+            pipeline,
+            kernel: BaselineKernel::new(),
+            spine,
+        }));
+
+        // Start HTTP API.
+        let forge_port: u16 = std::env::var("FORGE_PORT")
+            .unwrap_or_else(|_| "3002".to_string())
+            .parse()
+            .unwrap_or(3002);
+
+        let app = build_api(shared.clone());
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{forge_port}"))
+            .await
+            .expect("failed to bind forge port");
+        tracing::info!("forge: HTTP API listening on :{forge_port}");
+
+        // Spawn the tick loop.
+        let tick_shared = shared.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(tick_ms));
+            loop {
+                interval.tick().await;
+                let mut state = tick_shared.write().await;
+                // Clone kernel snapshot to avoid borrowing state immutably and mutably.
+                let kernel = state.kernel.clone();
+                let output = state.pipeline.tick(&kernel);
+
+                // Emit pipeline events to the spine.
+                for event in &output.events {
+                    if let Some(ref spine) = state.spine {
+                        emit_pipeline_event(spine, event).await;
+                    }
+                    match event {
+                        PipelineEvent::IdleTick => {}
+                        _ => tracing::info!("forge tick: {event:?}"),
+                    }
+                }
+            }
+        });
+
+        // Run the HTTP server.
+        axum::serve(listener, app).await.unwrap();
     });
+}
+
+/// Build the Forge HTTP API router.
+fn build_api(shared: SharedForge) -> axum::Router {
+    use axum::routing::get;
+
+    axum::Router::new()
+        .route("/api/health", get(health))
+        .route("/api/status", get(status))
+        .route(
+            "/api/artifacts",
+            get(list_artifacts).post(register_artifact),
+        )
+        .route("/api/artifacts/{id}", get(get_artifact))
+        .with_state(shared)
+}
+
+async fn health() -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({ "status": "ok", "service": "forge" }))
+}
+
+async fn status(
+    axum::extract::State(shared): axum::extract::State<SharedForge>,
+) -> axum::Json<serde_json::Value> {
+    let state = shared.read().await;
+    let active = state.pipeline.store.active_artifacts();
+    let process_state = state.pipeline.state.current();
+    axum::Json(serde_json::json!({
+        "process_state": format!("{process_state:?}"),
+        "active_artifacts": active.len(),
+        "artifacts": active.iter().map(|a| serde_json::json!({
+            "id": a.artifact_id.as_str(),
+            "kind": a.kind.to_string(),
+            "name": a.name,
+            "state": format!("{:?}", a.state),
+            "version": a.current_version,
+        })).collect::<Vec<_>>(),
+    }))
+}
+
+#[derive(serde::Deserialize)]
+struct RegisterRequest {
+    kind: String,
+    name: String,
+    owner: String,
+}
+
+async fn register_artifact(
+    axum::extract::State(shared): axum::extract::State<SharedForge>,
+    axum::Json(req): axum::Json<RegisterRequest>,
+) -> impl axum::response::IntoResponse {
+    let kind = match req.kind.as_str() {
+        "code" => Kind::Code,
+        "document" => Kind::Document,
+        "report" => Kind::Report,
+        "dataset" => Kind::Dataset,
+        "config" => Kind::Config,
+        "api_call" => Kind::ApiCall,
+        other => Kind::Custom(other.to_string()),
+    };
+
+    let mut state = shared.write().await;
+    let id = state
+        .pipeline
+        .store
+        .register(kind.clone(), &req.name, &req.owner);
+
+    // Persist to spine database.
+    if let Some(ref spine) = state.spine {
+        let _ = sqlx::query(
+            "INSERT INTO artifacts (artifact_id, kind, name, owner, created_by, state, current_version) \
+             VALUES ($1, $2, $3, $4, 'forge', 'draft', 0) \
+             ON CONFLICT (artifact_id) DO NOTHING",
+        )
+        .bind(id.as_str())
+        .bind(&req.kind)
+        .bind(&req.name)
+        .bind(&req.owner)
+        .execute(spine.pool())
+        .await;
+    }
+
+    (
+        axum::http::StatusCode::CREATED,
+        axum::Json(serde_json::json!({
+            "artifact": {
+                "id": id.as_str(),
+                "kind": req.kind,
+                "name": req.name,
+                "owner": req.owner,
+                "state": "draft",
+                "current_version": 0,
+            }
+        })),
+    )
+}
+
+async fn list_artifacts(
+    axum::extract::State(shared): axum::extract::State<SharedForge>,
+) -> axum::Json<serde_json::Value> {
+    let state = shared.read().await;
+    let artifacts: Vec<_> = state
+        .pipeline
+        .store
+        .active_artifacts()
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "id": a.artifact_id.as_str(),
+                "kind": a.kind.to_string(),
+                "name": a.name,
+                "state": format!("{:?}", a.state),
+                "owner": a.owner,
+                "version": a.current_version,
+            })
+        })
+        .collect();
+    axum::Json(serde_json::json!({ "artifacts": artifacts }))
+}
+
+async fn get_artifact(
+    axum::extract::State(shared): axum::extract::State<SharedForge>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> impl axum::response::IntoResponse {
+    let state = shared.read().await;
+    let aid = onsager_spine::artifact::ArtifactId::new(&id);
+    match state.pipeline.store.get(&aid) {
+        Some(a) => axum::Json(serde_json::json!({
+            "artifact": {
+                "id": a.artifact_id.as_str(),
+                "kind": a.kind.to_string(),
+                "name": a.name,
+                "state": format!("{:?}", a.state),
+                "owner": a.owner,
+                "version": a.current_version,
+            }
+        }))
+        .into_response(),
+        None => (
+            axum::http::StatusCode::NOT_FOUND,
+            axum::Json(serde_json::json!({ "error": "artifact not found" })),
+        )
+            .into_response(),
+    }
+}
+
+/// Emit a pipeline event to the event spine.
+async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
+    let metadata = onsager_spine::EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: "forge".to_string(),
+    };
+
+    let (stream_id, event_type, data) = match event {
+        PipelineEvent::DecisionMade(d) => (
+            format!("forge:{}", d.artifact_id),
+            "forge.decision_made",
+            serde_json::json!({
+                "artifact_id": d.artifact_id.as_str(),
+                "target_version": d.target_version,
+                "priority": d.priority,
+            }),
+        ),
+        PipelineEvent::ShapingDispatched {
+            request_id,
+            artifact_id,
+            target_version,
+        } => (
+            format!("forge:{artifact_id}"),
+            "forge.shaping_dispatched",
+            serde_json::json!({
+                "request_id": request_id,
+                "artifact_id": artifact_id,
+                "target_version": target_version,
+            }),
+        ),
+        PipelineEvent::ShapingReturned {
+            request_id,
+            artifact_id,
+            outcome,
+        } => (
+            format!("forge:{artifact_id}"),
+            "forge.shaping_returned",
+            serde_json::json!({
+                "request_id": request_id,
+                "artifact_id": artifact_id,
+                "outcome": outcome,
+            }),
+        ),
+        PipelineEvent::GateRequested {
+            artifact_id,
+            gate_point,
+        } => (
+            format!("forge:{artifact_id}"),
+            "forge.gate_requested",
+            serde_json::json!({
+                "artifact_id": artifact_id,
+                "gate_point": format!("{gate_point:?}"),
+            }),
+        ),
+        PipelineEvent::GateVerdictReceived {
+            artifact_id,
+            gate_point,
+            verdict,
+        } => (
+            format!("forge:{artifact_id}"),
+            "forge.gate_verdict",
+            serde_json::json!({
+                "artifact_id": artifact_id,
+                "gate_point": format!("{gate_point:?}"),
+                "verdict": format!("{verdict:?}"),
+            }),
+        ),
+        PipelineEvent::ArtifactAdvanced {
+            artifact_id,
+            from_state,
+            to_state,
+        } => (
+            format!("forge:{artifact_id}"),
+            "artifact.state_changed",
+            serde_json::json!({
+                "artifact_id": artifact_id,
+                "from_state": format!("{from_state:?}"),
+                "to_state": format!("{to_state:?}"),
+            }),
+        ),
+        PipelineEvent::IdleTick => return,
+        PipelineEvent::Error(msg) => (
+            "forge:system".to_string(),
+            "forge.error",
+            serde_json::json!({ "error": msg }),
+        ),
+    };
+
+    if let Err(e) = spine
+        .append_ext(&stream_id, "forge", event_type, data, &metadata, None)
+        .await
+    {
+        tracing::warn!("failed to emit forge event: {e}");
+    }
 }

--- a/crates/forge/src/core/artifact_store.rs
+++ b/crates/forge/src/core/artifact_store.rs
@@ -41,17 +41,24 @@ impl ArtifactStore {
     }
 
     /// Register an artifact with a pre-assigned ID (for loading from the database).
+    ///
+    /// Restores the persisted `state` and `current_version` so in-memory state
+    /// matches the database after restart.
     pub fn register_with_id(
         &mut self,
         id: impl Into<String>,
         kind: Kind,
         name: impl Into<String>,
         owner: impl Into<String>,
+        state: ArtifactState,
+        current_version: u32,
     ) -> ArtifactId {
         let id_str = id.into();
         let artifact_id = ArtifactId::new(&id_str);
         let mut artifact = Artifact::new(kind, name, owner, "forge", vec![]);
         artifact.artifact_id = artifact_id.clone();
+        artifact.state = state;
+        artifact.current_version = current_version;
         self.artifacts.insert(id_str, artifact);
         artifact_id
     }

--- a/crates/forge/src/core/artifact_store.rs
+++ b/crates/forge/src/core/artifact_store.rs
@@ -40,6 +40,22 @@ impl ArtifactStore {
         id
     }
 
+    /// Register an artifact with a pre-assigned ID (for loading from the database).
+    pub fn register_with_id(
+        &mut self,
+        id: impl Into<String>,
+        kind: Kind,
+        name: impl Into<String>,
+        owner: impl Into<String>,
+    ) -> ArtifactId {
+        let id_str = id.into();
+        let artifact_id = ArtifactId::new(&id_str);
+        let mut artifact = Artifact::new(kind, name, owner, "forge", vec![]);
+        artifact.artifact_id = artifact_id.clone();
+        self.artifacts.insert(id_str, artifact);
+        artifact_id
+    }
+
     /// Get an artifact by ID.
     pub fn get(&self, id: &ArtifactId) -> Option<&Artifact> {
         self.artifacts.get(id.as_str())

--- a/crates/forge/src/core/kernel.rs
+++ b/crates/forge/src/core/kernel.rs
@@ -77,7 +77,7 @@ impl Ord for SchedulableArtifact {
 /// - Picks the highest-priority artifact in `Draft` or `InProgress` state
 /// - Skips artifacts that are `UnderReview`, `Released`, or `Archived`
 /// - Respects `max_in_flight` concurrency limit
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BaselineKernel {
     /// Failure counts per artifact (from Ising insights).
     failure_counts: std::collections::HashMap<String, u32>,

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+ulid = { version = "1", features = ["serde"] }
 thiserror = { workspace = true }
 
 # From stiglab-server

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -53,7 +53,10 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         .route("/api/governance/{*path}", any(routes::governance::proxy))
         // Spine API — exposes shared event spine data to the dashboard
         .route("/api/spine/events", get(routes::spine::list_events))
-        .route("/api/spine/artifacts", get(routes::spine::list_artifacts))
+        .route(
+            "/api/spine/artifacts",
+            get(routes::spine::list_artifacts).post(routes::spine::register_artifact),
+        )
         .route(
             "/api/spine/artifacts/{id}",
             get(routes::spine::get_artifact),

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -35,11 +35,39 @@ pub struct SpineEvent {
 pub struct SpineArtifact {
     pub id: String,
     pub kind: String,
+    pub name: String,
     pub state: String,
     pub owner: String,
     pub current_version: i32,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, FromRow)]
+pub struct ArtifactVersionRow {
+    pub version: i32,
+    pub content_ref_uri: String,
+    pub content_ref_checksum: Option<String>,
+    pub change_summary: String,
+    pub created_by_session: String,
+    pub parent_version: Option<i32>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, FromRow)]
+pub struct VerticalLineageRow {
+    pub version: i32,
+    pub session_id: String,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterArtifactRequest {
+    pub kind: String,
+    pub name: String,
+    pub owner: String,
+    pub description: Option<String>,
+    pub working_dir: Option<String>,
 }
 
 /// GET /api/spine/events — query the events_ext table.
@@ -137,7 +165,7 @@ pub async fn list_artifacts(State(state): State<AppState>) -> impl IntoResponse 
     let pool = spine.pool();
 
     let result = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT id, kind, state, owner, current_version, created_at, updated_at \
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
          FROM artifacts ORDER BY updated_at DESC LIMIT 100",
     )
     .fetch_all(pool)
@@ -156,7 +184,99 @@ pub async fn list_artifacts(State(state): State<AppState>) -> impl IntoResponse 
     }
 }
 
-/// GET /api/spine/artifacts/:id — single artifact detail.
+/// POST /api/spine/artifacts — register a new artifact in Draft state.
+pub async fn register_artifact(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterArtifactRequest>,
+) -> impl IntoResponse {
+    let spine = match &state.spine {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "spine not connected" })),
+            )
+                .into_response()
+        }
+    };
+
+    let pool = spine.pool();
+    let artifact_id = format!("art_{}", ulid::Ulid::new());
+
+    let result = sqlx::query(
+        "INSERT INTO artifacts (artifact_id, kind, name, owner, created_by, state, current_version) \
+         VALUES ($1, $2, $3, $4, $5, 'draft', 0)",
+    )
+    .bind(&artifact_id)
+    .bind(&req.kind)
+    .bind(&req.name)
+    .bind(&req.owner)
+    .bind("dashboard") // created_by
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(_) => {
+            // Emit a spine event for the registration.
+            if let Some(ref spine) = state.spine {
+                let data = serde_json::json!({
+                    "artifact_id": artifact_id,
+                    "kind": req.kind,
+                    "name": req.name,
+                    "owner": req.owner,
+                    "description": req.description,
+                    "working_dir": req.working_dir,
+                });
+                if let Err(e) = spine
+                    .emit_raw(
+                        &format!("forge:{artifact_id}"),
+                        "forge",
+                        "artifact.registered",
+                        &data,
+                    )
+                    .await
+                {
+                    tracing::warn!("failed to emit artifact.registered event: {e}");
+                }
+            }
+
+            // Query back the inserted artifact.
+            let artifact = sqlx::query_as::<_, SpineArtifact>(
+                "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
+                 FROM artifacts WHERE artifact_id = $1",
+            )
+            .bind(&artifact_id)
+            .fetch_one(pool)
+            .await;
+
+            match artifact {
+                Ok(a) => (
+                    StatusCode::CREATED,
+                    Json(serde_json::json!({ "artifact": a })),
+                )
+                    .into_response(),
+                Err(e) => {
+                    tracing::error!("failed to read back artifact: {e}");
+                    (
+                        StatusCode::CREATED,
+                        Json(serde_json::json!({ "artifact": { "id": artifact_id } })),
+                    )
+                        .into_response()
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!("failed to register artifact: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("failed to register artifact: {e}") })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// GET /api/spine/artifacts/:id — single artifact detail with versions and lineage.
 pub async fn get_artifact(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -174,28 +294,78 @@ pub async fn get_artifact(
 
     let pool = spine.pool();
 
-    let result = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT id, kind, state, owner, current_version, created_at, updated_at \
-         FROM artifacts WHERE id = $1",
+    let artifact = sqlx::query_as::<_, SpineArtifact>(
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
+         FROM artifacts WHERE artifact_id = $1",
     )
     .bind(&id)
     .fetch_optional(pool)
     .await;
 
-    match result {
-        Ok(Some(a)) => Json(serde_json::json!({ "artifact": a })).into_response(),
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "artifact not found" })),
-        )
-            .into_response(),
-        Err(e) => {
-            tracing::error!("spine artifact query failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": "failed to query artifact" })),
+    let artifact = match artifact {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
             )
                 .into_response()
         }
-    }
+        Err(e) => {
+            tracing::error!("spine artifact query failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to query artifact" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Fetch versions
+    let versions = sqlx::query_as::<_, ArtifactVersionRow>(
+        "SELECT version, content_ref_uri, content_ref_checksum, change_summary, \
+         created_by_session, parent_version, created_at \
+         FROM artifact_versions WHERE artifact_id = $1 ORDER BY version DESC",
+    )
+    .bind(&id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    // Fetch vertical lineage
+    let lineage = sqlx::query_as::<_, VerticalLineageRow>(
+        "SELECT version, session_id, recorded_at \
+         FROM vertical_lineage WHERE artifact_id = $1 ORDER BY version DESC",
+    )
+    .bind(&id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    // Fetch created_by from artifacts table
+    let created_by: String =
+        sqlx::query_scalar("SELECT created_by FROM artifacts WHERE artifact_id = $1")
+            .bind(&id)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+
+    Json(serde_json::json!({
+        "artifact": {
+            "id": artifact.id,
+            "kind": artifact.kind,
+            "name": artifact.name,
+            "state": artifact.state,
+            "owner": artifact.owner,
+            "current_version": artifact.current_version,
+            "created_by": created_by,
+            "created_at": artifact.created_at,
+            "updated_at": artifact.updated_at,
+            "versions": versions,
+            "vertical_lineage": lineage,
+        }
+    }))
+    .into_response()
 }

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -39,6 +39,7 @@ pub struct SpineArtifact {
     pub state: String,
     pub owner: String,
     pub current_version: i32,
+    pub consumers: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -165,7 +166,7 @@ pub async fn list_artifacts(State(state): State<AppState>) -> impl IntoResponse 
     let pool = spine.pool();
 
     let result = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
          FROM artifacts ORDER BY updated_at DESC LIMIT 100",
     )
     .fetch_all(pool)
@@ -231,6 +232,7 @@ pub async fn register_artifact(
                     .emit_raw(
                         &format!("forge:{artifact_id}"),
                         "forge",
+                        "dashboard",
                         "artifact.registered",
                         &data,
                     )
@@ -242,7 +244,7 @@ pub async fn register_artifact(
 
             // Query back the inserted artifact.
             let artifact = sqlx::query_as::<_, SpineArtifact>(
-                "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
+                "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
                  FROM artifacts WHERE artifact_id = $1",
             )
             .bind(&artifact_id)
@@ -269,7 +271,7 @@ pub async fn register_artifact(
             tracing::error!("failed to register artifact: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("failed to register artifact: {e}") })),
+                Json(serde_json::json!({ "error": "failed to register artifact" })),
             )
                 .into_response()
         }
@@ -295,7 +297,7 @@ pub async fn get_artifact(
     let pool = spine.pool();
 
     let artifact = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT artifact_id AS id, kind, name, state, owner, current_version, created_at, updated_at \
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
          FROM artifacts WHERE artifact_id = $1",
     )
     .bind(&id)
@@ -322,7 +324,7 @@ pub async fn get_artifact(
     };
 
     // Fetch versions
-    let versions = sqlx::query_as::<_, ArtifactVersionRow>(
+    let versions = match sqlx::query_as::<_, ArtifactVersionRow>(
         "SELECT version, content_ref_uri, content_ref_checksum, change_summary, \
          created_by_session, parent_version, created_at \
          FROM artifact_versions WHERE artifact_id = $1 ORDER BY version DESC",
@@ -330,17 +332,37 @@ pub async fn get_artifact(
     .bind(&id)
     .fetch_all(pool)
     .await
-    .unwrap_or_default();
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("failed to load versions for artifact {id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load artifact versions" })),
+            )
+                .into_response();
+        }
+    };
 
     // Fetch vertical lineage
-    let lineage = sqlx::query_as::<_, VerticalLineageRow>(
+    let lineage = match sqlx::query_as::<_, VerticalLineageRow>(
         "SELECT version, session_id, recorded_at \
          FROM vertical_lineage WHERE artifact_id = $1 ORDER BY version DESC",
     )
     .bind(&id)
     .fetch_all(pool)
     .await
-    .unwrap_or_default();
+    {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("failed to load vertical lineage for artifact {id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load vertical lineage" })),
+            )
+                .into_response();
+        }
+    };
 
     // Fetch created_by from artifacts table
     let created_by: String =

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -39,6 +39,33 @@ impl SpineEmitter {
         self.store.pool()
     }
 
+    /// Emit a raw event to the extension event table under a given namespace.
+    /// Used for events that don't map to a `FactoryEventKind` variant (e.g.,
+    /// artifact registration from the dashboard).
+    pub async fn emit_raw(
+        &self,
+        stream_id: &str,
+        namespace: &str,
+        event_type: &str,
+        data: &serde_json::Value,
+    ) -> Result<i64, sqlx::Error> {
+        let metadata = EventMetadata {
+            correlation_id: None,
+            causation_id: None,
+            actor: namespace.to_string(),
+        };
+        self.store
+            .append_ext(
+                stream_id,
+                namespace,
+                event_type,
+                data.clone(),
+                &metadata,
+                None,
+            )
+            .await
+    }
+
     /// Emit a session-started event.
     pub async fn emit_session_started(
         &self,

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -42,17 +42,21 @@ impl SpineEmitter {
     /// Emit a raw event to the extension event table under a given namespace.
     /// Used for events that don't map to a `FactoryEventKind` variant (e.g.,
     /// artifact registration from the dashboard).
+    ///
+    /// `namespace` identifies the event store partition; `actor` identifies
+    /// the service or user that originated the event.
     pub async fn emit_raw(
         &self,
         stream_id: &str,
         namespace: &str,
+        actor: &str,
         event_type: &str,
         data: &serde_json::Value,
     ) -> Result<i64, sqlx::Error> {
         let metadata = EventMetadata {
             correlation_id: None,
             causation_id: None,
-            actor: namespace.to_string(),
+            actor: actor.to_string(),
         };
         self.store
             .append_ext(

--- a/crates/synodic/src/core/clustering.rs
+++ b/crates/synodic/src/core/clustering.rs
@@ -76,7 +76,7 @@ pub fn cluster_reasons(reasons: &[String]) -> Vec<ReasonCluster> {
         });
     }
 
-    clusters.sort_by(|a, b| b.reasons.len().cmp(&a.reasons.len()));
+    clusters.sort_by_key(|c| std::cmp::Reverse(c.reasons.len()));
     clusters
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Restructure the dashboard to be factory-first, matching the Onsager vision
that artifacts are the point, not sessions.

Dashboard changes:
- Factory Overview as landing page with pipeline visualization, stats, and
  recent events
- Sidebar reordered: Factory > Governance > Infrastructure > System
- Artifact registration UI (CreateArtifactSheet) as primary sidebar action
- ArtifactsPage upgraded with Register button and links to detail view
- ArtifactDetailPage with version history and vertical lineage
- API types extended for artifact detail, versions, lineage, registration

Backend changes (Stiglab):
- POST /api/spine/artifacts endpoint for artifact registration
- Enhanced GET /api/spine/artifacts/:id with versions and lineage joins
- SpineEmitter.emit_raw() for namespace-flexible event emission
- Artifact queries updated to include name column

Backend changes (Forge):
- Production serve loop wired to EventStore, Stiglab HTTP dispatch, and
  Synodic gate client
- HTTP API on port 3002 with /api/artifacts, /api/status, /api/health
- Loads existing artifacts from spine DB on startup
- Tick loop emits pipeline events to the event spine
- ArtifactStore.register_with_id() for DB-loaded artifacts
- BaselineKernel derives Clone for tick loop borrowing

https://claude.ai/code/session_01Qq3DvXTAqVrVVVmZbwNkoS