### PR TITLE
Add L1 E2E smoke tests with agent-browser CLI wrapper

### DIFF
--- a/.claude/skills/web-testing/SKILL.md
+++ b/.claude/skills/web-testing/SKILL.md
@@ -6,9 +6,10 @@ description: L2 AI-driven web UI testing for Onsager Dashboard. Use when testing
 # Web Testing Protocol (L2)
 
 Exploratory, AI-driven validation of Onsager Dashboard UI changes — **not**
-regression testing. Regression coverage is L1's job (`tests/smoke/` +
-`tests/e2e/`). L2 catches things L1 misses: layout bugs, mobile regressions,
-interaction flows that only fail in a real browser.
+regression testing. Regression coverage is L1's job
+(`apps/dashboard/tests/smoke/` + `apps/dashboard/tests/e2e/`). L2 catches
+things L1 misses: layout bugs, mobile regressions, interaction flows that
+only fail in a real browser.
 
 ## When to invoke
 

--- a/.claude/skills/web-testing/SKILL.md
+++ b/.claude/skills/web-testing/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: web-testing
+description: L2 AI-driven web UI testing for Onsager Dashboard. Use when testing UI on PRs, triaging L1 test failures, or verifying UI behavior at desktop + mobile viewports. Triggers include "test the UI", "check the dashboard", "triage L1 failure", "run L2 tests", "validate this PR", "exploratory test the web app".
+---
+
+# Web Testing Protocol (L2)
+
+Exploratory, AI-driven validation of Onsager Dashboard UI changes — **not**
+regression testing. Regression coverage is L1's job (`tests/smoke/` +
+`tests/e2e/`). L2 catches things L1 misses: layout bugs, mobile regressions,
+interaction flows that only fail in a real browser.
+
+## When to invoke
+
+- A PR touches `apps/dashboard/**`
+- L1 e2e fails and you need to know if it's a real regression, flaky, or env
+- Someone says "validate the UI" / "dogfood this change"
+
+## The app under test
+
+The CI pipeline builds `crates/stiglab/deploy/Dockerfile` — a single image
+bundling the Rust backends (`stiglab` + `synodic`) and the prebuilt dashboard
+SPA. It listens on `http://localhost:3000`.
+
+Primary routes:
+
+| Route              | Page                    | Heading      |
+|--------------------|-------------------------|--------------|
+| `/`                | Factory overview        | `Factory`    |
+| `/sessions`        | Sessions list           | `Sessions`   |
+| `/sessions/:id`    | Session detail          | — (dynamic)  |
+| `/nodes`           | Nodes list              | `Nodes`      |
+| `/artifacts`       | Artifacts list          | `Artifacts`  |
+| `/spine`           | Event spine viewer      | — (dynamic)  |
+| `/governance`      | Governance              | `Governance` |
+| `/settings`        | Settings + credentials  | `Settings`   |
+
+## Viewports (always test both)
+
+- Desktop: `agent-browser set viewport 1280 720`
+- Mobile:  `agent-browser set viewport 375 812`
+
+Mobile matters — the dashboard ships with a responsive layout (see the
+`md:` breakpoints throughout). Horizontal overflow and hidden nav are the
+top-two regression classes.
+
+## Procedure
+
+1. **Read the diff** (`git diff $DIFF_RANGE`) — you will receive
+   `DIFF_RANGE` as an env var from CI.
+2. **Map changes to routes.** A change in `src/pages/SessionsPage.tsx` ⇒
+   `/sessions`. A change in `src/components/layout/**` ⇒ every route.
+3. **For each affected route, at each viewport:**
+   - `agent-browser open http://localhost:3000<route>`
+   - Snapshot the page; verify the heading + key elements render.
+   - Actively exercise interactive elements — don't just check markup:
+     - Click buttons, submit forms, open dialogs.
+     - **Verify the result** — did the UI state change, did the dialog close,
+       did new data appear? Presence of markup is not proof of working.
+   - Check for layout bugs. On mobile especially: horizontal scroll is a
+     failure; a nav that blocks content is a failure.
+   - `agent-browser screenshot --screenshot-dir /tmp/l2-screenshots` then
+     rename the output to `{route-slug}-{desktop|mobile}.png`.
+4. **Crystallize findings.** When you validate new behavior or catch a bug
+   whose fix you can describe, write a deterministic L1 test under
+   `apps/dashboard/tests/smoke/` (component-level) or
+   `apps/dashboard/tests/e2e/` (browser-level). This is how L2 discoveries
+   become permanent L1 coverage.
+5. **Emit the verdict.** Return JSON matching `tests/l2-verdict-schema.json`:
+   - `PASS` if every affected route passes at both viewports.
+   - `FAIL` if any route fails; include the specific failure in
+     `viewports[].issues[]`.
+
+## Triage mode
+
+When invoked after an L1 e2e failure, your job is different:
+
+1. Read the failing test file(s) under `apps/dashboard/tests/e2e/`.
+2. Reproduce against `http://localhost:3000` with agent-browser.
+3. For each failure, classify: **regression** (real bug), **flaky**
+   (intermittent / timing), or **environment** (test harness or CI issue).
+4. Return JSON matching `tests/l2-triage-schema.json` with root cause and
+   suggested fix.
+
+## Guardrails
+
+- Scope to the diff. Don't re-test the whole app on a one-line change.
+- Screenshots are required evidence — no screenshot, the viewport didn't run.
+- Don't invent routes. If a new route was added in the diff, use that one;
+  otherwise stick to the table above.
+- Keep it cheap. One browser session per viewport is plenty.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.ts",
-    "test:watch": "vitest --config vitest.config.ts"
+    "test:watch": "vitest --config vitest.config.ts",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/apps/dashboard/tests/e2e/smoke.test.ts
+++ b/apps/dashboard/tests/e2e/smoke.test.ts
@@ -4,9 +4,16 @@
  * Uses agent-browser to verify critical UI paths against a running stack
  * (the stiglab Docker image, which serves the dashboard + backend on :3000).
  *
+ * Assertions check both `browser.url()` (confirm routing actually happened)
+ * and page-unique content (confirm the page itself rendered). This avoids
+ * false positives from sidebar labels like "Sessions" / "Nodes" which
+ * appear on every authenticated page.
+ *
  * Prerequisites:
  *   - Stack running at ONSAGER_TEST_URL (default http://localhost:3000)
- *   - Chrome installed: `pnpm exec agent-browser install --with-deps`
+ *   - `agent-browser` on PATH (install globally: `npm i -g agent-browser`,
+ *     or add as a devDependency) with Chrome prepared via
+ *     `agent-browser install --with-deps`.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createBrowser, type Browser } from "../helpers/browser";
@@ -25,47 +32,34 @@ afterAll(() => {
   }
 });
 
+// Each expected route: path, unique text only that page renders, and a URL
+// fragment to confirm the router landed on it.
+const routes = [
+  { path: "/", unique: "Artifact Pipeline", urlEndsWith: "/" },
+  { path: "/sessions", unique: "All Sessions", urlEndsWith: "/sessions" },
+  { path: "/nodes", unique: "Registered Nodes", urlEndsWith: "/nodes" },
+  { path: "/artifacts", unique: "All Artifacts", urlEndsWith: "/artifacts" },
+  { path: "/governance", unique: "Governance", urlEndsWith: "/governance" },
+  { path: "/settings", unique: "Credentials", urlEndsWith: "/settings" },
+] as const;
+
 describe("E2E Smoke: Navigation", () => {
-  it("loads the factory overview", () => {
-    browser.open("/");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Factory");
-  });
-
-  it("navigates to Sessions page", () => {
-    browser.open("/sessions");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Sessions");
-  });
-
-  it("navigates to Nodes page", () => {
-    browser.open("/nodes");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Nodes");
-  });
-
-  it("navigates to Artifacts page", () => {
-    browser.open("/artifacts");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Artifacts");
-  });
-
-  it("navigates to Governance page", () => {
-    browser.open("/governance");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Governance");
-  });
-
-  it("navigates to Settings page", () => {
-    browser.open("/settings");
-    const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Settings");
-  });
+  for (const route of routes) {
+    it(`lands on ${route.path} and renders page-unique content`, () => {
+      browser.open(route.path);
+      browser.waitForText(route.unique);
+      const url = browser.url();
+      expect(url.endsWith(route.urlEndsWith)).toBe(true);
+      const snapshot = browser.snapshot();
+      expect(snapshot).toContain(route.unique);
+    });
+  }
 });
 
 describe("E2E Smoke: Factory Overview", () => {
   it("renders overview stat cards", () => {
     browser.open("/");
+    browser.waitForText("Artifact Pipeline");
     const snapshot = browser.snapshot();
 
     expect(snapshot).toContain("Nodes Online");
@@ -75,17 +69,19 @@ describe("E2E Smoke: Factory Overview", () => {
 });
 
 describe("E2E Smoke: Sessions Page", () => {
-  it("shows sessions heading", () => {
+  it("shows the All Sessions table", () => {
     browser.open("/sessions");
+    browser.waitForText("All Sessions");
     const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Sessions");
+    expect(snapshot).toContain("All Sessions");
   });
 });
 
 describe("E2E Smoke: Nodes Page", () => {
-  it("shows nodes heading", () => {
+  it("shows the Registered Nodes table", () => {
     browser.open("/nodes");
+    browser.waitForText("Registered Nodes");
     const snapshot = browser.snapshot();
-    expect(snapshot).toContain("Nodes");
+    expect(snapshot).toContain("Registered Nodes");
   });
 });

--- a/apps/dashboard/tests/e2e/smoke.test.ts
+++ b/apps/dashboard/tests/e2e/smoke.test.ts
@@ -1,0 +1,91 @@
+/**
+ * L1 Deterministic E2E Smoke Tests
+ *
+ * Uses agent-browser to verify critical UI paths against a running stack
+ * (the stiglab Docker image, which serves the dashboard + backend on :3000).
+ *
+ * Prerequisites:
+ *   - Stack running at ONSAGER_TEST_URL (default http://localhost:3000)
+ *   - Chrome installed: `pnpm exec agent-browser install --with-deps`
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createBrowser, type Browser } from "../helpers/browser";
+
+let browser: Browser;
+
+beforeAll(() => {
+  browser = createBrowser();
+});
+
+afterAll(() => {
+  try {
+    browser.close();
+  } catch {
+    // browser may already be closed
+  }
+});
+
+describe("E2E Smoke: Navigation", () => {
+  it("loads the factory overview", () => {
+    browser.open("/");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Factory");
+  });
+
+  it("navigates to Sessions page", () => {
+    browser.open("/sessions");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Sessions");
+  });
+
+  it("navigates to Nodes page", () => {
+    browser.open("/nodes");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Nodes");
+  });
+
+  it("navigates to Artifacts page", () => {
+    browser.open("/artifacts");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Artifacts");
+  });
+
+  it("navigates to Governance page", () => {
+    browser.open("/governance");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Governance");
+  });
+
+  it("navigates to Settings page", () => {
+    browser.open("/settings");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Settings");
+  });
+});
+
+describe("E2E Smoke: Factory Overview", () => {
+  it("renders overview stat cards", () => {
+    browser.open("/");
+    const snapshot = browser.snapshot();
+
+    expect(snapshot).toContain("Nodes Online");
+    expect(snapshot).toContain("Active Sessions");
+    expect(snapshot).toContain("Completed");
+  });
+});
+
+describe("E2E Smoke: Sessions Page", () => {
+  it("shows sessions heading", () => {
+    browser.open("/sessions");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Sessions");
+  });
+});
+
+describe("E2E Smoke: Nodes Page", () => {
+  it("shows nodes heading", () => {
+    browser.open("/nodes");
+    const snapshot = browser.snapshot();
+    expect(snapshot).toContain("Nodes");
+  });
+});

--- a/apps/dashboard/tests/helpers/browser.ts
+++ b/apps/dashboard/tests/helpers/browser.ts
@@ -1,9 +1,18 @@
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import { randomUUID } from "node:crypto";
 
+// Per-command timeout. Kept below Vitest's testTimeout (60s) so a single slow
+// command doesn't starve the test of its overall budget when a test runs
+// multiple commands (open + snapshot + ...). Override via env for slow CI.
+const EXEC_TIMEOUT_MS = (() => {
+  const raw = process.env.ONSAGER_BROWSER_EXEC_TIMEOUT_MS;
+  const n = raw ? Number.parseInt(raw, 10) : 30_000;
+  return Number.isFinite(n) && n > 0 ? n : 30_000;
+})();
+
 const EXEC_OPTIONS: ExecFileSyncOptions = {
   encoding: "utf-8",
-  timeout: 60_000,
+  timeout: EXEC_TIMEOUT_MS,
   stdio: ["pipe", "pipe", "pipe"],
 };
 
@@ -36,7 +45,7 @@ export class Browser {
   }
 
   open(path = "/"): string {
-    return this.run(["open", `${this.baseUrl}${path}`]);
+    return this.run(["open", new URL(path, this.baseUrl).toString()]);
   }
 
   snapshot(): string {

--- a/apps/dashboard/tests/helpers/browser.ts
+++ b/apps/dashboard/tests/helpers/browser.ts
@@ -1,0 +1,101 @@
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+const EXEC_OPTIONS: ExecFileSyncOptions = {
+  encoding: "utf-8",
+  timeout: 60_000,
+  stdio: ["pipe", "pipe", "pipe"],
+};
+
+/**
+ * Wrapper around the agent-browser CLI for deterministic e2e tests.
+ * Each instance manages a single browser session against a target URL.
+ */
+export class Browser {
+  private baseUrl: string;
+  private session: string;
+
+  constructor(baseUrl: string, session?: string) {
+    this.baseUrl = baseUrl;
+    this.session = session ?? `e2e-${randomUUID().slice(0, 8)}`;
+  }
+
+  private run(args: string[]): string {
+    try {
+      return execFileSync(
+        "agent-browser",
+        ["--session", this.session, ...args],
+        EXEC_OPTIONS,
+      ) as string;
+    } catch (err) {
+      const e = err as { stderr?: string; stdout?: string };
+      throw new Error(
+        `agent-browser command failed: agent-browser ${args.join(" ")}\nstderr: ${e.stderr ?? ""}\nstdout: ${e.stdout ?? ""}`,
+      );
+    }
+  }
+
+  open(path = "/"): string {
+    return this.run(["open", `${this.baseUrl}${path}`]);
+  }
+
+  snapshot(): string {
+    return this.run(["snapshot"]);
+  }
+
+  interactiveSnapshot(): string {
+    return this.run(["snapshot", "-i"]);
+  }
+
+  click(ref: string): string {
+    return this.run(["click", ref]);
+  }
+
+  fill(ref: string, value: string): string {
+    return this.run(["fill", ref, value]);
+  }
+
+  screenshot(outputPath?: string): string {
+    return outputPath
+      ? this.run(["screenshot", "--output", outputPath])
+      : this.run(["screenshot"]);
+  }
+
+  waitForText(text: string, timeoutMs = 10_000): string {
+    return this.run(["wait", "--text", text, "--timeout", String(timeoutMs)]);
+  }
+
+  waitForUrl(pattern: string, timeoutMs = 10_000): string {
+    return this.run(["wait", "--url", pattern, "--timeout", String(timeoutMs)]);
+  }
+
+  title(): string {
+    return this.run(["get", "title"]).trim();
+  }
+
+  url(): string {
+    return this.run(["get", "url"]).trim();
+  }
+
+  getText(ref?: string): string {
+    return ref ? this.run(["get", "text", ref]) : this.run(["get", "text"]);
+  }
+
+  evaluate(js: string): string {
+    return this.run(["eval", js]);
+  }
+
+  close(): string {
+    return this.run(["close"]);
+  }
+}
+
+/**
+ * Create a Browser instance pointed at the running stack.
+ * Defaults to ONSAGER_TEST_URL or http://localhost:3000 (the stiglab image).
+ */
+export function createBrowser(baseUrl?: string): Browser {
+  const url =
+    baseUrl ?? process.env.ONSAGER_TEST_URL ?? "http://localhost:3000";
+  return new Browser(url);
+}

--- a/apps/dashboard/vitest.e2e.config.ts
+++ b/apps/dashboard/vitest.e2e.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     testTimeout: 60_000,
     hookTimeout: 30_000,
     pool: "forks",
+    environment: "node",
   },
 });

--- a/apps/dashboard/vitest.e2e.config.ts
+++ b/apps/dashboard/vitest.e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/e2e/**/*.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 30_000,
+    pool: "forks",
+  },
+});


### PR DESCRIPTION
## Summary

Introduces deterministic end-to-end smoke tests for the Onsager Dashboard using the `agent-browser` CLI. This establishes L1 test coverage for critical UI navigation and rendering paths, complementing the existing L2 exploratory testing protocol.

## Key Changes

- **Browser CLI wrapper** (`apps/dashboard/tests/helpers/browser.ts`): New `Browser` class that wraps the `agent-browser` CLI tool, providing a TypeScript interface for programmatic browser automation. Supports session management, navigation, snapshots, clicks, form filling, waiting, and element inspection.

- **E2E smoke tests** (`apps/dashboard/tests/e2e/smoke.test.ts`): Initial suite of deterministic tests covering:
  - Navigation to all primary routes (Factory, Sessions, Nodes, Artifacts, Governance, Settings)
  - Factory overview stat card rendering
  - Page heading verification

- **Vitest E2E config** (`apps/dashboard/vitest.e2e.config.ts`): Dedicated test configuration for E2E tests with appropriate timeouts (60s test, 30s hook) and process pool isolation.

- **NPM script**: Added `test:e2e` command to run E2E tests separately from unit tests.

- **L2 testing protocol** (`.claude/skills/web-testing/SKILL.md`): Documentation for AI-driven exploratory testing, including viewport coverage (desktop + mobile), procedure for validating UI changes, and triage guidelines for L1 failures.

## Implementation Details

- The `Browser` class manages a single session per instance, identified by a random UUID or custom session ID, enabling parallel test execution.
- Error handling includes detailed stderr/stdout output from failed `agent-browser` commands for easier debugging.
- Tests default to `ONSAGER_TEST_URL` environment variable or `http://localhost:3000` (the stiglab Docker image).
- Proper cleanup via `afterAll` hook to close browser sessions.

https://claude.ai/code/session_01AG1Jzyd5Za8nZYe4Bov1MD