### PR TITLE
docs(claude): enforce multi-issue Closes + umbrella tracker refresh

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -32,7 +32,7 @@ Install the Claude GitHub App on `onsager-ai/onsager` if prompted.
 | File | Trigger | Purpose |
 |------|---------|---------|
 | [`pr-opened-progress.md`](pr-opened-progress.md) | `pull_request.opened` | Flip linked spec issue `planned`/`draft` → `in-progress`; verify PR body links a spec. |
-| [`pr-merged-progress.md`](pr-merged-progress.md) | `pull_request.closed` merged=true | Tick Plan checkboxes on parent spec for `Part of #N` merges. |
+| [`pr-merged-progress.md`](pr-merged-progress.md) | `pull_request.closed` merged=true | Tick Plan checkboxes on parent spec for `Part of #N` merges; refresh umbrella trackers that reference the closed issues; flag issues mentioned only in commits (no `Closes` line) so implicit acceptance doesn't silently leave them open. |
 | [`pr-closed-unmerged.md`](pr-closed-unmerged.md) | `pull_request.closed` merged=false | Revert linked spec back to `planned` if no other PR is in flight. |
 | [`spec-planned-review.md`](spec-planned-review.md) | `issues.labeled` = `planned` | Sanity-check the spec before a human/agent picks it up (open questions, plan items, test items). |
 

--- a/.claude/routines/pr-merged-progress.md
+++ b/.claude/routines/pr-merged-progress.md
@@ -10,45 +10,93 @@ repository: onsager-ai/onsager
 
 You are an autonomous Claude Code session reacting to a merged pull request
 on `onsager-ai/onsager`. The PR number is in the event payload. Your job is
-to update the linked spec issue's Plan checkboxes so a parent spec
-accurately reflects which slices have landed.
+to (a) update linked spec issue Plan checkboxes, (b) flag issues whose
+acceptance the PR may have met without an explicit `Closes` line, and
+(c) refresh any umbrella trackers that reference the just-closed issues.
 
 ## Do exactly this
 
-1. **Read the PR body** via `mcp__github__pull_request_read`. Identify the
-   linking line:
-   - `Closes #N`, `Fixes #N`, `Resolves #N` (any variant) → GitHub will
-     auto-close the issue on merge. Nothing to do for the close itself.
-   - `Part of #N`, `Refs #N`, `Related #N` → the parent spec stays open;
-     you update its checkboxes.
-2. **For every linked issue that is NOT being auto-closed** (i.e., `Part of`
-   / `Refs` / `Related`):
+1. **Read the PR body and commits** via `mcp__github__pull_request_read`
+   (methods `get` and `list_commits`). Build three sets:
+   - `closed_explicit` = issue numbers after `Closes` / `Fixes` /
+     `Resolves` keywords on the PR body's linking line. GitHub has already
+     auto-closed these on merge.
+   - `referenced_parts` = issue numbers after `Part of` / `Refs` /
+     `Related`. Parents stay open; you tick their checkboxes.
+   - `referenced_commits` = every `#N` that appears in any commit subject
+     or body on the PR but is **not** already in `closed_explicit` or
+     `referenced_parts`. These are implicit references — a PR may have
+     delivered their acceptance without the author writing `Closes #N`.
+
+2. **For every issue in `referenced_parts`**:
    a. Read the issue via `mcp__github__issue_read`.
    b. Identify which Plan checkboxes this PR delivered. The PR body should
       list the items it delivers in a `## Delivers` subsection, or reuse
       the exact Plan item text. If neither is present, post a comment on
       the spec issue naming the merged PR and listing its changed files,
-      asking a human to tick the right checkboxes. Stop.
+      asking a human to tick the right checkboxes. Continue.
    c. If the PR identifies deliverables unambiguously, edit the issue body
       via `mcp__github__issue_write` to tick the matching `- [ ]` →
       `- [x]` lines. Preserve the rest of the body verbatim.
    d. Post a brief issue comment: "Ticked by #<pr-number>: <list of items>".
-3. **For auto-closed issues** (the `Closes` case):
-   - The issue state transition is handled by GitHub. Do not add comments
-     or labels. The `in-progress` label disappears when the issue closes.
-4. **If the linked issue is a sub-issue of a parent spec**, re-read the
-   parent via `mcp__github__issue_read`. If all sub-issues under the
-   parent are now closed, post a comment on the parent: "All sub-issues
-   closed — ready to verify end-to-end and close the parent."
+
+3. **For every issue in `referenced_commits`** (implicit reference audit):
+   a. Read the issue. Skip if already closed — the reference was likely
+      retrospective.
+   b. Read the PR commits touching this `#N` and the issue's Acceptance
+      section. If the PR changes plausibly meet the acceptance criteria
+      (new files / functions / tests named in Acceptance; migration files
+      the issue called for; ADR linked from CLAUDE.md for ADR issues),
+      post a comment on the issue: "PR #<pr> referenced this issue in
+      commit <sha> but did not include a `Closes #<N>` line. Maintainer:
+      please confirm whether this PR meets acceptance and close if so."
+      Include a one-line summary of what the PR appeared to deliver for
+      this issue.
+   c. Do **not** close the issue yourself. Close-via-routine is reserved
+      for explicit `Closes` lines authored by humans. This step surfaces
+      the ambiguity without resolving it — the PR #43 failure mode
+      (#27/#30/#33 left open) would have produced three such comments
+      instead of silent drift.
+
+4. **For every issue in `closed_explicit`** (auto-closed by GitHub):
+   - No comments or labels on the closed issue itself — GitHub handled
+     that transition.
+   - Fall through to step 5 (umbrella refresh).
+
+5. **Umbrella tracker refresh.** For every issue number `N` in
+   `closed_explicit` ∪ `referenced_parts` whose Plan is now complete:
+   a. Search for trackers referencing it: `mcp__github__search_issues`
+      with `repo:onsager-ai/onsager #N in:body is:issue is:open`.
+   b. For each match whose title starts with `[Tracking]` or carries a
+      `tracking` label, or whose body contains a `## Progress` section
+      with a `- [ ] ... #N ...` line:
+      - Tick the matching checkbox via `mcp__github__issue_write`
+        (preserve the rest of the body verbatim).
+      - Collect the tick for a single summary comment per tracker.
+   c. After all ticks land, post **one** comment per tracker:
+      "PR #<pr> landed #<N1>, #<N2>, …; ticked in Progress." If all
+      sub-issues in the tracker's Progress section are now checked, add
+      a second sentence: "All tracked items closed — tracker is a
+      candidate for closure."
+   d. Never close a tracker unilaterally; leave that to a human.
+
+6. **If the linked issue is a sub-issue of a parent spec** (not a tracker
+   — a true parent/child relationship created via `sub_issue_write`),
+   re-read the parent. If all sub-issues are now closed, post a comment
+   on the parent: "All sub-issues closed — ready to verify end-to-end and
+   close the parent."
 
 ## Constraints
 
 - Use only `mcp__github__*` tools. No shell, no file edits in the repo.
 - Preserve the rest of the issue body exactly. Only tick existing
-  checkboxes; never add or remove Plan items.
+  checkboxes; never add or remove Plan / Progress items.
 - If the PR body has multiple linked issues, handle each independently.
 - If you cannot confidently map PR → Plan items, err on the side of posting
   a comment and letting a human decide. Do not guess.
+- The implicit-reference audit (step 3) must be conservative: when in
+  doubt whether the PR meets acceptance, skip the comment rather than
+  false-positive on every `#N` that appeared in a commit.
 
 ## Success
 

--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -51,6 +51,27 @@ the UI. Use them for scaffolding so the spec stays open for the real slice.
 Edit the PR body via `mcp__github__update_pull_request` (don't open a new PR
 just to fix the link). Put the linking line at the top of the body.
 
+### Multi-issue PRs — enumerate every closure
+
+If a single PR delivers acceptance for more than one issue (rare but
+legitimate — e.g. a refactor that completes two related specs), write
+**one `Closes` keyword per issue** on the linking line:
+
+```markdown
+Closes #27, Closes #30, Closes #33
+```
+
+GitHub only honors the auto-close keyword on each `#N` individually;
+`Closes #27, #30, #33` closes #27 and leaves #30/#33 open. This is how
+PR #43 quietly left three issues open even though their acceptance
+criteria were met — the PR title only mentioned `(#27)` and no `Closes`
+line enumerated the others.
+
+`onsager-pre-push` step 6.4 now scans the branch's commits for `#N`
+mentions and warns when they're missing from the linking line. The
+check is advisory at push time; this skill is where the discipline is
+enforced post-push if the pre-push scan was skipped or overridden.
+
 ### The `## Delivers` subsection
 
 For `Part of #N` PRs (and ideally all PRs), include a `## Delivers`
@@ -100,6 +121,33 @@ transitions. On PR open, flip the linked spec's label via
 Never bypass the `draft → planned` gate from within this skill — that's a
 human decision. If the linked spec is still `draft`, comment on the PR
 asking the author to drive the spec through review first.
+
+## Umbrella tracker refresh
+
+Some issues are **umbrella trackers** that reference several sub-issues as
+a checklist — identified by a `[Tracking]` title prefix, a `tracking`
+label, or a `## Progress` section whose items are `- [ ] #N` lines.
+Examples: #40 (architectural review), anything opened with
+`issue-spec`'s tracker flow.
+
+When a PR closes a sub-issue, the tracker does **not** update itself.
+After merge, for each auto-closed or explicitly-closed issue in the PR:
+
+1. Search for umbrella trackers that reference it:
+   `mcp__github__search_issues` with `repo:onsager-ai/onsager #N in:body
+   is:issue is:open` — trackers will list `#N` in their Progress section.
+2. For each match, read the tracker body. If there's a matching
+   `- [ ] ... #N ...` line in a Progress / Plan section, flip it to `- [x]`.
+3. Post one tracker comment summarizing the delta, not one per issue:
+   "PR #<pr> landed #N1, #N2, #N3; ticked in Progress."
+4. If after the tick every sub-issue in the Progress section is closed,
+   note that the tracker itself is now a candidate for closure — don't
+   close it unilaterally (the author or a human decides), just flag it.
+
+The `pr-merged-progress` routine automates the common case. This section
+is the manual fallback for when (a) routines aren't configured,
+(b) routines ran but couldn't disambiguate, or (c) the tracker uses a
+non-standard checklist shape the routine didn't recognize.
 
 ## CI triage
 

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -125,8 +125,33 @@ is explicitly trivial). This is the local counterpart to the
    Also draft a `## Delivers` subsection listing the exact Plan items you
    tick with this PR.
 
-4. **If this is genuinely trivial** (typo, doc-only, one-line obvious
-   fix), skip steps 6.1–6.3 and plan to apply the `trivial` label to the
+4. **Scan the branch's commit messages for implicit issue references**
+   (advisory, not blocking):
+
+   ```bash
+   git log --format='%s%n%b' origin/main..HEAD | grep -oE '#[0-9]+' | sort -u
+   ```
+
+   For each `#N` returned, check whether the drafted PR body already
+   mentions it on a linking line (`Closes` / `Fixes` / `Resolves` /
+   `Part of` / `Refs` / `Related`). If not, decide deliberately:
+
+   - **PR delivers that issue's acceptance** → add `Closes #N` to the
+     body. Multi-issue `Closes` lines are fine (`Closes #27, Closes #30,
+     Closes #33`). Auto-close doesn't fire for issues that are only
+     *mentioned* in commit subjects — without an explicit `Closes` line
+     those issues stay open after merge.
+   - **PR only touches that issue** → use `Refs #N` so it cross-links
+     without claiming closure.
+   - **False positive** (issue number inside a code identifier, commit
+     hash, etc.) → ignore.
+
+   This is the step that catches the PR #43 failure mode: three
+   acceptance criteria met across three commits, only one `#N` in the
+   title, two issues silently left open after merge.
+
+5. **If this is genuinely trivial** (typo, doc-only, one-line obvious
+   fix), skip steps 6.1–6.4 and plan to apply the `trivial` label to the
    PR immediately after `mcp__github__create_pull_request`. Use sparingly.
 
 ### 7. Push


### PR DESCRIPTION
Two failure modes from PR #43, which landed fixes for #27/#30/#33 but
only referenced #27 in the title — leaving #30 and #33 silently open
after merge and #40's Progress checklist four commits out of date.

- onsager-pre-push: new step 6.4 scans `git log origin/main..HEAD` for
  `#N` mentions and warns when any are missing from the drafted PR
  linking line. Advisory only; author still owns the Closes/Refs call.
- onsager-pr-lifecycle: documents the one-keyword-per-issue rule
  (Closes #27, Closes #30 — not Closes #27, #30) and adds an "Umbrella
  tracker refresh" manual fallback for when the routine isn't wired
  up.
- pr-merged-progress routine: now builds three sets (explicit closes,
  Part of references, commit-only #N mentions), audits implicit
  references conservatively with a per-issue "please confirm" comment,
  and sweeps umbrella trackers for matching `- [ ] ... #N ...` lines
  with one summary comment per tracker.
- routines README: updated table row to reflect broader scope.

https://claude.ai/code/session_01Cg5ykHqKeLdKcmHvyM8ReY