### PR TITLE
docs(routines): add main-ci-failure routine + ci-triage skill

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -35,6 +35,7 @@ Install the Claude GitHub App on `onsager-ai/onsager` if prompted.
 | [`pr-merged-progress.md`](pr-merged-progress.md) | `pull_request.closed` merged=true | Tick Plan checkboxes on parent spec for `Part of #N` merges. |
 | [`pr-closed-unmerged.md`](pr-closed-unmerged.md) | `pull_request.closed` merged=false | Revert linked spec back to `planned` if no other PR is in flight. |
 | [`spec-planned-review.md`](spec-planned-review.md) | `issues.labeled` = `planned` | Sanity-check the spec before a human/agent picks it up (open questions, plan items, test items). |
+| [`main-ci-failure.md`](main-ci-failure.md) | `workflow_run.completed` on `main` | Maintain one rolling `main-red` issue when L1 CI (`rust` / `frontend` / `e2e`) fails post-merge; close it when main goes green again. Delegates classification to the `ci-triage` skill. |
 
 ## Updating a routine
 
@@ -51,7 +52,11 @@ prompt drift auditable and reviewable like any other code change.
   all three and run under the account that owns the subscription.
 - **onsager-pr-lifecycle skill** covers the interactive, human-present case
   (triaging CI, replying to review comments). The routines cover the
-  unattended, mechanical case (label alignment).
+  unattended, mechanical case (label alignment, main-red bookkeeping).
+- **ci-triage skill** is shared logic: `main-ci-failure` calls it
+  unattended; humans call it via `onsager-pr-lifecycle` when looking at a
+  red PR check. Keeping the taxonomy in one place avoids two definitions
+  of "flake" drifting apart.
 
 The two are complementary. If you don't want to set up routines, read
 `onsager-pr-lifecycle` and flip labels manually — the skill documents the
@@ -63,3 +68,10 @@ Routines count against your daily run allowance (Pro: 5/day, Max: 15/day,
 Team/Enterprise: 25/day). For a project with steady PR flow, budget
 ~2 runs per PR (open + merge) and consider combining triggers on one
 routine if you're pressed for allowance.
+
+`main-ci-failure` fires once per workflow completion on main, so a flaky
+main burns allowance fast. The routine's first step filters the event to
+the three L1 workflows and only the `push` event — that keeps nightly +
+manual triggers out of the budget. If the allowance still hurts, drop the
+green-close path (manually close the `main-red` issue) before dropping the
+red-file path.

--- a/.claude/routines/main-ci-failure.md
+++ b/.claude/routines/main-ci-failure.md
@@ -1,0 +1,70 @@
+---
+name: main-ci-failure
+triggers:
+  - GitHub event — workflow_run.completed (branch=main, conclusion=failure)
+  - GitHub event — workflow_run.completed (branch=main, conclusion=success) — for the green-close path
+repository: onsager-ai/onsager
+---
+
+# Prompt
+
+You are an autonomous Claude Code session reacting to a completed GitHub
+Actions workflow run on `main` in `onsager-ai/onsager`. Your job is to keep
+the rolling `main-red` issue in sync with reality: file/update when CI goes
+red, close when it goes green.
+
+All classification logic lives in the [`ci-triage` skill](../skills/ci-triage/SKILL.md).
+This routine is a thin dispatcher — do not reimplement the taxonomy here.
+
+## Do exactly this
+
+1. **Read the event payload.** You have `workflow_run.name`,
+   `workflow_run.conclusion`, `workflow_run.head_sha`, `workflow_run.id`,
+   and `workflow_run.html_url`.
+
+2. **Ignore the event** if any of:
+   - `workflow_run.head_branch` is not `main`.
+   - `workflow_run.event` is not `push` (skip scheduled, workflow_dispatch,
+     pull_request — those aren't the merge signal).
+   - `workflow_run.name` is not one of `rust`, `frontend`, `e2e`
+     (the three L1 workflows).
+
+3. **If `conclusion == "success"`** (green-close path):
+   - `mcp__github__list_issues` with `labels: main-red, state: open`.
+   - If an open `main-red` issue exists and it was filed for the same
+     workflow name, close it via `mcp__github__issue_write` with a short
+     closing comment: "Green on run <html_url>. Closing."
+   - If no matching open issue exists, do nothing. Stop.
+
+4. **If `conclusion == "failure"`** (red-file path):
+   - Invoke the `ci-triage` skill with the event payload. It will:
+     - Classify the failure (`regression` / `flake` / `infra` / `needs-human`).
+     - Identify the suspect commit + author.
+     - Either append to the existing open `main-red` issue or open a new
+       one per its de-dup rules.
+   - For `e2e` failures specifically, `ci-triage` delegates to
+     [`web-testing`'s triage mode](../skills/web-testing/SKILL.md) for
+     regression-vs-flake classification. Let the skill handle it — don't
+     open the browser from this routine.
+
+5. **Stop.** Do not open a PR, do not revert, do not @-mention unless
+   `ci-triage` instructs you to (it already filters `infra`/`flake` out of
+   @-mention paths).
+
+## Constraints
+
+- Use only `mcp__github__*` tools. No shell, no repo edits.
+- Scope is `onsager-ai/onsager` only.
+- One `main-red` issue at a time. If `ci-triage` returns that it already
+  updated the existing issue, don't open a duplicate.
+- Never close a `main-red` issue from the red-file path.
+- Never open a `main-red` issue from the green-close path.
+- Budget: this routine should run in well under 2 minutes. If log access
+  is slow, let `ci-triage` fall back to `needs-human` rather than spinning.
+
+## Success
+
+When main is red, exactly one open `main-red` issue describes the current
+state, pointing at the suspect commit and author. When main goes green
+again, that issue closes automatically with a link to the passing run.
+Humans see one signal, not twelve.

--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ci-triage
+description: Triage failed CI runs on the Onsager repo — classify regression vs flake vs infra, maintain a single rolling `main-red` issue when main is broken, and point humans at the suspect commit. Use when a workflow fails on `main`, when the `main-ci-failure` routine hands off, or when a human asks "is main red?", "why did CI fail on main?", "triage this workflow run", "classify this failure". Paired with `onsager-pr-lifecycle` (PR-side CI triage) and the `web-testing` skill (invoked for `e2e` failures).
+---
+
+# ci-triage
+
+Shared logic for classifying a failed CI workflow run and recording the
+outcome. Callable from the `main-ci-failure` routine (unattended) and from
+`onsager-pr-lifecycle` when a human is triaging a red check on an open PR.
+
+This skill owns the taxonomy, the de-dup rules for the `main-red` issue, and
+the issue template. Workflow-specific reproduction steps live in other skills
+(`onsager-pr-lifecycle` for rust/frontend detail, `web-testing` for e2e).
+
+## Taxonomy
+
+Every failure lands in exactly one bucket. Be explicit — "unclear" is not a
+bucket, `needs-human` is.
+
+| Bucket         | Signal                                                               | Default action                                   |
+|----------------|----------------------------------------------------------------------|--------------------------------------------------|
+| `regression`   | Reproduces deterministically on `main` at HEAD                       | File/update `main-red`, @-mention suspect author |
+| `flake`        | Same workflow passed on the previous main commit without code change | Comment on the existing `main-red` issue if one is open; otherwise skip |
+| `infra`        | Postgres service didn't come up, rustup 403, pnpm registry down      | File/update `main-red` labelled `infra`; do not @-mention authors |
+| `needs-human`  | Logs truncated, auth failed, classification genuinely ambiguous      | Open a `main-red` issue with raw log excerpt, label `needs-human` |
+
+Do **not** invent a fifth bucket. If the signal you see fits nothing above,
+it's `needs-human`.
+
+## Suspect commit identification
+
+The GitHub `workflow_run` payload includes `head_sha`. That's the commit that
+*triggered* this run — on a `push: main` event, it is the merge commit.
+
+1. Fetch the commit via `mcp__github__get_commit`.
+2. If the commit message matches `Merge pull request #N`, the suspect PR is
+   `#N`; its author is the suspect author.
+3. Otherwise (direct push to main, squash-merge), use the commit author
+   directly.
+
+Never blame more than one commit per failure. If the previous main commit's
+CI was also red, link that issue rather than opening a new one.
+
+## The rolling `main-red` issue
+
+**One open `main-red` issue at a time.** If main is broken for three days,
+that's one issue accumulating comments — not twelve.
+
+Before filing:
+
+1. `mcp__github__list_issues` with `labels: main-red, state: open`.
+2. If one exists, append a comment:
+   > Run #<run-id> also failed. Workflow `<name>`, bucket `<bucket>`,
+   > suspect <sha-short> (#<pr-or-none>, @<author>). <one-line-cause>.
+3. Only open a new issue if none is open. Title:
+   `main is red: <workflow> (<bucket>)`. Labels: `main-red`, plus
+   `infra` or `needs-human` if applicable.
+
+When main goes green again (the next successful run on the same workflow),
+close the issue with a comment naming the green run id. The
+`main-ci-failure` routine handles this close path on success events.
+
+## Issue body template
+
+```markdown
+**Workflow**: <workflow-name>
+**Run**: <run-url>
+**First failed step**: <step-name>
+**Bucket**: <regression|flake|infra|needs-human>
+**Suspect**: <sha-short> — <commit-subject> (PR #<n>, @<author>)
+
+### Failure excerpt
+
+<last 30 lines of the failing step, or the ripgrep-extracted error block>
+
+### Reproduction
+
+<one of:>
+- Deterministic: `<exact command from the workflow yaml>`
+- Flake: passed on <prev-sha-short>; rerun button: <run-url>/attempts/2
+- Infra: <service name> — <symptom>
+- Needs human: <why the logs are ambiguous>
+
+### Next action
+
+<one line — "revert #N and reland", "rerun", "fix <specific thing>", "human eyes">
+```
+
+Keep the excerpt tight. Dumping the full log helps nobody.
+
+## Reproducing locally
+
+If the routine is running unattended it can't run `cargo` or `pnpm` — it must
+classify from logs alone. A human invoking this skill via
+`onsager-pr-lifecycle` should reproduce before filing, using the commands in
+[`onsager-pr-lifecycle`'s CI triage section](../onsager-pr-lifecycle/SKILL.md).
+
+For `e2e` failures specifically, delegate classification to
+[`web-testing`'s triage mode](../web-testing/SKILL.md) — it handles
+regression-vs-flake for browser-driven tests (the ambiguous case).
+
+## Log access
+
+`WebFetch` **cannot read authenticated GitHub Actions logs** (403). From the
+routine you have:
+
+- `mcp__github__pull_request_read` with `method: get_check_runs` — step
+  names, status, timings (no log body).
+- The workflow run's `jobs_url` via `mcp__github__get_commit` +
+  `check_suite` traversal — same metadata.
+
+Log bodies are not reliably accessible from the GitHub MCP. When the log
+body is unavailable, classify from step names + exit codes + the workflow
+yaml, and bias toward `needs-human` rather than guessing.
+
+## Flake-detection heuristic
+
+A failure is `flake` only if **both** hold:
+
+1. The same workflow on the previous main commit passed (check via
+   `mcp__github__list_commits` + check runs on the prior sha).
+2. The failing step's logs do not contain a symbol name, file path, or
+   assertion message that appears in the suspect commit's diff.
+
+One of those alone is not enough. A deterministic regression can pass on the
+prior commit; a real flake can mention a touched file by coincidence.
+
+## Constraints
+
+- Never open a PR from this skill. Triage is read-only on the codebase.
+- Never @-mention for `infra` or `flake` buckets — alert fatigue kills the
+  signal.
+- Never close a `main-red` issue without a green run id to cite.
+- Scope is `onsager-ai/onsager` only.
+
+## Relationship to other surfaces
+
+| Surface | Role |
+|---------|------|
+| [`.claude/routines/main-ci-failure.md`](../../routines/main-ci-failure.md) | Unattended caller; fires on `workflow_run.completed` for main. |
+| [`onsager-pr-lifecycle`](../onsager-pr-lifecycle/SKILL.md) | Interactive caller; humans use this when triaging a red PR check. |
+| [`web-testing`](../web-testing/SKILL.md) | Delegated to for `e2e` workflow classification. |

--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -103,6 +103,12 @@ asking the author to drive the spec through review first.
 
 ## CI triage
 
+For classification taxonomy (`regression` / `flake` / `infra` / `needs-human`),
+suspect-commit identification, and the rolling `main-red` issue convention,
+use the [`ci-triage` skill](../ci-triage/SKILL.md). This section covers the
+PR-side specifics — reproducing locally and the repo's common failure
+patterns.
+
 ### Accessing logs
 
 `WebFetch` **cannot read authenticated GitHub Actions logs** — both
@@ -222,3 +228,4 @@ commit message in chat — the user can see it on the PR.
 | [`issue-spec`](../issue-spec/SKILL.md) | Creates the spec issue this PR links to. |
 | [`onsager-pre-push`](../onsager-pre-push/SKILL.md) | Runs before `git push`; enforces the spec-link check locally. |
 | [`.claude/routines/`](../../routines/README.md) | Automates the label transitions this skill describes manually. |
+| [`ci-triage`](../ci-triage/SKILL.md) | Shared failure taxonomy + `main-red` issue convention; called from `main-ci-failure` routine and from this skill's CI triage flow. |


### PR DESCRIPTION
Introduces post-merge L1 regression bookkeeping on main via a thin
workflow_run.completed routine that delegates classification to a new
shared ci-triage skill. The skill owns the failure taxonomy, suspect-
commit identification, and the rolling main-red issue convention, so
onsager-pr-lifecycle (human-present) and main-ci-failure (unattended)
share one definition of regression vs flake vs infra.