### PR TITLE
Document Onsager's spec-issue-driven dev loop and Claude Routines

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -1,0 +1,65 @@
+# Onsager Claude Routines
+
+Claude Routines are GitHub-event-triggered Claude Code sessions that run on
+Anthropic's cloud infrastructure. We use them to keep issue-progress labels in
+sync with PR state so humans don't have to flip them by hand.
+
+Routines are defined in your claude.ai account at
+[claude.ai/code/routines](https://claude.ai/code/routines), not checked into
+this repo. What *is* checked in, in this directory, is the **prompt** for each
+recommended routine — version-controlled, reviewable, and easy to copy into
+the routine setup form.
+
+## Setup
+
+For each `*.md` file below:
+
+1. Go to [claude.ai/code/routines](https://claude.ai/code/routines) and click
+   **New routine**.
+2. Name it after the file (e.g. `pr-opened-progress`).
+3. Paste the prompt from the file (everything below the `---` frontmatter).
+4. Select repository: `onsager-ai/onsager`.
+5. Select an environment that has the Claude GitHub App installed.
+6. Under **Select a trigger**, add the GitHub trigger described in the
+   frontmatter (event + filters).
+7. Leave the default connectors. The prompt only uses the GitHub MCP.
+8. Save.
+
+Install the Claude GitHub App on `onsager-ai/onsager` if prompted.
+
+## Recommended routines
+
+| File | Trigger | Purpose |
+|------|---------|---------|
+| [`pr-opened-progress.md`](pr-opened-progress.md) | `pull_request.opened` | Flip linked spec issue `planned`/`draft` → `in-progress`; verify PR body links a spec. |
+| [`pr-merged-progress.md`](pr-merged-progress.md) | `pull_request.closed` merged=true | Tick Plan checkboxes on parent spec for `Part of #N` merges. |
+| [`pr-closed-unmerged.md`](pr-closed-unmerged.md) | `pull_request.closed` merged=false | Revert linked spec back to `planned` if no other PR is in flight. |
+| [`spec-planned-review.md`](spec-planned-review.md) | `issues.labeled` = `planned` | Sanity-check the spec before a human/agent picks it up (open questions, plan items, test items). |
+
+## Updating a routine
+
+Edit the prompt file here, commit it, then paste the new prompt into the
+routine's edit form on the web. Keeping the canonical prompt in-repo makes
+prompt drift auditable and reviewable like any other code change.
+
+## Why not hooks or webhooks?
+
+- **Hooks** (`settings.json`) run locally in a dev's CLI session. They can't
+  react to PR events from reviewers on other machines.
+- **GitHub Actions** could do this with the Anthropic API, but then we
+  maintain workflow YAML plus prompt plus token secrets. Routines package
+  all three and run under the account that owns the subscription.
+- **onsager-pr-lifecycle skill** covers the interactive, human-present case
+  (triaging CI, replying to review comments). The routines cover the
+  unattended, mechanical case (label alignment).
+
+The two are complementary. If you don't want to set up routines, read
+`onsager-pr-lifecycle` and flip labels manually — the skill documents the
+same transitions.
+
+## Limits
+
+Routines count against your daily run allowance (Pro: 5/day, Max: 15/day,
+Team/Enterprise: 25/day). For a project with steady PR flow, budget
+~2 runs per PR (open + merge) and consider combining triggers on one
+routine if you're pressed for allowance.

--- a/.claude/routines/pr-closed-unmerged.md
+++ b/.claude/routines/pr-closed-unmerged.md
@@ -1,0 +1,45 @@
+---
+name: pr-closed-unmerged
+trigger: GitHub event — pull_request.closed
+filters:
+  - Is merged: false
+repository: onsager-ai/onsager
+---
+
+# Prompt
+
+You are an autonomous Claude Code session reacting to a pull request that
+was closed *without* being merged on `onsager-ai/onsager`. Your job is to
+back out the `in-progress` label on the linked spec issue if no other PRs
+are still open against it.
+
+## Do exactly this
+
+1. **Read the PR body** via `mcp__github__pull_request_read` to find
+   linked spec issues (any of `Closes`, `Fixes`, `Resolves`, `Part of`,
+   `Refs`, `Related`).
+2. **For each linked issue that is still open and labeled `in-progress`:**
+   a. Search open PRs against the same repository that reference the same
+      issue number in their body (`mcp__github__list_pull_requests` with
+      state=open, then filter in memory).
+   b. If at least one *other* open PR still references the issue, do
+      nothing — another in-flight PR keeps the spec in progress.
+   c. If no other open PR references the issue, swap `in-progress` →
+      `planned` using `mcp__github__issue_write`. Post an issue comment:
+      "PR #<pr-number> closed without merging. No other PRs in flight —
+      spec returned to `planned`."
+3. **Do not reopen closed issues.** If an issue was already closed (by a
+   different PR's `Closes`), leave it alone.
+
+## Constraints
+
+- Use only `mcp__github__*` tools.
+- Do not delete or modify the Plan checkboxes. Closing a PR unmerged
+  should not revert work that actually landed elsewhere.
+- Keep comments short.
+
+## Success
+
+A spec that genuinely has no active implementation returns to `planned` so
+the next implementer knows it's available. A spec with another PR in
+flight keeps its `in-progress` label.

--- a/.claude/routines/pr-merged-progress.md
+++ b/.claude/routines/pr-merged-progress.md
@@ -1,0 +1,58 @@
+---
+name: pr-merged-progress
+trigger: GitHub event — pull_request.closed
+filters:
+  - Is merged: true
+repository: onsager-ai/onsager
+---
+
+# Prompt
+
+You are an autonomous Claude Code session reacting to a merged pull request
+on `onsager-ai/onsager`. The PR number is in the event payload. Your job is
+to update the linked spec issue's Plan checkboxes so a parent spec
+accurately reflects which slices have landed.
+
+## Do exactly this
+
+1. **Read the PR body** via `mcp__github__pull_request_read`. Identify the
+   linking line:
+   - `Closes #N`, `Fixes #N`, `Resolves #N` (any variant) → GitHub will
+     auto-close the issue on merge. Nothing to do for the close itself.
+   - `Part of #N`, `Refs #N`, `Related #N` → the parent spec stays open;
+     you update its checkboxes.
+2. **For every linked issue that is NOT being auto-closed** (i.e., `Part of`
+   / `Refs` / `Related`):
+   a. Read the issue via `mcp__github__issue_read`.
+   b. Identify which Plan checkboxes this PR delivered. The PR body should
+      list the items it delivers in a `## Delivers` subsection, or reuse
+      the exact Plan item text. If neither is present, post a comment on
+      the spec issue naming the merged PR and listing its changed files,
+      asking a human to tick the right checkboxes. Stop.
+   c. If the PR identifies deliverables unambiguously, edit the issue body
+      via `mcp__github__issue_write` to tick the matching `- [ ]` →
+      `- [x]` lines. Preserve the rest of the body verbatim.
+   d. Post a brief issue comment: "Ticked by #<pr-number>: <list of items>".
+3. **For auto-closed issues** (the `Closes` case):
+   - The issue state transition is handled by GitHub. Do not add comments
+     or labels. The `in-progress` label disappears when the issue closes.
+4. **If the linked issue is a sub-issue of a parent spec**, re-read the
+   parent via `mcp__github__issue_read`. If all sub-issues under the
+   parent are now closed, post a comment on the parent: "All sub-issues
+   closed — ready to verify end-to-end and close the parent."
+
+## Constraints
+
+- Use only `mcp__github__*` tools. No shell, no file edits in the repo.
+- Preserve the rest of the issue body exactly. Only tick existing
+  checkboxes; never add or remove Plan items.
+- If the PR body has multiple linked issues, handle each independently.
+- If you cannot confidently map PR → Plan items, err on the side of posting
+  a comment and letting a human decide. Do not guess.
+
+## Success
+
+Parent specs stay in sync with what has actually shipped. No Plan items
+get ticked for changes that weren't delivered. The sub-issue → parent
+relationship is respected: parent stays open until its own Plan is
+complete, which typically happens when all sub-issues close.

--- a/.claude/routines/pr-opened-progress.md
+++ b/.claude/routines/pr-opened-progress.md
@@ -1,0 +1,64 @@
+---
+name: pr-opened-progress
+trigger: GitHub event — pull_request.opened
+filters:
+  - Is draft: false
+repository: onsager-ai/onsager
+---
+
+# Prompt
+
+You are an autonomous Claude Code session reacting to a newly opened pull
+request on `onsager-ai/onsager`. The PR number is available in the event
+payload at the start of your session. Your job is to align the linked spec
+issue's status labels with the fact that implementation has started.
+
+## Do exactly this
+
+1. **Read the PR body** via `mcp__github__pull_request_read`. Look for a
+   linking line at the top of the body using one of these keywords followed
+   by `#<issue-number>`:
+   - Closing keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`,
+     `resolve`, `resolves`, `resolved`
+   - Cross-link keywords: `part of`, `refs`, `related`
+2. **If no spec issue is linked** and the PR does *not* carry the `trivial`
+   label, post one top-level comment on the PR explaining the project's
+   spec-issue-driven dev process and asking the author to either:
+   - Edit the PR body to add `Closes #N` / `Part of #N`, pointing at a spec
+     issue, or
+   - Apply the `trivial` label if this is a typo/doc-only fix that doesn't
+     warrant a spec.
+   Use `mcp__github__add_issue_comment`. Reference the
+   `onsager-dev-process` and `issue-spec` skills. Stop here.
+3. **If a spec issue is linked**:
+   a. Read the issue via `mcp__github__issue_read`.
+   b. If its labels include `draft`, post a comment on the PR warning that
+      the linked spec is still in `draft` (has not passed human-AI
+      alignment). Do not change the label. Stop. Humans must move the spec
+      to `planned` first.
+   c. If its labels include `planned`, swap `planned` → `in-progress`
+      using `mcp__github__issue_write`. Post a brief issue comment:
+      "PR #<pr-number> opened; transitioning to in-progress."
+   d. If it already has `in-progress` (because a prior PR touched the same
+      spec), do nothing to the labels, but post one issue comment noting
+      "Additional PR #<pr-number> attached to this spec."
+4. **Never** close the spec issue yourself. GitHub auto-closes on merge for
+   `Closes` keywords; `Part of` PRs never close the parent.
+
+## Constraints
+
+- Use only `mcp__github__*` tools. Do not run shell commands, do not modify
+  repository files, do not open PRs.
+- Target repo is `onsager-ai/onsager` only.
+- Keep all comments under 3 sentences.
+- If the PR body references multiple issues (e.g. `Closes #10, Part of #11`),
+  treat each linked issue per the rules above.
+- Do not retry on transient errors; the routine will fire again if the PR
+  is edited.
+
+## Success
+
+The linked spec issue's labels reflect reality: `in-progress` once work has
+started, `planned`/`draft` preserved when author hasn't done the alignment
+work yet. No duplicate comments (check for prior routine comments before
+posting).

--- a/.claude/routines/pr-opened-progress.md
+++ b/.claude/routines/pr-opened-progress.md
@@ -1,8 +1,8 @@
 ---
 name: pr-opened-progress
-trigger: GitHub event — pull_request.opened
-filters:
-  - Is draft: false
+triggers:
+  - GitHub event — pull_request.opened (no draft filter — handle draft PRs too)
+  - GitHub event — pull_request.ready_for_review (catches draft → ready transitions)
 repository: onsager-ai/onsager
 ---
 
@@ -30,12 +30,13 @@ issue's status labels with the fact that implementation has started.
      warrant a spec.
    Use `mcp__github__add_issue_comment`. Reference the
    `onsager-dev-process` and `issue-spec` skills. Stop here.
-3. **If a spec issue is linked**:
+3. **For each linked spec issue**, handle it independently:
    a. Read the issue via `mcp__github__issue_read`.
    b. If its labels include `draft`, post a comment on the PR warning that
-      the linked spec is still in `draft` (has not passed human-AI
-      alignment). Do not change the label. Stop. Humans must move the spec
-      to `planned` first.
+      this linked spec is still in `draft` (has not passed human-AI
+      alignment). Do not change the label for this issue. Continue
+      evaluating the remaining linked issues — humans must move this one
+      to `planned` separately.
    c. If its labels include `planned`, swap `planned` → `in-progress`
       using `mcp__github__issue_write`. Post a brief issue comment:
       "PR #<pr-number> opened; transitioning to in-progress."

--- a/.claude/routines/spec-planned-review.md
+++ b/.claude/routines/spec-planned-review.md
@@ -1,0 +1,53 @@
+---
+name: spec-planned-review
+trigger: GitHub event — issues.labeled
+filters:
+  - Label equals: planned
+repository: onsager-ai/onsager
+---
+
+# Prompt
+
+You are an autonomous Claude Code session reacting to a spec issue being
+moved from `draft` to `planned` on `onsager-ai/onsager`. A human has
+signalled the spec is ready for implementation. Your job is to sanity-check
+it before an implementer picks it up, and flag any problems via an issue
+comment.
+
+## Do exactly this
+
+1. **Read the issue** via `mcp__github__issue_read`.
+2. **Check preconditions** — the human-AI alignment gate should be clean:
+   - `spec` label is present.
+   - `area:*` label is present (at least one).
+   - `priority:*` label is present.
+   - `draft` label has been removed (it was replaced by `planned`).
+   - The body contains `## Overview`, `## Design`, `## Plan`, `## Test`,
+     and `## Alignment` sections.
+   - The `## Alignment` section has no unresolved questions in
+     `> blockquote` form under `### Open questions`, unless the subsection
+     is removed entirely.
+   - Every Plan `- [ ]` item is unambiguous (starts with a verb, names a
+     concrete deliverable).
+3. **If any precondition fails**, post one issue comment listing all the
+   failures as a bulleted checklist. Do not change labels. Stop.
+4. **If all preconditions pass**, post one issue comment confirming the
+   spec is ready:
+   - Summary of Plan size (N items).
+   - Which sub-issues, if any, this spec links to.
+   - A one-line "Ready for implementation" confirmation.
+5. **Do not** start implementation from this routine. Humans or a separate
+   `spec-in-progress` routine pick up the implementation.
+
+## Constraints
+
+- Read-only on the repo contents — do not modify files, do not open PRs.
+- Only the `mcp__github__*` tools are needed.
+- Post at most one top-level issue comment per routine run. If a prior
+  run already posted a check comment and nothing has changed, skip.
+
+## Success
+
+Every spec moving to `planned` gets a visible quality check before a human
+or routine starts implementing. Specs with missing metadata or unresolved
+open questions get flagged so a human can fix them.

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-spec
-description: "Create lean-spec style GitHub issues as specs for human-AI aligned implementation. Use when asked to 'create a spec', 'write a spec issue', 'spec this feature', 'spec this', or when planning work that needs a specification before implementation. Follows the lean-spec SDD methodology: small focused specs (<2000 tokens), intent over implementation, context economy. Creates GitHub issues with Overview, Design, Plan, Test, Alignment, and Notes sections."
+description: Create lean-spec style GitHub issues as specs for human-AI aligned implementation on Onsager. Use when asked to "create a spec", "write a spec issue", "spec this feature", "spec this", or when planning work that needs a specification before implementation. Follows the lean-spec SDD methodology — small focused specs (<2000 tokens), intent over implementation, context economy. Creates GitHub issues with Overview, Design, Plan, Test, Alignment, and Notes sections. Paired with `onsager-dev-process` (the SDD loop), `onsager-pre-push` (pre-push checks), and `onsager-pr-lifecycle` (post-push).
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(git show:*), mcp__github__issue_write, mcp__github__issue_read, mcp__github__list_issues, mcp__github__search_issues, mcp__github__sub_issue_write, mcp__github__get_label
 ---
 
-# Issue Spec
+# issue-spec
 
-Create GitHub issues as lean-spec style specifications for human-AI aligned implementation. Follows the [lean-spec](https://github.com/codervisor/lean-spec) SDD methodology, using GitHub issues as the sole spec medium — no spec files.
+Create GitHub issues as lean-spec style specifications for human-AI aligned implementation on Onsager. GitHub issues are the sole spec medium — no spec files.
 
 ## Why GitHub Issues, Not Files
 
@@ -14,7 +14,7 @@ lean-spec uses Markdown files with YAML frontmatter for metadata. We replace tha
 
 - **Status** → Issue state (open/closed) + status labels (`draft`, `planned`, `in-progress`)
 - **Priority** → Labels (`priority:critical`, `priority:high`, `priority:medium`, `priority:low`)
-- **Tags** → Labels (`area:core`, `area:ui`, `feat`, `fix`, `refactor`, `perf`)
+- **Tags** → Labels (`area:<subsystem>`, `feat`, `fix`, `refactor`, `perf`)
 - **Dependencies** → Issue references (`depends on #42`) and sub-issues
 - **Parent/Child** → Sub-issues via `mcp__github__sub_issue_write`
 - **Transitions** → Issue timeline (automatic, auditable)
@@ -30,14 +30,27 @@ Three principles from lean-spec:
 2. **Intent Over Implementation** — Document the *why* and *what*, not the *how*. Implementation details belong in PRs, not spec issues. The spec captures human intent that isn't in the code.
 3. **Living Documents** — Specs evolve via issue comments and edits. Status labels track lifecycle. The issue thread becomes the decision record.
 
+## When to use this skill
+
+Use when:
+- A change touches multiple files or subsystems.
+- Multiple stakeholders need alignment before implementation.
+- The AI needs explicit boundaries for a non-trivial feature.
+- Work will span multiple PRs (parent + child specs).
+
+Skip when:
+- A typo or doc-only fix. Use the `trivial` label on the PR instead.
+- A one-line bug fix with an obvious reproduction. Just open a PR with `Fixes #existing`.
+- The feature already has a spec issue — extend that spec, don't create another.
+
 ## Setup
 
 | Parameter | Default | Example override |
 |-----------|---------|-----------------|
 | **Topic** | _(required)_ | `"session timeout"`, `"fix heartbeat race"` |
-| **Scope** | Inferred from codebase | `"only stiglab-core"` |
+| **Scope** | Inferred from codebase | `"only stiglab"` |
 | **Priority** | `medium` | `critical`, `high`, `low` |
-| **Labels** | Auto from type + area | `"spec, feat, area:core"` |
+| **Labels** | Auto from type + area | `"spec, feat, area:stiglab"` |
 | **Parent** | None | `#42` (umbrella issue) |
 
 If the user says "spec session timeout", start immediately. Do not ask clarifying questions unless the topic is genuinely ambiguous.
@@ -138,12 +151,12 @@ Create the issue using `mcp__github__issue_write`:
 
 **Title format**: `spec(<area>): <short description>`
 
-Examples: `spec(core): add session timeout`, `spec(ui): fix node status badge`
+Examples: `spec(stiglab): add session timeout`, `spec(dashboard): fix node status badge`, `spec(forge): enforce synodic fail policy`
 
 **Labels**: Apply via the issue creation:
 - `spec` — always, marks this as a spec issue
 - Type: `feat`, `fix`, `refactor`, `perf`
-- Area: `area:core`, `area:server`, `area:agent`, `area:ui`
+- Area (see taxonomy below)
 - Priority: `priority:critical`, `priority:high`, `priority:medium`, `priority:low`
 - Status: `draft` (initial state)
 
@@ -155,6 +168,22 @@ Examples: `spec(core): add session timeout`, `spec(ui): fix node status badge`
 - Any open questions that need human decisions
 - Sub-issue links if the spec was split
 
+## Area label taxonomy (Onsager monorepo)
+
+Pick one or more, aligned with `crates/` and `apps/`:
+
+- `area:spine` — `onsager-spine` (event bus client library)
+- `area:forge` — production line / artifact lifecycle
+- `area:ising` — continuous improvement engine
+- `area:stiglab` — agent session orchestration
+- `area:synodic` — agent governance
+- `area:dashboard` — React UI under `apps/dashboard`
+- `area:onsager` — the `onsager` dispatcher CLI
+- `area:infra` — CI, migrations, docker-compose, justfile, workflows
+- `area:docs` — README, CLAUDE.md, specs
+
+Respect the architectural invariant: a spec should not cross subsystem boundaries except via the spine event bus. If a spec requires changes in two subsystems, split it — one child spec per subsystem, parent tracks the end-to-end slice.
+
 ## Status Lifecycle via Labels
 
 GitHub issue state (open/closed) combined with status labels:
@@ -165,10 +194,10 @@ open + draft  →  open + planned  →  open + in-progress  →  closed (complet
 
 - **draft**: Spec created, open questions may remain. AI wrote it, human hasn't reviewed.
 - **planned**: Human reviewed, decisions made, ready for implementation. Remove `draft`, add `planned`.
-- **in-progress**: Someone is actively working. Remove `planned`, add `in-progress`.
-- **closed**: All plan items done, tests passing. Remove `in-progress`, close issue.
+- **in-progress**: Someone/something is actively working (PR opened). Remove `planned`, add `in-progress`. `onsager-pr-lifecycle` automates this transition on PR open.
+- **closed**: All plan items done, tests passing. PR merge with `Closes #N` closes it automatically.
 
-**Key rule**: `draft → planned` is the human-AI alignment gate. A spec moves to `planned` only after a human reviews it and resolves open questions.
+**Key rule**: `draft → planned` is the human-AI alignment gate. A spec moves to `planned` only after a human reviews it and resolves open questions. The AI does not flip this label unprompted.
 
 ## Spec Relationships via Sub-Issues
 
@@ -184,22 +213,32 @@ Use GitHub sub-issues for parent/child decomposition:
 
 **Example decomposition:**
 ```
-spec(server): session lifecycle improvements       ← parent issue
-├── spec(core): session timeout mechanism          ← sub-issue
-├── spec(core): session retry on failure           ← sub-issue
-└── spec(ui): timeout warning indicator            ← sub-issue
+spec(stiglab): session lifecycle improvements       ← parent issue
+├── spec(stiglab): session timeout mechanism        ← sub-issue
+├── spec(stiglab): session retry on failure         ← sub-issue
+└── spec(dashboard): timeout warning indicator      ← sub-issue
 ```
 
 ## Guidance
 
 - **Small is better.** A 500-token spec that captures intent clearly beats a 3000-token spec that tries to cover everything. Split into sub-issues early.
 - **Discover first.** Always search existing issues before creating. Duplicate specs create confusion.
-- **Status labels reflect reality.** Don't label `planned` if decisions are still open. Don't label `in-progress` until someone is actually working.
+- **Status labels reflect reality.** Don't label `planned` if decisions are still open. Don't label `in-progress` until a PR is open.
 - **One concern per issue.** If a spec covers two independent changes, split into sub-issues with a shared parent.
-- **Reference code, not concepts.** Point to actual types, functions, files — not abstract ideas. Use `crates/stiglab-core/src/session.rs` not "the session module."
+- **Reference code, not concepts.** Point to actual types, functions, files — not abstract ideas. Use `crates/stiglab/src/session.rs` not "the session module."
 - **Open questions are alignment points.** These are where AI must stop and ask a human. Make them explicit, specific, and include the impact of each decision.
 - **Comments are the decision record.** When a human resolves an open question, they comment on the issue. The thread becomes the audit trail.
 - **Use specs for alignment, not for everything.** Regular bugs and small tasks don't need specs. Use specs when: multiple stakeholders need alignment, intent needs persistence, or the AI needs clear boundaries.
+
+## Handoff to implementation
+
+Once a spec moves to `planned`:
+
+1. Create a branch referencing the issue: `claude/spec-<N>-<slug>` or similar.
+2. Follow the SDD loop in `onsager-dev-process`.
+3. Pre-push via `onsager-pre-push` (includes a spec-link check).
+4. PR body must include `Closes #N` (slice complete) or `Part of #N` (scaffolding).
+5. `onsager-pr-lifecycle` flips the issue to `in-progress` on PR open and handles merge.
 
 ## References
 

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -194,7 +194,7 @@ open + draft  →  open + planned  →  open + in-progress  →  closed (complet
 
 - **draft**: Spec created, open questions may remain. AI wrote it, human hasn't reviewed.
 - **planned**: Human reviewed, decisions made, ready for implementation. Remove `draft`, add `planned`.
-- **in-progress**: Someone/something is actively working (PR opened). Remove `planned`, add `in-progress`. `onsager-pr-lifecycle` automates this transition on PR open.
+- **in-progress**: Someone/something is actively working (PR opened). Remove `planned`, add `in-progress`. The `pr-opened-progress` Claude Routine automates this transition on PR open when configured; otherwise flip manually per `onsager-pr-lifecycle`.
 - **closed**: All plan items done, tests passing. PR merge with `Closes #N` closes it automatically.
 
 **Key rule**: `draft → planned` is the human-AI alignment gate. A spec moves to `planned` only after a human reviews it and resolves open questions. The AI does not flip this label unprompted.
@@ -225,7 +225,7 @@ spec(stiglab): session lifecycle improvements       ← parent issue
 - **Discover first.** Always search existing issues before creating. Duplicate specs create confusion.
 - **Status labels reflect reality.** Don't label `planned` if decisions are still open. Don't label `in-progress` until a PR is open.
 - **One concern per issue.** If a spec covers two independent changes, split into sub-issues with a shared parent.
-- **Reference code, not concepts.** Point to actual types, functions, files — not abstract ideas. Use `crates/stiglab/src/session.rs` not "the session module."
+- **Reference code, not concepts.** Point to actual types, functions, files — not abstract ideas. Use `crates/stiglab/src/core/session.rs` not "the session module."
 - **Open questions are alignment points.** These are where AI must stop and ask a human. Make them explicit, specific, and include the impact of each decision.
 - **Comments are the decision record.** When a human resolves an open question, they comment on the issue. The thread becomes the audit trail.
 - **Use specs for alignment, not for everything.** Regular bugs and small tasks don't need specs. Use specs when: multiple stakeholders need alignment, intent needs persistence, or the AI needs clear boundaries.
@@ -238,7 +238,7 @@ Once a spec moves to `planned`:
 2. Follow the SDD loop in `onsager-dev-process`.
 3. Pre-push via `onsager-pre-push` (includes a spec-link check).
 4. PR body must include `Closes #N` (slice complete) or `Part of #N` (scaffolding).
-5. `onsager-pr-lifecycle` flips the issue to `in-progress` on PR open and handles merge.
+5. The `pr-opened-progress` routine flips the issue to `in-progress` on PR open (or `onsager-pr-lifecycle` covers the manual fallback); the `pr-merged-progress` routine handles merge.
 
 ## References
 

--- a/.claude/skills/issue-spec/references/spec-format.md
+++ b/.claude/skills/issue-spec/references/spec-format.md
@@ -1,6 +1,6 @@
 # Spec Format Reference
 
-Section-by-section guide for writing lean-spec style GitHub issue specs. Based on the [lean-spec SDD methodology](https://github.com/codervisor/lean-spec), adapted to use GitHub issues as the sole spec medium.
+Section-by-section guide for writing lean-spec style GitHub issue specs on Onsager. Based on the [lean-spec SDD methodology](https://github.com/codervisor/lean-spec), adapted to use GitHub issues as the sole spec medium.
 
 ## Metadata via GitHub Issue Features
 
@@ -10,7 +10,7 @@ No YAML frontmatter — all metadata lives in native GitHub features:
 |----------------|-------------------|---------|
 | `status` | Labels | `draft`, `planned`, `in-progress` |
 | `priority` | Labels | `priority:high` |
-| `tags` | Labels | `area:core`, `feat` |
+| `tags` | Labels | `area:stiglab`, `feat` |
 | `depends_on` | Issue body reference | `depends on #42` |
 | `parent/child` | Sub-issues | Created via `mcp__github__sub_issue_write` |
 | `assignee` | Issue assignee | `@username` |
@@ -30,11 +30,18 @@ Apply labels when creating the issue:
 - `refactor` — restructuring without behavior change
 - `perf` — performance improvement
 
-**Area** (pick one or more):
-- `area:core` — `stiglab-core` crate
-- `area:server` — `stiglab-server` crate
-- `area:agent` — `stiglab-agent` crate
-- `area:ui` — `stiglab-ui` package
+**Area** (pick one or more, aligned with `crates/` and `apps/`):
+- `area:spine` — `onsager-spine` (event bus client library)
+- `area:forge` — production line / artifact lifecycle
+- `area:ising` — continuous improvement engine
+- `area:stiglab` — agent session orchestration
+- `area:synodic` — agent governance
+- `area:dashboard` — React UI under `apps/dashboard`
+- `area:onsager` — the `onsager` dispatcher CLI
+- `area:infra` — CI, migrations, docker-compose, justfile, workflows
+- `area:docs` — README, CLAUDE.md, specs
+
+Respect the architectural invariant: a spec that crosses subsystem boundaries (other than via the spine event bus) must be split into per-subsystem child specs with a shared parent.
 
 **Priority** (pick one):
 - `priority:critical` — blocks other work, needs immediate attention
@@ -45,7 +52,7 @@ Apply labels when creating the issue:
 **Status** (pick one, update as lifecycle progresses):
 - `draft` — initial state, AI-generated, human review pending
 - `planned` — human reviewed, decisions made, ready for implementation
-- `in-progress` — actively being worked on
+- `in-progress` — actively being worked on (PR open)
 
 ### Status Lifecycle
 
@@ -57,6 +64,10 @@ The `draft → planned` transition is the **human-AI alignment gate**. Only a hu
 - Open questions are resolved
 - Design approach is approved
 - Scope and priority are accepted
+
+`planned → in-progress` happens automatically when a PR referencing the issue is opened (see the `pr-opened-progress` Claude Routine in `.claude/routines/`). If you're working without routines, flip the label manually when you open the PR.
+
+`in-progress → closed` happens automatically on PR merge with a `Closes #N` keyword. `Part of #N` PRs don't close the parent; the routine updates the parent's Plan checkboxes instead.
 
 ## Sections
 
@@ -111,6 +122,7 @@ Per-session overrides are out of scope for now.
 - Include what's explicitly **out of scope** to prevent scope creep.
 - If design is complex, create child sub-issues for subsections.
 - Reference existing architecture when relevant.
+- Cross-subsystem designs must route through the spine event bus, not direct imports.
 
 ### Plan
 
@@ -121,7 +133,7 @@ Per-session overrides are out of scope for now.
 
 - [ ] Add `STIGLAB_SESSION_TIMEOUT` env var to server config (default: 30m)
 - [ ] Implement per-session inactivity timer in `SessionManager`
-- [ ] Add `SessionTimeoutWarning` event type to `stiglab-core`
+- [ ] Add `SessionTimeoutWarning` event type to `stiglab`
 - [ ] Emit warning event 5 minutes before timeout
 - [ ] Transition `WaitingInput → Failed` on timeout expiry
 - [ ] Preserve session output on timeout (no data deletion)
@@ -133,7 +145,7 @@ Per-session overrides are out of scope for now.
 - Items should be small enough to verify in isolation.
 - Order reflects implementation sequence.
 - If a plan has more than ~10 items, the spec is too big — split into sub-issues.
-- Checkboxes serve as progress tracking on the issue itself.
+- Checkboxes serve as progress tracking on the issue itself; the `pr-merged-progress` routine ticks them as `Part of #N` PRs merge.
 
 ### Test
 
@@ -228,10 +240,10 @@ Smaller specs produce better results — for both AI implementation and human re
 
 **Example:**
 ```
-#50 spec(server): session lifecycle improvements       ← parent
-  ├── #51 spec(core): session timeout mechanism        ← sub-issue
-  ├── #52 spec(core): session retry on failure         ← sub-issue
-  └── #53 spec(ui): timeout warning indicator          ← sub-issue
+#50 spec(stiglab): session lifecycle improvements      ← parent
+  ├── #51 spec(stiglab): session timeout mechanism     ← sub-issue
+  ├── #52 spec(stiglab): session retry on failure      ← sub-issue
+  └── #53 spec(dashboard): timeout warning indicator   ← sub-issue
 ```
 
 ## Title Convention
@@ -241,7 +253,8 @@ spec(<area>): <short description in imperative mood>
 ```
 
 Examples:
-- `spec(core): add session timeout for idle sessions`
-- `spec(server): handle WebSocket reconnection gracefully`
-- `spec(ui): show real-time node heartbeat status`
-- `spec(agent): retry failed session dispatch`
+- `spec(stiglab): add session timeout for idle sessions`
+- `spec(stiglab): handle WebSocket reconnection gracefully`
+- `spec(dashboard): show real-time node heartbeat status`
+- `spec(forge): retry failed synodic verdict dispatch`
+- `spec(spine): add backpressure on events_ext ingestion`

--- a/.claude/skills/issue-spec/templates/issue-spec-template.md
+++ b/.claude/skills/issue-spec/templates/issue-spec-template.md
@@ -12,7 +12,9 @@
 
 <!-- Technical approach at intent level.
      Data flow, state changes, API surface — not line-by-line code.
-     Include what's explicitly OUT OF SCOPE. -->
+     Include what's explicitly OUT OF SCOPE.
+     Respect the architectural invariant: subsystems communicate via the
+     spine event bus, not direct imports. -->
 
 ## Plan
 

--- a/.claude/skills/onsager-dev-process/SKILL.md
+++ b/.claude/skills/onsager-dev-process/SKILL.md
@@ -7,9 +7,10 @@ description: The end-to-end spec-issue-driven dev loop for Onsager — spec → 
 
 The spec-issue-driven development (SDD) loop on Onsager. Every non-trivial
 change starts as a GitHub spec issue, proceeds through a PR that references
-it, and closes when the PR merges. Status labels on the issue track progress
-automatically via Claude Routines; humans only touch the `draft → planned`
-alignment gate.
+it, and closes when the PR merges. When Claude Routines are configured,
+status labels on the issue track progress automatically; otherwise follow
+the manual fallback documented in `onsager-pr-lifecycle`. Humans only touch
+the `draft → planned` alignment gate.
 
 ## The loop
 

--- a/.claude/skills/onsager-dev-process/SKILL.md
+++ b/.claude/skills/onsager-dev-process/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: onsager-dev-process
+description: The end-to-end spec-issue-driven dev loop for Onsager — spec → branch → implement → PR → merge → closure. Use when asked "how do I start work", "what's the process", "SDD loop", "spec-driven development", "how do we ship a change", "from scratch what do I do", or when you're about to begin a non-trivial change and haven't yet decided how to split spec/PR. Delegates to `issue-spec` (spec writing), `onsager-pre-push` (pre-push checks), `onsager-pr-lifecycle` (post-push), and the GitHub-triggered Claude Routines under `.claude/routines/`.
+---
+
+# onsager-dev-process
+
+The spec-issue-driven development (SDD) loop on Onsager. Every non-trivial
+change starts as a GitHub spec issue, proceeds through a PR that references
+it, and closes when the PR merges. Status labels on the issue track progress
+automatically via Claude Routines; humans only touch the `draft → planned`
+alignment gate.
+
+## The loop
+
+```
+     ┌─────────────────────────────────────────────────────────────────┐
+     │                                                                 │
+     │   idea/request                                                  │
+     │        ↓                                                        │
+     │   spec(<area>): ...    ← issue-spec skill                       │
+     │        │                                                        │
+     │        │ label: draft                                           │
+     │        ↓                                                        │
+     │   human review   ← alignment gate (human sets label=planned)    │
+     │        │                                                        │
+     │        │ label: planned                                         │
+     │        ↓                                                        │
+     │   spec-planned-review routine  ← sanity check                   │
+     │        │                                                        │
+     │        ↓                                                        │
+     │   branch + implement                                            │
+     │        │                                                        │
+     │        ↓                                                        │
+     │   onsager-pre-push skill  ← merge preview, strict warnings      │
+     │        │                                                        │
+     │        ↓                                                        │
+     │   git push → open PR (body: "Closes #N" or "Part of #N")        │
+     │        │                                                        │
+     │        │ pr-opened-progress routine → label: in-progress        │
+     │        ↓                                                        │
+     │   onsager-pr-lifecycle skill  ← CI triage, review, iterate      │
+     │        │                                                        │
+     │        ↓                                                        │
+     │   merge                                                         │
+     │        │                                                        │
+     │        │ pr-merged-progress routine → tick Plan items / close   │
+     │        ↓                                                        │
+     │   spec closed (Closes) OR Plan items ticked (Part of)           │
+     │                                                                 │
+     └─────────────────────────────────────────────────────────────────┘
+```
+
+## Stages
+
+### 1. Write the spec
+
+Trigger `issue-spec` (or say "spec this"). It creates a GitHub issue with:
+
+- `## Overview`, `## Design`, `## Plan`, `## Test`, `## Alignment`, `## Notes`
+- Labels: `spec`, one `area:*`, one type (`feat`/`fix`/`refactor`/`perf`),
+  one `priority:*`, status `draft`.
+- Open questions under `### Open questions` in the Alignment section.
+
+Hard rule: no spec → no PR, unless the PR is labeled `trivial` (typos,
+doc-only fixes, one-line obvious bug repair).
+
+Body size: <~2000 tokens. Larger features split into parent + sub-issues
+via `mcp__github__sub_issue_write`. The SDD loop runs independently on each
+sub-issue; the parent tracks overall progress.
+
+### 2. The alignment gate (`draft → planned`)
+
+Only a human moves the `draft` label to `planned`. This signals:
+
+- Open questions resolved (answered via comments; Alignment section
+  updated).
+- Design approach approved.
+- Scope and priority accepted.
+
+If the `spec-planned-review` routine is configured, it posts a sanity-check
+comment when the label flips. If the routine flags issues, fix them before
+starting implementation.
+
+Never bypass this gate automatically. An AI may draft the spec and propose
+the flip; it may not execute the flip.
+
+### 3. Branch and implement
+
+Branch naming convention:
+
+- Human-owned branches: any name.
+- Claude-owned branches: `claude/spec-<N>-<slug>` or `claude/<descriptor>`.
+  The harness enforces the `claude/` prefix on cloud routines.
+
+Implement the spec's Plan items in order. Keep commits small and focused.
+Commit messages should be imperative and under 72 chars.
+
+Respect the architectural invariant: subsystems (`forge`, `stiglab`,
+`synodic`, `ising`) do not import each other. If your spec forces a
+cross-subsystem dependency, split it into parent + sub-issues before
+continuing.
+
+### 4. Pre-push
+
+Trigger `onsager-pre-push` (or say "ready to push"). It runs:
+
+1. Sync `origin/main` into the branch (CI tests a merge preview, not the
+   branch alone).
+2. `RUSTFLAGS="-D warnings" cargo build --workspace`.
+3. `RUSTFLAGS="-D warnings" cargo test --workspace --lib`.
+4. `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`.
+5. `cargo fmt --all --check`.
+6. Verify a spec issue is linked (this skill is what enforces the
+   no-PR-without-spec rule locally).
+
+Fix any blocker; don't paper over with `#[allow(dead_code)]` or `--no-verify`.
+
+### 5. Open the PR
+
+PR body must begin with a linking line:
+
+| PR delivers                                       | Use            |
+| ------------------------------------------------- | -------------- |
+| The full spec / acceptance test / vertical slice  | `Closes #N`    |
+| A bug fix for a specific defect                   | `Fixes #N`     |
+| Scaffolding / one phase of a multi-phase spec     | `Part of #N`   |
+| Related work that shouldn't close the spec        | `Refs #N`      |
+
+Under `## Delivers`, list the Plan items this PR ticks (exact text from the
+spec's Plan). The `pr-merged-progress` routine uses this to tick checkboxes.
+
+If the PR is genuinely trivial (typo, doc-only, one-line obvious fix),
+apply the `trivial` label and skip the spec-linking requirement. Use
+sparingly — if reviewers flag it as needing context, escalate to a spec.
+
+### 6. During review
+
+Trigger `onsager-pr-lifecycle` (or say "triage PR" / "CI is failing" /
+respond to a webhook). It covers:
+
+- CI triage: what `cargo build` failed for (merge preview? migration
+  collision? enum variant removed on main?).
+- Review-comment discipline: fix the code, don't reply per comment.
+- Copilot vs real defects.
+- Webhook subscription to stream CI + review events.
+
+The `pr-opened-progress` routine has already flipped the spec to
+`in-progress`. No human action needed on labels during review.
+
+### 7. Merge
+
+- `Closes #N` PRs auto-close the spec on merge.
+- `Part of #N` / `Refs #N` PRs leave the spec open; the
+  `pr-merged-progress` routine ticks the delivered Plan items and, if all
+  sub-issues of a parent are closed, pings the parent.
+- The `in-progress` label disappears when the issue closes; for parents,
+  a human closes the parent once the spec is end-to-end verified.
+
+### 8. Closed-unmerged path
+
+If you close a PR without merging (e.g. abandoned approach), the
+`pr-closed-unmerged` routine checks whether any other PR still references
+the spec. If none, it flips the spec back to `planned` so the next
+implementer can pick it up.
+
+## The `trivial` escape hatch
+
+Not every change needs a spec. The `trivial` label on a PR explicitly opts
+out. Use for:
+
+- Typos in comments, docs, commit messages.
+- One-line obvious bug fixes where the repro is in the diff itself.
+- Formatting-only changes (`cargo fmt`, `prettier`).
+- Dependency version bumps (unless they break APIs).
+
+Do NOT use for:
+
+- Anything touching multiple files.
+- Anything in `crates/` that changes behavior.
+- Anything that could plausibly merit a follow-up.
+
+When in doubt, write the spec. A 200-token spec is cheap; a merged change
+with no spec is invisible to the next maintainer.
+
+## Issue progress is the source of truth
+
+The labels on a spec issue must reflect reality at all times:
+
+| Label | Meaning |
+|-------|---------|
+| `draft` | AI-drafted or human-drafted, human review pending. |
+| `planned` | Ready for implementation. Preconditions met. |
+| `in-progress` | At least one PR is open against this spec. |
+| (closed) | All Plan items delivered, spec closed. |
+
+Routines maintain these on PR events. If the routines are disabled or
+fail, the `onsager-pr-lifecycle` skill documents the manual transitions.
+
+## Anti-patterns (don't)
+
+- **PR without a spec and no `trivial` label.** The `pr-opened-progress`
+  routine will comment; the PR should not merge until the author either
+  adds a spec link or the `trivial` label.
+- **Moving `draft → planned` as the AI.** Human-only transition.
+- **Closing a spec manually when you meant `Closes #N`.** Let GitHub do it
+  via the PR merge so the timeline has the auditable link.
+- **Editing Plan checkboxes to mark items done before the PR merges.** The
+  routine ticks them on merge. Editing them early breaks the audit trail.
+- **Cross-subsystem PRs.** If a PR touches two subsystems (other than
+  spine), it should have been split at the spec stage. Stop, split the
+  spec, split the PR.
+- **Skipping `onsager-pre-push`.** CI failures cost more time than the
+  checklist does.
+
+## Delegation map
+
+| Stage | Skill / routine |
+|-------|-----------------|
+| Write the spec | [`issue-spec`](../issue-spec/SKILL.md) |
+| Sanity-check `planned` specs | [`spec-planned-review`](../../routines/spec-planned-review.md) |
+| Pre-push checks | [`onsager-pre-push`](../onsager-pre-push/SKILL.md) |
+| On PR open → flip to `in-progress` | [`pr-opened-progress`](../../routines/pr-opened-progress.md) |
+| CI triage, review, iterate | [`onsager-pr-lifecycle`](../onsager-pr-lifecycle/SKILL.md) |
+| On PR merge → tick Plan items | [`pr-merged-progress`](../../routines/pr-merged-progress.md) |
+| On PR close (unmerged) → revert label | [`pr-closed-unmerged`](../../routines/pr-closed-unmerged.md) |
+
+Routines live at [claude.ai/code/routines](https://claude.ai/code/routines);
+their version-controlled prompts are in `.claude/routines/`. See that
+directory's `README.md` for setup.

--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: onsager-pr-lifecycle
-description: Manage an Onsager PR after it's been pushed — issue linking, CI triage, review-comment discipline, webhook subscription. Triggers include "CI is failing", "check is red", "link this issue", "Closes vs Part of", "respond to review", "subscribe to PR", "triage PR", "the PR is ready" or when a github-webhook-activity event arrives.
+description: Manage an Onsager PR after it's been pushed — spec-issue linking, CI triage, review-comment discipline, webhook subscription, and label alignment. Triggers include "CI is failing", "check is red", "link this issue", "Closes vs Part of", "respond to review", "subscribe to PR", "triage PR", "the PR is ready" or when a github-webhook-activity event arrives. Paired with `onsager-dev-process` (overall loop), `issue-spec` (spec creation), and the GitHub-triggered Claude Routines under `.claude/routines/`.
 ---
 
 # onsager-pr-lifecycle
 
-Everything that happens after `git push` on an Onsager PR. Covers CI triage,
-issue↔PR linking conventions, review-comment response discipline, and webhook
-subscriptions.
+Everything that happens after `git push` on an Onsager PR. Covers spec-issue
+linking (and its enforcement), CI triage, review-comment response discipline,
+webhook subscriptions, and the manual fallback for label alignment when
+routines aren't configured.
 
 ## Tool discipline
 
@@ -16,7 +17,20 @@ subscriptions.
 - Don't open PRs unless the user explicitly asks. Creating one is a
   one-way door in this project's workflow.
 
-## Issue linking
+## Spec-issue linking (mandatory)
+
+Every PR must either:
+
+1. Link to a spec issue in its body via `Closes #N` / `Fixes #N` /
+   `Resolves #N` (slice complete) or `Part of #N` / `Refs #N` (scaffolding),
+   **OR**
+2. Carry the `trivial` label (typo, doc-only, one-line obvious fix).
+
+If neither, the PR is out of process. Ask the author (via PR comment) to
+either add a spec link — creating one via `issue-spec` if none exists — or
+apply the `trivial` label.
+
+### Which keyword to use
 
 GitHub closes issues on merge when PR body contains one of:
 `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`,
@@ -26,16 +40,66 @@ Pick the keyword based on **what this PR actually delivers**:
 
 | PR delivers                                                  | Use         |
 | ------------------------------------------------------------ | ----------- |
-| The acceptance test / vertical slice the issue asks for     | `Closes #N` |
+| The acceptance test / vertical slice the spec asks for       | `Closes #N` |
 | A bug fix for a specific defect                              | `Fixes #N`  |
-| Scaffolding / one phase of a multi-phase issue               | `Part of #N` |
-| Related work that shouldn't close the issue                  | `Refs #N`   |
+| Scaffolding / one phase of a multi-phase spec                | `Part of #N` |
+| Related work that shouldn't close the spec                   | `Refs #N`   |
 
 `Part of` / `Refs` are **not** auto-close keywords — they just cross-link in
-the UI. Use them for scaffolding so the issue stays open for the real slice.
+the UI. Use them for scaffolding so the spec stays open for the real slice.
 
 Edit the PR body via `mcp__github__update_pull_request` (don't open a new PR
 just to fix the link). Put the linking line at the top of the body.
+
+### The `## Delivers` subsection
+
+For `Part of #N` PRs (and ideally all PRs), include a `## Delivers`
+subsection in the body listing the exact Plan items this PR ticks, copied
+verbatim from the spec's `## Plan`. The `pr-merged-progress` routine uses
+this on merge to tick the parent spec's checkboxes. Without it, a human
+has to tick them manually.
+
+Example PR body:
+
+```markdown
+Part of #42
+
+## Delivers
+- [x] Add `STIGLAB_SESSION_TIMEOUT` env var to server config (default: 30m)
+- [x] Implement per-session inactivity timer in `SessionManager`
+
+## Summary
+First slice of the session-timeout work. Timer plumbing only; event
+emission lands in the next PR.
+```
+
+## Issue progress labels
+
+The linked spec issue's status label should always reflect reality:
+
+| Spec label | What it means | Who flips it |
+|------------|---------------|--------------|
+| `draft` | AI/human-drafted, not yet reviewed | Human (via `planned` move) |
+| `planned` | Ready for implementation | Human (alignment gate) |
+| `in-progress` | At least one open PR | `pr-opened-progress` routine |
+| closed | Delivered, tests passing | GitHub (via `Closes` keyword on merge) |
+
+**If Claude Routines are configured** (see `.claude/routines/`), these
+transitions happen automatically on PR events:
+
+- PR open → `planned` becomes `in-progress`.
+- PR closed unmerged with no other open PR → reverts to `planned`.
+- PR merged with `Closes #N` → issue auto-closes (GitHub).
+- PR merged with `Part of #N` → Plan checkboxes tick on the parent spec.
+
+**If routines are NOT configured**, you are responsible for the manual
+transitions. On PR open, flip the linked spec's label via
+`mcp__github__issue_write`. On merge, either GitHub auto-closes (for
+`Closes`) or tick checkboxes on the parent spec manually.
+
+Never bypass the `draft → planned` gate from within this skill — that's a
+human decision. If the linked spec is still `draft`, comment on the PR
+asking the author to drive the spec through review first.
 
 ## CI triage
 
@@ -85,6 +149,11 @@ never top-level comments unless summarizing multiple responses at once.
 locally before "fixing" a non-bug — but prefer the clearer form (let binding)
 even when the lint was wrong.
 
+If a review comment raises a design concern that the spec didn't address,
+pause and update the linked spec issue (add an open question under
+`## Alignment`, comment on the spec, let a human decide). Don't silently
+expand scope in the PR.
+
 ## Webhook subscription
 
 Events from CI and reviewers arrive wrapped in `<github-webhook-activity>`
@@ -97,8 +166,21 @@ tags. The harness forwards them as user messages.
 - Events are already filtered to CI failures + reviews. Treat each as
   actionable; skip only if it's a duplicate of one you just addressed.
 
+Routine-triggered events (label flips, Plan checkbox ticks) do not flow
+through webhook subscription — they're handled in the routine's own
+session, visible at claude.ai/code under the routine's run list.
+
 ## Reporting back to the user
 
 After handling a webhook event, end with one or two sentences: what the
 failure was, what you changed, whether CI is re-running. Don't dump the full
 commit message in chat — the user can see it on the PR.
+
+## Relationship to other skills
+
+| Related surface | Role |
+|-----------------|------|
+| [`onsager-dev-process`](../onsager-dev-process/SKILL.md) | Top-level SDD loop; points here for the post-push stage. |
+| [`issue-spec`](../issue-spec/SKILL.md) | Creates the spec issue this PR links to. |
+| [`onsager-pre-push`](../onsager-pre-push/SKILL.md) | Runs before `git push`; enforces the spec-link check locally. |
+| [`.claude/routines/`](../../routines/README.md) | Automates the label transitions this skill describes manually. |

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -102,8 +102,10 @@ is explicitly trivial). This is the local counterpart to the
    whose title or body matches the branch's purpose:
 
    ```
-   mcp__github__list_issues  labels=[spec, planned]   state=open
+   mcp__github__list_issues  labels=[spec]   state=open
    ```
+
+   Then filter in memory for `planned` or `in-progress` status labels.
 
    Or read your commit messages (`git log origin/main..HEAD`) for a
    `#N` reference. The SDD loop assumes you already know which spec this

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: onsager-pre-push
-description: Run before pushing code to the Onsager repo to catch what CI would fail on. Reproduces CI's merge preview + strict-warnings environment and renumbers colliding migrations. Triggers include "before push", "ready to push", "pre-push check", "push readiness", "prep for PR", or proactively before any git push on an Onsager branch.
+description: Run before pushing code to the Onsager repo to catch what CI would fail on, and confirm the branch has a linked spec issue in a valid state. Reproduces CI's merge preview + strict-warnings environment and renumbers colliding migrations. Triggers include "before push", "ready to push", "pre-push check", "push readiness", "prep for PR", or proactively before any git push on an Onsager branch.
 ---
 
 # onsager-pre-push
 
-Mechanical checklist that catches the CI failures this repo has actually had.
-Runs in a few minutes end-to-end. **Never skip steps — they each exist because
-something failed once.**
+Mechanical checklist that catches the CI failures this repo has actually had,
+plus a spec-link check that enforces the SDD loop locally. Runs in a few
+minutes end-to-end. **Never skip steps — they each exist because something
+failed once.**
 
 ## Why
 
@@ -15,6 +16,10 @@ something failed once.**
 `origin/main` + the PR branch**, not the branch alone. The workflow also sets
 `RUSTFLAGS: -D warnings`. Local `cargo build` without those two things is
 insufficient. Skipping this checklist is how we got three red CI runs in a row.
+
+The spec-link step enforces "no PR without a spec or a `trivial` label" at
+push time, before the PR is open — so the author sees the problem locally
+instead of hearing about it from `pr-opened-progress` after the fact.
 
 ## Steps
 
@@ -87,7 +92,42 @@ cargo fmt --all -- --check
 First line applies, second verifies. If the second fails after the first,
 something is interfering with rustfmt (rare — usually a tool config drift).
 
-### 6. Push
+### 6. Spec-issue link check
+
+Before pushing, confirm this branch corresponds to a known spec issue (or
+is explicitly trivial). This is the local counterpart to the
+`pr-opened-progress` routine — catching the miss here avoids a round-trip.
+
+1. **Find the spec issue.** Search open issues with the `spec` label
+   whose title or body matches the branch's purpose:
+
+   ```
+   mcp__github__list_issues  labels=[spec, planned]   state=open
+   ```
+
+   Or read your commit messages (`git log origin/main..HEAD`) for a
+   `#N` reference. The SDD loop assumes you already know which spec this
+   work closes or is part of — if you don't, stop and create one via
+   `issue-spec` (or triage whether this is truly `trivial`).
+
+2. **Confirm the spec's status is `planned` or `in-progress`.** If still
+   `draft`, stop — the human-AI alignment gate has not been passed.
+   Resolve open questions on the spec issue first.
+
+3. **Draft the PR body linking line** so you can paste it into the PR:
+
+   - `Closes #N` if this PR delivers the full spec.
+   - `Part of #N` if it's one slice of a multi-PR spec.
+   - `Fixes #N` for a defect referenced by a bug spec.
+
+   Also draft a `## Delivers` subsection listing the exact Plan items you
+   tick with this PR.
+
+4. **If this is genuinely trivial** (typo, doc-only, one-line obvious
+   fix), skip steps 6.1–6.3 and plan to apply the `trivial` label to the
+   PR immediately after `mcp__github__create_pull_request`. Use sparingly.
+
+### 7. Push
 
 ```bash
 git push -u origin <branch>
@@ -96,13 +136,19 @@ git push -u origin <branch>
 Retry up to 4 times with exponential backoff on transient network errors.
 **Never** use `--force` on main or long-lived branches without explicit ask.
 
+After push, the `pr-opened-progress` routine (if configured) will flip the
+linked spec to `in-progress` automatically. If routines aren't configured,
+do it manually via `onsager-pr-lifecycle`.
+
 ## Fast path
 
 If nothing under `crates/` or migrations changed (e.g. docs only), steps 2–4
-are optional. Step 1 is not — main still may have moved.
+are optional. Step 1 is not — main still may have moved. Step 6 is not —
+the spec-link requirement applies to all non-trivial PRs.
 
 ## What this skill does NOT cover
 
-- Opening or managing the PR — see `onsager-pr-lifecycle`.
-- Writing the code — that's the actual task.
+- Writing the spec issue — see [`issue-spec`](../issue-spec/SKILL.md).
+- Opening or managing the PR — see [`onsager-pr-lifecycle`](../onsager-pr-lifecycle/SKILL.md).
+- The end-to-end dev loop — see [`onsager-dev-process`](../onsager-dev-process/SKILL.md).
 - Smoke-testing Railway deploys — see the `railway` skill.


### PR DESCRIPTION
This PR adds comprehensive documentation for Onsager's spec-issue-driven development (SDD) workflow and the Claude Routines that automate issue-progress tracking.

## Summary

Establishes the canonical reference for how work flows through Onsager: from spec issue creation, through the human-AI alignment gate, into implementation, pre-push checks, PR lifecycle, and merge. Introduces four GitHub-event-triggered Claude Routines that keep spec-issue labels in sync with PR state, eliminating manual label flips.

## Key changes

**New documentation:**
- `.claude/skills/onsager-dev-process/SKILL.md` — The end-to-end SDD loop, with a visual flowchart, stage-by-stage breakdown, anti-patterns, and delegation map to related skills and routines.
- `.claude/routines/README.md` — Setup guide for Claude Routines, explaining why they exist and how to configure them on claude.ai.
- `.claude/routines/pr-opened-progress.md` — Routine that flips a spec issue `planned` → `in-progress` when a PR opens, and enforces the spec-link requirement.
- `.claude/routines/pr-merged-progress.md` — Routine that ticks Plan checkboxes on parent specs when `Part of #N` PRs merge.
- `.claude/routines/pr-closed-unmerged.md` — Routine that reverts a spec to `planned` if a PR closes without merging and no other PRs are in flight.
- `.claude/routines/spec-planned-review.md` — Routine that sanity-checks specs when they move from `draft` to `planned`.

**Updated documentation:**
- `issue-spec/SKILL.md` — Clarified scope, added "when to use" section, updated area labels to match Onsager's subsystems (spine, forge, ising, stiglab, synodic, dashboard, etc.), and cross-linked to the SDD loop.
- `onsager-pr-lifecycle/SKILL.md` — Expanded spec-issue linking section with mandatory enforcement rules, added `## Delivers` subsection guidance, documented label transitions and routine automation, and clarified the manual fallback when routines aren't configured.
- `onsager-pre-push/SKILL.md` — Added step 6 (spec-issue link check) to enforce the no-PR-without-spec rule locally before push, with guidance on finding the spec, confirming its status, and drafting the PR body.
- `issue-spec/references/spec-format.md` — Updated area labels and added architectural invariant note about cross-subsystem specs.

## Notable details

- The SDD loop is **mandatory for non-trivial changes**; the `trivial` label provides an escape hatch for typos, doc-only fixes, and one-line obvious bug repairs.
- The `draft → planned` transition is a **human-only gate** — it signals that open questions are resolved and design is approved. No AI can flip it automatically.
- Routines are **optional but recommended** — if not configured, the skills document the manual label transitions so humans can do them by hand.
- The architectural invariant (subsystems don't import each other except via spine) is now explicit in the spec-format reference and enforced at the spec stage.
- All four routines use only GitHub MCP tools and are designed to be idempotent and safe to re-run.

https://claude.ai/code/session_01TMFZJmYknjQ2rtjZJ6V6fE