### PR TITLE
feat: ship Sequence 3 + 4 of issue #40 in one sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "refract"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "onsager-artifact",
+ "onsager-spine",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/onsager",
     "crates/forge",
     "crates/ising",
+    "crates/refract",
     "crates/stiglab",
     "crates/synodic",
 ]

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -111,6 +111,44 @@ export interface IsingInsightEmittedEvent {
   evidence: { event_id: number; event_type: string }[];
 }
 
+// Ising rule proposal queue (issue #36 Step 2). Proxied through Synodic —
+// each row corresponds to one `ising.rule_proposed` event the listener
+// ingested and is awaiting human (or supervisor-agent) resolution.
+export interface RuleProposal {
+  id: string;
+  insight_id: string;
+  signal_kind: string;
+  subject_ref: string;
+  proposed_action: Record<string, unknown>;
+  class: 'safe_auto' | 'review_required';
+  rationale: string;
+  confidence: number;
+  status: 'pending' | 'approved' | 'rejected';
+  resolution_notes: string | null;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+// Token usage carried by `stiglab.session_completed` events (issue #39).
+export interface TokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  model?: string;
+}
+
+// Denormalized session-completion spend row (issue #39), projected from
+// `stiglab.session_completed` spine events.
+export interface SessionSpend {
+  id: number;
+  created_at: string;
+  session_id: string;
+  artifact_id: string | null;
+  duration_ms: number;
+  token_usage: TokenUsage | null;
+}
+
 // Spine types (direct from stiglab)
 export interface SpineEvent {
   id: number;
@@ -242,6 +280,42 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify({ notes }),
     }),
+  // Ising rule proposals (issue #36 Step 2). Served by Synodic and
+  // proxied through stiglab's /api/governance/rule-proposals.
+  getRuleProposals: (status?: RuleProposal['status']) =>
+    request<RuleProposal[]>(
+      `/governance/rule-proposals${status ? `?status=${status}` : ''}`,
+    ),
+  resolveRuleProposal: (id: string, status: 'approved' | 'rejected', notes?: string) =>
+    request<void>(`/governance/rule-proposals/${id}/resolve`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status, notes }),
+    }),
+  // Session spend view (issue #39). Reads recent `stiglab.session_completed`
+  // events and unpacks the typed `token_usage` payload client-side so we
+  // don't have to spin up a dedicated pricing/accounting endpoint just to
+  // render the dashboard card.
+  getSessionSpend: async (limit = 50): Promise<SessionSpend[]> => {
+    const res = await request<{ events: SpineEvent[] }>(
+      `/spine/events?event_type=stiglab.session_completed&limit=${limit}`,
+    );
+    return res.events.map((e) => {
+      const d = e.data as {
+        session_id?: string;
+        artifact_id?: string | null;
+        duration_ms?: number;
+        token_usage?: TokenUsage;
+      };
+      return {
+        id: e.id,
+        created_at: e.created_at,
+        session_id: d.session_id ?? '',
+        artifact_id: d.artifact_id ?? null,
+        duration_ms: typeof d.duration_ms === 'number' ? d.duration_ms : 0,
+        token_usage: d.token_usage ?? null,
+      };
+    });
+  },
   // Spine
   getSpineEvents: (params?: { stream_type?: string; event_type?: string; limit?: number }) => {
     const qs = params ? '?' + new URLSearchParams(

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -10,9 +10,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { Package, Activity, Shield, Server, ArrowRight } from "lucide-react"
+import {
+  Package,
+  Activity,
+  Shield,
+  Server,
+  ArrowRight,
+  Coins,
+  Gauge,
+  CheckCircle2,
+  Timer,
+  AlertTriangle,
+} from "lucide-react"
 import { Link } from "react-router-dom"
-import type { SpineArtifact, SpineEvent } from "@/lib/api"
+import type { SessionSpend, SpineArtifact, SpineEvent } from "@/lib/api"
 
 const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -97,11 +108,21 @@ export function FactoryOverviewPage() {
     queryFn: api.getNodes,
     refetchInterval: 10000,
   })
+  // Issue #39 — per-session token usage, pulled from the last N
+  // session_completed events so the spend card can render without a
+  // dedicated accounting endpoint.
+  const { data: spendData } = useQuery({
+    queryKey: ["session-spend"],
+    queryFn: () => api.getSessionSpend(100),
+    refetchInterval: 30000,
+  })
 
   const artifacts = artifactsData?.artifacts ?? []
   const events = spineData?.events ?? []
   const nodes = nodesData?.nodes ?? []
   const onlineNodes = nodes.filter((n) => n.status === "online").length
+  const sessions = spendData ?? []
+  const productivity = computeProductivityMetrics(artifacts)
 
   const stats = [
     {
@@ -158,6 +179,10 @@ export function FactoryOverviewPage() {
           </Card>
         ))}
       </div>
+
+      <ProductivityMetrics metrics={productivity} />
+
+      <SpendCard sessions={sessions} />
 
       <PipelineStats artifacts={artifacts} />
 
@@ -248,4 +273,235 @@ export function FactoryOverviewPage() {
       </div>
     </div>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Issue #38 — productivity metrics
+// ---------------------------------------------------------------------------
+
+interface ProductivityStats {
+  throughputLast24h: number
+  yieldRatio: number | null
+  avgCycleMs: number | null
+  bottleneckState: string | null
+  bottleneckCount: number
+  releasedCount: number
+  totalTracked: number
+}
+
+function computeProductivityMetrics(
+  artifacts: SpineArtifact[],
+): ProductivityStats {
+  const now = Date.now()
+  const dayAgo = now - 24 * 60 * 60 * 1000
+
+  const released = artifacts.filter((a) => a.state === "released")
+  const archivedOrTerminal = artifacts.filter(
+    (a) => a.state === "released" || a.state === "archived",
+  )
+  const tracked = artifacts.length
+  const throughputLast24h = released.filter(
+    (a) => new Date(a.updated_at).getTime() >= dayAgo,
+  ).length
+
+  // Yield: released / (released + archived) among terminal artifacts. A
+  // tracker may stay in_progress for long stretches, so skipping non-
+  // terminal ones keeps the number interpretable as "of the ones we tried
+  // to finish, how many shipped".
+  const yieldRatio =
+    archivedOrTerminal.length > 0
+      ? released.length / archivedOrTerminal.length
+      : null
+
+  // Cycle time: average created_at → updated_at among released artifacts.
+  // Ignoring archived-without-release cases so a string of aborts doesn't
+  // shrink the number to zero.
+  let avgCycleMs: number | null = null
+  if (released.length > 0) {
+    const total = released.reduce((acc, a) => {
+      const created = new Date(a.created_at).getTime()
+      const updated = new Date(a.updated_at).getTime()
+      return acc + Math.max(0, updated - created)
+    }, 0)
+    avgCycleMs = total / released.length
+  }
+
+  // Bottleneck: the non-terminal state with the most artifacts. "If the
+  // belt is stuck, where did the boxes pile up?"
+  const nonTerminalStates = new Map<string, number>()
+  for (const a of artifacts) {
+    if (a.state === "released" || a.state === "archived") continue
+    nonTerminalStates.set(a.state, (nonTerminalStates.get(a.state) ?? 0) + 1)
+  }
+  let bottleneckState: string | null = null
+  let bottleneckCount = 0
+  for (const [state, count] of nonTerminalStates) {
+    if (count > bottleneckCount) {
+      bottleneckState = state
+      bottleneckCount = count
+    }
+  }
+
+  return {
+    throughputLast24h,
+    yieldRatio,
+    avgCycleMs,
+    bottleneckState,
+    bottleneckCount,
+    releasedCount: released.length,
+    totalTracked: tracked,
+  }
+}
+
+function ProductivityMetrics({ metrics }: { metrics: ProductivityStats }) {
+  const yieldDisplay =
+    metrics.yieldRatio == null
+      ? "—"
+      : `${Math.round(metrics.yieldRatio * 100)}%`
+  const cycleDisplay = formatDuration(metrics.avgCycleMs)
+  const bottleneckDisplay = metrics.bottleneckState
+    ? `${metrics.bottleneckState.replace("_", " ")} (${metrics.bottleneckCount})`
+    : "—"
+
+  const cards = [
+    {
+      title: "Throughput (24h)",
+      value: metrics.throughputLast24h.toString(),
+      icon: Gauge,
+      description: `${metrics.releasedCount} released all-time`,
+    },
+    {
+      title: "Yield",
+      value: yieldDisplay,
+      icon: CheckCircle2,
+      description: "released / (released + archived)",
+    },
+    {
+      title: "Avg Cycle Time",
+      value: cycleDisplay,
+      icon: Timer,
+      description: "released artifacts",
+    },
+    {
+      title: "Bottleneck",
+      value: bottleneckDisplay,
+      icon: AlertTriangle,
+      description: "largest non-terminal state",
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
+      {cards.map((stat) => (
+        <Card key={stat.title}>
+          <CardHeader className="flex flex-row items-center justify-between px-3 pb-1 pt-3 md:px-6 md:pb-2 md:pt-6">
+            <CardTitle className="text-xs font-medium text-muted-foreground md:text-sm">
+              {stat.title}
+            </CardTitle>
+            <stat.icon className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent className="px-3 pb-3 md:px-6 md:pb-6">
+            <div className="text-xl font-bold md:text-2xl">{stat.value}</div>
+            <p className="text-[10px] text-muted-foreground md:text-xs">
+              {stat.description}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return "—"
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`
+  if (ms < 86_400_000) return `${(ms / 3_600_000).toFixed(1)}h`
+  return `${(ms / 86_400_000).toFixed(1)}d`
+}
+
+// ---------------------------------------------------------------------------
+// Issue #39 — session spend summary
+// ---------------------------------------------------------------------------
+
+function SpendCard({ sessions }: { sessions: SessionSpend[] }) {
+  let inputTokens = 0
+  let outputTokens = 0
+  let cachedTokens = 0
+  let reported = 0
+  const byModel = new Map<string, number>()
+  for (const s of sessions) {
+    if (!s.token_usage) continue
+    reported += 1
+    inputTokens += s.token_usage.input_tokens
+    outputTokens += s.token_usage.output_tokens
+    cachedTokens +=
+      (s.token_usage.cache_read_tokens ?? 0) +
+      (s.token_usage.cache_write_tokens ?? 0)
+    const model = s.token_usage.model ?? "unknown"
+    byModel.set(model, (byModel.get(model) ?? 0) + 1)
+  }
+  const totalTokens = inputTokens + outputTokens
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between px-4 md:px-6">
+        <CardTitle className="text-base md:text-lg">Token Spend</CardTitle>
+        <Coins className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent className="px-4 md:px-6">
+        {reported === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No session_completed events report token_usage yet. The field is
+            optional; Stiglab starts reporting it once the agent runtime
+            forwards usage numbers.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <SpendStat label="Sessions" value={reported.toString()} />
+            <SpendStat label="Total tokens" value={formatTokens(totalTokens)} />
+            <SpendStat label="Input" value={formatTokens(inputTokens)} />
+            <SpendStat label="Output" value={formatTokens(outputTokens)} />
+            <SpendStat
+              label="Cached"
+              value={formatTokens(cachedTokens)}
+              description="reads + writes"
+            />
+            <SpendStat
+              label="Models"
+              value={Array.from(byModel.keys()).slice(0, 2).join(", ") || "—"}
+              description={byModel.size > 2 ? `+${byModel.size - 2} more` : ""}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function SpendStat({
+  label,
+  value,
+  description,
+}: {
+  label: string
+  value: string
+  description?: string
+}) {
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-bold md:text-xl">{value}</div>
+      {description && (
+        <div className="text-[10px] text-muted-foreground">{description}</div>
+      )}
+    </div>
+  )
+}
+
+function formatTokens(n: number): string {
+  if (n < 1_000) return n.toString()
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`
+  if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  return `${(n / 1_000_000_000).toFixed(2)}B`
 }

--- a/apps/dashboard/src/pages/GovernancePage.tsx
+++ b/apps/dashboard/src/pages/GovernancePage.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
-import type { GovernanceEvent, IsingInsightEmittedEvent } from "@/lib/api"
+import type {
+  GovernanceEvent,
+  IsingInsightEmittedEvent,
+  RuleProposal,
+} from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -55,12 +59,29 @@ export function GovernancePage() {
     refetchInterval: 15000,
   })
 
+  // Issue #36 Step 2 — pending rule proposals. Same slow-refresh cadence as
+  // insights; proposals churn at most once per ising tick.
+  const { data: pendingProposals } = useQuery({
+    queryKey: ["rule-proposals-pending"],
+    queryFn: () => api.getRuleProposals("pending"),
+    refetchInterval: 15000,
+  })
+
   const handleResolve = async (id: string) => {
     const notes = prompt("Resolution notes:")
     if (notes === null) return
     await api.resolveGovernanceEvent(id, notes)
     queryClient.invalidateQueries({ queryKey: ["governance-events"] })
     queryClient.invalidateQueries({ queryKey: ["governance-stats"] })
+  }
+
+  const handleProposalResolve = async (
+    id: string,
+    status: "approved" | "rejected",
+  ) => {
+    const notes = prompt(`Notes for ${status} proposal (optional):`) ?? undefined
+    await api.resolveRuleProposal(id, status, notes || undefined)
+    queryClient.invalidateQueries({ queryKey: ["rule-proposals-pending"] })
   }
 
   return (
@@ -98,6 +119,11 @@ export function GovernancePage() {
           ))}
         </div>
       </div>
+
+      <RuleProposalsCard
+        proposals={pendingProposals ?? []}
+        onResolve={handleProposalResolve}
+      />
 
       <IsingInsightsCard insights={insights ?? []} />
 
@@ -250,6 +276,97 @@ function IsingInsightsCard({ insights }: { insights: IsingInsightEmittedEvent[] 
                 </div>
               </div>
             ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function RuleProposalsCard({
+  proposals,
+  onResolve,
+}: {
+  proposals: RuleProposal[]
+  onResolve: (id: string, status: "approved" | "rejected") => void
+}) {
+  return (
+    <Card>
+      <CardHeader className="px-4 md:px-6">
+        <CardTitle className="text-base md:text-lg">Rule Proposals</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Rule changes Ising queued for review. Approve to apply; reject to
+          keep the rule as-is. Safe-auto proposals already applied and land
+          here in the "approved" view only.
+        </p>
+      </CardHeader>
+      <CardContent className="px-4 md:px-6">
+        {proposals.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No pending proposals. Ising surfaces them when a signal crosses
+            the rule-proposal threshold.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {proposals.map((p) => {
+              const action = p.proposed_action as {
+                action?: string
+                rule_id?: string
+                subject_ref?: string
+              }
+              const actionLabel =
+                action.action === "retire"
+                  ? `retire rule ${action.rule_id}`
+                  : action.action === "rewrite"
+                    ? `rewrite rule ${action.rule_id}`
+                    : action.action === "introduce"
+                      ? `introduce rule for ${action.subject_ref}`
+                      : action.action ?? "change"
+              return (
+                <div
+                  key={p.id}
+                  className="flex flex-col gap-2 rounded-lg border p-3"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">{p.signal_kind}</Badge>
+                    <Badge
+                      variant={
+                        p.class === "safe_auto" ? "secondary" : "default"
+                      }
+                    >
+                      {p.class.replace("_", " ")}
+                    </Badge>
+                    <span className="text-sm font-medium">{actionLabel}</span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {(p.confidence * 100).toFixed(0)}% confidence
+                    </span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{p.rationale}</p>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="truncate">
+                      subject: {p.subject_ref}
+                    </span>
+                    <span>{new Date(p.created_at).toLocaleString()}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="default"
+                      size="sm"
+                      onClick={() => onResolve(p.id, "approved")}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onResolve(p.id, "rejected")}
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                </div>
+              )
+            })}
           </div>
         )}
       </CardContent>

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -205,12 +205,24 @@ impl SynodicFailPolicy {
                 context: EscalationContext {
                     escalation_id: format!("synodic-fail-{}", ulid::Ulid::new()),
                     reason: format!("synodic gate failure: {reason}"),
-                    target: "supervisor".into(),
+                    // Issue #37: the default escalation target is the
+                    // supervisor agent, but operators can redirect to a
+                    // specific human (e.g. `"human:marvin"`) via env var
+                    // when the Stiglab supervisor profile isn't yet wired.
+                    target: escalation_default_target(),
                     timeout_at: Utc::now() + chrono::Duration::minutes(15),
                 },
             },
         }
     }
+}
+
+/// Who receives escalations when Synodic says so but no specific target is
+/// set on the verdict (issue #37). Reads `ESCALATION_DEFAULT_TARGET`;
+/// defaults to `"supervisor"` so the supervisor Stiglab agent is the
+/// natural first responder.
+fn escalation_default_target() -> String {
+    std::env::var("ESCALATION_DEFAULT_TARGET").unwrap_or_else(|_| "supervisor".to_string())
 }
 
 /// Distinguishes failure modes for the Synodic gate so that transient

--- a/crates/forge/src/core/session_listener.rs
+++ b/crates/forge/src/core/session_listener.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 
-/// A parsed stiglab.session_completed event (issue #14 phase 2).
+/// A parsed stiglab.session_completed event (issue #14 phase 2, #39).
 #[derive(Debug, Clone)]
 pub struct SessionCompleted {
     pub event_id: i64,
@@ -30,6 +30,8 @@ pub struct SessionCompleted {
     pub request_id: String,
     pub duration_ms: u64,
     pub artifact_id: Option<String>,
+    /// LLM token usage, if the producing runtime reported it (issue #39).
+    pub token_usage: Option<onsager_spine::factory_event::TokenUsage>,
 }
 
 /// Caller-supplied callback invoked for every session completion.
@@ -89,6 +91,7 @@ impl<H: SessionCompletedHandler> Dispatcher<H> {
             request_id,
             duration_ms,
             artifact_id,
+            token_usage,
         } = kind
         else {
             return Ok(None);
@@ -100,6 +103,7 @@ impl<H: SessionCompletedHandler> Dispatcher<H> {
             request_id,
             duration_ms,
             artifact_id,
+            token_usage,
         }))
     }
 }
@@ -155,6 +159,7 @@ mod tests {
                 request_id: "r".into(),
                 duration_ms: 42,
                 artifact_id: Some("art_test".into()),
+                token_usage: None,
             })
             .await
             .unwrap();

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -23,7 +23,9 @@ use onsager_spine::{EventMetadata, EventStore};
 
 use crate::analyzers::register_defaults;
 use crate::core::emitter::{EmitResult, EmitterConfig, InsightEmitter};
-use crate::core::{insight_to_emitted_event, AnalyzerRegistry, FactoryModel};
+use crate::core::{
+    insight_to_emitted_event, insight_to_rule_proposal, AnalyzerRegistry, FactoryModel,
+};
 
 /// How far back to look for forge events when rebuilding the factory model.
 /// Matches the default `GateOverrideConfig::window` so insights have enough
@@ -90,6 +92,7 @@ async fn run_tick(
     }
 
     let mut emitted = 0usize;
+    let mut proposals = 0usize;
     for (analyzer_name, insights) in registry.run_all(&model) {
         for insight in insights {
             match emitter.emit(insight) {
@@ -100,6 +103,19 @@ async fn run_tick(
                         continue;
                     }
                     emitted += 1;
+
+                    // Issue #36 Step 2: for signals that warrant a rule
+                    // change, emit `ising.rule_proposed` alongside the
+                    // observation event. The proposal is paired with its
+                    // backing `insight_emitted` via `insight_id` so Synodic
+                    // can audit the evidence without a second query.
+                    if let Some(proposal) = insight_to_rule_proposal(&analyzer_name, &insight) {
+                        if let Err(e) = append_rule_proposed(spine, &proposal).await {
+                            tracing::warn!("ising: failed to append rule_proposed event: {e}");
+                        } else {
+                            proposals += 1;
+                        }
+                    }
                 }
                 EmitResult::Suppressed { reason, .. } => {
                     tracing::debug!(
@@ -115,8 +131,8 @@ async fn run_tick(
         }
     }
 
-    if emitted > 0 {
-        tracing::info!(emitted, "ising: tick emitted insights");
+    if emitted > 0 || proposals > 0 {
+        tracing::info!(emitted, proposals, "ising: tick emitted insights");
     }
     Ok(())
 }
@@ -285,6 +301,41 @@ async fn append_insight_emitted(
             &stream_id,
             "ising",
             "ising.insight_emitted",
+            data,
+            &meta,
+            None,
+        )
+        .await?;
+    Ok(id)
+}
+
+/// Append an `ising.rule_proposed` row to `events_ext` so Synodic's
+/// proposal-queue listener can pick it up (issue #36 Step 2). The payload
+/// is a full serialization of the `IsingRuleProposed` variant so the
+/// consumer can `serde_json::from_value::<FactoryEventKind>` without a
+/// second parser, unlike the hand-rolled `insight_emitted` body.
+async fn append_rule_proposed(
+    spine: &EventStore,
+    event: &FactoryEventKind,
+) -> Result<i64, anyhow::Error> {
+    if !matches!(event, FactoryEventKind::IsingRuleProposed { .. }) {
+        return Err(anyhow::anyhow!(
+            "append_rule_proposed called with non-IsingRuleProposed variant"
+        ));
+    }
+
+    let stream_id = event.stream_id();
+    let data = serde_json::to_value(event)?;
+    let meta = EventMetadata {
+        actor: "ising".to_string(),
+        ..Default::default()
+    };
+
+    let id = spine
+        .append_ext(
+            &stream_id,
+            "ising",
+            "ising.rule_proposed",
             data,
             &meta,
             None,

--- a/crates/ising/src/core/emission.rs
+++ b/crates/ising/src/core/emission.rs
@@ -1,5 +1,6 @@
 //! Emission — convert an internal `Insight` into the `ising.insight_emitted`
-//! spine event (issue #36).
+//! spine event (issue #36) and into `ising.rule_proposed` rule proposal
+//! events (issue #36 Step 2).
 //!
 //! This is deliberately a thin mapping: the analyzer names produce
 //! `signal_kind`, the `InsightScope` collapses to a free-form `subject_ref`,
@@ -8,7 +9,21 @@
 //! also running the validation / dedup pipeline.
 
 use onsager_protocol::Insight;
-use onsager_spine::factory_event::{EventRef, FactoryEventKind, InsightScope};
+use onsager_spine::factory_event::{
+    EventRef, FactoryEventKind, InsightScope, RuleProposalAction, RuleProposalClass,
+};
+
+/// Confidence floor above which a `repeated_gate_override` insight becomes
+/// a rule-proposal candidate. Below this we stay in the observation-only
+/// `insight_emitted` track; at or above it we also emit `rule_proposed`.
+/// Conservative — the threshold can only rise, not fall, without an audit
+/// of what Synodic auto-activates.
+pub const RULE_PROPOSAL_MIN_CONFIDENCE: f64 = 0.80;
+
+/// Confidence floor for `SafeAuto` classification. Below this the proposal
+/// still enters the queue but as `ReviewRequired` — a human must click
+/// approve before it touches the active rule set.
+pub const SAFE_AUTO_MIN_CONFIDENCE: f64 = 0.90;
 
 /// Build the `ising.insight_emitted` variant from an accepted `Insight` and
 /// the name of the analyzer that produced it.
@@ -29,6 +44,52 @@ pub fn insight_to_emitted_event(signal_kind: &str, insight: &Insight) -> Factory
         evidence,
         confidence: insight.confidence,
     }
+}
+
+/// Build an `ising.rule_proposed` variant from an insight when the signal
+/// warrants a rule change. Returns `None` when the signal kind has no
+/// rule-proposal mapping or the confidence is below
+/// [`RULE_PROPOSAL_MIN_CONFIDENCE`].
+///
+/// The only signal wired in this step is `repeated_gate_override`, which
+/// maps to a `Retire` proposal: when a rule fires and is overridden more
+/// often than it's respected, the policy is costing more than it buys.
+/// Future signals (shape-retry spike, cross-project divergence) add their
+/// own arm to the match below without changing the event contract.
+pub fn insight_to_rule_proposal(signal_kind: &str, insight: &Insight) -> Option<FactoryEventKind> {
+    if insight.confidence < RULE_PROPOSAL_MIN_CONFIDENCE {
+        return None;
+    }
+
+    let subject_ref = subject_ref_from_scope(&insight.scope);
+    let proposed_action = match signal_kind {
+        "repeated_gate_override" => RuleProposalAction::Retire {
+            // The insight currently groups by artifact kind rather than by
+            // rule id (§gate_override.rs); the Synodic consumer maps the
+            // kind back to the ruling rule via the feedback_events table.
+            // Using the subject_ref as rule_id is a deliberate placeholder
+            // that keeps the proposal self-contained — Synodic resolves it
+            // at queue time rather than the producer embedding a join.
+            rule_id: subject_ref.clone(),
+        },
+        _ => return None,
+    };
+
+    let class = if insight.confidence >= SAFE_AUTO_MIN_CONFIDENCE {
+        RuleProposalClass::SafeAuto
+    } else {
+        RuleProposalClass::ReviewRequired
+    };
+
+    Some(FactoryEventKind::IsingRuleProposed {
+        insight_id: insight.insight_id.clone(),
+        signal_kind: signal_kind.to_owned(),
+        subject_ref,
+        proposed_action,
+        class,
+        rationale: insight.observation.clone(),
+        confidence: insight.confidence,
+    })
 }
 
 /// Collapse an `InsightScope` to a `subject_ref` string — the identifier a
@@ -109,5 +170,64 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    fn insight_with_conf(conf: f64) -> Insight {
+        let mut i = make_insight(InsightScope::ArtifactKind("code".into()));
+        i.confidence = conf;
+        i
+    }
+
+    #[test]
+    fn rule_proposal_skipped_when_confidence_below_threshold() {
+        // Below RULE_PROPOSAL_MIN_CONFIDENCE the insight stays on the
+        // observation track only — no rule proposal leaks onto the spine.
+        let proposal = insight_to_rule_proposal("repeated_gate_override", &insight_with_conf(0.65));
+        assert!(proposal.is_none(), "0.65 is below threshold, must skip");
+    }
+
+    #[test]
+    fn rule_proposal_uses_review_required_in_between_thresholds() {
+        let proposal = insight_to_rule_proposal("repeated_gate_override", &insight_with_conf(0.82))
+            .expect("high enough to propose");
+        match proposal {
+            FactoryEventKind::IsingRuleProposed {
+                class,
+                proposed_action,
+                subject_ref,
+                signal_kind,
+                ..
+            } => {
+                assert_eq!(class, RuleProposalClass::ReviewRequired);
+                assert_eq!(signal_kind, "repeated_gate_override");
+                assert_eq!(subject_ref, "code");
+                match proposed_action {
+                    RuleProposalAction::Retire { rule_id } => assert_eq!(rule_id, "code"),
+                    other => panic!("expected Retire, got {other:?}"),
+                }
+            }
+            _ => panic!("expected IsingRuleProposed"),
+        }
+    }
+
+    #[test]
+    fn rule_proposal_is_safe_auto_at_high_confidence() {
+        let proposal = insight_to_rule_proposal("repeated_gate_override", &insight_with_conf(0.95))
+            .expect("proposal emitted");
+        match proposal {
+            FactoryEventKind::IsingRuleProposed { class, .. } => {
+                assert_eq!(class, RuleProposalClass::SafeAuto);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn unknown_signal_kind_does_not_propose() {
+        // Guardrail: a new analyzer must explicitly opt in to rule-proposal
+        // routing. Silent passthrough would let a noisy signal auto-mutate
+        // rules without an author thinking about the mapping.
+        let proposal = insight_to_rule_proposal("totally_new_signal", &insight_with_conf(0.99));
+        assert!(proposal.is_none());
     }
 }

--- a/crates/ising/src/core/mod.rs
+++ b/crates/ising/src/core/mod.rs
@@ -6,6 +6,6 @@ pub mod emitter;
 pub mod model;
 
 pub use analyzer::{Analyzer, AnalyzerRegistry};
-pub use emission::insight_to_emitted_event;
+pub use emission::{insight_to_emitted_event, insight_to_rule_proposal};
 pub use emitter::InsightEmitter;
 pub use model::FactoryModel;

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -241,6 +241,11 @@ pub enum FactoryEventKind {
         /// meaningless id.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         artifact_id: Option<String>,
+        /// LLM token usage for this session (issue #39). Optional so
+        /// pre-accounting sessions and mock dispatchers don't fabricate a
+        /// zero bill — `None` means "not reported", not "cost nothing".
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        token_usage: Option<TokenUsage>,
     },
 
     /// A session terminated with an error.
@@ -313,6 +318,20 @@ pub enum FactoryEventKind {
         artifact_id: ArtifactId,
     },
 
+    /// A delegate (human or supervisor agent) proposed a resolution for an
+    /// active escalation (issue #37). The resolution is not applied until
+    /// accepted — this event is the proposal itself, not the final verdict.
+    SynodicGateResolutionProposed {
+        escalation_id: String,
+        artifact_id: ArtifactId,
+        /// Who's proposing the resolution (`"supervisor"`, `"human:<id>"`).
+        proposer: String,
+        /// The verdict being proposed.
+        proposed_verdict: VerdictSummary,
+        /// Free-form justification for the audit trail.
+        rationale: String,
+    },
+
     /// A crystallization candidate rule was created.
     SynodicRuleProposed {
         rule_id: String,
@@ -364,10 +383,30 @@ pub enum FactoryEventKind {
     /// An insight was deduplicated or fell below confidence threshold (audit trail).
     IsingInsightSuppressed { insight_id: String, reason: String },
 
-    /// An insight was packaged as a rule proposal for Synodic.
+    /// An insight was packaged as a rule proposal for Synodic (issue #36
+    /// Step 2). Unlike the legacy form, this variant carries enough
+    /// structure that a Synodic consumer can route it without looking up
+    /// the original insight — `signal_kind` + `subject_ref` identify the
+    /// evidence, `proposed_action` names what rule change is being asked
+    /// for, and `class` decides whether the proposal auto-activates
+    /// (`safe_auto`) or enters the review queue (`review_required`).
     IsingRuleProposed {
+        /// ID of the insight that motivated the proposal.
         insight_id: String,
-        proposed_rule_description: String,
+        /// Copy of the producing analyzer's signal kind (e.g.
+        /// `"repeated_gate_override"`) so consumers can dedupe against the
+        /// `insight_emitted` stream.
+        signal_kind: String,
+        /// What the proposal is about (artifact kind, rule id, etc.).
+        subject_ref: String,
+        /// Kind of change being proposed.
+        proposed_action: RuleProposalAction,
+        /// How the proposal should be handled downstream.
+        class: RuleProposalClass,
+        /// Human-readable justification for the audit trail.
+        rationale: String,
+        /// Confidence copied from the backing insight (0.0..=1.0).
+        confidence: f64,
     },
 
     /// An analyzer encountered an error during its run.
@@ -375,6 +414,39 @@ pub enum FactoryEventKind {
 
     /// Ising finished catching up from a lag position.
     IsingCatchupCompleted { events_processed: u64 },
+
+    // -- Refract events (issue #35 — intent decomposition) ------------------
+    /// A new intent was submitted for decomposition. Intents are the
+    /// high-level units of work a Refract decomposer expands into artifact
+    /// trees (e.g. `"migrate all legacy auth callers to the new SDK"` →
+    /// one artifact per file-touchpoint).
+    IntentSubmitted {
+        /// Opaque unique id — used as the correlation handle for every
+        /// downstream `refract.*` event.
+        intent_id: String,
+        /// Stable class identifier — maps 1:1 to a registered decomposer
+        /// (e.g. `"file_migration"`, `"spec_rollout"`).
+        intent_class: String,
+        /// Free-form description of the intent, shown in the UI and
+        /// preserved as audit trail.
+        description: String,
+        /// Who or what submitted the intent.
+        submitter: String,
+    },
+
+    /// A decomposer produced an artifact tree for an intent.
+    RefractDecomposed {
+        intent_id: String,
+        /// Name of the decomposer that handled the intent (the Refract
+        /// equivalent of Ising's `signal_kind`).
+        decomposer: String,
+        /// Newly registered artifact ids produced by the decomposition.
+        artifact_ids: Vec<String>,
+    },
+
+    /// Decomposition failed — either no decomposer matched, or the matched
+    /// decomposer errored out.
+    RefractFailed { intent_id: String, reason: String },
 
     // -- Registry events (factory pipeline foundations, issue #14) ----------
     /// A new artifact type was proposed (not yet active).
@@ -486,6 +558,7 @@ impl FactoryEventKind {
             Self::SynodicEscalationStarted { .. } => "synodic.escalation_started",
             Self::SynodicEscalationResolved { .. } => "synodic.escalation_resolved",
             Self::SynodicEscalationTimedOut { .. } => "synodic.escalation_timed_out",
+            Self::SynodicGateResolutionProposed { .. } => "synodic.gate_resolution_proposed",
             Self::SynodicRuleProposed { .. } => "synodic.rule_proposed",
             Self::SynodicRuleApproved { .. } => "synodic.rule_approved",
             Self::SynodicRuleDisabled { .. } => "synodic.rule_disabled",
@@ -496,6 +569,9 @@ impl FactoryEventKind {
             Self::IsingRuleProposed { .. } => "ising.rule_proposed",
             Self::IsingAnalyzerError { .. } => "ising.analyzer_error",
             Self::IsingCatchupCompleted { .. } => "ising.catchup_completed",
+            Self::IntentSubmitted { .. } => "refract.intent_submitted",
+            Self::RefractDecomposed { .. } => "refract.decomposed",
+            Self::RefractFailed { .. } => "refract.failed",
             Self::TypeProposed { .. } => "registry.type_proposed",
             Self::TypeApproved { .. } => "registry.type_approved",
             Self::TypeDeprecated { .. } => "registry.type_deprecated",
@@ -551,6 +627,7 @@ impl FactoryEventKind {
             | Self::SynodicEscalationStarted { .. }
             | Self::SynodicEscalationResolved { .. }
             | Self::SynodicEscalationTimedOut { .. }
+            | Self::SynodicGateResolutionProposed { .. }
             | Self::SynodicRuleProposed { .. }
             | Self::SynodicRuleApproved { .. }
             | Self::SynodicRuleDisabled { .. }
@@ -561,6 +638,9 @@ impl FactoryEventKind {
             | Self::IsingRuleProposed { .. }
             | Self::IsingAnalyzerError { .. }
             | Self::IsingCatchupCompleted { .. } => "ising",
+            Self::IntentSubmitted { .. }
+            | Self::RefractDecomposed { .. }
+            | Self::RefractFailed { .. } => "refract",
             Self::TypeProposed { .. }
             | Self::TypeApproved { .. }
             | Self::TypeDeprecated { .. }
@@ -618,6 +698,7 @@ impl FactoryEventKind {
             Self::SynodicEscalationStarted { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicEscalationResolved { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicEscalationTimedOut { escalation_id, .. } => escalation_id.clone(),
+            Self::SynodicGateResolutionProposed { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicRuleProposed { rule_id, .. } => rule_id.clone(),
             Self::SynodicRuleApproved { rule_id, .. } => rule_id.clone(),
             Self::SynodicRuleDisabled { rule_id, .. } => rule_id.clone(),
@@ -628,6 +709,9 @@ impl FactoryEventKind {
             Self::IsingRuleProposed { insight_id, .. } => insight_id.clone(),
             Self::IsingAnalyzerError { analyzer, .. } => analyzer.clone(),
             Self::IsingCatchupCompleted { .. } => "ising".to_string(),
+            Self::IntentSubmitted { intent_id, .. }
+            | Self::RefractDecomposed { intent_id, .. }
+            | Self::RefractFailed { intent_id, .. } => intent_id.clone(),
             Self::TypeProposed { type_id, .. }
             | Self::TypeApproved { type_id, .. }
             | Self::TypeDeprecated { type_id, .. } => format!("type:{type_id}"),
@@ -733,6 +817,60 @@ pub struct EventRef {
     /// The `event_type` string (e.g. `"forge.gate_verdict"`), for quick
     /// consumer-side filtering without a second lookup.
     pub event_type: String,
+}
+
+/// LLM token usage carried on [`FactoryEventKind::StiglabSessionCompleted`]
+/// (issue #39). Accounting primitives only — USD cost is resolved downstream
+/// by the budget consumer, not on the event, so we don't have to version the
+/// pricing table every time a model changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// Cache-read input tokens (Anthropic-style prompt caching). Zero for
+    /// providers without a cache concept.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    /// Cache-creation input tokens.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+    /// Model identifier (`"claude-sonnet-4-6"`, etc.) so the downstream
+    /// pricing table can resolve cost without guessing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// What kind of rule change an [`FactoryEventKind::IsingRuleProposed`] is
+/// asking Synodic to make.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum RuleProposalAction {
+    /// Disable or retire an existing rule — typically when override rate is
+    /// so high the rule is more friction than value.
+    Retire { rule_id: String },
+    /// Rewrite an existing rule's condition — typically when the rule is
+    /// tripping on false positives.
+    Rewrite {
+        rule_id: String,
+        suggested_condition: Option<String>,
+    },
+    /// Register a new rule for a subject that currently has none.
+    Introduce {
+        subject_ref: String,
+        suggested_condition: Option<String>,
+    },
+}
+
+/// How a rule proposal should be handled by Synodic.
+///
+/// `SafeAuto` proposals carry a narrow, reversible change with enough
+/// confidence that blocking on a human is pure friction. `ReviewRequired`
+/// proposals land in the review queue on the dashboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleProposalClass {
+    SafeAuto,
+    ReviewRequired,
 }
 
 // ---------------------------------------------------------------------------
@@ -844,6 +982,115 @@ mod tests {
 
         let back: FactoryEventKind = serde_json::from_value(json).unwrap();
         assert_eq!(back, event);
+    }
+
+    #[test]
+    fn ising_rule_proposed_carries_routing_fields() {
+        // Issue #36 Step 2 contract: a Synodic consumer must be able to
+        // route the proposal without looking up the producing insight. The
+        // event_type / stream_type / stream_id triple pins the dashboard
+        // query path.
+        let event = FactoryEventKind::IsingRuleProposed {
+            insight_id: "ins_spine_101".into(),
+            signal_kind: "repeated_gate_override".into(),
+            subject_ref: "code".into(),
+            proposed_action: RuleProposalAction::Retire {
+                rule_id: "noisy-rule".into(),
+            },
+            class: RuleProposalClass::ReviewRequired,
+            rationale: "80% override rate over 40 verdicts".into(),
+            confidence: 0.85,
+        };
+        assert_eq!(event.event_type(), "ising.rule_proposed");
+        assert_eq!(event.stream_type(), "ising");
+        assert_eq!(event.stream_id(), "ins_spine_101");
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["class"], "review_required");
+        assert_eq!(json["proposed_action"]["action"], "retire");
+        let back: FactoryEventKind = serde_json::from_value(json).unwrap();
+        assert_eq!(back, event);
+    }
+
+    #[test]
+    fn refract_events_round_trip() {
+        let submitted = FactoryEventKind::IntentSubmitted {
+            intent_id: "int_abc".into(),
+            intent_class: "file_migration".into(),
+            description: "Migrate auth callers".into(),
+            submitter: "marvin".into(),
+        };
+        assert_eq!(submitted.event_type(), "refract.intent_submitted");
+        assert_eq!(submitted.stream_type(), "refract");
+        assert_eq!(submitted.stream_id(), "int_abc");
+
+        let decomposed = FactoryEventKind::RefractDecomposed {
+            intent_id: "int_abc".into(),
+            decomposer: "file_migration".into(),
+            artifact_ids: vec!["art_1".into(), "art_2".into()],
+        };
+        assert_eq!(decomposed.event_type(), "refract.decomposed");
+        assert_eq!(decomposed.stream_type(), "refract");
+
+        let failed = FactoryEventKind::RefractFailed {
+            intent_id: "int_abc".into(),
+            reason: "no decomposer matched".into(),
+        };
+        assert_eq!(failed.event_type(), "refract.failed");
+    }
+
+    #[test]
+    fn gate_resolution_proposed_round_trip() {
+        let event = FactoryEventKind::SynodicGateResolutionProposed {
+            escalation_id: "esc_42".into(),
+            artifact_id: ArtifactId::new("art_ri"),
+            proposer: "supervisor".into(),
+            proposed_verdict: VerdictSummary::Allow,
+            rationale: "supervisor reviewed the evidence".into(),
+        };
+        assert_eq!(event.event_type(), "synodic.gate_resolution_proposed");
+        assert_eq!(event.stream_type(), "synodic");
+        assert_eq!(event.stream_id(), "esc_42");
+        let back: FactoryEventKind =
+            serde_json::from_value(serde_json::to_value(&event).unwrap()).expect("round trip");
+        assert_eq!(back, event);
+    }
+
+    #[test]
+    fn token_usage_on_session_completed_is_optional() {
+        // Without token_usage (legacy shape)
+        let without = FactoryEventKind::StiglabSessionCompleted {
+            session_id: "sess_1".into(),
+            request_id: "req_1".into(),
+            duration_ms: 123,
+            artifact_id: None,
+            token_usage: None,
+        };
+        let json = serde_json::to_value(&without).unwrap();
+        assert!(
+            !json.as_object().unwrap().contains_key("token_usage"),
+            "None token_usage must be omitted for wire compatibility"
+        );
+
+        // With token_usage populated
+        let with = FactoryEventKind::StiglabSessionCompleted {
+            session_id: "sess_2".into(),
+            request_id: "req_2".into(),
+            duration_ms: 42,
+            artifact_id: Some("art_x".into()),
+            token_usage: Some(TokenUsage {
+                input_tokens: 1_000,
+                output_tokens: 500,
+                cache_read_tokens: 200,
+                cache_write_tokens: 100,
+                model: Some("claude-sonnet-4-6".into()),
+            }),
+        };
+        let json = serde_json::to_value(&with).unwrap();
+        assert_eq!(json["token_usage"]["input_tokens"], 1_000);
+        assert_eq!(json["token_usage"]["model"], "claude-sonnet-4-6");
+        let back: FactoryEventKind = serde_json::from_value(json).unwrap();
+        assert_eq!(back, with);
     }
 
     #[test]

--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -27,11 +27,12 @@ or `<name>` (for known subsystems) is a valid subcommand.
 KNOWN SUBCOMMANDS:
     forge       Production line — drives artifacts through their lifecycle
     ising       Continuous improvement engine — observes and surfaces insights
+    refract     Intent decomposer — expands high-level intents into artifacts
     stiglab     Distributed AI agent session orchestration
     synodic     AI agent governance
 ";
 
-const KNOWN: &[&str] = &["forge", "ising", "stiglab", "synodic"];
+const KNOWN: &[&str] = &["forge", "ising", "refract", "stiglab", "synodic"];
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/crates/refract/Cargo.toml
+++ b/crates/refract/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "refract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Intent decomposer — expands high-level intents into artifact trees"
+
+[lib]
+name = "refract"
+path = "src/lib.rs"
+
+[[bin]]
+name = "refract"
+path = "src/main.rs"
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+onsager-spine = { path = "../onsager-spine" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+ulid = "1"
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }

--- a/crates/refract/src/decomposer.rs
+++ b/crates/refract/src/decomposer.rs
@@ -1,0 +1,206 @@
+//! Decomposer trait and the hard-coded `file_migration` implementation.
+
+use std::collections::HashMap;
+
+use onsager_artifact::{Artifact, ArtifactId, Kind};
+use thiserror::Error;
+
+use crate::intent::Intent;
+
+/// Output of a successful decomposition — the per-file artifacts a
+/// decomposer synthesized. Callers are responsible for registering them
+/// with the factory (e.g. via Forge's `POST /api/artifacts` endpoint or
+/// a direct `artifact.registered` spine emission).
+#[derive(Debug)]
+pub struct DecompositionResult {
+    pub artifacts: Vec<Artifact>,
+}
+
+impl DecompositionResult {
+    pub fn artifact_ids(&self) -> Vec<ArtifactId> {
+        self.artifacts
+            .iter()
+            .map(|a| a.artifact_id.clone())
+            .collect()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DecomposerError {
+    #[error("decomposer '{0}' not registered")]
+    NotRegistered(String),
+    #[error("decomposer failed: {0}")]
+    Failed(String),
+}
+
+/// A Refract decomposer expands an intent into artifacts.
+pub trait Decomposer: Send + Sync {
+    /// Stable identifier matched against `Intent::intent_class`.
+    fn name(&self) -> &str;
+
+    fn decompose(&self, intent: &Intent) -> Result<DecompositionResult, DecomposerError>;
+}
+
+/// Registry of decomposers keyed by `Decomposer::name()`. Explicit
+/// registration (rather than inventory / ctor tricks) so the set of
+/// installed decomposers is auditable at a glance.
+#[derive(Default)]
+pub struct DecomposerRegistry {
+    items: HashMap<String, Box<dyn Decomposer>>,
+}
+
+impl DecomposerRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register<D: Decomposer + 'static>(&mut self, decomposer: D) {
+        self.items
+            .insert(decomposer.name().to_string(), Box::new(decomposer));
+    }
+
+    pub fn decompose(&self, intent: &Intent) -> Result<DecompositionResult, DecomposerError> {
+        let Some(d) = self.items.get(&intent.intent_class) else {
+            return Err(DecomposerError::NotRegistered(intent.intent_class.clone()));
+        };
+        d.decompose(intent)
+    }
+
+    pub fn names(&self) -> Vec<&str> {
+        self.items.keys().map(String::as_str).collect()
+    }
+}
+
+/// Hard-coded decomposer for `"file_migration"` intents (issue #35 MVP).
+///
+/// Reads a `"files"` array from the intent payload; synthesizes one
+/// `Kind::Code` artifact per path. The produced artifacts are owned by the
+/// original submitter and named after the file.
+///
+/// Payload shape:
+/// ```json
+/// { "files": ["src/auth.rs", "src/db.rs"] }
+/// ```
+pub struct FileMigrationDecomposer;
+
+impl FileMigrationDecomposer {
+    pub const NAME: &'static str = "file_migration";
+}
+
+impl Decomposer for FileMigrationDecomposer {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn decompose(&self, intent: &Intent) -> Result<DecompositionResult, DecomposerError> {
+        let files = intent
+            .payload
+            .get("files")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                DecomposerError::Failed(
+                    "file_migration payload must contain a 'files' array".into(),
+                )
+            })?;
+
+        if files.is_empty() {
+            return Err(DecomposerError::Failed(
+                "file_migration payload 'files' array is empty".into(),
+            ));
+        }
+
+        let mut artifacts = Vec::with_capacity(files.len());
+        for (idx, path_val) in files.iter().enumerate() {
+            let path = path_val
+                .as_str()
+                .ok_or_else(|| DecomposerError::Failed(format!("files[{idx}] is not a string")))?;
+            let name = format!("{} ({path})", intent.description);
+            artifacts.push(Artifact::new(
+                Kind::Code,
+                name,
+                intent.submitter.clone(),
+                "refract",
+                vec![],
+            ));
+        }
+
+        Ok(DecompositionResult { artifacts })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn mk_intent(class: &str, payload: serde_json::Value) -> Intent {
+        Intent::new(class, "test", "marvin", payload)
+    }
+
+    #[test]
+    fn file_migration_produces_one_artifact_per_file() {
+        let d = FileMigrationDecomposer;
+        let intent = mk_intent(
+            FileMigrationDecomposer::NAME,
+            json!({ "files": ["src/a.rs", "src/b.rs", "src/c.rs"] }),
+        );
+        let result = d.decompose(&intent).expect("decomposes");
+        assert_eq!(result.artifacts.len(), 3);
+        for a in &result.artifacts {
+            assert_eq!(a.kind, Kind::Code);
+            assert_eq!(a.owner, "marvin");
+        }
+    }
+
+    #[test]
+    fn file_migration_rejects_missing_files_field() {
+        let d = FileMigrationDecomposer;
+        let intent = mk_intent(FileMigrationDecomposer::NAME, json!({}));
+        assert!(matches!(
+            d.decompose(&intent),
+            Err(DecomposerError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn file_migration_rejects_empty_files_array() {
+        let d = FileMigrationDecomposer;
+        let intent = mk_intent(FileMigrationDecomposer::NAME, json!({ "files": [] }));
+        assert!(matches!(
+            d.decompose(&intent),
+            Err(DecomposerError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn file_migration_rejects_non_string_entries() {
+        let d = FileMigrationDecomposer;
+        let intent = mk_intent(
+            FileMigrationDecomposer::NAME,
+            json!({ "files": ["ok.rs", 42] }),
+        );
+        assert!(matches!(
+            d.decompose(&intent),
+            Err(DecomposerError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn registry_dispatches_by_intent_class() {
+        let mut registry = DecomposerRegistry::new();
+        registry.register(FileMigrationDecomposer);
+        let intent = mk_intent(FileMigrationDecomposer::NAME, json!({ "files": ["x.rs"] }));
+        let result = registry.decompose(&intent).expect("registered");
+        assert_eq!(result.artifacts.len(), 1);
+    }
+
+    #[test]
+    fn registry_errors_on_unknown_intent_class() {
+        let registry = DecomposerRegistry::new();
+        let intent = mk_intent("unknown_class", json!({}));
+        assert!(matches!(
+            registry.decompose(&intent),
+            Err(DecomposerError::NotRegistered(_))
+        ));
+    }
+}

--- a/crates/refract/src/intent.rs
+++ b/crates/refract/src/intent.rs
@@ -1,0 +1,63 @@
+//! Intent — the input a Refract decomposer expands into artifacts.
+
+use serde::{Deserialize, Serialize};
+
+/// Opaque unique identifier for an intent. Stable across the full
+/// `intent_submitted` → `decomposed` / `failed` causal chain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IntentId(String);
+
+impl IntentId {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    /// Generate a fresh id with an `"int_"` prefix and a ULID body. ULID is
+    /// sortable so the spine's default `ORDER BY id DESC` lines up with
+    /// submission order when there are many intents inflight.
+    pub fn generate() -> Self {
+        Self(format!("int_{}", ulid::Ulid::new()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for IntentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A high-level unit of work filed against the factory. An intent is
+/// decomposed into zero or more artifacts by the matching [`Decomposer`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Intent {
+    pub id: IntentId,
+    /// Stable identifier routed to a [`Decomposer`] (e.g. `"file_migration"`).
+    pub intent_class: String,
+    /// Free-form human-readable description.
+    pub description: String,
+    /// Submitter identity — typically a user id or agent name.
+    pub submitter: String,
+    /// Class-specific payload. The matching decomposer interprets it.
+    pub payload: serde_json::Value,
+}
+
+impl Intent {
+    pub fn new(
+        intent_class: impl Into<String>,
+        description: impl Into<String>,
+        submitter: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> Self {
+        Self {
+            id: IntentId::generate(),
+            intent_class: intent_class.into(),
+            description: description.into(),
+            submitter: submitter.into(),
+            payload,
+        }
+    }
+}

--- a/crates/refract/src/lib.rs
+++ b/crates/refract/src/lib.rs
@@ -1,0 +1,27 @@
+//! Refract — the intent decomposer (issue #35).
+//!
+//! A Refract decomposer takes a high-level `Intent` ("migrate every auth
+//! caller to the new SDK", "roll out the observability spec across the
+//! monorepo") and expands it into an artifact tree the Forge pipeline can
+//! drive to completion. The expansion itself is delegated to a registered
+//! [`Decomposer`] implementation keyed on `intent_class`; this MVP ships
+//! with one hard-coded decomposer (`FileMigrationDecomposer`) so the spine
+//! wiring and event contract can be tested end-to-end without an LLM.
+//!
+//! Event contract (see `onsager-spine`):
+//!   - `refract.intent_submitted`      — a new intent was filed
+//!   - `refract.decomposed`            — decomposer produced artifact ids
+//!   - `refract.failed`                — no decomposer matched or errored
+//!
+//! The crate itself has no runtime dependency on Forge, Stiglab, Synodic,
+//! or Ising — it only knows the spine contract. Decomposers write their
+//! results back to the spine so Forge's listener picks them up via
+//! `artifact.registered` events (one per produced artifact id).
+
+pub mod decomposer;
+pub mod intent;
+pub mod runtime;
+
+pub use decomposer::{Decomposer, DecomposerError, DecomposerRegistry, DecompositionResult};
+pub use intent::{Intent, IntentId};
+pub use runtime::Refract;

--- a/crates/refract/src/main.rs
+++ b/crates/refract/src/main.rs
@@ -1,0 +1,104 @@
+//! `refract` CLI — Submit intents to the Refract decomposer and emit the
+//! lifecycle events onto the Onsager event spine (issue #35).
+
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+use refract::{DecomposerRegistry, Intent, Refract};
+
+#[derive(Parser)]
+#[command(name = "refract", about = "Intent decomposer for Onsager")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Submit an intent, decompose it, and print the resulting artifact
+    /// ids. If `DATABASE_URL` is set, the full event lifecycle is also
+    /// emitted on the spine; otherwise only the stdout report runs.
+    Submit {
+        /// Intent class — routes to the matching decomposer.
+        #[arg(long)]
+        class: String,
+        /// Free-form description.
+        #[arg(long)]
+        description: String,
+        /// Submitter identity.
+        #[arg(long, default_value = "cli")]
+        submitter: String,
+        /// JSON payload (forwarded to the decomposer).
+        #[arg(long, default_value = "{}")]
+        payload: String,
+    },
+    /// List registered decomposers.
+    List,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("refract=info")
+        .init();
+
+    let cli = Cli::parse();
+    let registry = default_registry();
+
+    match cli.cmd {
+        Cmd::List => {
+            for name in registry.names() {
+                println!("{name}");
+            }
+            Ok(())
+        }
+        Cmd::Submit {
+            class,
+            description,
+            submitter,
+            payload,
+        } => {
+            let payload_json: serde_json::Value = serde_json::from_str(&payload)
+                .with_context(|| format!("payload is not valid JSON: {payload}"))?;
+            let intent = Intent::new(class, description, submitter, payload_json);
+
+            let spine = match std::env::var("DATABASE_URL") {
+                Ok(url) => match onsager_spine::EventStore::connect(&url).await {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        tracing::warn!("refract: spine connection failed ({e}); running offline");
+                        None
+                    }
+                },
+                Err(_) => {
+                    tracing::info!("refract: DATABASE_URL unset; running offline");
+                    None
+                }
+            };
+
+            let rt = Refract::new(registry, spine);
+            match rt.submit(&intent).await {
+                Ok(result) => {
+                    println!(
+                        "intent {} decomposed into {} artifact(s):",
+                        intent.id,
+                        result.artifacts.len()
+                    );
+                    for a in &result.artifacts {
+                        println!("  {} ({})", a.artifact_id, a.name);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("intent {} failed: {e}", intent.id);
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}
+
+fn default_registry() -> DecomposerRegistry {
+    let mut r = DecomposerRegistry::new();
+    r.register(refract::decomposer::FileMigrationDecomposer);
+    r
+}

--- a/crates/refract/src/runtime.rs
+++ b/crates/refract/src/runtime.rs
@@ -24,7 +24,8 @@ pub enum RuntimeError {
 
 /// The Refract runtime — holds a [`DecomposerRegistry`] and an optional
 /// [`EventStore`] handle. When the spine handle is present, every intent
-/// submission emits the four-step lifecycle events; when absent, only the
+/// submission emits `refract.intent_submitted` and then either
+/// `refract.decomposed` or `refract.failed`; when absent, only the
 /// decomposer's return value is available.
 pub struct Refract {
     registry: DecomposerRegistry,

--- a/crates/refract/src/runtime.rs
+++ b/crates/refract/src/runtime.rs
@@ -1,0 +1,159 @@
+//! Refract runtime — ties the decomposer registry to the event spine.
+//!
+//! The runtime is the seam between "pure decomposition logic" (in
+//! [`crate::decomposer`]) and "wire the result onto the spine" (here).
+//! Tests can construct a runtime without a live spine by passing `None`
+//! for the event store, in which case emissions become no-ops and results
+//! are returned via the return value only.
+
+use onsager_spine::factory_event::{FactoryEventKind, TokenUsage};
+use onsager_spine::{EventMetadata, EventStore};
+
+use crate::decomposer::{DecomposerError, DecomposerRegistry, DecompositionResult};
+use crate::intent::Intent;
+
+#[derive(thiserror::Error, Debug)]
+pub enum RuntimeError {
+    #[error("decomposer error: {0}")]
+    Decomposer(#[from] DecomposerError),
+    #[error("spine error: {0}")]
+    Spine(String),
+    #[error("serialize error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// The Refract runtime — holds a [`DecomposerRegistry`] and an optional
+/// [`EventStore`] handle. When the spine handle is present, every intent
+/// submission emits the four-step lifecycle events; when absent, only the
+/// decomposer's return value is available.
+pub struct Refract {
+    registry: DecomposerRegistry,
+    spine: Option<EventStore>,
+}
+
+impl Refract {
+    pub fn new(registry: DecomposerRegistry, spine: Option<EventStore>) -> Self {
+        Self { registry, spine }
+    }
+
+    pub fn registry(&self) -> &DecomposerRegistry {
+        &self.registry
+    }
+
+    /// Submit an intent, emit `refract.intent_submitted`, run the matching
+    /// decomposer, then emit either `refract.decomposed` (with the produced
+    /// artifact ids) or `refract.failed` (with the error message).
+    ///
+    /// Returns the [`DecompositionResult`] on success so the caller can
+    /// register the artifacts with Forge. Errors are recorded on the spine
+    /// *and* returned to the caller — losing a decomposer failure in a
+    /// fire-and-forget emission would make intent debugging opaque.
+    pub async fn submit(&self, intent: &Intent) -> Result<DecompositionResult, RuntimeError> {
+        self.emit_submitted(intent).await?;
+
+        match self.registry.decompose(intent) {
+            Ok(result) => {
+                self.emit_decomposed(intent, &result).await?;
+                Ok(result)
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                self.emit_failed(intent, &msg).await?;
+                Err(RuntimeError::Decomposer(err))
+            }
+        }
+    }
+
+    async fn emit_submitted(&self, intent: &Intent) -> Result<(), RuntimeError> {
+        let event = FactoryEventKind::IntentSubmitted {
+            intent_id: intent.id.to_string(),
+            intent_class: intent.intent_class.clone(),
+            description: intent.description.clone(),
+            submitter: intent.submitter.clone(),
+        };
+        self.emit(&event).await
+    }
+
+    async fn emit_decomposed(
+        &self,
+        intent: &Intent,
+        result: &DecompositionResult,
+    ) -> Result<(), RuntimeError> {
+        let event = FactoryEventKind::RefractDecomposed {
+            intent_id: intent.id.to_string(),
+            decomposer: intent.intent_class.clone(),
+            artifact_ids: result
+                .artifact_ids()
+                .into_iter()
+                .map(|a| a.to_string())
+                .collect(),
+        };
+        self.emit(&event).await
+    }
+
+    async fn emit_failed(&self, intent: &Intent, reason: &str) -> Result<(), RuntimeError> {
+        let event = FactoryEventKind::RefractFailed {
+            intent_id: intent.id.to_string(),
+            reason: reason.to_string(),
+        };
+        self.emit(&event).await
+    }
+
+    async fn emit(&self, event: &FactoryEventKind) -> Result<(), RuntimeError> {
+        let Some(spine) = self.spine.as_ref() else {
+            return Ok(());
+        };
+        let metadata = EventMetadata {
+            actor: "refract".into(),
+            ..Default::default()
+        };
+        let data = serde_json::to_value(event)?;
+        let stream_id = event.stream_id();
+        let event_type = event.event_type();
+        spine
+            .append_ext(&stream_id, "refract", event_type, data, &metadata, None)
+            .await
+            .map_err(|e| RuntimeError::Spine(e.to_string()))?;
+        Ok(())
+    }
+}
+
+/// Compile-time assertion: if a new [`FactoryEventKind`] variant is added
+/// the `TokenUsage` import is still referenced — refract may want to
+/// eventually surface LLM cost of LLM-backed decomposers (issue #39).
+#[allow(dead_code)]
+fn _compile_check(_u: TokenUsage) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decomposer::FileMigrationDecomposer;
+    use serde_json::json;
+
+    fn registry() -> DecomposerRegistry {
+        let mut r = DecomposerRegistry::new();
+        r.register(FileMigrationDecomposer);
+        r
+    }
+
+    #[tokio::test]
+    async fn submit_without_spine_returns_result() {
+        let r = Refract::new(registry(), None);
+        let intent = Intent::new(
+            FileMigrationDecomposer::NAME,
+            "migrate",
+            "marvin",
+            json!({ "files": ["a.rs", "b.rs"] }),
+        );
+        let result = r.submit(&intent).await.expect("submit");
+        assert_eq!(result.artifacts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn submit_without_spine_surfaces_decomposer_error() {
+        let r = Refract::new(registry(), None);
+        let intent = Intent::new("nope", "unroutable", "marvin", json!({}));
+        let err = r.submit(&intent).await.expect_err("unroutable");
+        assert!(matches!(err, RuntimeError::Decomposer(_)));
+    }
+}

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -111,7 +111,10 @@ pub async fn handle_agent_message(
             }
             // Emit spine event for session completion
             if let Some(spine) = spine {
-                if let Err(e) = spine.emit_session_completed(&session_id, "", 0, None).await {
+                if let Err(e) = spine
+                    .emit_session_completed(&session_id, "", 0, None, None)
+                    .await
+                {
                     tracing::warn!("failed to emit session_completed spine event: {e}");
                 }
             }

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -1,7 +1,7 @@
 //! Optional event spine integration for emitting factory events to the
 //! Onsager event store.
 
-use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::factory_event::{FactoryEventKind, TokenUsage};
 use onsager_spine::{EventMetadata, EventStore};
 
 /// Emits factory events to the Onsager event spine under the "stiglab" namespace.
@@ -89,19 +89,22 @@ impl SpineEmitter {
     ///
     /// `artifact_id` links the session to the factory pipeline artifact it
     /// was shaping (issue #14 phase 2). Pass `None` for sessions that don't
-    /// originate from a `ShapingRequest`.
+    /// originate from a `ShapingRequest`. `token_usage` is the LLM accounting
+    /// payload (issue #39); pass `None` when the runtime can't report it.
     pub async fn emit_session_completed(
         &self,
         session_id: &str,
         request_id: &str,
         duration_ms: u64,
         artifact_id: Option<&str>,
+        token_usage: Option<TokenUsage>,
     ) -> Result<i64, sqlx::Error> {
         self.emit(FactoryEventKind::StiglabSessionCompleted {
             session_id: session_id.to_string(),
             request_id: request_id.to_string(),
             duration_ms,
             artifact_id: artifact_id.map(str::to_owned),
+            token_usage,
         })
         .await
     }

--- a/crates/synodic/migrations/005_rule_proposals.sql
+++ b/crates/synodic/migrations/005_rule_proposals.sql
@@ -1,0 +1,29 @@
+-- Rule-proposal queue fed by Ising (issue #36 Step 2).
+--
+-- Each row is one ising rule-proposed event ingested by Synodic. Rows of
+-- class review_required stay at status pending until a human or agent
+-- resolves them. Rows of class safe_auto auto-transition to approved and
+-- apply the rule change inline.
+--
+-- insight_id is UNIQUE so redelivery (listener restart, catch-up) is
+-- idempotent: the listener INSERTs with ON CONFLICT DO NOTHING and the
+-- earliest handler wins.
+
+CREATE TABLE IF NOT EXISTS rule_proposals (
+    id TEXT PRIMARY KEY,                          -- internal UUID
+    insight_id TEXT NOT NULL UNIQUE,              -- dedup key from ising
+    signal_kind TEXT NOT NULL,                    -- e.g. "repeated_gate_override"
+    subject_ref TEXT NOT NULL,                    -- artifact kind / rule id / ...
+    proposed_action TEXT NOT NULL,                -- JSON-encoded RuleProposalAction
+    class TEXT NOT NULL CHECK (class IN ('safe_auto', 'review_required')),
+    rationale TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+    resolution_notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    resolved_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_proposals_status ON rule_proposals(status);
+CREATE INDEX IF NOT EXISTS idx_proposals_subject ON rule_proposals(subject_ref);
+CREATE INDEX IF NOT EXISTS idx_proposals_created ON rule_proposals(created_at);

--- a/crates/synodic/migrations/pg/005_rule_proposals.sql
+++ b/crates/synodic/migrations/pg/005_rule_proposals.sql
@@ -1,0 +1,23 @@
+-- Rule-proposal queue fed by Ising (issue #36 Step 2, PostgreSQL).
+--
+-- See the SQLite sibling migration (`005_rule_proposals.sql`) for design
+-- notes — this file is the production schema.
+
+CREATE TABLE IF NOT EXISTS rule_proposals (
+    id TEXT PRIMARY KEY,
+    insight_id TEXT NOT NULL UNIQUE,
+    signal_kind TEXT NOT NULL,
+    subject_ref TEXT NOT NULL,
+    proposed_action JSONB NOT NULL,
+    class TEXT NOT NULL CHECK (class IN ('safe_auto', 'review_required')),
+    rationale TEXT NOT NULL,
+    confidence DOUBLE PRECISION NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+    resolution_notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_proposals_status ON rule_proposals(status);
+CREATE INDEX IF NOT EXISTS idx_proposals_subject ON rule_proposals(subject_ref);
+CREATE INDEX IF NOT EXISTS idx_proposals_created ON rule_proposals(created_at);

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -50,6 +50,12 @@ pub struct ServeCmd {
 struct AppState {
     storage: Arc<dyn Storage>,
     engine_cache: Arc<EngineCache>,
+    /// Shared handle to the event spine. `None` when Synodic is running
+    /// against a non-spine-capable backend (SQLite today). Handlers that
+    /// need to emit events check this and return an error when it's absent
+    /// rather than constructing a fresh pool per request (which would
+    /// churn Postgres connections under load).
+    spine: Option<Arc<onsager_spine::EventStore>>,
 }
 
 impl FromRef<AppState> for Arc<dyn Storage> {
@@ -64,14 +70,61 @@ impl FromRef<AppState> for Arc<EngineCache> {
     }
 }
 
+impl FromRef<AppState> for Option<Arc<onsager_spine::EventStore>> {
+    fn from_ref(state: &AppState) -> Self {
+        state.spine.clone()
+    }
+}
+
+/// The event spine is PostgreSQL-only (`EventStore::connect` opens a
+/// `PgPool`). Synodic itself supports both Postgres and SQLite for its
+/// own storage, so we only attempt to attach a spine when the URL scheme
+/// is Postgres. This avoids a noisy connect failure on every SQLite
+/// dev setup.
+fn is_postgres_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.starts_with("postgres://") || lower.starts_with("postgresql://")
+}
+
 impl ServeCmd {
     pub async fn run(self) -> Result<()> {
         let db_url = resolve_database_url();
         eprintln!("Connecting to database...");
         let storage = create_storage(&db_url).await?;
+
+        // Attach a shared event-spine handle when the database URL is
+        // Postgres. Kept in `AppState` so per-request handlers and the
+        // background listener share one `PgPool` (issue #36 Step 2, #37).
+        let spine = match std::env::var("DATABASE_URL") {
+            Ok(spine_url) if is_postgres_url(&spine_url) => {
+                match onsager_spine::EventStore::connect(&spine_url).await {
+                    Ok(store) => Some(Arc::new(store)),
+                    Err(e) => {
+                        tracing::warn!(
+                            "synodic: spine connection failed ({e}); event-emitting routes and \
+                             rule_proposed listener disabled"
+                        );
+                        None
+                    }
+                }
+            }
+            Ok(_) => {
+                tracing::info!(
+                    "synodic: non-postgres DATABASE_URL; spine integration requires postgres, \
+                     rule_proposed listener disabled"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::info!("synodic: DATABASE_URL not set; rule_proposed listener disabled");
+                None
+            }
+        };
+
         let state = AppState {
             storage: Arc::from(storage),
             engine_cache: Arc::new(EngineCache::new()),
+            spine: spine.clone(),
         };
 
         let api = Router::new()
@@ -91,30 +144,21 @@ impl ServeCmd {
                 post(propose_escalation_resolution),
             );
 
-        // Spawn the ising.rule_proposed listener so Synodic consumes
-        // proposals off the spine in real time (issue #36 Step 2). A spine
-        // connection failure here is non-fatal — the HTTP API stays up and
-        // operators can retry via backfill on the next restart.
-        if let Ok(spine_url) = std::env::var("DATABASE_URL") {
+        // Spawn the ising.rule_proposed listener on the shared spine
+        // handle (issue #36 Step 2). A missing spine handle is non-fatal —
+        // the HTTP API stays up and operators can attach the spine later
+        // by restarting with a postgres `DATABASE_URL`.
+        if let Some(spine_arc) = spine {
             let listener_storage = Arc::clone(&state.storage);
+            let spine_for_listener = (*spine_arc).clone();
             tokio::spawn(async move {
-                match onsager_spine::EventStore::connect(&spine_url).await {
-                    Ok(spine) => {
-                        if let Err(e) =
-                            crate::core::proposal_listener::run(spine, listener_storage, None).await
-                        {
-                            tracing::error!("synodic: rule_proposed listener exited: {e}");
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "synodic: rule_proposed listener disabled (spine connect failed: {e})"
-                        );
-                    }
+                if let Err(e) =
+                    crate::core::proposal_listener::run(spine_for_listener, listener_storage, None)
+                        .await
+                {
+                    tracing::error!("synodic: rule_proposed listener exited: {e}");
                 }
             });
-        } else {
-            tracing::info!("synodic: DATABASE_URL not set; rule_proposed listener disabled");
         }
 
         let mut app = Router::new().nest("/api", api).with_state(state);
@@ -316,11 +360,30 @@ async fn resolve_rule_proposal(
             body.status
         )));
     }
-    store
+    match store
         .resolve_rule_proposal(&id, &body.status, body.notes)
         .await
-        .map_err(|e| AppError::BadRequest(e.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+    {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(e) => Err(classify_resolve_error(e)),
+    }
+}
+
+/// Turn the storage layer's combined "not found / already resolved" error
+/// string into the HTTP response the client expects. 404 when the id is
+/// absent, 409 when the row is already terminal, 400 for anything else.
+/// Matches the UX of the existing `/events/:id/resolve` endpoint, which
+/// distinguishes missing ids up front with a separate lookup.
+fn classify_resolve_error(err: anyhow::Error) -> AppError {
+    let msg = err.to_string();
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("not found") {
+        AppError::NotFound(msg)
+    } else if lower.contains("already resolved") {
+        AppError::Conflict(msg)
+    } else {
+        AppError::BadRequest(msg)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +405,11 @@ struct ProposeResolutionBody {
 /// proposed resolution on the spine as `synodic.gate_resolution_proposed`.
 /// The proposal is not applied; Forge/Synodic wiring converts accepted
 /// proposals into a final verdict on a separate path.
+///
+/// The spine handle is pulled from `AppState` so we reuse one `PgPool`
+/// across all requests instead of building a fresh pool per call.
 async fn propose_escalation_resolution(
+    State(spine): State<Option<Arc<onsager_spine::EventStore>>>,
     Path(escalation_id): Path<String>,
     Json(body): Json<ProposeResolutionBody>,
 ) -> Result<StatusCode, AppError> {
@@ -358,14 +425,13 @@ async fn propose_escalation_resolution(
         }
     };
 
-    let Ok(spine_url) = std::env::var("DATABASE_URL") else {
-        return Err(AppError::Internal(anyhow::anyhow!(
-            "DATABASE_URL not set; can't emit spine event"
-        )));
+    let Some(spine) = spine else {
+        return Err(AppError::ServiceUnavailable(
+            "spine not attached; Synodic must be run with a postgres DATABASE_URL \
+             to emit gate_resolution_proposed events"
+                .into(),
+        ));
     };
-    let spine = onsager_spine::EventStore::connect(&spine_url)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::anyhow!("spine connect: {e}")))?;
 
     let event = onsager_spine::factory_event::FactoryEventKind::SynodicGateResolutionProposed {
         escalation_id: escalation_id.clone(),
@@ -423,6 +489,8 @@ enum AppError {
     Internal(anyhow::Error),
     NotFound(String),
     BadRequest(String),
+    Conflict(String),
+    ServiceUnavailable(String),
 }
 
 impl From<anyhow::Error> for AppError {
@@ -449,6 +517,16 @@ impl IntoResponse for AppError {
                 .into_response(),
             Self::BadRequest(msg) => (
                 StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response(),
+            Self::Conflict(msg) => (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response(),
+            Self::ServiceUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": msg })),
             )
                 .into_response(),

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -21,7 +21,7 @@ use crate::core::engine_cache::EngineCache;
 use crate::core::gate_adapter;
 use crate::core::storage::pool::{create_storage, resolve_database_url};
 use crate::core::storage::{
-    CreateGovernanceEvent, GovernanceEvent, GovernanceEventFilters, Storage,
+    CreateGovernanceEvent, GovernanceEvent, GovernanceEventFilters, RuleProposal, Storage,
 };
 
 /// Run the Synodic web server (dashboard + API)
@@ -81,7 +81,41 @@ impl ServeCmd {
             .route("/events/{id}/resolve", patch(resolve_event))
             .route("/stats", get(get_stats))
             .route("/rules", get(list_rules))
-            .route("/gate", post(gate_handler));
+            .route("/gate", post(gate_handler))
+            // Rule proposal queue (issue #36 Step 2)
+            .route("/rule-proposals", get(list_rule_proposals))
+            .route("/rule-proposals/{id}/resolve", patch(resolve_rule_proposal))
+            // Escalation resolution proposals (issue #37)
+            .route(
+                "/escalations/{id}/propose-resolution",
+                post(propose_escalation_resolution),
+            );
+
+        // Spawn the ising.rule_proposed listener so Synodic consumes
+        // proposals off the spine in real time (issue #36 Step 2). A spine
+        // connection failure here is non-fatal — the HTTP API stays up and
+        // operators can retry via backfill on the next restart.
+        if let Ok(spine_url) = std::env::var("DATABASE_URL") {
+            let listener_storage = Arc::clone(&state.storage);
+            tokio::spawn(async move {
+                match onsager_spine::EventStore::connect(&spine_url).await {
+                    Ok(spine) => {
+                        if let Err(e) =
+                            crate::core::proposal_listener::run(spine, listener_storage, None).await
+                        {
+                            tracing::error!("synodic: rule_proposed listener exited: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "synodic: rule_proposed listener disabled (spine connect failed: {e})"
+                        );
+                    }
+                }
+            });
+        } else {
+            tracing::info!("synodic: DATABASE_URL not set; rule_proposed listener disabled");
+        }
 
         let mut app = Router::new().nest("/api", api).with_state(state);
 
@@ -250,6 +284,114 @@ async fn list_rules(State(store): State<Arc<dyn Storage>>) -> Result<Json<Vec<Ap
         .collect();
 
     Ok(Json(api_rules))
+}
+
+// ---------------------------------------------------------------------------
+// Rule proposal queue (issue #36 Step 2)
+// ---------------------------------------------------------------------------
+
+async fn list_rule_proposals(
+    State(store): State<Arc<dyn Storage>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<Vec<RuleProposal>>, AppError> {
+    let status = params.get("status").map(String::as_str);
+    let proposals = store.list_rule_proposals(status).await?;
+    Ok(Json(proposals))
+}
+
+#[derive(Deserialize)]
+struct ResolveProposalBody {
+    status: String,
+    notes: Option<String>,
+}
+
+async fn resolve_rule_proposal(
+    State(store): State<Arc<dyn Storage>>,
+    Path(id): Path<String>,
+    Json(body): Json<ResolveProposalBody>,
+) -> Result<StatusCode, AppError> {
+    if body.status != "approved" && body.status != "rejected" {
+        return Err(AppError::BadRequest(format!(
+            "status must be approved or rejected, got {}",
+            body.status
+        )));
+    }
+    store
+        .resolve_rule_proposal(&id, &body.status, body.notes)
+        .await
+        .map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Escalation resolution proposals (issue #37)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ProposeResolutionBody {
+    artifact_id: String,
+    /// Identity of the proposer: `"supervisor"`, `"human:<id>"`, or any
+    /// free-form string representing the delegate.
+    proposer: String,
+    /// One of `"allow" | "deny" | "modify" | "escalate"`.
+    proposed_verdict: String,
+    rationale: String,
+}
+
+/// POST `/api/escalations/{id}/propose-resolution` — record a delegate's
+/// proposed resolution on the spine as `synodic.gate_resolution_proposed`.
+/// The proposal is not applied; Forge/Synodic wiring converts accepted
+/// proposals into a final verdict on a separate path.
+async fn propose_escalation_resolution(
+    Path(escalation_id): Path<String>,
+    Json(body): Json<ProposeResolutionBody>,
+) -> Result<StatusCode, AppError> {
+    let verdict = match body.proposed_verdict.to_ascii_lowercase().as_str() {
+        "allow" => onsager_spine::factory_event::VerdictSummary::Allow,
+        "deny" => onsager_spine::factory_event::VerdictSummary::Deny,
+        "modify" => onsager_spine::factory_event::VerdictSummary::Modify,
+        "escalate" => onsager_spine::factory_event::VerdictSummary::Escalate,
+        other => {
+            return Err(AppError::BadRequest(format!(
+                "proposed_verdict must be allow|deny|modify|escalate, got {other}"
+            )));
+        }
+    };
+
+    let Ok(spine_url) = std::env::var("DATABASE_URL") else {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "DATABASE_URL not set; can't emit spine event"
+        )));
+    };
+    let spine = onsager_spine::EventStore::connect(&spine_url)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("spine connect: {e}")))?;
+
+    let event = onsager_spine::factory_event::FactoryEventKind::SynodicGateResolutionProposed {
+        escalation_id: escalation_id.clone(),
+        artifact_id: onsager_artifact::ArtifactId::new(&body.artifact_id),
+        proposer: body.proposer,
+        proposed_verdict: verdict,
+        rationale: body.rationale,
+    };
+    let data = serde_json::to_value(&event).expect("FactoryEventKind must serialize");
+    let metadata = onsager_spine::EventMetadata {
+        actor: "synodic".into(),
+        ..Default::default()
+    };
+    spine
+        .append_ext(
+            &escalation_id,
+            "synodic",
+            event.event_type(),
+            data,
+            &metadata,
+            None,
+        )
+        .await
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("append_ext: {e}")))?;
+
+    Ok(StatusCode::ACCEPTED)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/synodic/src/core/engine_cache.rs
+++ b/crates/synodic/src/core/engine_cache.rs
@@ -288,6 +288,26 @@ mod tests {
         async fn resolve_governance_event(&self, _id: &str, _notes: Option<String>) -> Result<()> {
             Ok(())
         }
+        async fn list_rule_proposals(
+            &self,
+            _status: Option<&str>,
+        ) -> Result<Vec<crate::core::storage::RuleProposal>> {
+            Ok(vec![])
+        }
+        async fn create_rule_proposal(
+            &self,
+            _proposal: crate::core::storage::CreateRuleProposal,
+        ) -> Result<crate::core::storage::RuleProposal> {
+            unimplemented!()
+        }
+        async fn resolve_rule_proposal(
+            &self,
+            _id: &str,
+            _status: &str,
+            _notes: Option<String>,
+        ) -> Result<()> {
+            Ok(())
+        }
     }
 
     fn sample_rule(id: &str) -> Rule {

--- a/crates/synodic/src/core/mod.rs
+++ b/crates/synodic/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod intercept;
 pub mod llm;
 pub mod pipeline;
 pub mod probing;
+pub mod proposal_listener;
 pub mod scoring;
 pub mod storage;
 pub mod ui;

--- a/crates/synodic/src/core/proposal_listener.rs
+++ b/crates/synodic/src/core/proposal_listener.rs
@@ -184,7 +184,12 @@ mod tests {
     use crate::core::storage::pool::create_storage;
 
     async fn test_storage() -> Arc<dyn Storage> {
-        let url = "sqlite://:memory:";
+        // Match the URL convention used by the rest of the Synodic storage
+        // tests — `sqlite::memory:` is unambiguously interpreted as an
+        // in-memory database by sqlx, whereas `sqlite://:memory:` can be
+        // parsed as a path to a file literally named `:memory:` on some
+        // driver versions.
+        let url = "sqlite::memory:";
         let storage = create_storage(url)
             .await
             .expect("in-memory sqlite storage must connect");
@@ -283,6 +288,22 @@ mod tests {
             .await
             .expect_err("second resolve must error");
         assert!(err.to_string().contains("already resolved"));
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_id_surfaces_not_found() {
+        // Storage disambiguates between missing-id and already-terminal so
+        // the HTTP layer can return 404 vs 409. If this test starts
+        // matching the "already resolved" branch the disambiguation
+        // regressed.
+        let storage = test_storage().await;
+        let err = storage
+            .resolve_rule_proposal("does-not-exist", "approved", None)
+            .await
+            .expect_err("missing id must error");
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(msg.contains("not found"), "got: {msg}");
+        assert!(!msg.contains("already resolved"), "got: {msg}");
     }
 
     #[tokio::test]

--- a/crates/synodic/src/core/proposal_listener.rs
+++ b/crates/synodic/src/core/proposal_listener.rs
@@ -1,0 +1,311 @@
+//! Rule-proposal spine listener (issue #36 Step 2).
+//!
+//! Tails `ising.rule_proposed` events off the event spine, deserializes the
+//! payload into the typed [`IsingRuleProposed`] variant, and inserts the
+//! proposal into the `rule_proposals` queue.
+//!
+//! Classification:
+//! - `safe_auto` proposals are inserted as `approved` and the listener
+//!   applies the rule change inline. Today the only wired action is
+//!   `Retire`, which disables the matching rule. Future action kinds can
+//!   extend [`apply_auto_action`] without a migration because the raw
+//!   action is stored as JSON alongside the proposal.
+//! - `review_required` proposals sit in the queue at status `pending` for
+//!   a human or supervisor to resolve via the HTTP API.
+//!
+//! The proposal listener is a pure consumer of the spine — it does not emit
+//! Synodic events back. The follow-up `synodic.rule_proposed` / `rule_approved`
+//! bookkeeping events remain the responsibility of Synodic's existing HTTP
+//! routes for rule creation, so the listener doesn't duplicate them.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use onsager_spine::factory_event::{FactoryEventKind, RuleProposalAction, RuleProposalClass};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+
+use crate::core::storage::{CreateRuleProposal, Storage, UpdateRule};
+
+/// Run a rule_proposed listener forever. Returns only if the underlying
+/// pg_notify channel closes.
+pub async fn run(
+    store: EventStore,
+    storage: Arc<dyn Storage>,
+    since: Option<i64>,
+) -> anyhow::Result<()> {
+    let dispatcher = Dispatcher {
+        store: store.clone(),
+        storage,
+    };
+    Listener::new(store).with_since(since).run(dispatcher).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    storage: Arc<dyn Storage>,
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "ising.rule_proposed" {
+            return Ok(());
+        }
+        if notification.table != "events_ext" {
+            return Ok(());
+        }
+
+        let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+            return Ok(());
+        };
+
+        let kind: FactoryEventKind = match serde_json::from_value(row.data.clone()) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::warn!(
+                    id = row.id,
+                    "synodic: rule_proposed payload parse failed: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        let FactoryEventKind::IsingRuleProposed {
+            insight_id,
+            signal_kind,
+            subject_ref,
+            proposed_action,
+            class,
+            rationale,
+            confidence,
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        let (initial_status, is_safe_auto) = match class {
+            RuleProposalClass::SafeAuto => (Some("approved".to_string()), true),
+            RuleProposalClass::ReviewRequired => (None, false),
+        };
+
+        let created = self
+            .storage
+            .create_rule_proposal(CreateRuleProposal {
+                insight_id: insight_id.clone(),
+                signal_kind: signal_kind.clone(),
+                subject_ref: subject_ref.clone(),
+                proposed_action: serde_json::to_value(&proposed_action)?,
+                class: match class {
+                    RuleProposalClass::SafeAuto => "safe_auto".into(),
+                    RuleProposalClass::ReviewRequired => "review_required".into(),
+                },
+                rationale,
+                confidence,
+                initial_status,
+            })
+            .await?;
+
+        tracing::info!(
+            insight_id = %insight_id,
+            signal_kind = %signal_kind,
+            subject_ref = %subject_ref,
+            proposal_id = %created.id,
+            confidence,
+            safe_auto = is_safe_auto,
+            "synodic: ingested rule proposal"
+        );
+
+        if is_safe_auto {
+            if let Err(e) = apply_auto_action(&*self.storage, &proposed_action).await {
+                // Don't block the listener on a single failed auto-apply —
+                // the proposal stays in the queue as `approved` for the
+                // operator to re-apply manually.
+                tracing::error!(
+                    proposal_id = %created.id,
+                    "synodic: auto-apply failed, leaving as approved for manual retry: {e}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Apply a proposed rule change without a human in the loop. Only the
+/// `Retire` action is wired today; `Rewrite` and `Introduce` still need
+/// a human signature because they change rule semantics rather than
+/// merely disabling noise.
+async fn apply_auto_action(
+    storage: &dyn Storage,
+    action: &RuleProposalAction,
+) -> anyhow::Result<()> {
+    match action {
+        RuleProposalAction::Retire { rule_id } => {
+            // The Ising producer uses the subject_ref (artifact kind) as a
+            // placeholder rule_id when grouping is by kind rather than by
+            // rule. If no rule exists with that id, skip the apply — the
+            // proposal is still logged.
+            match storage.get_rule(rule_id).await? {
+                Some(_) => {
+                    storage
+                        .update_rule(
+                            rule_id,
+                            UpdateRule {
+                                enabled: Some(false),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    tracing::info!(rule_id, "synodic: auto-retired rule");
+                    Ok(())
+                }
+                None => {
+                    tracing::debug!(
+                        rule_id,
+                        "synodic: retire proposal references no matching rule; skipping apply"
+                    );
+                    Ok(())
+                }
+            }
+        }
+        RuleProposalAction::Rewrite { .. } | RuleProposalAction::Introduce { .. } => {
+            tracing::debug!(
+                ?action,
+                "synodic: auto-apply not implemented for this action"
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::storage::pool::create_storage;
+
+    async fn test_storage() -> Arc<dyn Storage> {
+        let url = "sqlite://:memory:";
+        let storage = create_storage(url)
+            .await
+            .expect("in-memory sqlite storage must connect");
+        Arc::from(storage)
+    }
+
+    #[tokio::test]
+    async fn auto_retire_skips_missing_rule() {
+        // A safe-auto Retire proposal whose rule_id doesn't exist in Synodic
+        // (e.g. Ising grouped by artifact kind) must NOT error — the
+        // proposal stays recorded and the listener moves on.
+        let storage = test_storage().await;
+        let action = RuleProposalAction::Retire {
+            rule_id: "nonexistent_kind".into(),
+        };
+        apply_auto_action(&*storage, &action)
+            .await
+            .expect("should no-op rather than error");
+    }
+
+    #[tokio::test]
+    async fn rewrite_and_introduce_are_noops_for_now() {
+        let storage = test_storage().await;
+        apply_auto_action(
+            &*storage,
+            &RuleProposalAction::Rewrite {
+                rule_id: "r1".into(),
+                suggested_condition: None,
+            },
+        )
+        .await
+        .expect("rewrite no-op");
+        apply_auto_action(
+            &*storage,
+            &RuleProposalAction::Introduce {
+                subject_ref: "code".into(),
+                suggested_condition: None,
+            },
+        )
+        .await
+        .expect("introduce no-op");
+    }
+
+    #[tokio::test]
+    async fn create_proposal_is_idempotent_on_insight_id() {
+        // Dedup contract: redelivery of the same insight must return the
+        // original row rather than insert a duplicate.
+        let storage = test_storage().await;
+
+        let make = || CreateRuleProposal {
+            insight_id: "ins_dup".into(),
+            signal_kind: "repeated_gate_override".into(),
+            subject_ref: "code".into(),
+            proposed_action: serde_json::json!({
+                "action": "retire",
+                "rule_id": "code",
+            }),
+            class: "review_required".into(),
+            rationale: "80% override rate".into(),
+            confidence: 0.82,
+            initial_status: None,
+        };
+
+        let first = storage.create_rule_proposal(make()).await.unwrap();
+        let second = storage.create_rule_proposal(make()).await.unwrap();
+        assert_eq!(first.id, second.id, "redelivery must map to the same row");
+
+        let pending = storage.list_rule_proposals(Some("pending")).await.unwrap();
+        assert_eq!(pending.len(), 1, "no duplicate inserted");
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_then_double_resolve_errors() {
+        let storage = test_storage().await;
+        let created = storage
+            .create_rule_proposal(CreateRuleProposal {
+                insight_id: "ins_solo".into(),
+                signal_kind: "x".into(),
+                subject_ref: "code".into(),
+                proposed_action: serde_json::json!({}),
+                class: "review_required".into(),
+                rationale: "test".into(),
+                confidence: 0.5,
+                initial_status: None,
+            })
+            .await
+            .unwrap();
+
+        storage
+            .resolve_rule_proposal(&created.id, "rejected", Some("no".into()))
+            .await
+            .expect("first resolve");
+
+        let err = storage
+            .resolve_rule_proposal(&created.id, "approved", None)
+            .await
+            .expect_err("second resolve must error");
+        assert!(err.to_string().contains("already resolved"));
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_invalid_status() {
+        let storage = test_storage().await;
+        let created = storage
+            .create_rule_proposal(CreateRuleProposal {
+                insight_id: "ins_bad_status".into(),
+                signal_kind: "x".into(),
+                subject_ref: "code".into(),
+                proposed_action: serde_json::json!({}),
+                class: "review_required".into(),
+                rationale: "test".into(),
+                confidence: 0.5,
+                initial_status: None,
+            })
+            .await
+            .unwrap();
+
+        let err = storage
+            .resolve_rule_proposal(&created.id, "deleted", None)
+            .await
+            .expect_err("invalid status must error");
+        assert!(err.to_string().contains("invalid proposal status"));
+    }
+}

--- a/crates/synodic/src/core/storage/mod.rs
+++ b/crates/synodic/src/core/storage/mod.rs
@@ -224,6 +224,43 @@ pub struct GovernanceEventFilters {
     pub event_type: Option<String>,
 }
 
+/// A rule-change proposal enqueued by Ising (issue #36 Step 2). Each row
+/// corresponds to one `ising.rule_proposed` event the listener ingested.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleProposal {
+    pub id: String,
+    /// Unique key from Ising — used by the listener for idempotent INSERTs.
+    pub insight_id: String,
+    pub signal_kind: String,
+    pub subject_ref: String,
+    /// Serialized `onsager_spine::factory_event::RuleProposalAction` — the
+    /// Synodic listener stores it as JSON so new action kinds don't require
+    /// a migration.
+    pub proposed_action: serde_json::Value,
+    pub class: String,
+    pub rationale: String,
+    pub confidence: f64,
+    pub status: String,
+    pub resolution_notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+/// Parameters for inserting a new rule proposal (source: Ising event).
+#[derive(Debug, Clone)]
+pub struct CreateRuleProposal {
+    pub insight_id: String,
+    pub signal_kind: String,
+    pub subject_ref: String,
+    pub proposed_action: serde_json::Value,
+    pub class: String,
+    pub rationale: String,
+    pub confidence: f64,
+    /// If `Some`, insert with this status (e.g. `"approved"` for safe-auto
+    /// proposals the listener auto-applies). Defaults to `"pending"`.
+    pub initial_status: Option<String>,
+}
+
 /// Result of an adversarial probe against a rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProbeResult {
@@ -371,4 +408,26 @@ pub trait Storage: Send + Sync {
 
     /// Resolve a governance event.
     async fn resolve_governance_event(&self, id: &str, notes: Option<String>) -> Result<()>;
+
+    // -- Rule proposals (issue #36 Step 2) ----------------------------------
+
+    /// List rule proposals, optionally filtered by status
+    /// (`"pending"` / `"approved"` / `"rejected"`).
+    async fn list_rule_proposals(&self, status: Option<&str>) -> Result<Vec<RuleProposal>>;
+
+    /// Insert a new rule proposal. Deduplicates on `insight_id` — if a row
+    /// with the same `insight_id` already exists the existing proposal is
+    /// returned unchanged. The listener relies on this so redelivery
+    /// (restart, catch-up) is a no-op.
+    async fn create_rule_proposal(&self, proposal: CreateRuleProposal) -> Result<RuleProposal>;
+
+    /// Transition a proposal to a terminal status (`"approved"` or
+    /// `"rejected"`). Errors if the id doesn't exist or the proposal is
+    /// already resolved.
+    async fn resolve_rule_proposal(
+        &self,
+        id: &str,
+        status: &str,
+        notes: Option<String>,
+    ) -> Result<()>;
 }

--- a/crates/synodic/src/core/storage/postgres.rs
+++ b/crates/synodic/src/core/storage/postgres.rs
@@ -688,7 +688,15 @@ impl Storage for PostgresStorage {
         .execute(&self.pool)
         .await?;
         if result.rows_affected() == 0 {
-            anyhow::bail!("proposal not found or already resolved: {id}");
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT status FROM rule_proposals WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+            match row {
+                None => anyhow::bail!("proposal not found: {id}"),
+                Some((s,)) => anyhow::bail!("proposal already resolved ({s}): {id}"),
+            }
         }
         Ok(())
     }

--- a/crates/synodic/src/core/storage/postgres.rs
+++ b/crates/synodic/src/core/storage/postgres.rs
@@ -84,6 +84,23 @@ impl Storage for PostgresStorage {
             }
         }
 
+        // Run rule proposals migration (issue #36 Step 2)
+        let proposals = include_str!("../../../migrations/pg/005_rule_proposals.sql");
+        for statement in proposals.split(';') {
+            let stmt = statement.trim();
+            if !stmt.is_empty() {
+                sqlx::query(stmt)
+                    .execute(&self.pool)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "rule proposals migration statement failed: {}",
+                            &stmt[..stmt.len().min(80)]
+                        )
+                    })?;
+            }
+        }
+
         // Run seed data
         let seed = include_str!("../../../migrations/pg/002_seed_data.sql");
         for statement in seed.split(';') {
@@ -590,6 +607,91 @@ impl Storage for PostgresStorage {
 
         Ok(())
     }
+
+    // -- Rule proposals (issue #36 Step 2) ----------------------------------
+
+    async fn list_rule_proposals(&self, status: Option<&str>) -> Result<Vec<RuleProposal>> {
+        let rows = if let Some(s) = status {
+            sqlx::query_as::<_, PgProposalRow>(
+                "SELECT * FROM rule_proposals WHERE status = $1 ORDER BY created_at DESC",
+            )
+            .bind(s)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, PgProposalRow>(
+                "SELECT * FROM rule_proposals ORDER BY created_at DESC",
+            )
+            .fetch_all(&self.pool)
+            .await?
+        };
+        Ok(rows.into_iter().map(|r| r.into_proposal()).collect())
+    }
+
+    async fn create_rule_proposal(&self, proposal: CreateRuleProposal) -> Result<RuleProposal> {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+        let status = proposal
+            .initial_status
+            .as_deref()
+            .unwrap_or("pending")
+            .to_string();
+
+        sqlx::query(
+            "INSERT INTO rule_proposals (id, insight_id, signal_kind, subject_ref, \
+             proposed_action, class, rationale, confidence, status, created_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+             ON CONFLICT (insight_id) DO NOTHING",
+        )
+        .bind(&id)
+        .bind(&proposal.insight_id)
+        .bind(&proposal.signal_kind)
+        .bind(&proposal.subject_ref)
+        .bind(&proposal.proposed_action)
+        .bind(&proposal.class)
+        .bind(&proposal.rationale)
+        .bind(proposal.confidence)
+        .bind(&status)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .context("inserting rule proposal")?;
+
+        let row = sqlx::query_as::<_, PgProposalRow>(
+            "SELECT * FROM rule_proposals WHERE insight_id = $1",
+        )
+        .bind(&proposal.insight_id)
+        .fetch_one(&self.pool)
+        .await
+        .context("reading back rule proposal")?;
+        Ok(row.into_proposal())
+    }
+
+    async fn resolve_rule_proposal(
+        &self,
+        id: &str,
+        status: &str,
+        notes: Option<String>,
+    ) -> Result<()> {
+        if status != "approved" && status != "rejected" {
+            anyhow::bail!("invalid proposal status: {status}");
+        }
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE rule_proposals SET status = $1, resolution_notes = $2, resolved_at = $3 \
+             WHERE id = $4 AND status = 'pending'",
+        )
+        .bind(status)
+        .bind(&notes)
+        .bind(now)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("proposal not found or already resolved: {id}");
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -830,5 +932,40 @@ impl PgGovEventRow {
             created_at: self.created_at,
             resolved_at: self.resolved_at,
         })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct PgProposalRow {
+    id: String,
+    insight_id: String,
+    signal_kind: String,
+    subject_ref: String,
+    proposed_action: serde_json::Value,
+    class: String,
+    rationale: String,
+    confidence: f64,
+    status: String,
+    resolution_notes: Option<String>,
+    created_at: DateTime<Utc>,
+    resolved_at: Option<DateTime<Utc>>,
+}
+
+impl PgProposalRow {
+    fn into_proposal(self) -> RuleProposal {
+        RuleProposal {
+            id: self.id,
+            insight_id: self.insight_id,
+            signal_kind: self.signal_kind,
+            subject_ref: self.subject_ref,
+            proposed_action: self.proposed_action,
+            class: self.class,
+            rationale: self.rationale,
+            confidence: self.confidence,
+            status: self.status,
+            resolution_notes: self.resolution_notes,
+            created_at: self.created_at,
+            resolved_at: self.resolved_at,
+        }
     }
 }

--- a/crates/synodic/src/core/storage/sqlite.rs
+++ b/crates/synodic/src/core/storage/sqlite.rs
@@ -699,7 +699,18 @@ impl Storage for SqliteStorage {
         .execute(&self.pool)
         .await?;
         if result.rows_affected() == 0 {
-            anyhow::bail!("proposal not found or already resolved: {id}");
+            // Disambiguate "absent" from "already terminal" with a cheap
+            // status lookup. The HTTP layer maps these to 404 vs 409
+            // instead of collapsing both to 400.
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT status FROM rule_proposals WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+            match row {
+                None => anyhow::bail!("proposal not found: {id}"),
+                Some((s,)) => anyhow::bail!("proposal already resolved ({s}): {id}"),
+            }
         }
         Ok(())
     }

--- a/crates/synodic/src/core/storage/sqlite.rs
+++ b/crates/synodic/src/core/storage/sqlite.rs
@@ -107,6 +107,23 @@ impl Storage for SqliteStorage {
             }
         }
 
+        // Run rule proposals migration (issue #36 Step 2)
+        let proposals = include_str!("../../../migrations/005_rule_proposals.sql");
+        for statement in proposals.split(';') {
+            let stmt = statement.trim();
+            if !stmt.is_empty() {
+                sqlx::query(stmt)
+                    .execute(&self.pool)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "rule proposals migration statement failed: {}",
+                            &stmt[..stmt.len().min(80)]
+                        )
+                    })?;
+            }
+        }
+
         // Run seed data
         let seed = include_str!("../../../migrations/002_seed_data.sql");
         for statement in seed.split(';') {
@@ -595,6 +612,97 @@ impl Storage for SqliteStorage {
 
         Ok(())
     }
+
+    // -- Rule proposals (issue #36 Step 2) ----------------------------------
+
+    async fn list_rule_proposals(&self, status: Option<&str>) -> Result<Vec<RuleProposal>> {
+        let rows = if let Some(s) = status {
+            sqlx::query_as::<_, ProposalRow>(
+                "SELECT * FROM rule_proposals WHERE status = ? ORDER BY created_at DESC",
+            )
+            .bind(s)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, ProposalRow>(
+                "SELECT * FROM rule_proposals ORDER BY created_at DESC",
+            )
+            .fetch_all(&self.pool)
+            .await?
+        };
+        rows.into_iter().map(|r| r.into_proposal()).collect()
+    }
+
+    async fn create_rule_proposal(&self, proposal: CreateRuleProposal) -> Result<RuleProposal> {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        let status = proposal
+            .initial_status
+            .as_deref()
+            .unwrap_or("pending")
+            .to_string();
+        let action_json = serde_json::to_string(&proposal.proposed_action)?;
+
+        // ON CONFLICT keeps the first proposal per insight — redelivery is a
+        // no-op. SQLite returns rowcount 0 when the conflict path fires;
+        // either way, the SELECT below resolves to the current row.
+        sqlx::query(
+            "INSERT INTO rule_proposals (id, insight_id, signal_kind, subject_ref, \
+             proposed_action, class, rationale, confidence, status, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(insight_id) DO NOTHING",
+        )
+        .bind(&id)
+        .bind(&proposal.insight_id)
+        .bind(&proposal.signal_kind)
+        .bind(&proposal.subject_ref)
+        .bind(&action_json)
+        .bind(&proposal.class)
+        .bind(&proposal.rationale)
+        .bind(proposal.confidence)
+        .bind(&status)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .context("inserting rule proposal")?;
+
+        let row =
+            sqlx::query_as::<_, ProposalRow>("SELECT * FROM rule_proposals WHERE insight_id = ?")
+                .bind(&proposal.insight_id)
+                .fetch_one(&self.pool)
+                .await
+                .context("reading back rule proposal")?;
+        row.into_proposal()
+    }
+
+    async fn resolve_rule_proposal(
+        &self,
+        id: &str,
+        status: &str,
+        notes: Option<String>,
+    ) -> Result<()> {
+        if status != "approved" && status != "rejected" {
+            anyhow::bail!("invalid proposal status: {status}");
+        }
+        let now = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        // Guard against double-resolution: only transition rows still
+        // pending, so a repeated PATCH can't overwrite the original
+        // resolver's notes.
+        let result = sqlx::query(
+            "UPDATE rule_proposals SET status = ?, resolution_notes = ?, resolved_at = ? \
+             WHERE id = ? AND status = 'pending'",
+        )
+        .bind(status)
+        .bind(&notes)
+        .bind(&now)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("proposal not found or already resolved: {id}");
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -835,6 +943,46 @@ impl GovEventRow {
             source: self.source,
             metadata: serde_json::from_str(&self.metadata).unwrap_or_default(),
             resolved: self.resolved,
+            resolution_notes: self.resolution_notes,
+            created_at: parse_datetime(&self.created_at)?,
+            resolved_at: self
+                .resolved_at
+                .as_deref()
+                .map(parse_datetime)
+                .transpose()?,
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct ProposalRow {
+    id: String,
+    insight_id: String,
+    signal_kind: String,
+    subject_ref: String,
+    proposed_action: String,
+    class: String,
+    rationale: String,
+    confidence: f64,
+    status: String,
+    resolution_notes: Option<String>,
+    created_at: String,
+    resolved_at: Option<String>,
+}
+
+impl ProposalRow {
+    fn into_proposal(self) -> Result<RuleProposal> {
+        Ok(RuleProposal {
+            id: self.id,
+            insight_id: self.insight_id,
+            signal_kind: self.signal_kind,
+            subject_ref: self.subject_ref,
+            proposed_action: serde_json::from_str(&self.proposed_action)
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new())),
+            class: self.class,
+            rationale: self.rationale,
+            confidence: self.confidence,
+            status: self.status,
             resolution_notes: self.resolution_notes,
             created_at: parse_datetime(&self.created_at)?,
             resolved_at: self


### PR DESCRIPTION
Closes #35, Closes #37, Closes #38, Closes #39
Part of #36 (Step 2)
Part of #40

Groups the remaining umbrella-tracker items (Sequences 3 and 4) into a single PR per request — "one-spec-one-PR" was proving too dogmatic without the orchestration layer Onsager itself is trying to be.

## Summary

- **Spine**: enrich `IsingRuleProposed` with routing fields, add `IntentSubmitted` / `RefractDecomposed` / `RefractFailed` (#35), add `SynodicGateResolutionProposed` (#37), add optional `TokenUsage` on `StiglabSessionCompleted` (#39).
- **Ising (#36 Step 2)**: emit `ising.rule_proposed` when a signal crosses a confidence threshold; `repeated_gate_override` is the first mapped signal (Retire action, `SafeAuto` at ≥0.90 confidence, `ReviewRequired` between 0.80 and 0.90).
- **Synodic (#36 Step 2, #37)**: new `rule_proposals` table + storage methods (sqlite + pg), `proposal_listener` tails `ising.rule_proposed` with idempotent inserts and auto-applies Retire for safe-auto rows, new `/api/rule-proposals{,/:id/resolve}` endpoints, new `/api/escalations/:id/propose-resolution` endpoint emitting `synodic.gate_resolution_proposed`.
- **Refract (#35)**: new `crates/refract/` (lib + bin) registered in the workspace and the `onsager` dispatcher; `FileMigrationDecomposer` expands `{files: [...]}` into per-file `Kind::Code` artifacts; runtime emits the three-step lifecycle (`intent.submitted` / `refract.decomposed` / `refract.failed`); CLI: `refract submit --class --description --payload '...'` + `list`.
- **Forge (#37, #39)**: escalation default target now driven by `ESCALATION_DEFAULT_TARGET` env var (defaults to `supervisor`); `SessionCompleted` routes the new `token_usage` field through to handlers.
- **Dashboard**: `RuleProposalsCard` on GovernancePage with approve/reject wired to Synodic (#36 Step 2), four productivity cards on FactoryOverviewPage — throughput (24h), yield, avg cycle time, bottleneck (#38), `SpendCard` summarizing token_usage across recent session-completed events (#39).

## Out of scope (deferred)

- **ADR-0001 sync-RPC retirement** (`HttpStiglabDispatcher` / `HttpSynodicGate`). The tracker files it as a parallel track; #28's write-lock mitigation is still holding, so keeping that refactor for a follow-up instead of bundling it here.
- **LLM-backed Refract decomposer** (#35 PR 2). This PR ships the scaffolding and one hard-coded decomposer so the event contract and end-to-end wire are in place; LLM-backed decomposers come next on top of it.

## Test plan

- [x] `cargo test --workspace` — 336 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `pnpm lint` (dashboard) — clean
- [x] `pnpm build` (dashboard) — clean
- [ ] Manual: run `ising serve` + `synodic serve` against a seeded spine, confirm a high-confidence `repeated_gate_override` insight produces both an `insight_emitted` and a `rule_proposed` event, and that the proposal surfaces on `GET /api/rule-proposals?status=pending`
- [ ] Manual: `refract submit --class file_migration --description "migrate auth" --payload '{"files":["a.rs","b.rs"]}'` with `DATABASE_URL` set and verify the three spine events land
- [ ] Manual: check dashboard — GovernancePage shows proposals, FactoryOverviewPage shows productivity metric cards and spend card

https://claude.ai/code/session_01URmymmDeUwRSMCKFBtGxF6