### PR TITLE
feat(ising): close the feedback loop with gate-override-rate insights (#36)

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -99,6 +99,18 @@ export interface GovernanceRule {
   enabled: boolean;
 }
 
+// Ising insight surface (issue #36). The emitter writes events to the spine
+// as `ising.insight_emitted`; the dashboard reads them back via the spine
+// events endpoint and presents the structured fields directly.
+export interface IsingInsightEmittedEvent {
+  id: number;
+  created_at: string;
+  signal_kind: string;
+  subject_ref: string;
+  confidence: number;
+  evidence: { event_id: number; event_type: string }[];
+}
+
 // Spine types (direct from stiglab)
 export interface SpineEvent {
   id: number;
@@ -201,6 +213,30 @@ export const api = {
     request<GovernanceEvent[]>(`/governance/events${type ? `?type=${type}` : ''}`),
   getGovernanceStats: () => request<GovernanceStats>('/governance/stats'),
   getGovernanceRules: () => request<GovernanceRule[]>('/governance/rules'),
+  // Ising insights — backed by the spine events endpoint (issue #36).
+  // Returns a typed view of the `ising.insight_emitted` events so the
+  // governance UI doesn't have to reach into each event's `data` blob.
+  getIsingInsights: async (limit = 20): Promise<IsingInsightEmittedEvent[]> => {
+    const res = await request<{ events: SpineEvent[] }>(
+      `/spine/events?event_type=ising.insight_emitted&limit=${limit}`,
+    );
+    return res.events.map((e) => {
+      const d = e.data as {
+        signal_kind?: string;
+        subject_ref?: string;
+        confidence?: number;
+        evidence?: { event_id: number; event_type: string }[];
+      };
+      return {
+        id: e.id,
+        created_at: e.created_at,
+        signal_kind: d.signal_kind ?? 'unknown',
+        subject_ref: d.subject_ref ?? '',
+        confidence: typeof d.confidence === 'number' ? d.confidence : 0,
+        evidence: Array.isArray(d.evidence) ? d.evidence : [],
+      };
+    });
+  },
   resolveGovernanceEvent: (id: string, notes?: string) =>
     request<void>(`/governance/events/${id}/resolve`, {
       method: 'PATCH',

--- a/apps/dashboard/src/pages/GovernancePage.tsx
+++ b/apps/dashboard/src/pages/GovernancePage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
-import type { GovernanceEvent } from "@/lib/api"
+import type { GovernanceEvent, IsingInsightEmittedEvent } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -44,6 +44,15 @@ export function GovernancePage() {
     queryKey: ["governance-stats"],
     queryFn: api.getGovernanceStats,
     refetchInterval: 5000,
+  })
+
+  // Issue #36 — gate-override-rate insights surfaced by Ising. Refreshes
+  // less aggressively than governance events since analyzers tick on a 7d
+  // window, so per-second polling would burn backend cycles for no signal.
+  const { data: insights } = useQuery({
+    queryKey: ["ising-insights"],
+    queryFn: () => api.getIsingInsights(20),
+    refetchInterval: 15000,
   })
 
   const handleResolve = async (id: string) => {
@@ -89,6 +98,8 @@ export function GovernancePage() {
           ))}
         </div>
       </div>
+
+      <IsingInsightsCard insights={insights ?? []} />
 
       <Card>
         <CardHeader className="px-4 md:px-6">
@@ -200,6 +211,49 @@ function EventsTable({ events, onResolve }: { events: GovernanceEvent[]; onResol
         ))}
       </TableBody>
     </Table>
+  )
+}
+
+function IsingInsightsCard({ insights }: { insights: IsingInsightEmittedEvent[] }) {
+  return (
+    <Card>
+      <CardHeader className="px-4 md:px-6">
+        <CardTitle className="text-base md:text-lg">Ising Insights</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Signals surfaced by the Ising observation loop. Each entry points at
+          an artifact kind or subject with notable recent behavior.
+        </p>
+      </CardHeader>
+      <CardContent className="px-4 md:px-6">
+        {insights.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No insights yet. Ising emits signals as enough factory traffic
+            accumulates.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {insights.map((i) => (
+              <div
+                key={i.id}
+                className="flex flex-col gap-1 rounded-lg border p-3 md:flex-row md:items-center md:justify-between"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">{i.signal_kind}</Badge>
+                  <span className="text-sm font-medium">{i.subject_ref || "—"}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {i.evidence.length} evidence event{i.evidence.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>confidence {(i.confidence * 100).toFixed(0)}%</span>
+                  <span>{new Date(i.created_at).toLocaleString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -16,6 +16,8 @@ use onsager_spine::factory_event::ShapingOutcome;
 use onsager_spine::EventStore;
 
 use crate::core::artifact_store::ArtifactStore;
+use crate::core::insight_cache::InsightCache;
+use crate::core::insight_listener;
 use crate::core::kernel::BaselineKernel;
 use crate::core::persistence;
 use crate::core::pipeline::{ForgePipeline, PipelineEvent, StiglabDispatcher, SynodicGate};
@@ -383,7 +385,9 @@ pub fn run(database_url: &str, tick_ms: u64) {
             fail_policy,
         };
 
-        let mut pipeline = ForgePipeline::new(stiglab, synodic);
+        let insight_cache = InsightCache::default();
+        let mut pipeline =
+            ForgePipeline::new(stiglab, synodic).with_insight_cache(insight_cache.clone());
         pipeline.store = artifact_store;
 
         let shared = Arc::new(RwLock::new(ForgeSharedState {
@@ -477,6 +481,25 @@ pub fn run(database_url: &str, tick_ms: u64) {
                         _ => tracing::info!("forge tick: {event:?}"),
                     }
                 }
+            }
+        });
+
+        // Spawn the ising.insight_emitted listener (issue #36). It pushes
+        // parsed insights into `insight_cache`, which the pipeline pulls
+        // into `WorldState.insights` on every tick.
+        let insight_listener_shared = shared.clone();
+        let insight_cache_for_listener = insight_cache.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = insight_listener_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: insight listener disabled (no spine connection)");
+                return;
+            };
+            if let Err(e) = insight_listener::run(store, insight_cache_for_listener, None).await {
+                tracing::error!("forge: insight listener exited: {e}");
             }
         });
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -487,6 +487,12 @@ pub fn run(database_url: &str, tick_ms: u64) {
         // Spawn the ising.insight_emitted listener (issue #36). It pushes
         // parsed insights into `insight_cache`, which the pipeline pulls
         // into `WorldState.insights` on every tick.
+        //
+        // Warm-start the listener at the current max event id so it skips
+        // history-wide backfill. Replaying the entire spine on every boot
+        // would delay startup and push unbounded rows through the handler;
+        // insights are advisory priors, so forgoing old ones is correct —
+        // new emissions arrive live via pg_notify.
         let insight_listener_shared = shared.clone();
         let insight_cache_for_listener = insight_cache.clone();
         tokio::spawn(async move {
@@ -498,7 +504,17 @@ pub fn run(database_url: &str, tick_ms: u64) {
                 tracing::info!("forge: insight listener disabled (no spine connection)");
                 return;
             };
-            if let Err(e) = insight_listener::run(store, insight_cache_for_listener, None).await {
+            let since = match store.max_event_id().await {
+                Ok(cursor) => cursor,
+                Err(e) => {
+                    tracing::warn!(
+                        "forge: max_event_id lookup failed ({e}); starting insight \
+                         listener from the beginning"
+                    );
+                    None
+                }
+            };
+            if let Err(e) = insight_listener::run(store, insight_cache_for_listener, since).await {
                 tracing::error!("forge: insight listener exited: {e}");
             }
         });

--- a/crates/forge/src/core/insight_cache.rs
+++ b/crates/forge/src/core/insight_cache.rs
@@ -1,0 +1,145 @@
+//! Bounded, thread-safe cache of the most recent Ising insights
+//! (issue #36 — close the feedback loop).
+//!
+//! Forge pulls up to `max_len` most-recent insights into `WorldState.insights`
+//! on every pipeline tick so the scheduling kernel can take them into
+//! account. The cache is push-only with FIFO eviction — once the oldest
+//! insight rolls off the queue, it's gone. A downstream consumer that needs
+//! an audit trail should read the `ising.insight_emitted` events directly
+//! from the spine; this cache is a hot-path view, not a log.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use onsager_protocol::Insight;
+
+/// Default cache capacity. Small on purpose — insights are advisory priors
+/// for the scheduler, and stale ones waste kernel cycles.
+pub const DEFAULT_INSIGHT_CACHE_CAPACITY: usize = 64;
+
+/// A bounded ring-buffer of insights.
+#[derive(Clone)]
+pub struct InsightCache {
+    inner: Arc<Mutex<InsightCacheInner>>,
+}
+
+struct InsightCacheInner {
+    buf: VecDeque<Insight>,
+    capacity: usize,
+}
+
+impl InsightCache {
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            inner: Arc::new(Mutex::new(InsightCacheInner {
+                buf: VecDeque::with_capacity(capacity),
+                capacity,
+            })),
+        }
+    }
+
+    /// Push a new insight, evicting the oldest if at capacity.
+    pub fn push(&self, insight: Insight) {
+        let mut inner = self.inner.lock().expect("insight cache poisoned");
+        if inner.buf.len() == inner.capacity {
+            inner.buf.pop_front();
+        }
+        inner.buf.push_back(insight);
+    }
+
+    /// Snapshot the cache, newest-first.
+    pub fn recent(&self) -> Vec<Insight> {
+        let inner = self.inner.lock().expect("insight cache poisoned");
+        inner.buf.iter().rev().cloned().collect()
+    }
+
+    /// Number of insights currently held.
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("insight cache poisoned").buf.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("insight cache poisoned")
+            .buf
+            .is_empty()
+    }
+}
+
+impl Default for InsightCache {
+    fn default() -> Self {
+        Self::new(DEFAULT_INSIGHT_CACHE_CAPACITY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_protocol::FactoryEventRef;
+    use onsager_spine::{InsightKind, InsightScope};
+
+    fn make(id: &str) -> Insight {
+        Insight {
+            insight_id: id.into(),
+            kind: InsightKind::Failure,
+            scope: InsightScope::Global,
+            observation: "x".into(),
+            evidence: vec![FactoryEventRef {
+                event_id: 1,
+                event_type: "forge.gate_verdict".into(),
+            }],
+            suggested_action: None,
+            confidence: 0.7,
+        }
+    }
+
+    #[test]
+    fn newest_first_snapshot() {
+        let cache = InsightCache::new(10);
+        cache.push(make("a"));
+        cache.push(make("b"));
+        cache.push(make("c"));
+
+        let snap = cache.recent();
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].insight_id, "c");
+        assert_eq!(snap[2].insight_id, "a");
+    }
+
+    #[test]
+    fn evicts_oldest_at_capacity() {
+        let cache = InsightCache::new(2);
+        cache.push(make("a"));
+        cache.push(make("b"));
+        cache.push(make("c"));
+
+        let snap = cache.recent();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].insight_id, "c");
+        assert_eq!(snap[1].insight_id, "b");
+    }
+
+    #[test]
+    fn clone_shares_backing_store() {
+        // The cache is Arc-wrapped; one clone pushes and the other sees it,
+        // which is what the serve loop relies on for handing an "insight
+        // sink" to the listener task while the pipeline reads the same data.
+        let a = InsightCache::new(4);
+        let b = a.clone();
+        a.push(make("a"));
+        assert_eq!(b.len(), 1);
+    }
+
+    #[test]
+    fn zero_capacity_clamped_to_one() {
+        // Defensive: a zero-capacity cache would panic on push_back-then-
+        // pop_front; clamp rather than crash.
+        let cache = InsightCache::new(0);
+        cache.push(make("a"));
+        cache.push(make("b"));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.recent()[0].insight_id, "b");
+    }
+}

--- a/crates/forge/src/core/insight_listener.rs
+++ b/crates/forge/src/core/insight_listener.rs
@@ -1,0 +1,140 @@
+//! Event-driven listener that tails `ising.insight_emitted` from the spine
+//! and pushes parsed insights into the shared [`InsightCache`] (issue #36).
+//!
+//! Parallel to `session_listener` — filters on the `event_type` string rather
+//! than the stream_id namespace so the same wiring catches ising events
+//! regardless of how the producer stamps the `stream_id` (`"ising:<subject>"`
+//! vs. bare subject).
+//!
+//! Ising emits the event via `append_ext` with a hand-coded JSON body that
+//! matches the `IsingInsightEmitted` variant's field names but without the
+//! serde `"type"` tag. This listener therefore reads the fields directly
+//! from the raw `data` column rather than deserializing the full envelope.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use onsager_protocol::{FactoryEventRef, Insight};
+use onsager_spine::{
+    EventHandler, EventNotification, EventStore, InsightKind, InsightScope, Listener,
+};
+
+use super::insight_cache::InsightCache;
+
+/// Run the ising-insight listener forever. Returns only if the underlying
+/// pg_notify channel closes.
+pub async fn run(store: EventStore, cache: InsightCache, since: Option<i64>) -> anyhow::Result<()> {
+    let dispatcher = Dispatcher {
+        store: store.clone(),
+        cache: Arc::new(cache),
+    };
+    Listener::new(store).with_since(since).run(dispatcher).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    cache: Arc<InsightCache>,
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "ising.insight_emitted" {
+            return Ok(());
+        }
+        if notification.table != "events_ext" {
+            return Ok(());
+        }
+
+        let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+            return Ok(());
+        };
+
+        match parse_insight_from_emitted(row.id, &row.data) {
+            Some(insight) => self.cache.push(insight),
+            None => tracing::warn!(
+                id = row.id,
+                "forge: ising.insight_emitted payload failed to parse"
+            ),
+        }
+        Ok(())
+    }
+}
+
+/// Parse an `ising.insight_emitted` JSON payload into an `Insight` the
+/// scheduling kernel understands. We lose the `signal_kind` → kind mapping
+/// at this point (the variant uses `Failure` as a conservative default)
+/// since nothing in the scheduler branches on kind today; when it does,
+/// this mapping moves to a dedicated table.
+pub fn parse_insight_from_emitted(event_id: i64, data: &serde_json::Value) -> Option<Insight> {
+    let signal_kind = data.get("signal_kind")?.as_str()?;
+    let subject_ref = data.get("subject_ref")?.as_str()?;
+    let confidence = data.get("confidence")?.as_f64()?;
+
+    let evidence: Vec<FactoryEventRef> = data
+        .get("evidence")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| {
+                    Some(FactoryEventRef {
+                        event_id: e.get("event_id")?.as_i64()?,
+                        event_type: e.get("event_type")?.as_str()?.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(Insight {
+        insight_id: format!("ins_spine_{event_id}"),
+        kind: InsightKind::Failure,
+        scope: InsightScope::ArtifactKind(subject_ref.to_string()),
+        observation: format!("ising signal: {signal_kind}"),
+        evidence,
+        suggested_action: None,
+        confidence,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_emitted_payload() {
+        let data = json!({
+            "signal_kind": "repeated_gate_override",
+            "subject_ref": "code",
+            "evidence": [
+                {"event_id": 101, "event_type": "forge.gate_verdict"},
+                {"event_id": 98, "event_type": "forge.gate_verdict"},
+            ],
+            "confidence": 0.82,
+        });
+        let insight = parse_insight_from_emitted(555, &data).expect("parses");
+        assert_eq!(insight.evidence.len(), 2);
+        assert_eq!(insight.evidence[0].event_id, 101);
+        assert!((insight.confidence - 0.82).abs() < 1e-9);
+        assert_eq!(insight.scope, InsightScope::ArtifactKind("code".into()));
+        assert!(insight.observation.contains("repeated_gate_override"));
+    }
+
+    #[test]
+    fn tolerates_missing_evidence_array() {
+        let data = json!({
+            "signal_kind": "x",
+            "subject_ref": "code",
+            "confidence": 0.6,
+        });
+        let insight = parse_insight_from_emitted(1, &data).expect("parses");
+        assert!(insight.evidence.is_empty());
+    }
+
+    #[test]
+    fn rejects_when_required_fields_missing() {
+        let data = json!({ "signal_kind": "x" });
+        assert!(parse_insight_from_emitted(1, &data).is_none());
+    }
+}

--- a/crates/forge/src/core/insight_listener.rs
+++ b/crates/forge/src/core/insight_listener.rs
@@ -66,25 +66,31 @@ impl EventHandler for Dispatcher {
 /// at this point (the variant uses `Failure` as a conservative default)
 /// since nothing in the scheduler branches on kind today; when it does,
 /// this mapping moves to a dedicated table.
+///
+/// The spine contract says `evidence` is non-empty (enforced by Ising's
+/// `InsightEmitter`). We enforce the same here so a malformed producer
+/// can't silently feed contract-violating rows into the scheduling cache;
+/// missing, malformed, or empty evidence returns `None` so the caller
+/// logs and drops the row.
 pub fn parse_insight_from_emitted(event_id: i64, data: &serde_json::Value) -> Option<Insight> {
     let signal_kind = data.get("signal_kind")?.as_str()?;
     let subject_ref = data.get("subject_ref")?.as_str()?;
     let confidence = data.get("confidence")?.as_f64()?;
 
     let evidence: Vec<FactoryEventRef> = data
-        .get("evidence")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|e| {
-                    Some(FactoryEventRef {
-                        event_id: e.get("event_id")?.as_i64()?,
-                        event_type: e.get("event_type")?.as_str()?.to_string(),
-                    })
-                })
-                .collect()
+        .get("evidence")?
+        .as_array()?
+        .iter()
+        .map(|e| {
+            Some(FactoryEventRef {
+                event_id: e.get("event_id")?.as_i64()?,
+                event_type: e.get("event_type")?.as_str()?.to_string(),
+            })
         })
-        .unwrap_or_default();
+        .collect::<Option<Vec<_>>>()?;
+    if evidence.is_empty() {
+        return None;
+    }
 
     Some(Insight {
         insight_id: format!("ins_spine_{event_id}"),
@@ -122,14 +128,39 @@ mod tests {
     }
 
     #[test]
-    fn tolerates_missing_evidence_array() {
+    fn rejects_missing_evidence_array() {
+        // Contract violation: the spine event variant documents evidence as
+        // non-empty, so a payload with no evidence must not reach the cache.
         let data = json!({
             "signal_kind": "x",
             "subject_ref": "code",
             "confidence": 0.6,
         });
-        let insight = parse_insight_from_emitted(1, &data).expect("parses");
-        assert!(insight.evidence.is_empty());
+        assert!(parse_insight_from_emitted(1, &data).is_none());
+    }
+
+    #[test]
+    fn rejects_empty_evidence_array() {
+        let data = json!({
+            "signal_kind": "x",
+            "subject_ref": "code",
+            "confidence": 0.6,
+            "evidence": [],
+        });
+        assert!(parse_insight_from_emitted(1, &data).is_none());
+    }
+
+    #[test]
+    fn rejects_evidence_row_with_wrong_shape() {
+        // A single bad row taints the whole parse — the cache should never
+        // see partial evidence for a signal.
+        let data = json!({
+            "signal_kind": "x",
+            "subject_ref": "code",
+            "confidence": 0.6,
+            "evidence": [{"event_id": 1}],
+        });
+        assert!(parse_insight_from_emitted(1, &data).is_none());
     }
 
     #[test]

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -1,6 +1,8 @@
 //! Core Forge logic — scheduling kernel, artifact store, pipeline, and state machine.
 
 pub mod artifact_store;
+pub mod insight_cache;
+pub mod insight_listener;
 pub mod kernel;
 pub mod persistence;
 pub mod pipeline;
@@ -8,6 +10,7 @@ pub mod session_listener;
 pub mod state;
 
 pub use artifact_store::ArtifactStore;
+pub use insight_cache::{InsightCache, DEFAULT_INSIGHT_CACHE_CAPACITY};
 pub use kernel::{BaselineKernel, SchedulingKernel, WorldState};
 pub use pipeline::ForgePipeline;
 pub use session_listener::{SessionCompleted, SessionCompletedHandler};

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -21,6 +21,7 @@ use onsager_spine::factory_event::{GatePoint, ShapingOutcome, VerdictSummary};
 use onsager_warehouse::{Outputs, SealError, SealRequest, Warehouse};
 
 use super::artifact_store::ArtifactStore;
+use super::insight_cache::InsightCache;
 use super::kernel::{SchedulingKernel, WorldState};
 use super::state::ForgeState;
 
@@ -171,6 +172,11 @@ pub struct ForgePipeline<S: StiglabDispatcher, G: SynodicGate> {
     /// successful `Released` transitions (warehouse-and-delivery-v0.1 §5.1).
     /// Absent in legacy deployments; seals are skipped in that case.
     warehouse: Option<Box<dyn SealSink>>,
+    /// Shared cache of the most recent Ising insights (issue #36). The cache
+    /// is an `Arc<Mutex<...>>` so the ising listener can push to it without
+    /// holding the pipeline lock. Always present — the default cache is
+    /// empty, which preserves the pre-issue-#36 behavior.
+    insights: InsightCache,
 }
 
 impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
@@ -181,6 +187,7 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             stiglab,
             synodic,
             warehouse: None,
+            insights: InsightCache::default(),
         }
     }
 
@@ -189,6 +196,19 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
     pub fn with_warehouse(mut self, warehouse: Box<dyn SealSink>) -> Self {
         self.warehouse = Some(warehouse);
         self
+    }
+
+    /// Attach a shared [`InsightCache`]. Hand the same clone to the
+    /// ising-event listener so insights flow into `WorldState.insights`.
+    pub fn with_insight_cache(mut self, insights: InsightCache) -> Self {
+        self.insights = insights;
+        self
+    }
+
+    /// Clone of the shared insight cache — used by the serve binary to hand
+    /// the same backing store to the ising event listener.
+    pub fn insight_cache(&self) -> InsightCache {
+        self.insights.clone()
     }
 
     /// Execute one tick of the scheduling loop.
@@ -200,10 +220,12 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             return output;
         }
 
-        // Build world state.
+        // Build world state. `insights` is populated from the shared cache
+        // the ising-event listener writes into (issue #36); the vec was
+        // previously hardcoded empty.
         let world = WorldState {
             artifacts: self.store.active_artifacts().into_iter().cloned().collect(),
-            insights: vec![],
+            insights: self.insights.recent(),
             in_flight_count: 0,
             max_in_flight: 5,
         };
@@ -481,6 +503,56 @@ mod tests {
                 reason: "policy violation".into(),
             }
         }
+    }
+
+    /// Mock kernel that snapshots the `WorldState.insights` it sees on every
+    /// call. Tests use this to verify the pipeline threads insights from
+    /// the shared cache into the scheduling kernel (issue #36).
+    struct CapturingKernel {
+        seen: std::sync::Mutex<Vec<Vec<onsager_protocol::Insight>>>,
+    }
+    impl SchedulingKernel for CapturingKernel {
+        fn decide(&self, world: &WorldState) -> Option<ShapingDecision> {
+            self.seen.lock().unwrap().push(world.insights.clone());
+            // Return None so the tick ends early; we only care about what the
+            // kernel observed, not about driving a full lifecycle.
+            None
+        }
+        fn observe(&mut self, _event: &onsager_spine::factory_event::FactoryEvent) {}
+    }
+
+    #[test]
+    fn tick_feeds_insight_cache_into_world_state() {
+        use onsager_protocol::{FactoryEventRef, Insight};
+        use onsager_spine::{InsightKind, InsightScope};
+
+        let cache = InsightCache::default();
+        cache.push(Insight {
+            insight_id: "ins_1".into(),
+            kind: InsightKind::Failure,
+            scope: InsightScope::ArtifactKind("code".into()),
+            observation: "many overrides".into(),
+            evidence: vec![FactoryEventRef {
+                event_id: 7,
+                event_type: "forge.gate_verdict".into(),
+            }],
+            suggested_action: None,
+            confidence: 0.8,
+        });
+
+        let mut pipeline =
+            ForgePipeline::new(MockStiglab, MockSynodicAllow).with_insight_cache(cache.clone());
+        pipeline.store.register(Kind::Code, "x", "marvin");
+
+        let kernel = CapturingKernel {
+            seen: Default::default(),
+        };
+        pipeline.tick(&kernel);
+
+        let seen = kernel.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].len(), 1);
+        assert_eq!(seen[0][0].insight_id, "ins_1");
     }
 
     #[test]

--- a/crates/ising/src/analyzers/gate_override.rs
+++ b/crates/ising/src/analyzers/gate_override.rs
@@ -1,0 +1,225 @@
+//! Gate-override-rate analyzer (issue #36 — close the Ising feedback loop).
+//!
+//! Looks at every Forge `gate.verdict` event over a window (default 7 days)
+//! and flags artifact kinds whose deny-plus-escalate ratio crosses a
+//! configurable threshold. These are the kinds where policy friction is
+//! loudest — prime candidates for rule review, rewording, or retirement.
+//!
+//! The event stream doesn't yet carry `rule_id`, so grouping is by artifact
+//! kind (resolved via `FactoryModel.artifacts`). When gate verdicts start
+//! carrying rule identity, this analyzer extends to per-rule grouping
+//! without changing its emission contract.
+//!
+//! Emission shape: `signal_kind = "repeated_gate_override"`, `subject_ref`
+//! is the artifact kind (e.g. `"code"`), `evidence` is up to five recent
+//! override-verdict event ids, `confidence` scales linearly with the
+//! override ratio above the threshold.
+
+use chrono::Duration;
+use onsager_protocol::{FactoryEventRef, Insight};
+use onsager_spine::factory_event::{InsightKind, InsightScope};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+/// Stable signal identifier emitted on the spine for this analyzer's output.
+pub const SIGNAL_KIND: &str = "repeated_gate_override";
+
+/// Configuration for the gate-override analyzer.
+#[derive(Debug, Clone)]
+pub struct GateOverrideConfig {
+    /// Verdict lookback window (default 7 days — matches issue #36 MVP).
+    pub window: Duration,
+    /// Minimum verdicts observed per kind before a rate is computed.
+    pub min_samples: usize,
+    /// Override ratio that must be crossed before emitting.
+    pub threshold: f64,
+}
+
+impl Default for GateOverrideConfig {
+    fn default() -> Self {
+        Self {
+            window: Duration::days(7),
+            min_samples: 5,
+            threshold: 0.5,
+        }
+    }
+}
+
+/// Detects artifact kinds with a high gate deny/escalate rate.
+pub struct GateOverrideAnalyzer {
+    config: GateOverrideConfig,
+}
+
+impl GateOverrideAnalyzer {
+    pub fn new(config: GateOverrideConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for GateOverrideAnalyzer {
+    fn default() -> Self {
+        Self::new(GateOverrideConfig::default())
+    }
+}
+
+impl Analyzer for GateOverrideAnalyzer {
+    fn name(&self) -> &str {
+        SIGNAL_KIND
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let rates = model.override_rate_by_kind(self.config.window, self.config.min_samples);
+
+        rates
+            .into_iter()
+            .filter(|(_, (rate, _, _))| *rate >= self.config.threshold)
+            .map(|(kind, (rate, total, override_ids))| {
+                let kind_label = kind.to_string();
+                let evidence: Vec<FactoryEventRef> = override_ids
+                    .into_iter()
+                    .map(|event_id| FactoryEventRef {
+                        event_id,
+                        event_type: "forge.gate_verdict".into(),
+                    })
+                    .collect();
+
+                // Confidence: scale linearly from threshold → 1.0 with headroom
+                // so a rate exactly at the threshold still emits with a modest
+                // signal (0.5) rather than dropping through `min_confidence`.
+                let range = (1.0 - self.config.threshold).max(f64::EPSILON);
+                let excess = (rate - self.config.threshold).max(0.0) / range;
+                let confidence = (0.5 + excess * 0.4).min(0.95);
+
+                Insight {
+                    insight_id: format!("ins_gor_{}_{}", kind_label, model.events_processed),
+                    kind: InsightKind::Failure,
+                    scope: InsightScope::ArtifactKind(kind_label.clone()),
+                    observation: format!(
+                        "{} artifacts: {:.0}% gate-override rate over {} verdicts in the \
+                         last {} day(s) — rules governing this kind may need review",
+                        kind_label,
+                        rate * 100.0,
+                        total,
+                        self.config.window.num_days(),
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                }
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::{ArtifactId, Kind};
+    use onsager_spine::factory_event::{FactoryEventKind, GatePoint, VerdictSummary};
+
+    fn register(model: &mut FactoryModel, id: &ArtifactId, kind: Kind, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind,
+                name: "t".into(),
+                owner: "marvin".into(),
+            },
+        );
+    }
+
+    fn verdict(model: &mut FactoryModel, id: &ArtifactId, v: VerdictSummary, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ForgeGateVerdict {
+                artifact_id: id.clone(),
+                gate_point: GatePoint::PreDispatch,
+                verdict: v,
+            },
+        );
+    }
+
+    #[test]
+    fn emits_when_override_rate_exceeds_threshold() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_c");
+        register(&mut model, &id, Kind::Code, 1);
+
+        // 4 deny + 1 allow = 80% > 50% threshold, 5 samples = min.
+        for (i, v) in [
+            VerdictSummary::Deny,
+            VerdictSummary::Deny,
+            VerdictSummary::Deny,
+            VerdictSummary::Deny,
+            VerdictSummary::Allow,
+        ]
+        .iter()
+        .enumerate()
+        {
+            verdict(&mut model, &id, v.clone(), i as i64 + 10);
+        }
+
+        let insights = GateOverrideAnalyzer::default().run(&model);
+        assert_eq!(insights.len(), 1);
+        let ins = &insights[0];
+        assert_eq!(ins.kind, InsightKind::Failure);
+        assert_eq!(
+            ins.scope,
+            InsightScope::ArtifactKind("code".into()),
+            "scope carries the kind label for downstream routing",
+        );
+        assert!(!ins.evidence.is_empty());
+        assert!(ins.confidence >= 0.5 && ins.confidence <= 0.95);
+        assert!(ins.observation.contains("gate-override"));
+    }
+
+    #[test]
+    fn no_emission_below_threshold() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_c");
+        register(&mut model, &id, Kind::Code, 1);
+
+        // 1 deny + 4 allow = 20% < 50% threshold.
+        for (i, v) in [
+            VerdictSummary::Deny,
+            VerdictSummary::Allow,
+            VerdictSummary::Allow,
+            VerdictSummary::Allow,
+            VerdictSummary::Allow,
+        ]
+        .iter()
+        .enumerate()
+        {
+            verdict(&mut model, &id, v.clone(), i as i64 + 10);
+        }
+
+        assert!(GateOverrideAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn no_emission_when_below_min_samples() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_c");
+        register(&mut model, &id, Kind::Code, 1);
+
+        // All denies but only 2 samples — not enough to be confident.
+        verdict(&mut model, &id, VerdictSummary::Deny, 10);
+        verdict(&mut model, &id, VerdictSummary::Deny, 11);
+
+        assert!(GateOverrideAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn analyzer_name_is_signal_kind() {
+        // The Ising emitter uses Analyzer::name() as the signal_kind on the
+        // spine event — this test pins the contract so it doesn't silently
+        // drift if the analyzer is renamed.
+        assert_eq!(GateOverrideAnalyzer::default().name(), SIGNAL_KIND);
+    }
+}

--- a/crates/ising/src/analyzers/mod.rs
+++ b/crates/ising/src/analyzers/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! v0.1 ships with heuristic analyzers, not learned models (ising-v0.1 §6).
 
+pub mod gate_override;
 pub mod repeated_failures;
 pub mod stuck_artifacts;
 
+pub use gate_override::GateOverrideAnalyzer;
 pub use repeated_failures::RepeatedFailuresAnalyzer;
 pub use stuck_artifacts::StuckArtifactsAnalyzer;
 
@@ -14,4 +16,5 @@ use crate::core::AnalyzerRegistry;
 pub fn register_defaults(registry: &mut AnalyzerRegistry) {
     registry.register(Box::new(RepeatedFailuresAnalyzer::default()));
     registry.register(Box::new(StuckArtifactsAnalyzer::default()));
+    registry.register(Box::new(GateOverrideAnalyzer::default()));
 }

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -60,27 +60,34 @@ pub fn run(database_url: &str, tick_ms: u64) {
         register_defaults(&mut registry);
         tracing::info!(analyzers = registry.len(), "ising: analyzer registry ready");
 
+        // Long-lived emitter: keeping the dedup window across ticks prevents
+        // the same insight pattern from being re-appended to `events_ext` on
+        // every rebuild as long as its fingerprint is unchanged. Without
+        // this the spine — and the dashboard reading from it — would get
+        // flooded with duplicates every `tick_ms` while the evidence
+        // remains inside the lookback window.
+        let mut emitter = InsightEmitter::new(EmitterConfig::default());
+
         let mut interval = tokio::time::interval(std::time::Duration::from_millis(tick_ms));
         loop {
             interval.tick().await;
-            if let Err(e) = run_tick(&spine, &registry).await {
+            if let Err(e) = run_tick(&spine, &registry, &mut emitter).await {
                 tracing::error!("ising: tick failed: {e}");
             }
         }
     });
 }
 
-async fn run_tick(spine: &EventStore, registry: &AnalyzerRegistry) -> Result<(), anyhow::Error> {
+async fn run_tick(
+    spine: &EventStore,
+    registry: &AnalyzerRegistry,
+    emitter: &mut InsightEmitter,
+) -> Result<(), anyhow::Error> {
     let model = build_model(spine).await?;
     if model.events_processed == 0 {
         // No observable factory activity yet — nothing to reason about.
         return Ok(());
     }
-
-    // A fresh emitter per tick: dedup is tick-scoped, matching the
-    // "rebuild the world each time" loop. Persistent dedup against already-
-    // emitted insights is a v0.2 concern once we move to streaming.
-    let mut emitter = InsightEmitter::new(EmitterConfig::default());
 
     let mut emitted = 0usize;
     for (analyzer_name, insights) in registry.run_all(&model) {
@@ -119,16 +126,37 @@ async fn run_tick(spine: &EventStore, registry: &AnalyzerRegistry) -> Result<(),
 /// today — once events are emitted through a typed spine helper this parser
 /// collapses to `serde_json::from_value`.
 async fn build_model(spine: &EventStore) -> Result<FactoryModel, anyhow::Error> {
+    let cutoff = Utc::now() - LOOKBACK;
     let rows = spine
         .query_ext_events(None, Some("forge"), EVENT_FETCH_LIMIT)
         .await?;
+
+    // If we pulled the whole fetch cap and the oldest row we got is still
+    // inside the lookback window, there are events we didn't load. The
+    // override rate is then computed from a truncated slice — surface it
+    // loudly rather than silently under-count. A DB-side `created_at >=
+    // cutoff` filter is the structural fix and belongs in the EventStore
+    // API; this warning is the cheap forcing function to get us there.
+    if rows.len() as i64 >= EVENT_FETCH_LIMIT
+        && rows
+            .iter()
+            .map(|r| r.created_at)
+            .min()
+            .is_some_and(|oldest| oldest >= cutoff)
+    {
+        tracing::warn!(
+            event_fetch_limit = EVENT_FETCH_LIMIT,
+            lookback_days = LOOKBACK.num_days(),
+            "ising: forge event fetch cap reached before lookback cutoff; \
+             model window may be incomplete"
+        );
+    }
 
     // Rows come back newest-first; ingest oldest-first so event_id ordering
     // inside the model matches spine order.
     let mut rows = rows;
     rows.sort_by_key(|r| r.id);
 
-    let cutoff = Utc::now() - LOOKBACK;
     let mut model = FactoryModel::new();
     let mut seen_ids: HashSet<i64> = HashSet::new();
 
@@ -142,7 +170,10 @@ async fn build_model(spine: &EventStore) -> Result<FactoryModel, anyhow::Error> 
         let Some(event) = parse_forge_event(&row.event_type, &row.data) else {
             continue;
         };
-        model.ingest(row.id, &event);
+        // Use the spine row's `created_at` so windowed analyzers honor event
+        // time, not ingest time — otherwise every tick's rebuild makes old
+        // events look fresh.
+        model.ingest_at(row.id, row.created_at, &event);
     }
 
     Ok(model)

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -1,26 +1,339 @@
-//! `ising serve` — start the Ising observation loop.
+//! `ising serve` — start the Ising observation loop (issue #36 MVP).
+//!
+//! Each tick:
+//!   1. Query recent forge events from `events_ext` (artifact.registered +
+//!      forge.gate_verdict) to rebuild a fresh [`FactoryModel`].
+//!   2. Run the registered analyzers against the model.
+//!   3. Pass each produced insight through the [`InsightEmitter`]
+//!      (validation + dedup) and append accepted emissions to `events_ext`
+//!      as `ising.insight_emitted` so Forge and the dashboard can read
+//!      them.
+//!
+//! The rebuild-per-tick approach is intentionally naive — it's O(N) in
+//! recent events but avoids a second cursor source-of-truth while the
+//! ising pipeline is bedding in. A streaming `Listener`-based path is the
+//! next iteration once the emission contract is stable.
+
+use std::collections::HashSet;
+
+use chrono::{Duration, Utc};
+use onsager_artifact::{ArtifactId, Kind};
+use onsager_spine::factory_event::{FactoryEventKind, GatePoint, VerdictSummary};
+use onsager_spine::{EventMetadata, EventStore};
+
+use crate::analyzers::register_defaults;
+use crate::core::emitter::{EmitResult, EmitterConfig, InsightEmitter};
+use crate::core::{insight_to_emitted_event, AnalyzerRegistry, FactoryModel};
+
+/// How far back to look for forge events when rebuilding the factory model.
+/// Matches the default `GateOverrideConfig::window` so insights have enough
+/// evidence to compute stable override ratios.
+const LOOKBACK: Duration = Duration::days(7);
+
+/// Upper bound on how many recent events to pull per tick. Comfortably above
+/// the expected volume for a dev factory; real deployments will want a
+/// cursor-based stream instead.
+const EVENT_FETCH_LIMIT: i64 = 2000;
 
 /// Start the Ising observation loop.
-///
-/// In production, this connects to the event spine, instantiates the analyzer
-/// registry, and runs the core observation loop. For v0.1, this is a skeleton.
-pub fn run(_database_url: &str, tick_ms: u64) {
+pub fn run(database_url: &str, tick_ms: u64) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async move {
         tracing_subscriber::fmt()
             .with_env_filter("ising=info")
             .init();
 
-        tracing::info!(tick_ms = tick_ms, "ising: starting observation loop");
+        tracing::info!(tick_ms, "ising: starting observation loop");
 
-        // In production this would:
-        // 1. Connect to the event spine (EventStore)
-        // 2. Register all analyzers (register_defaults)
-        // 3. Subscribe to pg_notify and consume events
-        // 4. Run analyzers on each tick
-        // 5. Emit insights back to the spine
-        //
-        // For now, log and exit.
-        tracing::info!("ising: v0.1 scaffold — observation loop not yet connected to spine");
+        let spine = match EventStore::connect(database_url).await {
+            Ok(s) => {
+                tracing::info!("ising: connected to event spine");
+                s
+            }
+            Err(e) => {
+                tracing::error!("ising: spine connection failed ({e}); exiting");
+                return;
+            }
+        };
+
+        let mut registry = AnalyzerRegistry::new();
+        register_defaults(&mut registry);
+        tracing::info!(analyzers = registry.len(), "ising: analyzer registry ready");
+
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(tick_ms));
+        loop {
+            interval.tick().await;
+            if let Err(e) = run_tick(&spine, &registry).await {
+                tracing::error!("ising: tick failed: {e}");
+            }
+        }
     });
+}
+
+async fn run_tick(spine: &EventStore, registry: &AnalyzerRegistry) -> Result<(), anyhow::Error> {
+    let model = build_model(spine).await?;
+    if model.events_processed == 0 {
+        // No observable factory activity yet — nothing to reason about.
+        return Ok(());
+    }
+
+    // A fresh emitter per tick: dedup is tick-scoped, matching the
+    // "rebuild the world each time" loop. Persistent dedup against already-
+    // emitted insights is a v0.2 concern once we move to streaming.
+    let mut emitter = InsightEmitter::new(EmitterConfig::default());
+
+    let mut emitted = 0usize;
+    for (analyzer_name, insights) in registry.run_all(&model) {
+        for insight in insights {
+            match emitter.emit(insight) {
+                EmitResult::Accepted { insight, .. } => {
+                    let event = insight_to_emitted_event(&analyzer_name, &insight);
+                    if let Err(e) = append_insight_emitted(spine, &event).await {
+                        tracing::warn!("ising: failed to append insight event: {e}");
+                        continue;
+                    }
+                    emitted += 1;
+                }
+                EmitResult::Suppressed { reason, .. } => {
+                    tracing::debug!(
+                        analyzer = analyzer_name,
+                        reason,
+                        "ising: insight suppressed"
+                    );
+                }
+                EmitResult::Rejected { reason } => {
+                    tracing::warn!(analyzer = analyzer_name, reason, "ising: insight rejected");
+                }
+            }
+        }
+    }
+
+    if emitted > 0 {
+        tracing::info!(emitted, "ising: tick emitted insights");
+    }
+    Ok(())
+}
+
+/// Rebuild an in-memory [`FactoryModel`] from the recent-events window in
+/// `events_ext`. Parses the hand-coded JSON payloads Forge / Stiglab write
+/// today — once events are emitted through a typed spine helper this parser
+/// collapses to `serde_json::from_value`.
+async fn build_model(spine: &EventStore) -> Result<FactoryModel, anyhow::Error> {
+    let rows = spine
+        .query_ext_events(None, Some("forge"), EVENT_FETCH_LIMIT)
+        .await?;
+
+    // Rows come back newest-first; ingest oldest-first so event_id ordering
+    // inside the model matches spine order.
+    let mut rows = rows;
+    rows.sort_by_key(|r| r.id);
+
+    let cutoff = Utc::now() - LOOKBACK;
+    let mut model = FactoryModel::new();
+    let mut seen_ids: HashSet<i64> = HashSet::new();
+
+    for row in rows {
+        if !seen_ids.insert(row.id) {
+            continue;
+        }
+        if row.created_at < cutoff {
+            continue;
+        }
+        let Some(event) = parse_forge_event(&row.event_type, &row.data) else {
+            continue;
+        };
+        model.ingest(row.id, &event);
+    }
+
+    Ok(model)
+}
+
+/// Translate one forge-namespace row from `events_ext` into a
+/// [`FactoryEventKind`] the model can ingest. Returns `None` for event types
+/// Ising doesn't care about, or payloads too malformed to use.
+fn parse_forge_event(event_type: &str, data: &serde_json::Value) -> Option<FactoryEventKind> {
+    match event_type {
+        "artifact.registered" => {
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let kind_str = data.get("kind")?.as_str()?;
+            let name = data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let owner = data
+                .get("owner")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(FactoryEventKind::ArtifactRegistered {
+                artifact_id: ArtifactId::new(artifact_id),
+                kind: parse_kind(kind_str),
+                name,
+                owner,
+            })
+        }
+        "forge.gate_verdict" => {
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let gate_point = parse_gate_point(data.get("gate_point")?.as_str()?)?;
+            let verdict = parse_verdict(data.get("verdict")?.as_str()?)?;
+            Some(FactoryEventKind::ForgeGateVerdict {
+                artifact_id: ArtifactId::new(artifact_id),
+                gate_point,
+                verdict,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_kind(s: &str) -> Kind {
+    match s {
+        "code" => Kind::Code,
+        "document" => Kind::Document,
+        "pull_request" => Kind::PullRequest,
+        other => Kind::Custom(other.to_string()),
+    }
+}
+
+fn parse_gate_point(s: &str) -> Option<GatePoint> {
+    // Forge emits via `{:?}` (Debug), so strings arrive as CamelCase variant
+    // names; Synodic may emit the serde snake_case form. Accept both.
+    match s {
+        "PreDispatch" | "pre_dispatch" => Some(GatePoint::PreDispatch),
+        "StateTransition" | "state_transition" => Some(GatePoint::StateTransition),
+        "ConsumerRouting" | "consumer_routing" => Some(GatePoint::ConsumerRouting),
+        "ToolLevel" | "tool_level" => Some(GatePoint::ToolLevel),
+        _ => None,
+    }
+}
+
+fn parse_verdict(s: &str) -> Option<VerdictSummary> {
+    match s {
+        "Allow" | "allow" => Some(VerdictSummary::Allow),
+        "Deny" | "deny" => Some(VerdictSummary::Deny),
+        "Modify" | "modify" => Some(VerdictSummary::Modify),
+        "Escalate" | "escalate" => Some(VerdictSummary::Escalate),
+        _ => None,
+    }
+}
+
+/// Append an `ising.insight_emitted` row to `events_ext` so Forge and the
+/// dashboard can consume it. Uses the same pattern as Forge's hand-coded
+/// emissions so dashboard queries (`namespace = "ising"`) keep working.
+async fn append_insight_emitted(
+    spine: &EventStore,
+    event: &FactoryEventKind,
+) -> Result<i64, anyhow::Error> {
+    let FactoryEventKind::IsingInsightEmitted {
+        signal_kind,
+        subject_ref,
+        evidence,
+        confidence,
+    } = event
+    else {
+        return Err(anyhow::anyhow!(
+            "append_insight_emitted called with non-IsingInsightEmitted variant"
+        ));
+    };
+
+    let stream_id = format!("ising:{subject_ref}");
+    let data = serde_json::json!({
+        "signal_kind": signal_kind,
+        "subject_ref": subject_ref,
+        "evidence": evidence,
+        "confidence": confidence,
+    });
+    let meta = EventMetadata {
+        actor: "ising".to_string(),
+        ..Default::default()
+    };
+
+    let id = spine
+        .append_ext(
+            &stream_id,
+            "ising",
+            "ising.insight_emitted",
+            data,
+            &meta,
+            None,
+        )
+        .await?;
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_artifact_registered_payload() {
+        let data = json!({
+            "artifact_id": "art_x",
+            "kind": "code",
+            "name": "svc",
+            "owner": "marvin",
+        });
+        let parsed = parse_forge_event("artifact.registered", &data).expect("parses");
+        match parsed {
+            FactoryEventKind::ArtifactRegistered {
+                artifact_id, kind, ..
+            } => {
+                assert_eq!(artifact_id.as_str(), "art_x");
+                assert_eq!(kind, Kind::Code);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parses_gate_verdict_debug_format() {
+        // Forge emits via `{:?}`: CamelCase variants.
+        let data = json!({
+            "artifact_id": "art_x",
+            "gate_point": "PreDispatch",
+            "verdict": "Deny",
+        });
+        let parsed = parse_forge_event("forge.gate_verdict", &data).expect("parses");
+        match parsed {
+            FactoryEventKind::ForgeGateVerdict {
+                gate_point,
+                verdict,
+                ..
+            } => {
+                assert_eq!(gate_point, GatePoint::PreDispatch);
+                assert_eq!(verdict, VerdictSummary::Deny);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parses_gate_verdict_snake_case_format() {
+        // A future typed emitter would use serde snake_case — accept that too.
+        let data = json!({
+            "artifact_id": "art_x",
+            "gate_point": "state_transition",
+            "verdict": "escalate",
+        });
+        let parsed = parse_forge_event("forge.gate_verdict", &data).expect("parses");
+        match parsed {
+            FactoryEventKind::ForgeGateVerdict {
+                gate_point,
+                verdict,
+                ..
+            } => {
+                assert_eq!(gate_point, GatePoint::StateTransition);
+                assert_eq!(verdict, VerdictSummary::Escalate);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn ignores_unknown_event_types() {
+        let data = json!({});
+        assert!(parse_forge_event("forge.shaping_returned", &data).is_none());
+    }
 }

--- a/crates/ising/src/core/emission.rs
+++ b/crates/ising/src/core/emission.rs
@@ -1,0 +1,113 @@
+//! Emission — convert an internal `Insight` into the `ising.insight_emitted`
+//! spine event (issue #36).
+//!
+//! This is deliberately a thin mapping: the analyzer names produce
+//! `signal_kind`, the `InsightScope` collapses to a free-form `subject_ref`,
+//! and `FactoryEventRef` fields become spine-native `EventRef`s. Kept
+//! separate from the emitter so the serve loop can build the event without
+//! also running the validation / dedup pipeline.
+
+use onsager_protocol::Insight;
+use onsager_spine::factory_event::{EventRef, FactoryEventKind, InsightScope};
+
+/// Build the `ising.insight_emitted` variant from an accepted `Insight` and
+/// the name of the analyzer that produced it.
+pub fn insight_to_emitted_event(signal_kind: &str, insight: &Insight) -> FactoryEventKind {
+    let subject_ref = subject_ref_from_scope(&insight.scope);
+    let evidence = insight
+        .evidence
+        .iter()
+        .map(|e| EventRef {
+            event_id: e.event_id,
+            event_type: e.event_type.clone(),
+        })
+        .collect();
+
+    FactoryEventKind::IsingInsightEmitted {
+        signal_kind: signal_kind.to_owned(),
+        subject_ref,
+        evidence,
+        confidence: insight.confidence,
+    }
+}
+
+/// Collapse an `InsightScope` to a `subject_ref` string — the identifier a
+/// downstream consumer joins on.
+fn subject_ref_from_scope(scope: &InsightScope) -> String {
+    match scope {
+        InsightScope::Global => "global".to_string(),
+        InsightScope::ArtifactKind(k) => k.clone(),
+        InsightScope::SpecificArtifact(id) => id.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::ArtifactId;
+    use onsager_protocol::FactoryEventRef;
+    use onsager_spine::factory_event::InsightKind;
+
+    fn make_insight(scope: InsightScope) -> Insight {
+        Insight {
+            insight_id: "ins_1".into(),
+            kind: InsightKind::Failure,
+            scope,
+            observation: "o".into(),
+            evidence: vec![FactoryEventRef {
+                event_id: 7,
+                event_type: "forge.gate_verdict".into(),
+            }],
+            suggested_action: None,
+            confidence: 0.73,
+        }
+    }
+
+    #[test]
+    fn maps_artifact_kind_scope() {
+        let evt = insight_to_emitted_event(
+            "repeated_gate_override",
+            &make_insight(InsightScope::ArtifactKind("code".into())),
+        );
+        match evt {
+            FactoryEventKind::IsingInsightEmitted {
+                signal_kind,
+                subject_ref,
+                evidence,
+                confidence,
+            } => {
+                assert_eq!(signal_kind, "repeated_gate_override");
+                assert_eq!(subject_ref, "code");
+                assert_eq!(evidence.len(), 1);
+                assert_eq!(evidence[0].event_id, 7);
+                assert!((confidence - 0.73).abs() < 1e-9);
+            }
+            _ => panic!("expected IsingInsightEmitted"),
+        }
+    }
+
+    #[test]
+    fn maps_specific_artifact_scope_to_artifact_id() {
+        let evt = insight_to_emitted_event(
+            "shape_retry_spike",
+            &make_insight(InsightScope::SpecificArtifact(ArtifactId::new("art_abc"))),
+        );
+        match evt {
+            FactoryEventKind::IsingInsightEmitted { subject_ref, .. } => {
+                assert_eq!(subject_ref, "art_abc");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn maps_global_scope() {
+        let evt = insight_to_emitted_event("x", &make_insight(InsightScope::Global));
+        match evt {
+            FactoryEventKind::IsingInsightEmitted { subject_ref, .. } => {
+                assert_eq!(subject_ref, "global");
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/crates/ising/src/core/mod.rs
+++ b/crates/ising/src/core/mod.rs
@@ -1,9 +1,11 @@
 //! Core Ising logic — analyzer trait, factory model, insight pipeline.
 
 pub mod analyzer;
+pub mod emission;
 pub mod emitter;
 pub mod model;
 
 pub use analyzer::{Analyzer, AnalyzerRegistry};
+pub use emission::insight_to_emitted_event;
 pub use emitter::InsightEmitter;
 pub use model::FactoryModel;

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -10,10 +10,10 @@
 
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 
 use onsager_artifact::{ArtifactId, ArtifactState, Kind};
-use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
+use onsager_spine::factory_event::{FactoryEventKind, GatePoint, ShapingOutcome, VerdictSummary};
 
 /// A tracked shaping attempt.
 #[derive(Debug, Clone)]
@@ -24,6 +24,21 @@ pub struct ShapingRecord {
     pub artifact_id: ArtifactId,
     pub outcome: ShapingOutcome,
     pub duration_ms: Option<u64>,
+    pub recorded_at: DateTime<Utc>,
+}
+
+/// A tracked gate verdict emitted by Forge after consulting Synodic.
+///
+/// The verdict variant itself is the override signal: `Deny` / `Escalate`
+/// are the "override-equivalent" outcomes that flag rule friction for the
+/// gate-override-rate insight. The event doesn't carry a rule_id today, so
+/// grouping happens by artifact kind (resolved via `FactoryModel.artifacts`).
+#[derive(Debug, Clone)]
+pub struct GateVerdictRecord {
+    pub event_id: i64,
+    pub artifact_id: ArtifactId,
+    pub gate_point: GatePoint,
+    pub verdict: VerdictSummary,
     pub recorded_at: DateTime<Utc>,
 }
 
@@ -46,6 +61,8 @@ pub struct FactoryModel {
     pub artifacts: HashMap<String, TrackedArtifact>,
     /// Recent shaping records (bounded by retention window).
     pub shaping_records: Vec<ShapingRecord>,
+    /// Recent gate verdict records (bounded by retention window).
+    pub gate_verdict_records: Vec<GateVerdictRecord>,
     /// Total events processed.
     pub events_processed: u64,
     /// Last processed event ID (for catch-up).
@@ -57,6 +74,7 @@ impl FactoryModel {
         Self {
             artifacts: HashMap::new(),
             shaping_records: Vec::new(),
+            gate_verdict_records: Vec::new(),
             events_processed: 0,
             last_event_id: None,
         }
@@ -130,8 +148,86 @@ impl FactoryModel {
                 });
             }
 
+            FactoryEventKind::ForgeGateVerdict {
+                artifact_id,
+                gate_point,
+                verdict,
+            } => {
+                self.gate_verdict_records.push(GateVerdictRecord {
+                    event_id,
+                    artifact_id: artifact_id.clone(),
+                    gate_point: *gate_point,
+                    verdict: verdict.clone(),
+                    recorded_at: Utc::now(),
+                });
+            }
+
             _ => {}
         }
+    }
+
+    /// Gate verdict records no older than `cutoff`.
+    pub fn gate_verdicts_since(&self, cutoff: DateTime<Utc>) -> Vec<&GateVerdictRecord> {
+        self.gate_verdict_records
+            .iter()
+            .filter(|r| r.recorded_at >= cutoff)
+            .collect()
+    }
+
+    /// Deny+Escalate rate per artifact `Kind` over the given window, along
+    /// with the count of verdicts observed. Only kinds with at least
+    /// `min_samples` verdicts in the window appear in the output, so rates
+    /// aren't computed from noise.
+    ///
+    /// `Deny` and `Escalate` are both counted as "overrides" — the signal is
+    /// "rules rejecting proposed actions often enough that the policy is
+    /// worth revisiting," which both verdicts evidence.
+    pub fn override_rate_by_kind(
+        &self,
+        window: Duration,
+        min_samples: usize,
+    ) -> HashMap<Kind, (f64, usize, Vec<i64>)> {
+        let cutoff = Utc::now() - window;
+        let mut buckets: HashMap<Kind, Vec<&GateVerdictRecord>> = HashMap::new();
+        for record in self.gate_verdicts_since(cutoff) {
+            let Some(artifact) = self.artifacts.get(record.artifact_id.as_str()) else {
+                continue;
+            };
+            buckets
+                .entry(artifact.kind.clone())
+                .or_default()
+                .push(record);
+        }
+
+        buckets
+            .into_iter()
+            .filter_map(|(kind, records)| {
+                if records.len() < min_samples {
+                    return None;
+                }
+                let total = records.len();
+                let overrides = records
+                    .iter()
+                    .filter(|r| {
+                        matches!(r.verdict, VerdictSummary::Deny | VerdictSummary::Escalate)
+                    })
+                    .count();
+                // Evidence event-ids: the most recent override verdicts. Ordering
+                // by event_id descending matches "most recent first" (spine ids
+                // are monotonic) without needing to resort by timestamp.
+                let mut override_ids: Vec<i64> = records
+                    .iter()
+                    .filter(|r| {
+                        matches!(r.verdict, VerdictSummary::Deny | VerdictSummary::Escalate)
+                    })
+                    .map(|r| r.event_id)
+                    .collect();
+                override_ids.sort_unstable_by(|a, b| b.cmp(a));
+                override_ids.truncate(5);
+                let rate = overrides as f64 / total as f64;
+                Some((kind, (rate, total, override_ids)))
+            })
+            .collect()
     }
 
     /// Get shaping records for a specific artifact.
@@ -314,5 +410,101 @@ mod tests {
         let model = FactoryModel::new();
         let id = ArtifactId::new("art_nonexistent");
         assert!((model.failure_rate(&id, 5)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ingests_gate_verdict_records() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_gv1");
+
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "svc".into(),
+                owner: "marvin".into(),
+            },
+        );
+        model.ingest(
+            2,
+            &FactoryEventKind::ForgeGateVerdict {
+                artifact_id: id.clone(),
+                gate_point: GatePoint::PreDispatch,
+                verdict: VerdictSummary::Deny,
+            },
+        );
+
+        assert_eq!(model.gate_verdict_records.len(), 1);
+        assert_eq!(model.gate_verdict_records[0].event_id, 2);
+        assert_eq!(model.gate_verdict_records[0].verdict, VerdictSummary::Deny);
+    }
+
+    #[test]
+    fn override_rate_groups_by_kind_and_respects_min_samples() {
+        let mut model = FactoryModel::new();
+
+        // Kind::Code: 4 deny + 1 allow = 80% override (meets min_samples=3).
+        let code_id = ArtifactId::new("art_code");
+        model.ingest(
+            1,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: code_id.clone(),
+                kind: Kind::Code,
+                name: "svc".into(),
+                owner: "marvin".into(),
+            },
+        );
+        for (i, verdict) in [
+            VerdictSummary::Deny,
+            VerdictSummary::Deny,
+            VerdictSummary::Deny,
+            VerdictSummary::Allow,
+            VerdictSummary::Deny,
+        ]
+        .iter()
+        .enumerate()
+        {
+            model.ingest(
+                i as i64 + 100,
+                &FactoryEventKind::ForgeGateVerdict {
+                    artifact_id: code_id.clone(),
+                    gate_point: GatePoint::PreDispatch,
+                    verdict: verdict.clone(),
+                },
+            );
+        }
+
+        // Kind::Document: 1 deny only (below default min_samples=3 — filtered).
+        let doc_id = ArtifactId::new("art_doc");
+        model.ingest(
+            50,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: doc_id.clone(),
+                kind: Kind::Document,
+                name: "readme".into(),
+                owner: "marvin".into(),
+            },
+        );
+        model.ingest(
+            51,
+            &FactoryEventKind::ForgeGateVerdict {
+                artifact_id: doc_id,
+                gate_point: GatePoint::StateTransition,
+                verdict: VerdictSummary::Deny,
+            },
+        );
+
+        let rates = model.override_rate_by_kind(Duration::days(7), 3);
+        assert!(rates.contains_key(&Kind::Code), "code must be present");
+        assert!(
+            !rates.contains_key(&Kind::Document),
+            "document under min_samples must be dropped"
+        );
+        let (rate, total, evidence) = &rates[&Kind::Code];
+        assert_eq!(*total, 5);
+        assert!((rate - 0.8).abs() < 1e-9);
+        assert!(!evidence.is_empty());
+        assert!(evidence.windows(2).all(|w| w[0] >= w[1]), "evidence sorted");
     }
 }

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -59,9 +59,12 @@ pub struct TrackedArtifact {
 pub struct FactoryModel {
     /// Tracked artifacts by ID.
     pub artifacts: HashMap<String, TrackedArtifact>,
-    /// Recent shaping records (bounded by retention window).
+    /// Shaping records observed by the model (no retention trimming here —
+    /// the ingest caller is responsible for windowing, e.g. via the serve
+    /// loop's event-fetch cutoff).
     pub shaping_records: Vec<ShapingRecord>,
-    /// Recent gate verdict records (bounded by retention window).
+    /// Gate verdict records observed by the model (same retention contract
+    /// as `shaping_records`).
     pub gate_verdict_records: Vec<GateVerdictRecord>,
     /// Total events processed.
     pub events_processed: u64,
@@ -80,8 +83,24 @@ impl FactoryModel {
         }
     }
 
-    /// Ingest a factory event into the model.
+    /// Ingest a factory event into the model, using `Utc::now()` as the
+    /// record timestamp. Prefer [`Self::ingest_at`] when a source timestamp
+    /// is available (e.g. `events_ext.created_at`) so windowed analyzers
+    /// reflect event time, not ingest time.
     pub fn ingest(&mut self, event_id: i64, event: &FactoryEventKind) {
+        self.ingest_at(event_id, Utc::now(), event);
+    }
+
+    /// Ingest a factory event into the model with an explicit event-time
+    /// timestamp. Using the spine row's `created_at` keeps the 7-day
+    /// `override_rate_by_kind` window honest when the serve loop rebuilds
+    /// the model from historical `events_ext` rows.
+    pub fn ingest_at(
+        &mut self,
+        event_id: i64,
+        recorded_at: DateTime<Utc>,
+        event: &FactoryEventKind,
+    ) {
         self.events_processed += 1;
         self.last_event_id = Some(event_id);
 
@@ -100,8 +119,8 @@ impl FactoryModel {
                         current_state: ArtifactState::Draft,
                         version: 0,
                         shaping_count: 0,
-                        first_seen: Utc::now(),
-                        last_updated: Utc::now(),
+                        first_seen: recorded_at,
+                        last_updated: recorded_at,
                     },
                 );
             }
@@ -113,7 +132,7 @@ impl FactoryModel {
             } => {
                 if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
                     tracked.current_state = *to_state;
-                    tracked.last_updated = Utc::now();
+                    tracked.last_updated = recorded_at;
                 }
             }
 
@@ -124,7 +143,7 @@ impl FactoryModel {
             } => {
                 if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
                     tracked.version = *version;
-                    tracked.last_updated = Utc::now();
+                    tracked.last_updated = recorded_at;
                 }
             }
 
@@ -135,7 +154,7 @@ impl FactoryModel {
             } => {
                 if let Some(tracked) = self.artifacts.get_mut(artifact_id.as_str()) {
                     tracked.shaping_count += 1;
-                    tracked.last_updated = Utc::now();
+                    tracked.last_updated = recorded_at;
                 }
 
                 self.shaping_records.push(ShapingRecord {
@@ -144,7 +163,7 @@ impl FactoryModel {
                     artifact_id: artifact_id.clone(),
                     outcome: *outcome,
                     duration_ms: None,
-                    recorded_at: Utc::now(),
+                    recorded_at,
                 });
             }
 
@@ -158,7 +177,7 @@ impl FactoryModel {
                     artifact_id: artifact_id.clone(),
                     gate_point: *gate_point,
                     verdict: verdict.clone(),
-                    recorded_at: Utc::now(),
+                    recorded_at,
                 });
             }
 
@@ -438,6 +457,49 @@ mod tests {
         assert_eq!(model.gate_verdict_records.len(), 1);
         assert_eq!(model.gate_verdict_records[0].event_id, 2);
         assert_eq!(model.gate_verdict_records[0].verdict, VerdictSummary::Deny);
+    }
+
+    #[test]
+    fn override_rate_window_uses_event_time_not_ingest_time() {
+        // Regression: `ingest` used to stamp Utc::now() so historical rows
+        // re-ingested during a tick rebuild always appeared fresh, defeating
+        // the window filter. `ingest_at` must honor the caller's timestamp.
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_code_old");
+        let stale = Utc::now() - Duration::days(30);
+
+        model.ingest_at(
+            1,
+            stale,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind: Kind::Code,
+                name: "s".into(),
+                owner: "marvin".into(),
+            },
+        );
+        for i in 0..5 {
+            model.ingest_at(
+                i + 2,
+                stale,
+                &FactoryEventKind::ForgeGateVerdict {
+                    artifact_id: id.clone(),
+                    gate_point: GatePoint::PreDispatch,
+                    verdict: VerdictSummary::Deny,
+                },
+            );
+        }
+
+        // All verdicts fall outside a 7-day window — expect no entry.
+        let rates = model.override_rate_by_kind(Duration::days(7), 3);
+        assert!(
+            rates.is_empty(),
+            "stale verdicts must be excluded by the window"
+        );
+
+        // But a wide-enough window should pick them back up.
+        let rates_wide = model.override_rate_by_kind(Duration::days(60), 3);
+        assert!(rates_wide.contains_key(&Kind::Code));
     }
 
     #[test]

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -338,6 +338,29 @@ pub enum FactoryEventKind {
         confidence: f64,
     },
 
+    /// A structured signal Ising surfaces on the spine for other subsystems
+    /// to consume (issue #36 — close the feedback loop). Unlike
+    /// `IsingInsightDetected`, which carries a human-readable observation,
+    /// this variant is the machine-readable edge: each emission names the
+    /// signal kind, the subject it attaches to, and the events that evidence
+    /// it. Forge tails these into `WorldState.insights`; a future Synodic
+    /// consumer will treat high-confidence emissions as rule-proposal input.
+    IsingInsightEmitted {
+        /// Stable signal identifier (e.g. `"repeated_gate_override"`,
+        /// `"shape_retry_spike"`). Consumers match on this string.
+        signal_kind: String,
+        /// What the signal is about — an artifact kind, artifact id, rule id,
+        /// or intent class — serialized as a free-form string so the event
+        /// contract doesn't need to know every possible subject type.
+        subject_ref: String,
+        /// Spine events that evidence this signal. Invariant: non-empty
+        /// (enforced by the producer).
+        evidence: Vec<EventRef>,
+        /// 0.0..=1.0; downstream consumers use this to route (advisory vs.
+        /// crystallization threshold).
+        confidence: f64,
+    },
+
     /// An insight was deduplicated or fell below confidence threshold (audit trail).
     IsingInsightSuppressed { insight_id: String, reason: String },
 
@@ -468,6 +491,7 @@ impl FactoryEventKind {
             Self::SynodicRuleDisabled { .. } => "synodic.rule_disabled",
             Self::SynodicRuleVersionCreated { .. } => "synodic.rule_version_created",
             Self::IsingInsightDetected { .. } => "ising.insight_detected",
+            Self::IsingInsightEmitted { .. } => "ising.insight_emitted",
             Self::IsingInsightSuppressed { .. } => "ising.insight_suppressed",
             Self::IsingRuleProposed { .. } => "ising.rule_proposed",
             Self::IsingAnalyzerError { .. } => "ising.analyzer_error",
@@ -532,6 +556,7 @@ impl FactoryEventKind {
             | Self::SynodicRuleDisabled { .. }
             | Self::SynodicRuleVersionCreated { .. } => "synodic",
             Self::IsingInsightDetected { .. }
+            | Self::IsingInsightEmitted { .. }
             | Self::IsingInsightSuppressed { .. }
             | Self::IsingRuleProposed { .. }
             | Self::IsingAnalyzerError { .. }
@@ -598,6 +623,7 @@ impl FactoryEventKind {
             Self::SynodicRuleDisabled { rule_id, .. } => rule_id.clone(),
             Self::SynodicRuleVersionCreated { rule_id, .. } => rule_id.clone(),
             Self::IsingInsightDetected { insight_id, .. } => insight_id.clone(),
+            Self::IsingInsightEmitted { subject_ref, .. } => subject_ref.clone(),
             Self::IsingInsightSuppressed { insight_id, .. } => insight_id.clone(),
             Self::IsingRuleProposed { insight_id, .. } => insight_id.clone(),
             Self::IsingAnalyzerError { analyzer, .. } => analyzer.clone(),
@@ -696,6 +722,19 @@ pub enum EscalationResolution {
     TimedOut,
 }
 
+/// Reference to a spine event used as evidence for a signal (`insight.emitted`
+/// variant carries a `Vec<EventRef>`). This is the spine-native counterpart to
+/// `onsager_protocol::FactoryEventRef` — kept in the spine crate so the event
+/// vocabulary has no protocol-crate dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventRef {
+    /// The `id` column in the `events` or `events_ext` table.
+    pub event_id: i64,
+    /// The `event_type` string (e.g. `"forge.gate_verdict"`), for quick
+    /// consumer-side filtering without a second lookup.
+    pub event_type: String,
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -771,6 +810,40 @@ mod tests {
         let specific = InsightScope::SpecificArtifact(ArtifactId::new("art_12345678"));
         let json = serde_json::to_string(&specific).unwrap();
         assert!(json.contains("art_12345678"));
+    }
+
+    #[test]
+    fn ising_insight_emitted_roundtrip() {
+        // Regression: the event_type / stream_type / stream_id triple must
+        // survive a roundtrip so the listener can filter on `ising:<subject>`
+        // and the dashboard can query by `event_type = "ising.insight_emitted"`.
+        let event = FactoryEventKind::IsingInsightEmitted {
+            signal_kind: "repeated_gate_override".into(),
+            subject_ref: "code".into(),
+            evidence: vec![
+                EventRef {
+                    event_id: 101,
+                    event_type: "forge.gate_verdict".into(),
+                },
+                EventRef {
+                    event_id: 103,
+                    event_type: "forge.gate_verdict".into(),
+                },
+            ],
+            confidence: 0.82,
+        };
+        assert_eq!(event.event_type(), "ising.insight_emitted");
+        assert_eq!(event.stream_type(), "ising");
+        assert_eq!(event.stream_id(), "code");
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "ising_insight_emitted");
+        assert_eq!(json["signal_kind"], "repeated_gate_override");
+        assert_eq!(json["subject_ref"], "code");
+        assert_eq!(json["evidence"][0]["event_id"], 101);
+
+        let back: FactoryEventKind = serde_json::from_value(json).unwrap();
+        assert_eq!(back, event);
     }
 
     #[test]

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -53,7 +53,7 @@ pub use onsager_artifact::{
 
 pub use extension_event::ExtensionEventRecord;
 pub use factory_event::{
-    EscalationResolution, FactoryEvent, FactoryEventKind, ForgeProcessState, GatePoint,
+    EscalationResolution, EventRef, FactoryEvent, FactoryEventKind, ForgeProcessState, GatePoint,
     InsightKind, InsightScope, LineageType, ShapingOutcome, VerdictSummary,
 };
 pub use listener::{EventHandler, Listener};

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -210,6 +210,22 @@ impl EventStore {
         .await
     }
 
+    /// Return the highest id present in either `events` or `events_ext`,
+    /// or `None` if both tables are empty. Callers use this as a
+    /// warm-start cursor so a [`Listener`] with `with_since` skips
+    /// backfill over history it doesn't need to replay.
+    pub async fn max_event_id(&self) -> Result<Option<i64>, sqlx::Error> {
+        let row: (Option<i64>,) = sqlx::query_as(
+            "SELECT GREATEST( \
+                (SELECT MAX(id) FROM events), \
+                (SELECT MAX(id) FROM events_ext) \
+             )",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
     /// Fetch a single extension event by id. Returns `None` if not found.
     pub async fn get_ext_event_by_id(
         &self,


### PR DESCRIPTION
Sequence 3 step 1 of #40. Earns the Ising name by shipping one real
end-to-end signal: when deny+escalate verdicts cross a configurable
threshold for an artifact kind over a 7-day window, Ising publishes an
`ising.insight_emitted` event the Forge kernel and the governance UI
both consume.

Spine: new `IsingInsightEmitted { signal_kind, subject_ref, evidence,
confidence }` variant and spine-native `EventRef` so the event contract
doesn't back-depend on `onsager-protocol`.

Ising: extend `FactoryModel` with gate-verdict tracking; new
`GateOverrideAnalyzer` emits on rate >= threshold with real evidence
ids; `ising serve` wired to connect, rebuild the model per tick from
`events_ext`, validate/dedup via `InsightEmitter`, and append accepted
emissions back to the spine.

Forge: bounded `InsightCache` feeding `WorldState.insights` (was
hardcoded `vec![]`); `insight_listener` tails `ising.insight_emitted`
from the spine and pushes into the cache so the scheduling kernel sees
priors from the most recent signals.

Dashboard: new "Ising Insights" card on the Governance page with a
typed API helper so the data comes through as structured fields rather
than raw JSON blobs.

The rule-proposal flow (`ising.rule_proposed` + Synodic consumer) and
the supervisor / Refract primitives stay as follow-up PRs per the
tracker's sequencing.

Part of #36
Part of #40