### PR TITLE
feat(ising): shape_retry_spike signal + closure drift cleanup (#40)

### DIFF
--- a/crates/ising/src/analyzers/mod.rs
+++ b/crates/ising/src/analyzers/mod.rs
@@ -4,10 +4,12 @@
 
 pub mod gate_override;
 pub mod repeated_failures;
+pub mod shape_retry_spike;
 pub mod stuck_artifacts;
 
 pub use gate_override::GateOverrideAnalyzer;
 pub use repeated_failures::RepeatedFailuresAnalyzer;
+pub use shape_retry_spike::ShapeRetrySpikeAnalyzer;
 pub use stuck_artifacts::StuckArtifactsAnalyzer;
 
 use crate::core::AnalyzerRegistry;
@@ -17,4 +19,5 @@ pub fn register_defaults(registry: &mut AnalyzerRegistry) {
     registry.register(Box::new(RepeatedFailuresAnalyzer::default()));
     registry.register(Box::new(StuckArtifactsAnalyzer::default()));
     registry.register(Box::new(GateOverrideAnalyzer::default()));
+    registry.register(Box::new(ShapeRetrySpikeAnalyzer::default()));
 }

--- a/crates/ising/src/analyzers/shape_retry_spike.rs
+++ b/crates/ising/src/analyzers/shape_retry_spike.rs
@@ -1,0 +1,245 @@
+//! Shape-retry-spike analyzer (issue #36 follow-up — second wired signal).
+//!
+//! Looks at the average shaping attempts per artifact within a window, grouped
+//! by artifact `Kind`. A kind whose artifacts systematically need many reshape
+//! cycles is a kind whose decomposer or shaping rules are underspecified —
+//! the right downstream response is a Synodic rule that caps rework or tightens
+//! the spec, hence the `Introduce`-action rule proposal.
+//!
+//! Emission shape: `signal_kind = "shape_retry_spike"`, `subject_ref` is the
+//! artifact kind, `evidence` is up to five recent `forge.shaping_returned`
+//! event ids, `confidence` scales with how far above the per-artifact retry
+//! threshold the kind sits.
+
+use chrono::Duration;
+use onsager_protocol::{FactoryEventRef, Insight};
+use onsager_spine::factory_event::{InsightKind, InsightScope};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+/// Stable signal identifier emitted on the spine for this analyzer's output.
+pub const SIGNAL_KIND: &str = "shape_retry_spike";
+
+/// Configuration for the shape-retry-spike analyzer.
+#[derive(Debug, Clone)]
+pub struct ShapeRetrySpikeConfig {
+    /// Lookback window over which shaping records are considered.
+    pub window: Duration,
+    /// Minimum distinct artifacts of a kind required before a rate is computed.
+    pub min_artifacts: usize,
+    /// Average shaping attempts per artifact above which the kind is flagged.
+    pub min_avg_shapings: f64,
+}
+
+impl Default for ShapeRetrySpikeConfig {
+    fn default() -> Self {
+        Self {
+            window: Duration::days(7),
+            min_artifacts: 3,
+            // 4 reshapes/artifact on average is generous — Forge's default
+            // budget is small, so anything north of this is real friction.
+            min_avg_shapings: 4.0,
+        }
+    }
+}
+
+/// Detects artifact kinds with elevated shaping-retry averages.
+pub struct ShapeRetrySpikeAnalyzer {
+    config: ShapeRetrySpikeConfig,
+}
+
+impl ShapeRetrySpikeAnalyzer {
+    pub fn new(config: ShapeRetrySpikeConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for ShapeRetrySpikeAnalyzer {
+    fn default() -> Self {
+        Self::new(ShapeRetrySpikeConfig::default())
+    }
+}
+
+impl Analyzer for ShapeRetrySpikeAnalyzer {
+    fn name(&self) -> &str {
+        SIGNAL_KIND
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let spikes = model.retry_spike_by_kind(self.config.window, self.config.min_artifacts);
+
+        spikes
+            .into_iter()
+            .filter(|(_, (avg, _, _))| *avg >= self.config.min_avg_shapings)
+            .map(|(kind, (avg, artifact_count, evidence_ids))| {
+                let kind_label = kind.to_string();
+                let evidence: Vec<FactoryEventRef> = evidence_ids
+                    .into_iter()
+                    .map(|event_id| FactoryEventRef {
+                        event_id,
+                        event_type: "forge.shaping_returned".into(),
+                    })
+                    .collect();
+
+                // Confidence: 0.6 at the threshold, climbing toward 0.95 as
+                // the kind drifts further above it. Mirrors the gate-override
+                // analyzer's shape so dashboard sorting stays comparable.
+                let denom = self.config.min_avg_shapings.max(1.0);
+                let excess = ((avg - self.config.min_avg_shapings) / denom).max(0.0);
+                let confidence = (0.6 + excess * 0.3).min(0.95);
+
+                Insight {
+                    insight_id: format!("ins_srs_{}_{}", kind_label, model.events_processed),
+                    kind: InsightKind::Waste,
+                    scope: InsightScope::ArtifactKind(kind_label.clone()),
+                    observation: format!(
+                        "{} artifacts: avg {:.1} shaping attempts per artifact across {} \
+                         artifacts in the last {} day(s) — decomposition or shaping rules \
+                         for this kind may be underspecified",
+                        kind_label,
+                        avg,
+                        artifact_count,
+                        self.config.window.num_days(),
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                }
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::{ArtifactId, Kind};
+    use onsager_spine::factory_event::{FactoryEventKind, ShapingOutcome};
+
+    fn register(model: &mut FactoryModel, id: &ArtifactId, kind: Kind, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind,
+                name: "t".into(),
+                owner: "marvin".into(),
+            },
+        );
+    }
+
+    fn shape(model: &mut FactoryModel, id: &ArtifactId, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ForgeShapingReturned {
+                request_id: format!("req_{seq}"),
+                artifact_id: id.clone(),
+                outcome: ShapingOutcome::Partial,
+            },
+        );
+    }
+
+    #[test]
+    fn emits_when_avg_shapings_exceeds_threshold() {
+        // 3 code artifacts, each with 5 shapings = avg 5.0 (> default 4.0).
+        let mut model = FactoryModel::new();
+        let mut seq = 1i64;
+        for n in 0..3 {
+            let id = ArtifactId::new(format!("art_code_{n}"));
+            register(&mut model, &id, Kind::Code, seq);
+            seq += 1;
+            for _ in 0..5 {
+                shape(&mut model, &id, seq);
+                seq += 1;
+            }
+        }
+
+        let insights = ShapeRetrySpikeAnalyzer::default().run(&model);
+        assert_eq!(insights.len(), 1);
+        let ins = &insights[0];
+        assert_eq!(ins.kind, InsightKind::Waste);
+        assert_eq!(
+            ins.scope,
+            InsightScope::ArtifactKind("code".into()),
+            "scope must carry the kind label for downstream rule routing",
+        );
+        assert!(!ins.evidence.is_empty());
+        assert!(ins.evidence.len() <= 5, "evidence is capped at 5");
+        assert!(
+            ins.evidence
+                .iter()
+                .all(|e| e.event_type == "forge.shaping_returned"),
+            "evidence must reference shaping events",
+        );
+        assert!(ins.confidence >= 0.6 && ins.confidence <= 0.95);
+        assert!(ins.observation.contains("shaping attempts"));
+    }
+
+    #[test]
+    fn no_emission_below_avg_threshold() {
+        // 3 code artifacts, each with 2 shapings = avg 2.0 (< default 4.0).
+        let mut model = FactoryModel::new();
+        let mut seq = 1i64;
+        for n in 0..3 {
+            let id = ArtifactId::new(format!("art_code_{n}"));
+            register(&mut model, &id, Kind::Code, seq);
+            seq += 1;
+            for _ in 0..2 {
+                shape(&mut model, &id, seq);
+                seq += 1;
+            }
+        }
+        assert!(ShapeRetrySpikeAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn no_emission_below_min_artifacts() {
+        // 1 code artifact with 20 shapings — high rework but only 1 artifact,
+        // so it's a `stuck_artifacts` story, not a kind-wide spike.
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_code_0");
+        register(&mut model, &id, Kind::Code, 1);
+        for i in 0..20 {
+            shape(&mut model, &id, i + 2);
+        }
+        assert!(ShapeRetrySpikeAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn analyzer_name_is_signal_kind() {
+        // The Ising emitter uses Analyzer::name() as the signal_kind on the
+        // spine event — pin the contract so renames don't silently drift.
+        assert_eq!(ShapeRetrySpikeAnalyzer::default().name(), SIGNAL_KIND);
+    }
+
+    #[test]
+    fn confidence_climbs_with_avg() {
+        let make = |shapings_per_artifact: usize| {
+            let mut model = FactoryModel::new();
+            let mut seq = 1i64;
+            for n in 0..3 {
+                let id = ArtifactId::new(format!("art_code_{n}"));
+                register(&mut model, &id, Kind::Code, seq);
+                seq += 1;
+                for _ in 0..shapings_per_artifact {
+                    shape(&mut model, &id, seq);
+                    seq += 1;
+                }
+            }
+            model
+        };
+
+        let low = ShapeRetrySpikeAnalyzer::default().run(&make(5));
+        let high = ShapeRetrySpikeAnalyzer::default().run(&make(15));
+        assert!(!low.is_empty() && !high.is_empty());
+        assert!(
+            high[0].confidence >= low[0].confidence,
+            "more rework must not reduce confidence",
+        );
+    }
+}

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 
 use chrono::{Duration, Utc};
 use onsager_artifact::{ArtifactId, Kind};
-use onsager_spine::factory_event::{FactoryEventKind, GatePoint, VerdictSummary};
+use onsager_spine::factory_event::{FactoryEventKind, GatePoint, ShapingOutcome, VerdictSummary};
 use onsager_spine::{EventMetadata, EventStore};
 
 use crate::analyzers::register_defaults;
@@ -230,6 +230,19 @@ fn parse_forge_event(event_type: &str, data: &serde_json::Value) -> Option<Facto
                 verdict,
             })
         }
+        "forge.shaping_returned" => {
+            // Required for the `shape_retry_spike` analyzer — without ingest
+            // here, `FactoryModel.shaping_records` stays empty and the
+            // analyzer never fires in production.
+            let request_id = data.get("request_id")?.as_str()?.to_string();
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let outcome = parse_shaping_outcome(data.get("outcome")?.as_str()?)?;
+            Some(FactoryEventKind::ForgeShapingReturned {
+                request_id,
+                artifact_id: ArtifactId::new(artifact_id),
+                outcome,
+            })
+        }
         _ => None,
     }
 }
@@ -261,6 +274,19 @@ fn parse_verdict(s: &str) -> Option<VerdictSummary> {
         "Deny" | "deny" => Some(VerdictSummary::Deny),
         "Modify" | "modify" => Some(VerdictSummary::Modify),
         "Escalate" | "escalate" => Some(VerdictSummary::Escalate),
+        _ => None,
+    }
+}
+
+fn parse_shaping_outcome(s: &str) -> Option<ShapingOutcome> {
+    // Forge emits via `format!("{:?}", outcome)` (Debug), so strings arrive
+    // as CamelCase. A future typed emitter would use serde snake_case —
+    // accept both, like `parse_gate_point` / `parse_verdict`.
+    match s {
+        "Completed" | "completed" => Some(ShapingOutcome::Completed),
+        "Failed" | "failed" => Some(ShapingOutcome::Failed),
+        "Partial" | "partial" => Some(ShapingOutcome::Partial),
+        "Aborted" | "aborted" => Some(ShapingOutcome::Aborted),
         _ => None,
     }
 }
@@ -416,6 +442,59 @@ mod tests {
     #[test]
     fn ignores_unknown_event_types() {
         let data = json!({});
+        assert!(parse_forge_event("forge.unknown", &data).is_none());
+    }
+
+    #[test]
+    fn parses_shaping_returned_debug_format() {
+        // Forge emits the outcome via `format!("{:?}", outcome)` — pin the
+        // CamelCase parse so the `shape_retry_spike` analyzer actually sees
+        // shaping records in production.
+        let data = json!({
+            "request_id": "req_x",
+            "artifact_id": "art_x",
+            "outcome": "Completed",
+        });
+        let parsed = parse_forge_event("forge.shaping_returned", &data).expect("parses");
+        match parsed {
+            FactoryEventKind::ForgeShapingReturned {
+                request_id,
+                artifact_id,
+                outcome,
+            } => {
+                assert_eq!(request_id, "req_x");
+                assert_eq!(artifact_id.as_str(), "art_x");
+                assert_eq!(outcome, ShapingOutcome::Completed);
+            }
+            _ => panic!("expected ForgeShapingReturned"),
+        }
+    }
+
+    #[test]
+    fn parses_shaping_returned_snake_case_format() {
+        // A future typed emitter would use serde snake_case — accept that
+        // too, mirroring `parse_gate_verdict_snake_case_format`.
+        let data = json!({
+            "request_id": "req_y",
+            "artifact_id": "art_y",
+            "outcome": "failed",
+        });
+        let parsed = parse_forge_event("forge.shaping_returned", &data).expect("parses");
+        match parsed {
+            FactoryEventKind::ForgeShapingReturned { outcome, .. } => {
+                assert_eq!(outcome, ShapingOutcome::Failed);
+            }
+            _ => panic!("expected ForgeShapingReturned"),
+        }
+    }
+
+    #[test]
+    fn shaping_returned_with_unknown_outcome_returns_none() {
+        let data = json!({
+            "request_id": "req_z",
+            "artifact_id": "art_z",
+            "outcome": "WeirdNewVariant",
+        });
         assert!(parse_forge_event("forge.shaping_returned", &data).is_none());
     }
 }

--- a/crates/ising/src/core/emission.rs
+++ b/crates/ising/src/core/emission.rs
@@ -51,11 +51,15 @@ pub fn insight_to_emitted_event(signal_kind: &str, insight: &Insight) -> Factory
 /// rule-proposal mapping or the confidence is below
 /// [`RULE_PROPOSAL_MIN_CONFIDENCE`].
 ///
-/// The only signal wired in this step is `repeated_gate_override`, which
-/// maps to a `Retire` proposal: when a rule fires and is overridden more
-/// often than it's respected, the policy is costing more than it buys.
-/// Future signals (shape-retry spike, cross-project divergence) add their
-/// own arm to the match below without changing the event contract.
+/// Wired signals:
+/// - `repeated_gate_override` → `Retire` the kind-scoped rule (the policy is
+///   costing more than it buys).
+/// - `shape_retry_spike` → `Introduce` a rework-budget rule for the kind
+///   (issue #36 follow-up — second wired signal).
+///
+/// New signal kinds add their own arm here; the unknown-signal branch keeps
+/// the unmapped path silent so analyzers can ship in observation-only mode
+/// before being promoted to rule-proposal producers.
 pub fn insight_to_rule_proposal(signal_kind: &str, insight: &Insight) -> Option<FactoryEventKind> {
     if insight.confidence < RULE_PROPOSAL_MIN_CONFIDENCE {
         return None;
@@ -71,6 +75,17 @@ pub fn insight_to_rule_proposal(signal_kind: &str, insight: &Insight) -> Option<
             // that keeps the proposal self-contained — Synodic resolves it
             // at queue time rather than the producer embedding a join.
             rule_id: subject_ref.clone(),
+        },
+        "shape_retry_spike" => RuleProposalAction::Introduce {
+            // Rework spikes are kind-wide friction; the `Introduce` action
+            // tells Synodic to draft a new rule rather than mutate an
+            // existing one. `suggested_condition` is a free-form hint —
+            // the proposal listener currently treats it as a no-op apply,
+            // so the proposal lands in the review queue regardless of class.
+            subject_ref: subject_ref.clone(),
+            suggested_condition: Some(format!(
+                "cap rework on `{subject_ref}` artifacts (e.g. max_shapings_per_artifact)"
+            )),
         },
         _ => return None,
     };
@@ -228,6 +243,64 @@ mod tests {
         // routing. Silent passthrough would let a noisy signal auto-mutate
         // rules without an author thinking about the mapping.
         let proposal = insight_to_rule_proposal("totally_new_signal", &insight_with_conf(0.99));
+        assert!(proposal.is_none());
+    }
+
+    #[test]
+    fn shape_retry_spike_maps_to_introduce() {
+        // Issue #36 follow-up: a kind-scoped rework spike must propose
+        // introducing a new rule (not retiring an existing one), with the
+        // subject_ref carried verbatim so Synodic can route by kind.
+        let proposal = insight_to_rule_proposal("shape_retry_spike", &insight_with_conf(0.85))
+            .expect("above threshold");
+        match proposal {
+            FactoryEventKind::IsingRuleProposed {
+                signal_kind,
+                subject_ref,
+                proposed_action,
+                class,
+                ..
+            } => {
+                assert_eq!(signal_kind, "shape_retry_spike");
+                assert_eq!(subject_ref, "code");
+                assert_eq!(class, RuleProposalClass::ReviewRequired);
+                match proposed_action {
+                    RuleProposalAction::Introduce {
+                        subject_ref: subj,
+                        suggested_condition,
+                    } => {
+                        assert_eq!(subj, "code");
+                        let hint = suggested_condition.expect("condition hint must be set");
+                        assert!(
+                            hint.contains("`code`"),
+                            "hint should reference the kind subject_ref"
+                        );
+                    }
+                    other => panic!("expected Introduce, got {other:?}"),
+                }
+            }
+            _ => panic!("expected IsingRuleProposed"),
+        }
+    }
+
+    #[test]
+    fn shape_retry_spike_safe_auto_at_high_confidence() {
+        let proposal = insight_to_rule_proposal("shape_retry_spike", &insight_with_conf(0.95))
+            .expect("above threshold");
+        match proposal {
+            FactoryEventKind::IsingRuleProposed { class, .. } => {
+                assert_eq!(class, RuleProposalClass::SafeAuto);
+            }
+            _ => panic!("expected IsingRuleProposed"),
+        }
+    }
+
+    #[test]
+    fn shape_retry_spike_below_threshold_skipped() {
+        // Same confidence floor as every other signal — the analyzer can
+        // still emit on the observation track at low confidence, but no
+        // rule proposal escapes.
+        let proposal = insight_to_rule_proposal("shape_retry_spike", &insight_with_conf(0.65));
         assert!(proposal.is_none());
     }
 }

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -257,6 +257,66 @@ impl FactoryModel {
             .collect()
     }
 
+    /// Per-`Kind` average shaping attempts per artifact within `window`,
+    /// alongside the count of distinct artifacts contributing and a recent
+    /// evidence event-id list. Filters out kinds with fewer than
+    /// `min_artifacts` distinct artifacts so a single rework-heavy artifact
+    /// can't libel a kind on its own.
+    ///
+    /// "Retry spike" here means high *average* rework, not just one pathological
+    /// artifact — a kind whose decomposer or shaping rules are systematically
+    /// underspecified shows up as elevated rework across many artifacts at
+    /// once. The numerator counts every shaping attempt (Completed, Failed,
+    /// Partial, Aborted alike) because all of them indicate the agent had to
+    /// reshape the artifact at least once.
+    pub fn retry_spike_by_kind(
+        &self,
+        window: Duration,
+        min_artifacts: usize,
+    ) -> HashMap<Kind, (f64, usize, Vec<i64>)> {
+        let cutoff = Utc::now() - window;
+        let mut buckets: HashMap<Kind, HashMap<String, Vec<&ShapingRecord>>> = HashMap::new();
+
+        for record in &self.shaping_records {
+            if record.recorded_at < cutoff {
+                continue;
+            }
+            let Some(artifact) = self.artifacts.get(record.artifact_id.as_str()) else {
+                continue;
+            };
+            buckets
+                .entry(artifact.kind.clone())
+                .or_default()
+                .entry(record.artifact_id.as_str().to_owned())
+                .or_default()
+                .push(record);
+        }
+
+        buckets
+            .into_iter()
+            .filter_map(|(kind, by_artifact)| {
+                let artifact_count = by_artifact.len();
+                if artifact_count < min_artifacts {
+                    return None;
+                }
+                let total_shapings: usize = by_artifact.values().map(|recs| recs.len()).sum();
+                let avg = total_shapings as f64 / artifact_count as f64;
+
+                // Evidence: most recent shaping event ids across all artifacts
+                // of this kind. Sorted by id desc (monotonic on the spine) so
+                // the dashboard surfaces the freshest rework first.
+                let mut evidence: Vec<i64> = by_artifact
+                    .values()
+                    .flat_map(|recs| recs.iter().map(|r| r.event_id))
+                    .collect();
+                evidence.sort_unstable_by(|a, b| b.cmp(a));
+                evidence.truncate(5);
+
+                Some((kind, (avg, artifact_count, evidence)))
+            })
+            .collect()
+    }
+
     /// Get shaping records for a specific artifact kind.
     pub fn shaping_history_by_kind(
         &self,
@@ -500,6 +560,119 @@ mod tests {
         // But a wide-enough window should pick them back up.
         let rates_wide = model.override_rate_by_kind(Duration::days(60), 3);
         assert!(rates_wide.contains_key(&Kind::Code));
+    }
+
+    #[test]
+    fn retry_spike_groups_by_kind_and_respects_min_artifacts() {
+        let mut model = FactoryModel::new();
+        let mut seq = 1i64;
+
+        // Kind::Code: 3 artifacts × 5 shapings = avg 5.0 (meets min_artifacts=2).
+        for n in 0..3 {
+            let id = ArtifactId::new(format!("art_code_{n}"));
+            model.ingest(
+                seq,
+                &FactoryEventKind::ArtifactRegistered {
+                    artifact_id: id.clone(),
+                    kind: Kind::Code,
+                    name: "svc".into(),
+                    owner: "marvin".into(),
+                },
+            );
+            seq += 1;
+            for _ in 0..5 {
+                model.ingest(
+                    seq,
+                    &FactoryEventKind::ForgeShapingReturned {
+                        request_id: format!("req_{seq}"),
+                        artifact_id: id.clone(),
+                        outcome: ShapingOutcome::Partial,
+                    },
+                );
+                seq += 1;
+            }
+        }
+
+        // Kind::Document: 1 artifact only — under min_artifacts=2, must drop.
+        let doc = ArtifactId::new("art_doc_0");
+        model.ingest(
+            seq,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: doc.clone(),
+                kind: Kind::Document,
+                name: "readme".into(),
+                owner: "marvin".into(),
+            },
+        );
+        seq += 1;
+        for _ in 0..10 {
+            model.ingest(
+                seq,
+                &FactoryEventKind::ForgeShapingReturned {
+                    request_id: format!("req_{seq}"),
+                    artifact_id: doc.clone(),
+                    outcome: ShapingOutcome::Partial,
+                },
+            );
+            seq += 1;
+        }
+
+        let spikes = model.retry_spike_by_kind(Duration::days(7), 2);
+        assert!(spikes.contains_key(&Kind::Code), "code must be present");
+        assert!(
+            !spikes.contains_key(&Kind::Document),
+            "document under min_artifacts must be dropped",
+        );
+        let (avg, artifact_count, evidence) = &spikes[&Kind::Code];
+        assert!((avg - 5.0).abs() < 1e-9);
+        assert_eq!(*artifact_count, 3);
+        assert!(!evidence.is_empty() && evidence.len() <= 5);
+        assert!(
+            evidence.windows(2).all(|w| w[0] >= w[1]),
+            "evidence must be sorted by event_id desc",
+        );
+    }
+
+    #[test]
+    fn retry_spike_window_excludes_stale_records() {
+        // Mirrors override_rate_window_uses_event_time — historical records
+        // re-ingested with explicit timestamps must be excluded from a
+        // tighter window.
+        let mut model = FactoryModel::new();
+        let stale = Utc::now() - Duration::days(30);
+        let mut seq = 1i64;
+        for n in 0..3 {
+            let id = ArtifactId::new(format!("art_code_old_{n}"));
+            model.ingest_at(
+                seq,
+                stale,
+                &FactoryEventKind::ArtifactRegistered {
+                    artifact_id: id.clone(),
+                    kind: Kind::Code,
+                    name: "svc".into(),
+                    owner: "marvin".into(),
+                },
+            );
+            seq += 1;
+            for _ in 0..5 {
+                model.ingest_at(
+                    seq,
+                    stale,
+                    &FactoryEventKind::ForgeShapingReturned {
+                        request_id: format!("req_{seq}"),
+                        artifact_id: id.clone(),
+                        outcome: ShapingOutcome::Partial,
+                    },
+                );
+                seq += 1;
+            }
+        }
+
+        let recent = model.retry_spike_by_kind(Duration::days(7), 2);
+        assert!(recent.is_empty(), "stale shapings must be dropped");
+
+        let wide = model.retry_spike_by_kind(Duration::days(60), 2);
+        assert!(wide.contains_key(&Kind::Code));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Continues the remaining work on the #40 architectural-review tracker.

### Closure drift cleanup
- Closed #28, #29, #31, #36 manually. Their work shipped in #41 / #49 / #51 without `Closes #N` trailers, so they had been lingering open. Tracker comment posted on #40.

### #36 follow-up — second wired Ising signal

Adds `shape_retry_spike`, the second analyzer-to-rule-proposal pipeline beyond `repeated_gate_override`:

- **`FactoryModel::retry_spike_by_kind(window, min_artifacts)`** — per-`Kind` aggregate of average shaping attempts per artifact, with the same windowed contract as `override_rate_by_kind`. Returns `(avg, artifact_count, evidence_event_ids)`.
- **`ShapeRetrySpikeAnalyzer`** — emits `IsingInsightEmitted { signal_kind: "shape_retry_spike", scope: ArtifactKind(...) }` when a kind's average rework crosses the threshold.
- **`emission::insight_to_rule_proposal`** — new `"shape_retry_spike"` arm that maps to `RuleProposalAction::Introduce { subject_ref, suggested_condition }`. Synodic's existing `proposal_listener` already accepts `Introduce` actions as queue-only (no auto-apply), so the proposal lands on the governance review card without governance-side changes.

The interpretation: a `repeated_gate_override` insight says *retire the rule that's costing more than it buys*; a `shape_retry_spike` insight says *introduce a rule that caps rework on a kind whose decomposer is underspecified*. Two distinct policy surfaces, same proposal pipeline.

## Test plan

- [x] `cargo test -p ising --lib` (49/49 pass — 6 new tests across model + analyzer + emission)
- [x] `cargo test --workspace --lib` (all suites green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual UI walkthrough — not exercised; the dashboard `RuleProposalsCard` already renders `Introduce` proposals, so no UI change was needed.

Part of #40.

https://claude.ai/code/session_01MrzDd7vbXrnSbJorKeXvjM