### PR TITLE
docs(skills): cover merge-conflict resolution

### DIFF
--- a/.claude/skills/onsager-dev-process/SKILL.md
+++ b/.claude/skills/onsager-dev-process/SKILL.md
@@ -107,7 +107,11 @@ continuing.
 Trigger `onsager-pre-push` (or say "ready to push"). It runs:
 
 1. Sync `origin/main` into the branch (CI tests a merge preview, not the
-   branch alone).
+   branch alone). If that surfaces merge conflicts, `onsager-pre-push`
+   owns the resolution walkthrough — inventory, pattern-match against
+   the repo's recurring collisions (migrations, enum variants, event
+   envelope, lockfiles), verify, then commit. Resolve locally, never on
+   the PR web editor.
 2. `RUSTFLAGS="-D warnings" cargo build --workspace`.
 3. `RUSTFLAGS="-D warnings" cargo test --workspace --lib`.
 4. `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`.
@@ -116,6 +120,10 @@ Trigger `onsager-pre-push` (or say "ready to push"). It runs:
    no-PR-without-spec rule locally).
 
 Fix any blocker; don't paper over with `#[allow(dead_code)]` or `--no-verify`.
+
+If a PR is already open and GitHub later flags "This branch has
+conflicts", don't use the web editor — `onsager-pr-lifecycle` covers
+the checkout-and-rerun flow that re-uses the same pre-push walkthrough.
 
 ### 5. Open the PR
 

--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onsager-pr-lifecycle
-description: Manage an Onsager PR after it's been pushed — spec-issue linking, CI triage, review-comment discipline, webhook subscription, and label alignment. Triggers include "CI is failing", "check is red", "link this issue", "Closes vs Part of", "respond to review", "subscribe to PR", "triage PR", "the PR is ready" or when a github-webhook-activity event arrives. Paired with `onsager-dev-process` (overall loop), `issue-spec` (spec creation), and the GitHub-triggered Claude Routines under `.claude/routines/`.
+description: Manage an Onsager PR after it's been pushed — spec-issue linking, CI triage, review-comment discipline, merge-conflict recovery on open PRs, webhook subscription, and label alignment. Triggers include "CI is failing", "check is red", "link this issue", "Closes vs Part of", "respond to review", "subscribe to PR", "triage PR", "the PR is ready", "PR has conflicts", "branch has conflicts with main", "merge conflict on the PR", or when a github-webhook-activity event arrives. Paired with `onsager-dev-process` (overall loop), `issue-spec` (spec creation), `onsager-pre-push` (which owns the pre-push conflict walkthrough), and the GitHub-triggered Claude Routines under `.claude/routines/`.
 ---
 
 # onsager-pr-lifecycle
@@ -129,6 +129,44 @@ error page. Don't waste time on them. Work instead from:
 
 Main and PR both add `NNN_foo.sql` → rename yours to the next unused `NNN`.
 Update **all three**: `justfile`, `docker-compose.yml`, `.github/workflows/rust.yml`.
+
+## Merge conflicts on an open PR
+
+When GitHub shows "This branch has conflicts that must be resolved" or the
+red banner appears on `mcp__github__pull_request_read` (`mergeable: false`),
+resolve **locally** — the GitHub web editor bypasses `cargo build` and
+routinely lands broken merges.
+
+1. **Don't** use `mcp__github__update_pull_request_branch` to auto-merge
+   main in via GitHub. That surfaces the same conflicts without giving
+   you the resolution workspace, then commits a broken merge if you
+   accept the default.
+
+2. Check out the branch locally and run the full conflict walkthrough
+   in [`onsager-pre-push`](../onsager-pre-push/SKILL.md) (step 1,
+   "Resolving conflicts") — inventory, pattern-match, resolve, verify,
+   commit. That section owns the repo's recurring patterns (migrations,
+   enum variants, event envelope, `Cargo.lock`, `pnpm-lock.yaml`, spine
+   event schema); don't duplicate them here.
+
+3. After the merge commit lands, continue with steps 2–5 of
+   `onsager-pre-push` (build, test, clippy, fmt) before pushing.
+   CI's `pull_request` job tests the new merge preview — if you didn't
+   rebuild locally, CI finds out first.
+
+4. Push the merge commit to the same branch with
+   `git push` (no `--force`). The existing PR updates in place; the
+   conflict banner clears when GitHub re-evaluates.
+
+5. If the PR is tied to a `Closes #N` / `Part of #N` line and the merge
+   touched the spec's surface area (enum variants, event schema), comment
+   on the spec flagging what drifted, so the parent stays accurate.
+
+If the branch is so far behind main that the conflict set is large
+(>10 files or crosses subsystem boundaries), close the PR, rebase the
+work into a fresh branch from `origin/main`, and open a new PR with the
+same linking line. This is cheaper than a multi-hour merge and keeps the
+audit trail clean — note the close reason on the old PR.
 
 ## Review comments
 

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onsager-pre-push
-description: Run before pushing code to the Onsager repo to catch what CI would fail on, and confirm the branch has a linked spec issue in a valid state. Reproduces CI's merge preview + strict-warnings environment and renumbers colliding migrations. Triggers include "before push", "ready to push", "pre-push check", "push readiness", "prep for PR", or proactively before any git push on an Onsager branch.
+description: Run before pushing code to the Onsager repo to catch what CI would fail on, and confirm the branch has a linked spec issue in a valid state. Reproduces CI's merge preview + strict-warnings environment, renumbers colliding migrations, and walks through the repo's common merge-conflict patterns. Triggers include "before push", "ready to push", "pre-push check", "push readiness", "prep for PR", "resolve merge conflict", "merge conflict", "branch has conflicts", "sync with main", or proactively before any git push on an Onsager branch.
 ---
 
 # onsager-pre-push
@@ -32,20 +32,96 @@ git fetch origin main
 git merge origin/main --no-edit
 ```
 
-If there are conflicts, resolve them **now**, not on the PR page. Common
-collision patterns in this repo:
+Resolve conflicts **locally**, before push — never on the PR "Resolve
+conflicts" web editor (it bypasses `cargo build`/`clippy` and routinely
+lands broken states). If the merge aborts cleanly, skip to step 2.
 
-- **Migrations**: both branches added `NNN_foo.sql`. Renumber yours to the
-  next unused N, then update all three reference sites:
-  `justfile` (`db-migrate`), `docker-compose.yml` (`migrate` service's
-  `entrypoint`), `.github/workflows/rust.yml` (`Apply database migrations`
-  step).
-- **Enum variants**: main removed `Kind::{Report, Dataset, Config, ApiCall}`
-  in favour of `Kind::PullRequest` once. If you see `variant not found`,
-  grep for the old variant names and update each `match` arm.
-- **Event envelope variants**: both branches added variants to
-  `FactoryEventKind` — the auto-merge succeeds textually but duplicates or
-  re-orders arms. Build verifies.
+#### Resolving conflicts
+
+1. **Inventory** what conflicted:
+
+   ```bash
+   git status --short                   # U* lines = unresolved paths
+   git diff --name-only --diff-filter=U
+   ```
+
+2. **Work by pattern, not by file.** A single logical conflict (e.g. an
+   enum variant change) usually spans several files. Match what you see
+   against the patterns below before touching conflict markers — the
+   right fix is often "take main's version and re-apply your change on
+   top", not a line-by-line merge.
+
+3. **Resolve**, then stage each resolved path with `git add <path>`.
+   Re-run `git status` until no `U*` entries remain.
+
+4. **Verify before committing the merge.** A passing merge means:
+
+   ```bash
+   RUSTFLAGS="-D warnings" cargo build --workspace
+   RUSTFLAGS="-D warnings" cargo test --workspace --lib
+   cargo fmt --all -- --check
+   ```
+
+   Only then:
+
+   ```bash
+   git commit --no-edit                 # default "Merge branch 'main' ..." message
+   ```
+
+5. **If you get lost**, bail and retry:
+
+   ```bash
+   git merge --abort
+   ```
+
+   This restores pre-merge state. Never `git reset --hard` or
+   `git checkout --` without confirming nothing is staged you care
+   about — the merge carries uncommitted resolutions.
+
+   Prefer `merge` over `rebase` for syncing main here: the branch is
+   likely already pushed, rebase rewrites history, and force-push is a
+   destructive action per repo policy.
+
+#### Common collision patterns in this repo
+
+Match the symptom in `git status` / build output to the pattern:
+
+- **Migrations (`migrations/NNN_*.sql`)**: both branches added the same
+  `NNN`. Keep main's file at `NNN`, renumber yours to the next unused
+  `NNN+k`, then update **all three** reference sites or the CI migrate
+  step will skip it:
+  - `justfile` — the `db-migrate` recipe.
+  - `docker-compose.yml` — the `migrate` service's `entrypoint`.
+  - `.github/workflows/rust.yml` — the `Apply database migrations` step.
+
+  Sanity check: `git grep -n '<old-NNN>_'` should return zero hits
+  after renumber.
+
+- **Enum variants** (e.g. `Kind::{Report,Dataset,Config,ApiCall}` →
+  `Kind::PullRequest`): main removed variants your branch still uses.
+  Build reports `variant not found`. `git grep` each removed variant
+  and update every `match` arm; don't add a catch-all `_ =>` just to
+  silence the compiler — the exhaustive check is load-bearing.
+
+- **Event envelope variants** (`FactoryEventKind`, `FactoryEvent`):
+  both branches added arms. Textual merge succeeds but may duplicate
+  or re-order variants. After merge, open the enum, dedupe, and
+  re-run `cargo build`; serde-renamed variants sharing a tag will
+  cause runtime dispatch errors that compile fine.
+
+- **`Cargo.lock`**: always resolve by re-running `cargo build --workspace`
+  after accepting either side — don't hand-edit. If both branches
+  bumped the same dep differently, prefer main's version and let your
+  change re-request an update.
+
+- **`pnpm-lock.yaml` / `package.json`**: take main's `pnpm-lock.yaml`,
+  re-apply your `package.json` edits, then `pnpm install` to
+  regenerate the lockfile deterministically.
+
+- **Spine event schema (`crates/onsager-spine/src/events/`)**: schema
+  drift between branches silently changes wire format. After resolving,
+  run `cargo test -p onsager-spine --lib` to catch serde round-trip
+  failures before CI does.
 
 ### 2. Build with CI's flags
 


### PR DESCRIPTION
Expand onsager-pre-push with a dedicated "resolving conflicts"
walkthrough (inventory, pattern-match, verify, commit, abort) and
extend the pattern catalogue with Cargo.lock, pnpm-lock, and spine
event schema cases. Add a "merge conflicts on an open PR" section to
onsager-pr-lifecycle that delegates to pre-push and warns off the
GitHub web editor. Link both from onsager-dev-process step 4, and
add trigger keywords ("resolve merge conflict", "branch has
conflicts") to the skill frontmatters so they match naturally.