### PR TITLE
fix(synodic): cache InterceptEngine across /gate calls (#32)

### DIFF
--- a/crates/synodic/migrations/001_initial_schema.sql
+++ b/crates/synodic/migrations/001_initial_schema.sql
@@ -30,8 +30,11 @@ CREATE TABLE IF NOT EXISTS rules (
     -- Metadata
     enabled INTEGER NOT NULL DEFAULT 1,      -- SQLite boolean
     project_id TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    -- Millisecond precision: `get_rules_revision` keys off MAX(updated_at)
+    -- and second-precision collisions silently serve stale rules
+    -- (issue #32 / PR #42 review).
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 
     -- Crystallization metadata
     crystallized_at TEXT,

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
-use axum::extract::{Path, Query, State};
+use axum::extract::{FromRef, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, patch, post};
@@ -17,8 +17,8 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use tower_http::services::{ServeDir, ServeFile};
 
+use crate::core::engine_cache::EngineCache;
 use crate::core::gate_adapter;
-use crate::core::intercept::{InterceptEngine, InterceptRule};
 use crate::core::storage::pool::{create_storage, resolve_database_url};
 use crate::core::storage::{
     CreateGovernanceEvent, GovernanceEvent, GovernanceEventFilters, Storage,
@@ -36,14 +36,43 @@ pub struct ServeCmd {
     dashboard_dir: Option<String>,
 }
 
-type AppState = Arc<dyn Storage>;
+/// HTTP application state.
+///
+/// Bundles the durable [`Storage`] handle with an in-process
+/// [`EngineCache`] so the `/gate` handler avoids rebuilding the full
+/// `InterceptEngine` on every call (issue #32). Cloning `AppState` is
+/// cheap — it's two `Arc` clones.
+///
+/// `FromRef` impls let handlers extract just the slice they need —
+/// existing handlers continue to take `State<Arc<dyn Storage>>` while
+/// `gate_handler` takes both.
+#[derive(Clone)]
+struct AppState {
+    storage: Arc<dyn Storage>,
+    engine_cache: Arc<EngineCache>,
+}
+
+impl FromRef<AppState> for Arc<dyn Storage> {
+    fn from_ref(state: &AppState) -> Self {
+        Arc::clone(&state.storage)
+    }
+}
+
+impl FromRef<AppState> for Arc<EngineCache> {
+    fn from_ref(state: &AppState) -> Self {
+        Arc::clone(&state.engine_cache)
+    }
+}
 
 impl ServeCmd {
     pub async fn run(self) -> Result<()> {
         let db_url = resolve_database_url();
         eprintln!("Connecting to database...");
         let storage = create_storage(&db_url).await?;
-        let state: AppState = Arc::from(storage);
+        let state = AppState {
+            storage: Arc::from(storage),
+            engine_cache: Arc::new(EngineCache::new()),
+        };
 
         let api = Router::new()
             .route("/health", get(health))
@@ -95,7 +124,7 @@ async fn health() -> impl IntoResponse {
 }
 
 async fn list_events(
-    State(store): State<AppState>,
+    State(store): State<Arc<dyn Storage>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<Vec<GovernanceEvent>>, AppError> {
     let filters = GovernanceEventFilters {
@@ -106,7 +135,7 @@ async fn list_events(
 }
 
 async fn get_event(
-    State(store): State<AppState>,
+    State(store): State<Arc<dyn Storage>>,
     Path(id): Path<String>,
 ) -> Result<Json<GovernanceEvent>, AppError> {
     let event = store
@@ -117,7 +146,7 @@ async fn get_event(
 }
 
 async fn create_event(
-    State(store): State<AppState>,
+    State(store): State<Arc<dyn Storage>>,
     Json(body): Json<CreateGovernanceEvent>,
 ) -> Result<(StatusCode, Json<GovernanceEvent>), AppError> {
     if let Some(ref sev) = body.severity {
@@ -138,7 +167,7 @@ struct ResolveBody {
 }
 
 async fn resolve_event(
-    State(store): State<AppState>,
+    State(store): State<Arc<dyn Storage>>,
     Path(id): Path<String>,
     Json(body): Json<ResolveBody>,
 ) -> Result<StatusCode, AppError> {
@@ -158,7 +187,7 @@ struct Stats {
     by_severity: HashMap<String, usize>,
 }
 
-async fn get_stats(State(store): State<AppState>) -> Result<Json<Stats>, AppError> {
+async fn get_stats(State(store): State<Arc<dyn Storage>>) -> Result<Json<Stats>, AppError> {
     let events = store
         .get_governance_events(GovernanceEventFilters::default())
         .await?;
@@ -193,7 +222,7 @@ struct ApiRule {
     enabled: bool,
 }
 
-async fn list_rules(State(store): State<AppState>) -> Result<Json<Vec<ApiRule>>, AppError> {
+async fn list_rules(State(store): State<Arc<dyn Storage>>) -> Result<Json<Vec<ApiRule>>, AppError> {
     let rules = store.get_rules(false).await?;
     let categories = store.get_threat_categories().await?;
 
@@ -228,14 +257,15 @@ async fn list_rules(State(store): State<AppState>) -> Result<Json<Vec<ApiRule>>,
 // ---------------------------------------------------------------------------
 
 async fn gate_handler(
-    State(store): State<AppState>,
+    State(store): State<Arc<dyn Storage>>,
+    State(engine_cache): State<Arc<EngineCache>>,
     Json(req): Json<onsager_protocol::GateRequest>,
 ) -> Result<Json<onsager_protocol::GateVerdict>, AppError> {
-    // Load active rules from storage and convert to InterceptRules
-    let storage_rules = store.get_rules(true).await?;
-    let rules: Vec<InterceptRule> = storage_rules.iter().map(InterceptRule::from).collect();
+    // Cached: if no rule has been added/updated/deleted since the last call,
+    // we reuse the compiled `InterceptEngine` (issue #32). The only DB cost
+    // on a hit is one cheap `(COUNT, MAX(updated_at))` aggregate.
+    let engine = engine_cache.get_or_refresh(&*store).await?;
 
-    let engine = InterceptEngine::new(rules);
     let intercept_req = gate_adapter::gate_request_to_intercept(&req);
     let resp = engine.evaluate(&intercept_req);
     let verdict = gate_adapter::intercept_to_gate_verdict(&resp);

--- a/crates/synodic/src/core/engine_cache.rs
+++ b/crates/synodic/src/core/engine_cache.rs
@@ -1,0 +1,344 @@
+//! Cached `InterceptEngine` keyed by [`RulesRevision`] (issue #32).
+//!
+//! Forge invokes Synodic's `/gate` endpoint twice per pipeline tick. The
+//! original handler reloaded every active rule from storage and constructed
+//! a fresh engine on each call — an O(N) cost in the active rule count, with
+//! no caching and no invalidation protocol.
+//!
+//! [`EngineCache`] caches a compiled engine behind the rule set's revision
+//! token. Steady state cost per call is one cheap `SELECT COUNT/MAX(updated_at)`
+//! roundtrip plus a clone of an `Arc`. On a rule mutation, the next call
+//! observes the new revision and rebuilds.
+//!
+//! ## Concurrency
+//!
+//! The fast path takes a read lock and clones the inner `Arc<InterceptEngine>`.
+//! On miss, it upgrades to a write lock and double-checks the revision before
+//! rebuilding so two concurrent misses don't both fetch + compile.
+//!
+//! ## Future work
+//!
+//! Per #32's "better" suggestion, a `synodic.rules_updated` pg_notify event
+//! would let the cache invalidate on mutation rather than on the next call's
+//! revision check. That requires the broader event-bus migration in #27 and
+//! is out of scope for this PR. The current revision check is portable
+//! across SQLite + Postgres and incurs ~ms per call — the rebuild cost it
+//! avoids is on the order of 100ms to 1s for a moderately sized rule set.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::RwLock;
+
+use crate::core::intercept::{InterceptEngine, InterceptRule};
+use crate::core::storage::{RulesRevision, Storage};
+
+/// A compiled engine plus the revision token it was built from.
+///
+/// The engine is wrapped in `Arc` so handlers can clone the snapshot
+/// without holding any cache lock across the (synchronous) `evaluate`
+/// call.
+struct CachedEngine {
+    revision: RulesRevision,
+    engine: Arc<InterceptEngine>,
+}
+
+/// Read-through cache for the compiled `InterceptEngine`.
+///
+/// Construct one per process and share via `Arc`. The cache is `active_only`
+/// because the gate path only consults enabled rules; an `enabled = FALSE`
+/// row that flips to `enabled = TRUE` will bump the revision via its
+/// `updated_at` change and force a rebuild.
+pub struct EngineCache {
+    cell: RwLock<Option<CachedEngine>>,
+}
+
+impl Default for EngineCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineCache {
+    pub fn new() -> Self {
+        Self {
+            cell: RwLock::new(None),
+        }
+    }
+
+    /// Return the engine matching the current rule set, fetching and
+    /// compiling only if the cached revision is stale (or empty).
+    pub async fn get_or_refresh(&self, store: &dyn Storage) -> Result<Arc<InterceptEngine>> {
+        let current = store.get_rules_revision(true).await?;
+
+        // Fast path: cached engine matches the current revision.
+        {
+            let guard = self.cell.read().await;
+            if let Some(ref entry) = *guard {
+                if entry.revision == current {
+                    return Ok(Arc::clone(&entry.engine));
+                }
+            }
+        }
+
+        // Slow path: rebuild under the write lock. Re-check inside the lock
+        // so two racing misses produce only one fetch.
+        let mut guard = self.cell.write().await;
+        if let Some(ref entry) = *guard {
+            if entry.revision == current {
+                return Ok(Arc::clone(&entry.engine));
+            }
+        }
+        let storage_rules = store.get_rules(true).await?;
+        let rules: Vec<InterceptRule> = storage_rules.iter().map(InterceptRule::from).collect();
+        let engine = Arc::new(InterceptEngine::new(rules));
+        *guard = Some(CachedEngine {
+            revision: current,
+            engine: Arc::clone(&engine),
+        });
+        Ok(engine)
+    }
+
+    /// Drop the cached engine, forcing the next `get_or_refresh` to rebuild.
+    /// Useful for tests; production callers rely on revision-based
+    /// invalidation via `get_or_refresh`.
+    #[cfg(test)]
+    pub async fn invalidate(&self) {
+        *self.cell.write().await = None;
+    }
+
+    /// Whether the cache currently holds a compiled engine.
+    #[cfg(test)]
+    pub async fn is_warm(&self) -> bool {
+        self.cell.read().await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::storage::{
+        CreateRule, FeedbackEvent, FeedbackFilters, GovernanceEvent, GovernanceEventFilters,
+        GovernanceScores, Lifecycle, PipelineRun, ProbeResult, Rule, RulesRevision, ThreatCategory,
+        UpdateRule,
+    };
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestStore {
+        revision: Mutex<RulesRevision>,
+        rules: Mutex<Vec<Rule>>,
+        get_rules_calls: Mutex<usize>,
+        get_revision_calls: Mutex<usize>,
+    }
+
+    impl TestStore {
+        fn bump(&self, label: &str) {
+            let mut r = self.revision.lock().unwrap();
+            r.count += 1;
+            r.max_updated_at = label.into();
+        }
+
+        fn get_rules_count(&self) -> usize {
+            *self.get_rules_calls.lock().unwrap()
+        }
+
+        fn get_revision_count(&self) -> usize {
+            *self.get_revision_calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl Storage for TestStore {
+        async fn migrate(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn get_rules(&self, _active_only: bool) -> Result<Vec<Rule>> {
+            *self.get_rules_calls.lock().unwrap() += 1;
+            Ok(self.rules.lock().unwrap().clone())
+        }
+        async fn get_rules_revision(&self, _active_only: bool) -> Result<RulesRevision> {
+            *self.get_revision_calls.lock().unwrap() += 1;
+            Ok(self.revision.lock().unwrap().clone())
+        }
+        async fn get_rule(&self, _id: &str) -> Result<Option<Rule>> {
+            Ok(None)
+        }
+        async fn create_rule(&self, _rule: CreateRule) -> Result<Rule> {
+            unimplemented!()
+        }
+        async fn update_rule(&self, _id: &str, _update: UpdateRule) -> Result<()> {
+            Ok(())
+        }
+        async fn delete_rule(&self, _id: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn get_threat_categories(&self) -> Result<Vec<ThreatCategory>> {
+            Ok(vec![])
+        }
+        async fn get_threat_category(&self, _id: &str) -> Result<Option<ThreatCategory>> {
+            Ok(None)
+        }
+        async fn record_feedback(&self, _event: FeedbackEvent) -> Result<()> {
+            Ok(())
+        }
+        async fn get_feedback(&self, _filters: FeedbackFilters) -> Result<Vec<FeedbackEvent>> {
+            Ok(vec![])
+        }
+        async fn record_scores(&self, _scores: GovernanceScores) -> Result<()> {
+            Ok(())
+        }
+        async fn get_scores(
+            &self,
+            _project_id: Option<&str>,
+            _since: DateTime<Utc>,
+        ) -> Result<Vec<GovernanceScores>> {
+            Ok(vec![])
+        }
+        async fn record_pipeline_run(&self, _run: PipelineRun) -> Result<()> {
+            Ok(())
+        }
+        async fn get_pipeline_runs(
+            &self,
+            _project_id: Option<&str>,
+            _limit: Option<i64>,
+        ) -> Result<Vec<PipelineRun>> {
+            Ok(vec![])
+        }
+        async fn record_probe(&self, _result: ProbeResult) -> Result<()> {
+            Ok(())
+        }
+        async fn get_probes(&self, _rule_id: &str) -> Result<Vec<ProbeResult>> {
+            Ok(vec![])
+        }
+        async fn get_governance_events(
+            &self,
+            _filters: GovernanceEventFilters,
+        ) -> Result<Vec<GovernanceEvent>> {
+            Ok(vec![])
+        }
+        async fn get_governance_event(&self, _id: &str) -> Result<Option<GovernanceEvent>> {
+            Ok(None)
+        }
+        async fn create_governance_event(
+            &self,
+            _ev: crate::core::storage::CreateGovernanceEvent,
+        ) -> Result<GovernanceEvent> {
+            unimplemented!()
+        }
+        async fn resolve_governance_event(&self, _id: &str, _notes: Option<String>) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn sample_rule(id: &str) -> Rule {
+        let now = Utc::now();
+        Rule {
+            id: id.into(),
+            description: format!("rule {id}"),
+            category_id: "general".into(),
+            tools: vec![],
+            condition_type: "regex".into(),
+            condition_value: "(?i)test".into(),
+            lifecycle: Lifecycle::Active,
+            alpha: 1,
+            beta: 1,
+            prior_alpha: 1,
+            prior_beta: 1,
+            enabled: true,
+            project_id: None,
+            created_at: now,
+            updated_at: now,
+            crystallized_at: None,
+            cross_project_validated: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn first_call_warms_cache() {
+        let store = TestStore::default();
+        let cache = EngineCache::new();
+        assert!(!cache.is_warm().await);
+
+        let _e = cache.get_or_refresh(&store).await.unwrap();
+        assert!(cache.is_warm().await);
+        assert_eq!(store.get_revision_count(), 1);
+        assert_eq!(store.get_rules_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn second_call_with_unchanged_revision_skips_get_rules() {
+        let store = TestStore::default();
+        let cache = EngineCache::new();
+
+        let e1 = cache.get_or_refresh(&store).await.unwrap();
+        let e2 = cache.get_or_refresh(&store).await.unwrap();
+        assert!(Arc::ptr_eq(&e1, &e2), "cache should hand back the same Arc");
+        assert_eq!(store.get_revision_count(), 2);
+        assert_eq!(store.get_rules_count(), 1, "no second fetch on hit");
+    }
+
+    #[tokio::test]
+    async fn revision_change_triggers_rebuild() {
+        let store = TestStore::default();
+        store.rules.lock().unwrap().push(sample_rule("r1"));
+        let cache = EngineCache::new();
+
+        let e1 = cache.get_or_refresh(&store).await.unwrap();
+        store.rules.lock().unwrap().push(sample_rule("r2"));
+        store.bump("after-r2");
+        let e2 = cache.get_or_refresh(&store).await.unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&e1, &e2),
+            "engine must be rebuilt on revision change"
+        );
+        assert_eq!(store.get_rules_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_invalidate_forces_rebuild() {
+        let store = TestStore::default();
+        let cache = EngineCache::new();
+
+        cache.get_or_refresh(&store).await.unwrap();
+        cache.invalidate().await;
+        cache.get_or_refresh(&store).await.unwrap();
+
+        assert_eq!(
+            store.get_rules_count(),
+            2,
+            "invalidate should drop the cached engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_misses_only_fetch_once() {
+        // Three concurrent first calls into an empty cache should produce
+        // exactly one rules fetch — the double-check inside the write lock
+        // is what guards this.
+        let store = Arc::new(TestStore::default());
+        let cache = Arc::new(EngineCache::new());
+
+        let mut handles = Vec::new();
+        for _ in 0..3 {
+            let store = Arc::clone(&store);
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move {
+                cache.get_or_refresh(&*store).await.unwrap()
+            }));
+        }
+        let mut results: Vec<Arc<InterceptEngine>> = Vec::with_capacity(handles.len());
+        for h in handles {
+            results.push(h.await.unwrap());
+        }
+
+        // All three handlers got the same compiled engine.
+        for w in results.windows(2) {
+            assert!(Arc::ptr_eq(&w[0], &w[1]));
+        }
+        assert_eq!(store.get_rules_count(), 1);
+    }
+}

--- a/crates/synodic/src/core/engine_cache.rs
+++ b/crates/synodic/src/core/engine_cache.rs
@@ -89,14 +89,49 @@ impl EngineCache {
                 return Ok(Arc::clone(&entry.engine));
             }
         }
-        let storage_rules = store.get_rules(true).await?;
-        let rules: Vec<InterceptRule> = storage_rules.iter().map(InterceptRule::from).collect();
+
+        // Fetch rules and bracket them with a second revision read to catch
+        // mutations that land between the outer `current` read and the fetch.
+        // If the revision is stable around the fetch, store (rev, rules) as a
+        // consistent snapshot; otherwise adopt the later revision and retry
+        // on the next call (bounded so we don't spin under heavy mutation
+        // pressure).
+        let (stable_revision, rules) = Self::fetch_consistent(store).await?;
         let engine = Arc::new(InterceptEngine::new(rules));
         *guard = Some(CachedEngine {
-            revision: current,
+            revision: stable_revision,
             engine: Arc::clone(&engine),
         });
         Ok(engine)
+    }
+
+    /// Fetch (revision, rules) as a consistent snapshot. Uses a bracketed
+    /// read — `get_rules_revision` before and after `get_rules` — and
+    /// retries on mismatch. Up to [`MAX_SNAPSHOT_ATTEMPTS`] tries, then
+    /// accepts the last pair so the caller always makes progress.
+    async fn fetch_consistent(store: &dyn Storage) -> Result<(RulesRevision, Vec<InterceptRule>)> {
+        const MAX_SNAPSHOT_ATTEMPTS: usize = 3;
+
+        let mut last_before = store.get_rules_revision(true).await?;
+        let mut last_rules = store.get_rules(true).await?;
+        let mut last_after = store.get_rules_revision(true).await?;
+
+        for _ in 0..MAX_SNAPSHOT_ATTEMPTS {
+            if last_before == last_after {
+                let compiled: Vec<InterceptRule> =
+                    last_rules.iter().map(InterceptRule::from).collect();
+                return Ok((last_after, compiled));
+            }
+            // Mutation raced the fetch; read again.
+            last_before = last_after;
+            last_rules = store.get_rules(true).await?;
+            last_after = store.get_rules_revision(true).await?;
+        }
+
+        // Couldn't stabilise — commit the most recent pair and let the next
+        // call's revision check trigger another rebuild if needed.
+        let compiled: Vec<InterceptRule> = last_rules.iter().map(InterceptRule::from).collect();
+        Ok((last_after, compiled))
     }
 
     /// Drop the cached engine, forcing the next `get_or_refresh` to rebuild.
@@ -128,17 +163,29 @@ mod tests {
 
     #[derive(Default)]
     struct TestStore {
-        revision: Mutex<RulesRevision>,
+        /// (count, label) — paired so the `TestStore` can build a
+        /// `RulesRevision` via its public constructor.
+        revision_state: Mutex<(i64, String)>,
         rules: Mutex<Vec<Rule>>,
         get_rules_calls: Mutex<usize>,
         get_revision_calls: Mutex<usize>,
+        /// Number of upcoming `get_rules` calls that should bump the
+        /// revision as a side effect. Simulates a concurrent mutation
+        /// landing between the bracketed revision reads in
+        /// `EngineCache::fetch_consistent`.
+        mutations_during_fetch: Mutex<usize>,
     }
 
     impl TestStore {
         fn bump(&self, label: &str) {
-            let mut r = self.revision.lock().unwrap();
-            r.count += 1;
-            r.max_updated_at = label.into();
+            let mut r = self.revision_state.lock().unwrap();
+            r.0 += 1;
+            r.1 = label.into();
+        }
+
+        fn current_revision(&self) -> RulesRevision {
+            let r = self.revision_state.lock().unwrap();
+            RulesRevision::new(r.0, r.1.clone())
         }
 
         fn get_rules_count(&self) -> usize {
@@ -157,11 +204,21 @@ mod tests {
         }
         async fn get_rules(&self, _active_only: bool) -> Result<Vec<Rule>> {
             *self.get_rules_calls.lock().unwrap() += 1;
-            Ok(self.rules.lock().unwrap().clone())
+            let snapshot = self.rules.lock().unwrap().clone();
+            // Side effect: if the test armed a pending mutation, bump the
+            // revision *after* snapshotting the rules so the `after` read
+            // in `fetch_consistent` sees the change.
+            let mut pending = self.mutations_during_fetch.lock().unwrap();
+            if *pending > 0 {
+                *pending -= 1;
+                drop(pending);
+                self.bump("mid-fetch");
+            }
+            Ok(snapshot)
         }
         async fn get_rules_revision(&self, _active_only: bool) -> Result<RulesRevision> {
             *self.get_revision_calls.lock().unwrap() += 1;
-            Ok(self.revision.lock().unwrap().clone())
+            Ok(self.current_revision())
         }
         async fn get_rule(&self, _id: &str) -> Result<Option<Rule>> {
             Ok(None)
@@ -264,8 +321,11 @@ mod tests {
 
         let _e = cache.get_or_refresh(&store).await.unwrap();
         assert!(cache.is_warm().await);
-        assert_eq!(store.get_revision_count(), 1);
+        // One rule fetch on the first call. Revision reads are
+        // implementation-detail (we bracket the fetch for consistency);
+        // tests assert the observable contract, not the exact count.
         assert_eq!(store.get_rules_count(), 1);
+        assert!(store.get_revision_count() >= 1);
     }
 
     #[tokio::test]
@@ -274,10 +334,14 @@ mod tests {
         let cache = EngineCache::new();
 
         let e1 = cache.get_or_refresh(&store).await.unwrap();
+        let fetches_after_first = store.get_rules_count();
         let e2 = cache.get_or_refresh(&store).await.unwrap();
         assert!(Arc::ptr_eq(&e1, &e2), "cache should hand back the same Arc");
-        assert_eq!(store.get_revision_count(), 2);
-        assert_eq!(store.get_rules_count(), 1, "no second fetch on hit");
+        assert_eq!(
+            store.get_rules_count(),
+            fetches_after_first,
+            "no second fetch on hit"
+        );
     }
 
     #[tokio::test]
@@ -311,6 +375,51 @@ mod tests {
             store.get_rules_count(),
             2,
             "invalidate should drop the cached engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn bracketed_read_retries_on_mid_fetch_mutation() {
+        // Arrange: one pending mid-fetch bump. fetch_consistent should
+        // detect the mismatch on the first attempt, retry, and commit the
+        // post-mutation revision to the cache.
+        let store = TestStore::default();
+        *store.mutations_during_fetch.lock().unwrap() = 1;
+        let cache = EngineCache::new();
+
+        cache.get_or_refresh(&store).await.unwrap();
+
+        // The first get_or_refresh burned: 1 current read + 1 before + 1
+        // fetch (which bumped) + 1 after (mismatch) + 1 fetch + 1 after =
+        // 4 revision reads and 2 rule fetches before stabilising.
+        assert_eq!(store.get_rules_count(), 2);
+
+        // A subsequent call with no pending mutation must hit cache:
+        // if the stored revision were stale (pre-mutation), it would
+        // mismatch the current revision and force a third fetch.
+        cache.get_or_refresh(&store).await.unwrap();
+        assert_eq!(
+            store.get_rules_count(),
+            2,
+            "cache should be consistent with the post-mutation revision"
+        );
+    }
+
+    #[tokio::test]
+    async fn bracketed_read_eventually_commits_under_sustained_mutation() {
+        // Every fetch bumps the revision, so no snapshot is ever stable.
+        // fetch_consistent must still commit something after the retry
+        // budget rather than looping forever.
+        let store = TestStore::default();
+        *store.mutations_during_fetch.lock().unwrap() = 1000;
+        let cache = EngineCache::new();
+
+        cache.get_or_refresh(&store).await.unwrap();
+        // We should have given up after a bounded number of rule fetches.
+        assert!(
+            store.get_rules_count() <= 5,
+            "expected bounded retries, got {} fetches",
+            store.get_rules_count()
         );
     }
 

--- a/crates/synodic/src/core/mod.rs
+++ b/crates/synodic/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod clustering;
+pub mod engine_cache;
 pub mod gate_adapter;
 pub mod intercept;
 pub mod llm;

--- a/crates/synodic/src/core/storage/mod.rs
+++ b/crates/synodic/src/core/storage/mod.rs
@@ -240,17 +240,21 @@ pub struct ProbeResult {
 
 /// Cache key for the compiled `InterceptEngine` (issue #32).
 ///
-/// Two revisions compare equal iff no enabled-rule mutation has happened
-/// between the calls that produced them. The exact encoding is opaque —
-/// callers must treat it as a token, not a numeric counter.
+/// Treat the value as an opaque token: the public API only supports
+/// equality / hashing, not inspection of the component fields. The exact
+/// encoding (currently `(COUNT(*), MAX(updated_at))`) is an implementation
+/// detail and may change.
 ///
-/// Implementations should derive this from a small SQL aggregate
-/// (e.g. `(COUNT(*), MAX(updated_at))`) so the per-request cost is a
-/// single round-trip.
+/// Contract: implementations MUST shift this token when a rule matching
+/// `active_only` is created, updated, or deleted. Two equal revisions are
+/// best-effort evidence that no such change happened — a backend with
+/// coarse `updated_at` precision can in principle collide, so this is not
+/// a linearizability guarantee. The current SQLite backend writes
+/// millisecond-precision timestamps; Postgres writes microsecond TIMESTAMPTZ.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct RulesRevision {
-    pub count: i64,
-    pub max_updated_at: String,
+    count: i64,
+    max_updated_at: String,
 }
 
 impl RulesRevision {
@@ -277,10 +281,15 @@ pub trait Storage: Send + Sync {
     async fn get_rules(&self, active_only: bool) -> Result<Vec<Rule>>;
 
     /// Cheap revision token for the rule set, used for engine caching
-    /// (issue #32). Two calls return the same `RulesRevision` iff no rule
-    /// matching `active_only` was created, updated, or deleted between
-    /// them. Implemented as a single SQL aggregate so the per-`/gate`-call
-    /// cost is one round-trip instead of a full rule fetch.
+    /// (issue #32). Implementations MUST shift this token when a rule
+    /// matching `active_only` is created, updated, or deleted. Equal
+    /// revisions are best-effort evidence that no such change happened —
+    /// backends with coarse `updated_at` precision may produce the same
+    /// token for distinct states. See [`RulesRevision`] for the full
+    /// contract.
+    ///
+    /// Implemented as a single SQL aggregate so the per-`/gate`-call cost
+    /// is one round-trip instead of a full rule fetch.
     async fn get_rules_revision(&self, active_only: bool) -> Result<RulesRevision>;
 
     /// Get a single rule by ID.

--- a/crates/synodic/src/core/storage/mod.rs
+++ b/crates/synodic/src/core/storage/mod.rs
@@ -238,6 +238,30 @@ pub struct ProbeResult {
     pub created_at: DateTime<Utc>,
 }
 
+/// Cache key for the compiled `InterceptEngine` (issue #32).
+///
+/// Two revisions compare equal iff no enabled-rule mutation has happened
+/// between the calls that produced them. The exact encoding is opaque —
+/// callers must treat it as a token, not a numeric counter.
+///
+/// Implementations should derive this from a small SQL aggregate
+/// (e.g. `(COUNT(*), MAX(updated_at))`) so the per-request cost is a
+/// single round-trip.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct RulesRevision {
+    pub count: i64,
+    pub max_updated_at: String,
+}
+
+impl RulesRevision {
+    pub fn new(count: i64, max_updated_at: impl Into<String>) -> Self {
+        Self {
+            count,
+            max_updated_at: max_updated_at.into(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Storage trait
 // ---------------------------------------------------------------------------
@@ -251,6 +275,13 @@ pub trait Storage: Send + Sync {
 
     /// Get all rules, optionally filtered to active-only.
     async fn get_rules(&self, active_only: bool) -> Result<Vec<Rule>>;
+
+    /// Cheap revision token for the rule set, used for engine caching
+    /// (issue #32). Two calls return the same `RulesRevision` iff no rule
+    /// matching `active_only` was created, updated, or deleted between
+    /// them. Implemented as a single SQL aggregate so the per-`/gate`-call
+    /// cost is one round-trip instead of a full rule fetch.
+    async fn get_rules_revision(&self, active_only: bool) -> Result<RulesRevision>;
 
     /// Get a single rule by ID.
     async fn get_rule(&self, id: &str) -> Result<Option<Rule>>;

--- a/crates/synodic/src/core/storage/postgres.rs
+++ b/crates/synodic/src/core/storage/postgres.rs
@@ -129,6 +129,25 @@ impl Storage for PostgresStorage {
         row.map(|r| r.into_rule()).transpose()
     }
 
+    async fn get_rules_revision(&self, active_only: bool) -> Result<RulesRevision> {
+        // Single round-trip: COUNT plus MAX(updated_at) cast to text so the
+        // value is portable across drivers and small enough to compare as a
+        // string. No row scan.
+        let row: (i64, Option<String>) = if active_only {
+            sqlx::query_as(
+                "SELECT COUNT(*)::BIGINT, MAX(updated_at)::TEXT \
+                 FROM rules WHERE enabled = TRUE",
+            )
+            .fetch_one(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as("SELECT COUNT(*)::BIGINT, MAX(updated_at)::TEXT FROM rules")
+                .fetch_one(&self.pool)
+                .await?
+        };
+        Ok(RulesRevision::new(row.0, row.1.unwrap_or_default()))
+    }
+
     async fn create_rule(&self, rule: CreateRule) -> Result<Rule> {
         let tools_json = serde_json::to_value(&rule.tools)?;
         let now = Utc::now();

--- a/crates/synodic/src/core/storage/postgres.rs
+++ b/crates/synodic/src/core/storage/postgres.rs
@@ -132,7 +132,8 @@ impl Storage for PostgresStorage {
     async fn get_rules_revision(&self, active_only: bool) -> Result<RulesRevision> {
         // Single round-trip: COUNT plus MAX(updated_at) cast to text so the
         // value is portable across drivers and small enough to compare as a
-        // string. No row scan.
+        // string. The rules table is small in practice (tens to low
+        // thousands), so the aggregate's scan cost is bounded.
         let row: (i64, Option<String>) = if active_only {
             sqlx::query_as(
                 "SELECT COUNT(*)::BIGINT, MAX(updated_at)::TEXT \

--- a/crates/synodic/src/core/storage/sqlite.rs
+++ b/crates/synodic/src/core/storage/sqlite.rs
@@ -4,7 +4,15 @@
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
+
+/// Format for timestamps written to rule columns. Uses millisecond precision
+/// so `get_rules_revision` can distinguish updates landing within the same
+/// second (issue #32 / PR #42 review): the cache keys off `MAX(updated_at)`
+/// and second-precision collisions silently serve stale rules.
+fn rule_ts_now() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 use uuid::Uuid;
 
@@ -153,7 +161,7 @@ impl Storage for SqliteStorage {
 
     async fn create_rule(&self, rule: CreateRule) -> Result<Rule> {
         let tools_json = serde_json::to_string(&rule.tools)?;
-        let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let now = rule_ts_now();
         let lifecycle = rule.lifecycle.as_str();
 
         sqlx::query(
@@ -184,7 +192,7 @@ impl Storage for SqliteStorage {
     }
 
     async fn update_rule(&self, id: &str, update: UpdateRule) -> Result<()> {
-        let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let now = rule_ts_now();
 
         if let Some(desc) = &update.description {
             sqlx::query("UPDATE rules SET description = ?, updated_at = ? WHERE id = ?")
@@ -839,10 +847,16 @@ impl GovEventRow {
 }
 
 fn parse_datetime(s: &str) -> Result<DateTime<Utc>> {
-    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ")
-        .map(|dt| dt.and_utc())
+    // Try RFC3339 first — this handles both second-precision `...HH:MM:SSZ`
+    // and millisecond-precision `...HH:MM:SS.fffZ` forms written by
+    // different code paths in this file, plus any other offset variant that
+    // ends up in the TEXT column.
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
         .or_else(|_| {
-            // Try alternative format
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ").map(|dt| dt.and_utc())
+        })
+        .or_else(|_| {
             chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").map(|dt| dt.and_utc())
         })
         .with_context(|| format!("parsing datetime: {s}"))

--- a/crates/synodic/src/core/storage/sqlite.rs
+++ b/crates/synodic/src/core/storage/sqlite.rs
@@ -136,6 +136,21 @@ impl Storage for SqliteStorage {
         row.map(|r| r.into_rule()).transpose()
     }
 
+    async fn get_rules_revision(&self, active_only: bool) -> Result<RulesRevision> {
+        // SQLite stores `updated_at` as TEXT (RFC3339), so MAX(updated_at)
+        // already returns a string-comparable token — no cast needed.
+        let row: (i64, Option<String>) = if active_only {
+            sqlx::query_as("SELECT COUNT(*), MAX(updated_at) FROM rules WHERE enabled = 1")
+                .fetch_one(&self.pool)
+                .await?
+        } else {
+            sqlx::query_as("SELECT COUNT(*), MAX(updated_at) FROM rules")
+                .fetch_one(&self.pool)
+                .await?
+        };
+        Ok(RulesRevision::new(row.0, row.1.unwrap_or_default()))
+    }
+
     async fn create_rule(&self, rule: CreateRule) -> Result<Rule> {
         let tools_json = serde_json::to_string(&rule.tools)?;
         let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();

--- a/crates/synodic/src/core/storage/tests.rs
+++ b/crates/synodic/src/core/storage/tests.rs
@@ -203,9 +203,10 @@ mod tests {
         let store = test_store().await;
         let v0 = store.get_rules_revision(true).await.unwrap();
 
-        // Sleep enough that the RFC3339 timestamp definitely advances on
-        // SQLite (which truncates to seconds).
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        // SQLite rule timestamps are millisecond-precision (PR #42 review
+        // fix for #32); 20ms is well beyond clock resolution and keeps
+        // the test fast.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         store
             .update_rule(
                 "destructive-git",

--- a/crates/synodic/src/core/storage/tests.rs
+++ b/crates/synodic/src/core/storage/tests.rs
@@ -195,6 +195,40 @@ mod tests {
         assert_eq!(rules.len(), 4);
     }
 
+    #[tokio::test]
+    async fn rules_revision_changes_on_mutation() {
+        // Cache invalidation contract for issue #32: every mutation that the
+        // gate handler cares about must shift the revision token returned by
+        // get_rules_revision so the cache rebuilds.
+        let store = test_store().await;
+        let v0 = store.get_rules_revision(true).await.unwrap();
+
+        // Sleep enough that the RFC3339 timestamp definitely advances on
+        // SQLite (which truncates to seconds).
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        store
+            .update_rule(
+                "destructive-git",
+                UpdateRule {
+                    lifecycle: Some(Lifecycle::Tuned),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let v1 = store.get_rules_revision(true).await.unwrap();
+        assert_ne!(v0, v1, "update should shift the revision");
+
+        // Reading without mutating should NOT shift the revision.
+        let v1b = store.get_rules_revision(true).await.unwrap();
+        assert_eq!(v1, v1b);
+
+        // Deleting an enabled rule shifts both the count and the timestamp.
+        store.delete_rule("dangerous-rm").await.unwrap();
+        let v2 = store.get_rules_revision(true).await.unwrap();
+        assert_ne!(v1, v2, "delete should shift the revision");
+    }
+
     // -- Feedback events ----------------------------------------------------
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #32 — last open P0 from the architectural-review tracker (#40).

The `/gate` handler reloaded every active rule and rebuilt the `InterceptEngine` on every call. Forge invokes `/gate` twice per tick, making it O(2N) per tick in the active rule count — fine at N=5, painful at N=1000, and amplifies the same Forge-write-lock starvation #28 fixed (slow Synodic = slower tick = longer lock window).

## Approach

- **`RulesRevision`** token on the `Storage` trait — `(count, MAX(updated_at))`, returned by a single SQL aggregate. Portable across SQLite + Postgres, comparable for equality. Two calls return equal revisions iff no rule was created / updated / deleted between them.
- **`EngineCache`** wraps `Arc<InterceptEngine>` behind that revision.
  - Fast path: read lock + revision check + `Arc` clone.
  - Slow path: write lock with **double-checked** rebuild so two racing misses produce only one fetch.
- **`AppState { storage, engine_cache }`** with `FromRef` shims — existing handlers continue to extract `State<Arc<dyn Storage>>` unchanged; only `gate_handler` extracts both.

Steady-state cost per `/gate` call: one ~ms `(COUNT, MAX(updated_at))` aggregate + an `Arc` clone. Cost on rule mutation: one fetch + compile, then back to fast path.

## What's NOT in this PR

- The full event-driven invalidation from #32's "Better" suggestion (`synodic.rules_updated` over pg_notify) — that depends on the broader event-bus migration in #27 and belongs in that PR.
- Throughput benchmarks at N=10/100/1000 — the cache contract is unit-tested but a wall-clock repro requires the full dev stack.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` clean
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` — 277 passed (incl. 6 new cache tests + 1 storage revision test)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- New tests cover:
  - `first_call_warms_cache`
  - `second_call_with_unchanged_revision_skips_get_rules` (handed back the same `Arc`, no re-fetch)
  - `revision_change_triggers_rebuild`
  - `manual_invalidate_forces_rebuild`
  - `concurrent_misses_only_fetch_once` (3 concurrent first-time callers → 1 fetch)
  - `rules_revision_changes_on_mutation` (SQLite integration: update + delete both shift the token; pure read does not)

🤖 Generated with [Claude Code](https://claude.ai/code)
