### PR TITLE
feat(stiglab,dashboard): Phase 0 tenant / workspace scaffolding

### DIFF
--- a/apps/dashboard/src/components/sessions/CreateSessionSheet.tsx
+++ b/apps/dashboard/src/components/sessions/CreateSessionSheet.tsx
@@ -1,5 +1,5 @@
-import { type FormEvent, useState, type ReactElement } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { type FormEvent, useMemo, useState, type ReactElement } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, type TaskRequest } from "@/lib/api"
 import { useNodes } from "@/hooks/useNodes"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -36,10 +36,28 @@ export function CreateSessionSheet({ children, open: openProp, onOpenChange }: C
   const [prompt, setPrompt] = useState("")
   const [nodeId, setNodeId] = useState("")
   const [workingDir, setWorkingDir] = useState("")
+  const [workspaceId, setWorkspaceId] = useState("")
+  const [projectId, setProjectId] = useState("")
   const isMobile = useIsMobile()
   const queryClient = useQueryClient()
   const { data: nodesData } = useNodes()
   const onlineNodes = nodesData?.nodes.filter((n) => n.status === "online") ?? []
+
+  const { data: wsData } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+  })
+  const workspaces = wsData?.tenants ?? []
+
+  const { data: projectsData } = useQuery({
+    queryKey: ["all-projects"],
+    queryFn: api.listAllProjects,
+  })
+
+  const visibleProjects = useMemo(() => {
+    const all = projectsData?.projects ?? []
+    return workspaceId ? all.filter((p) => p.tenant_id === workspaceId) : []
+  }, [projectsData, workspaceId])
 
   const mutation = useMutation({
     mutationFn: (task: TaskRequest) => api.createTask(task),
@@ -49,6 +67,8 @@ export function CreateSessionSheet({ children, open: openProp, onOpenChange }: C
       setPrompt("")
       setNodeId("")
       setWorkingDir("")
+      setWorkspaceId("")
+      setProjectId("")
     },
   })
 
@@ -56,10 +76,14 @@ export function CreateSessionSheet({ children, open: openProp, onOpenChange }: C
     e.preventDefault()
     if (!prompt.trim()) return
     const validNodeId = onlineNodes.some((n) => n.id === nodeId) ? nodeId : ""
+    const validProjectId = visibleProjects.some((p) => p.id === projectId)
+      ? projectId
+      : ""
     mutation.mutate({
       prompt: prompt.trim(),
       ...(validNodeId && { node_id: validNodeId }),
       ...(workingDir.trim() && { working_dir: workingDir.trim() }),
+      ...(validProjectId && { project_id: validProjectId }),
     })
   }
 
@@ -85,6 +109,61 @@ export function CreateSessionSheet({ children, open: openProp, onOpenChange }: C
               required
             />
           </div>
+
+          {workspaces.length > 0 && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label htmlFor="workspace" className="text-sm font-medium">
+                  Workspace <span className="text-muted-foreground font-normal">(optional)</span>
+                </label>
+                <Select
+                  value={workspaceId}
+                  onValueChange={(v) => {
+                    setWorkspaceId(v ?? "")
+                    setProjectId("")
+                  }}
+                >
+                  <SelectTrigger id="workspace" className="w-full">
+                    <SelectValue placeholder="Personal" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">Personal</SelectItem>
+                    {workspaces.map((w) => (
+                      <SelectItem key={w.id} value={w.id}>
+                        {w.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {workspaceId && (
+                <div className="space-y-1.5">
+                  <label htmlFor="project" className="text-sm font-medium">
+                    Project{" "}
+                    <span className="text-muted-foreground font-normal">
+                      (optional)
+                    </span>
+                  </label>
+                  <Select
+                    value={projectId}
+                    onValueChange={(v) => setProjectId(v ?? "")}
+                  >
+                    <SelectTrigger id="project" className="w-full">
+                      <SelectValue placeholder="No project" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">No project</SelectItem>
+                      {visibleProjects.map((p) => (
+                        <SelectItem key={p.id} value={p.id}>
+                          {p.repo_owner}/{p.repo_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
 
           {onlineNodes.length > 0 && (
             <div className="space-y-1.5">

--- a/apps/dashboard/src/components/settings/WorkspacesCard.tsx
+++ b/apps/dashboard/src/components/settings/WorkspacesCard.tsx
@@ -1,0 +1,537 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { api, type Workspace, type GitHubAppInstallation, type Project } from "@/lib/api"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Building2, GitBranch, Plus, Trash2 } from "lucide-react"
+
+/**
+ * Settings card that lists the user's Workspaces and the nested
+ * Members / GitHub installations / Projects for each.
+ *
+ * v1 is intentionally minimal (issue #59): no roles, no invites, no
+ * cascades, no auto-mirror. GitHub App installations are registered
+ * manually here — the full OAuth callback flow lands in a follow-up.
+ */
+export function WorkspacesCard() {
+  const [creating, setCreating] = useState(false)
+  const [newSlug, setNewSlug] = useState("")
+  const [newName, setNewName] = useState("")
+  const [createError, setCreateError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  const { data: wsData } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (body: { slug: string; name: string }) => api.createWorkspace(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workspaces"] })
+      setCreating(false)
+      setNewSlug("")
+      setNewName("")
+      setCreateError(null)
+    },
+    onError: (err) => {
+      setCreateError(err instanceof Error ? err.message : "Failed to create workspace")
+    },
+  })
+
+  const workspaces = wsData?.tenants ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+          <Building2 className="h-4 w-4" />
+          Workspaces
+        </CardTitle>
+        <CardDescription>
+          A workspace owns GitHub App installations and projects. Projects are
+          opt-in per repo — installing the App on an organization does not
+          auto-mirror its repositories.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {workspaces.length === 0 && !creating && (
+          <p className="text-sm text-muted-foreground">
+            You have no workspaces yet. Create one to onboard GitHub projects.
+          </p>
+        )}
+
+        {workspaces.map((ws) => (
+          <WorkspaceRow key={ws.id} workspace={ws} />
+        ))}
+
+        {creating ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (createMutation.isPending) return
+              if (newSlug && newName)
+                createMutation.mutate({ slug: newSlug, name: newName })
+            }}
+            className="space-y-2 rounded-md border border-dashed p-3"
+          >
+            <p className="text-sm font-medium">New workspace</p>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[auto_1fr]">
+              <Input
+                placeholder="slug (e.g. acme)"
+                value={newSlug}
+                onChange={(e) => setNewSlug(e.target.value.toLowerCase())}
+                className="sm:w-48"
+              />
+              <Input
+                placeholder="Display name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+            </div>
+            {createError && (
+              <p className="text-xs text-destructive">{createError}</p>
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                type="submit"
+                disabled={!newSlug || !newName || createMutation.isPending}
+              >
+                Create
+              </Button>
+              <Button
+                size="sm"
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setCreating(false)
+                  setNewSlug("")
+                  setNewName("")
+                  setCreateError(null)
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setCreating(true)
+              setCreateError(null)
+            }}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            New workspace
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function WorkspaceRow({ workspace }: { workspace: Workspace }) {
+  const { data: membersData } = useQuery({
+    queryKey: ["workspace-members", workspace.id],
+    queryFn: () => api.listWorkspaceMembers(workspace.id),
+  })
+  const { data: installsData } = useQuery({
+    queryKey: ["workspace-installations", workspace.id],
+    queryFn: () => api.listWorkspaceInstallations(workspace.id),
+  })
+  const { data: projectsData } = useQuery({
+    queryKey: ["workspace-projects", workspace.id],
+    queryFn: () => api.listWorkspaceProjects(workspace.id),
+  })
+
+  const members = membersData?.members ?? []
+  const installations = installsData?.installations ?? []
+  const projects = projectsData?.projects ?? []
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div>
+        <p className="font-medium">{workspace.name}</p>
+        <p className="text-xs text-muted-foreground">
+          Slug: <span className="font-mono">{workspace.slug}</span> · Created{" "}
+          {new Date(workspace.created_at).toLocaleDateString()}
+        </p>
+      </div>
+
+      {/* Members (read-only in v1) */}
+      <div className="space-y-1">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Members ({members.length})
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {members.map((m) => m.user_id).join(", ") || "—"}
+        </p>
+      </div>
+
+      {/* GitHub installations */}
+      <InstallationsSection
+        workspaceId={workspace.id}
+        installations={installations}
+      />
+
+      {/* Projects */}
+      <ProjectsSection
+        workspaceId={workspace.id}
+        installations={installations}
+        projects={projects}
+      />
+    </div>
+  )
+}
+
+function InstallationsSection({
+  workspaceId,
+  installations,
+}: {
+  workspaceId: string
+  installations: GitHubAppInstallation[]
+}) {
+  const [adding, setAdding] = useState(false)
+  const [installId, setInstallId] = useState("")
+  const [accountLogin, setAccountLogin] = useState("")
+  const [accountType, setAccountType] =
+    useState<"user" | "organization">("organization")
+  const [webhookSecret, setWebhookSecret] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: () =>
+      api.registerWorkspaceInstallation(workspaceId, {
+        install_id: Number(installId),
+        account_login: accountLogin,
+        account_type: accountType,
+        webhook_secret: webhookSecret || undefined,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["workspace-installations", workspaceId],
+      })
+      setAdding(false)
+      setInstallId("")
+      setAccountLogin("")
+      setWebhookSecret("")
+      setError(null)
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+  })
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api.deleteWorkspaceInstallation(workspaceId, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["workspace-installations", workspaceId],
+      })
+    },
+  })
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <GitBranch className="mr-1 inline h-3 w-3" />
+          GitHub installations ({installations.length})
+        </p>
+        {!adding && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setAdding(true)
+              setError(null)
+            }}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Link installation
+          </Button>
+        )}
+      </div>
+
+      {installations.map((inst) => (
+        <div
+          key={inst.id}
+          className="flex items-center justify-between gap-2 rounded-md bg-muted/50 p-2 text-xs"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-mono">
+              {inst.account_login} <span className="text-muted-foreground">({inst.account_type})</span>
+            </p>
+            <p className="text-muted-foreground">
+              Installation #{inst.install_id}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => remove.mutate(inst.id)}
+            disabled={remove.isPending}
+            aria-label="Unlink installation"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+
+      {adding && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (add.isPending) return
+            if (installId && accountLogin) add.mutate()
+          }}
+          className="space-y-2 rounded-md border border-dashed p-2"
+        >
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <Input
+              placeholder="Installation ID (numeric)"
+              value={installId}
+              onChange={(e) =>
+                setInstallId(e.target.value.replace(/\D/g, ""))
+              }
+            />
+            <Input
+              placeholder="Account login (org or user)"
+              value={accountLogin}
+              onChange={(e) => setAccountLogin(e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <Select
+              value={accountType}
+              onValueChange={(v) =>
+                setAccountType((v as "user" | "organization") ?? "organization")
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="organization">Organization</SelectItem>
+                <SelectItem value="user">User</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              type="password"
+              placeholder="Webhook secret (optional)"
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+            />
+          </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              type="submit"
+              disabled={!installId || !accountLogin || add.isPending}
+            >
+              Link
+            </Button>
+            <Button
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setAdding(false)
+                setError(null)
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}
+
+function ProjectsSection({
+  workspaceId,
+  installations,
+  projects,
+}: {
+  workspaceId: string
+  installations: GitHubAppInstallation[]
+  projects: Project[]
+}) {
+  const [adding, setAdding] = useState(false)
+  const [installationId, setInstallationId] = useState("")
+  const [repoOwner, setRepoOwner] = useState("")
+  const [repoName, setRepoName] = useState("")
+  const [defaultBranch, setDefaultBranch] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: () =>
+      api.addWorkspaceProject(workspaceId, {
+        github_app_installation_id: installationId,
+        repo_owner: repoOwner,
+        repo_name: repoName,
+        default_branch: defaultBranch || undefined,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["workspace-projects", workspaceId],
+      })
+      queryClient.invalidateQueries({ queryKey: ["all-projects"] })
+      setAdding(false)
+      setInstallationId("")
+      setRepoOwner("")
+      setRepoName("")
+      setDefaultBranch("")
+      setError(null)
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+  })
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api.deleteProject(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["workspace-projects", workspaceId],
+      })
+      queryClient.invalidateQueries({ queryKey: ["all-projects"] })
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+  })
+
+  const canAdd = installations.length > 0
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Projects ({projects.length})
+        </p>
+        {!adding && canAdd && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setAdding(true)
+              setError(null)
+              setInstallationId(installations[0]?.id ?? "")
+            }}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add project
+          </Button>
+        )}
+      </div>
+
+      {!canAdd && (
+        <p className="text-xs text-muted-foreground">
+          Link a GitHub installation first to add projects.
+        </p>
+      )}
+
+      {projects.map((p) => (
+        <div
+          key={p.id}
+          className="flex items-center justify-between gap-2 rounded-md bg-muted/50 p-2 text-xs"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-mono">
+              {p.repo_owner}/{p.repo_name}
+            </p>
+            <p className="text-muted-foreground">
+              default branch: {p.default_branch}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => remove.mutate(p.id)}
+            disabled={remove.isPending}
+            aria-label="Delete project"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+
+      {adding && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (add.isPending) return
+            if (installationId && repoOwner && repoName) add.mutate()
+          }}
+          className="space-y-2 rounded-md border border-dashed p-2"
+        >
+          <Select
+            value={installationId}
+            onValueChange={(v) => setInstallationId(v ?? "")}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select installation" />
+            </SelectTrigger>
+            <SelectContent>
+              {installations.map((i) => (
+                <SelectItem key={i.id} value={i.id}>
+                  {i.account_login} ({i.account_type})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <Input
+              placeholder="Repo owner"
+              value={repoOwner}
+              onChange={(e) => setRepoOwner(e.target.value)}
+            />
+            <Input
+              placeholder="Repo name"
+              value={repoName}
+              onChange={(e) => setRepoName(e.target.value)}
+            />
+          </div>
+          <Input
+            placeholder="Default branch (optional, defaults to main)"
+            value={defaultBranch}
+            onChange={(e) => setDefaultBranch(e.target.value)}
+          />
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              type="submit"
+              disabled={
+                !installationId || !repoOwner || !repoName || add.isPending
+              }
+            >
+              Add
+            </Button>
+            <Button
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setAdding(false)
+                setError(null)
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -54,6 +54,7 @@ export interface TaskRequest {
   working_dir?: string;
   allowed_tools?: string[];
   max_turns?: number;
+  project_id?: string;
 }
 
 export interface User {
@@ -67,6 +68,43 @@ export interface Credential {
   name: string;
   created_at: string;
   updated_at: string;
+}
+
+// Workspace (tenant) / membership / GitHub App installation / project
+// types, issue #59 (Phase 0).
+export interface Workspace {
+  id: string;
+  slug: string;
+  name: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface WorkspaceMember {
+  tenant_id: string;
+  user_id: string;
+  joined_at: string;
+}
+
+export type GitHubAccountType = 'user' | 'organization';
+
+export interface GitHubAppInstallation {
+  id: string;
+  tenant_id: string;
+  install_id: number;
+  account_login: string;
+  account_type: GitHubAccountType;
+  created_at: string;
+}
+
+export interface Project {
+  id: string;
+  tenant_id: string;
+  github_app_installation_id: string;
+  repo_owner: string;
+  repo_name: string;
+  default_branch: string;
+  created_at: string;
 }
 
 // Governance types (proxied to synodic via /api/governance/*)
@@ -244,6 +282,63 @@ export const api = {
     }),
   deleteCredential: (name: string) =>
     request<{ ok: boolean }>(`/credentials/${encodeURIComponent(name)}`, {
+      method: 'DELETE',
+    }),
+  // Workspaces / tenants (issue #59)
+  listWorkspaces: () => request<{ tenants: Workspace[] }>('/tenants'),
+  createWorkspace: (body: { slug: string; name: string }) =>
+    request<{ tenant: Workspace }>('/tenants', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  getWorkspace: (id: string) =>
+    request<{ tenant: Workspace }>(`/tenants/${encodeURIComponent(id)}`),
+  listWorkspaceMembers: (id: string) =>
+    request<{ members: WorkspaceMember[] }>(
+      `/tenants/${encodeURIComponent(id)}/members`,
+    ),
+  listWorkspaceInstallations: (id: string) =>
+    request<{ installations: GitHubAppInstallation[] }>(
+      `/tenants/${encodeURIComponent(id)}/github-installations`,
+    ),
+  registerWorkspaceInstallation: (
+    id: string,
+    body: {
+      install_id: number;
+      account_login: string;
+      account_type: GitHubAccountType;
+      webhook_secret?: string;
+    },
+  ) =>
+    request<{ installation: GitHubAppInstallation }>(
+      `/tenants/${encodeURIComponent(id)}/github-installations`,
+      { method: 'POST', body: JSON.stringify(body) },
+    ),
+  deleteWorkspaceInstallation: (tenantId: string, installId: string) =>
+    request<{ ok: boolean }>(
+      `/tenants/${encodeURIComponent(tenantId)}/github-installations/${encodeURIComponent(installId)}`,
+      { method: 'DELETE' },
+    ),
+  listWorkspaceProjects: (id: string) =>
+    request<{ projects: Project[] }>(
+      `/tenants/${encodeURIComponent(id)}/projects`,
+    ),
+  addWorkspaceProject: (
+    id: string,
+    body: {
+      github_app_installation_id: string;
+      repo_owner: string;
+      repo_name: string;
+      default_branch?: string;
+    },
+  ) =>
+    request<{ project: Project }>(
+      `/tenants/${encodeURIComponent(id)}/projects`,
+      { method: 'POST', body: JSON.stringify(body) },
+    ),
+  listAllProjects: () => request<{ projects: Project[] }>('/projects'),
+  deleteProject: (id: string) =>
+    request<{ ok: boolean }>(`/projects/${encodeURIComponent(id)}`, {
       method: 'DELETE',
     }),
   // Governance (proxied to synodic)

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Trash2, Plus, KeyRound, User } from "lucide-react"
+import { WorkspacesCard } from "@/components/settings/WorkspacesCard"
 
 const KNOWN_CREDENTIALS = [
   {
@@ -94,6 +95,9 @@ export function SettingsPage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Workspaces */}
+      <WorkspacesCard />
 
       {/* Credentials */}
       <Card>

--- a/crates/stiglab/src/core/github_app_installation.rs
+++ b/crates/stiglab/src/core/github_app_installation.rs
@@ -1,0 +1,48 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use crate::core::error::StiglabError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitHubAccountType {
+    User,
+    Organization,
+}
+
+impl fmt::Display for GitHubAccountType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GitHubAccountType::User => write!(f, "user"),
+            GitHubAccountType::Organization => write!(f, "organization"),
+        }
+    }
+}
+
+impl FromStr for GitHubAccountType {
+    type Err = StiglabError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" | "User" => Ok(GitHubAccountType::User),
+            "organization" | "Organization" => Ok(GitHubAccountType::Organization),
+            other => Err(StiglabError::InvalidState(format!(
+                "invalid github account type: {other}"
+            ))),
+        }
+    }
+}
+
+/// A GitHub App installation linked to a tenant. A tenant may have 0..N
+/// installations (typical: exactly one; but cross-org tenants can link more).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubAppInstallation {
+    pub id: String,
+    pub tenant_id: String,
+    pub install_id: i64,
+    pub account_login: String,
+    pub account_type: GitHubAccountType,
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/stiglab/src/core/mod.rs
+++ b/crates/stiglab/src/core/mod.rs
@@ -1,18 +1,26 @@
 pub mod adapter;
 pub mod error;
 pub mod event;
+pub mod github_app_installation;
 pub mod node;
+pub mod project;
 pub mod protocol;
 pub mod session;
 pub mod task;
+pub mod tenant;
+pub mod tenant_member;
 pub mod user;
 
 pub use error::StiglabError;
 pub use event::Event;
+pub use github_app_installation::{GitHubAccountType, GitHubAppInstallation};
 pub use node::{Node, NodeInfo, NodeStatus};
+pub use project::Project;
 pub use protocol::{AgentMessage, ServerMessage};
 pub use session::{Session, SessionState};
 pub use task::{Task, TaskRequest};
+pub use tenant::Tenant;
+pub use tenant_member::TenantMember;
 pub use user::User;
 
 #[cfg(test)]
@@ -98,5 +106,29 @@ mod tests {
             ServerMessage::Registered { node_id } => assert_eq!(node_id, "node-1"),
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn test_github_account_type_display_and_parse() {
+        assert_eq!(GitHubAccountType::User.to_string(), "user");
+        assert_eq!(GitHubAccountType::Organization.to_string(), "organization");
+        assert_eq!(
+            "user".parse::<GitHubAccountType>().unwrap(),
+            GitHubAccountType::User
+        );
+        assert_eq!(
+            "Organization".parse::<GitHubAccountType>().unwrap(),
+            GitHubAccountType::Organization
+        );
+        assert!("bot".parse::<GitHubAccountType>().is_err());
+    }
+
+    #[test]
+    fn test_github_account_type_serde() {
+        let user = GitHubAccountType::User;
+        let json = serde_json::to_string(&user).unwrap();
+        assert_eq!(json, "\"user\"");
+        let parsed: GitHubAccountType = serde_json::from_str("\"organization\"").unwrap();
+        assert_eq!(parsed, GitHubAccountType::Organization);
     }
 }

--- a/crates/stiglab/src/core/project.rs
+++ b/crates/stiglab/src/core/project.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A repo linked to both a tenant and a specific GitHub App installation.
+/// Opt-in per repo: installing the App on an org does not auto-mirror all
+/// of that org's repos; the user explicitly adds each one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: String,
+    pub tenant_id: String,
+    pub github_app_installation_id: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub default_branch: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/stiglab/src/core/task.rs
+++ b/crates/stiglab/src/core/task.rs
@@ -25,4 +25,9 @@ pub struct TaskRequest {
     pub model: Option<String>,
     pub system_prompt: Option<String>,
     pub permission_mode: Option<String>,
+    /// Optional tenant-owned project this session is scoped to (issue #59).
+    /// The server validates the caller is a member of the project's tenant;
+    /// omitted for personal sessions.
+    #[serde(default)]
+    pub project_id: Option<String>,
 }

--- a/crates/stiglab/src/core/tenant.rs
+++ b/crates/stiglab/src/core/tenant.rs
@@ -1,0 +1,14 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// An Onsager-native workspace identity. Owns membership, GitHub installations,
+/// and projects. Identity is owned by Onsager (not borrowed from any external
+/// provider), so future source providers can hang off the same tenant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tenant {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/stiglab/src/core/tenant_member.rs
+++ b/crates/stiglab/src/core/tenant_member.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Many-to-many join between users and tenants. v1 has no `role` column —
+/// every member has equal access. Role enum lands in a follow-up spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TenantMember {
+    pub tenant_id: String,
+    pub user_id: String,
+    pub joined_at: DateTime<Utc>,
+}

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -1019,6 +1019,36 @@ pub async fn insert_tenant(pool: &AnyPool, tenant: &Tenant) -> anyhow::Result<()
     Ok(())
 }
 
+/// Atomically insert a tenant and its creator-as-member row. Either both
+/// rows land or neither does — prevents a failed `tenant_members` insert
+/// from leaving an orphan workspace that permanently consumes its slug.
+pub async fn insert_tenant_with_creator(
+    pool: &AnyPool,
+    tenant: &Tenant,
+    member: &TenantMember,
+) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO tenants (id, slug, name, created_by, created_at) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(&tenant.id)
+    .bind(&tenant.slug)
+    .bind(&tenant.name)
+    .bind(&tenant.created_by)
+    .bind(tenant.created_at.to_rfc3339())
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("INSERT INTO tenant_members (tenant_id, user_id, joined_at) VALUES ($1, $2, $3)")
+        .bind(&member.tenant_id)
+        .bind(&member.user_id)
+        .bind(member.joined_at.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 pub async fn get_tenant(pool: &AnyPool, tenant_id: &str) -> anyhow::Result<Option<Tenant>> {
     let row = sqlx::query_as::<_, TenantRow>(
         "SELECT id, slug, name, created_by, created_at FROM tenants WHERE id = $1",
@@ -1141,6 +1171,25 @@ pub async fn delete_github_app_installation(
         .execute(pool)
         .await?;
     Ok(())
+}
+
+/// Count projects that still reference a given installation. Used by the
+/// delete-installation route for an app-layer referential-integrity check:
+/// the tables do not declare FK constraints (consistent with the rest of
+/// stiglab, which uses AnyPool across SQLite/Postgres — SQLite needs
+/// `PRAGMA foreign_keys = ON` to enforce FKs and the rest of the schema
+/// matches this convention), so callers must gate destructive operations
+/// explicitly.
+pub async fn count_projects_for_installation(
+    pool: &AnyPool,
+    install_id: &str,
+) -> anyhow::Result<i64> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM projects WHERE github_app_installation_id = $1")
+            .bind(install_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
 }
 
 pub async fn insert_project(pool: &AnyPool, project: &Project) -> anyhow::Result<()> {
@@ -1520,6 +1569,82 @@ mod tests {
 
         delete_project(&pool, &project.id).await.unwrap();
         assert!(get_project(&pool, &project.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn insert_tenant_with_creator_is_atomic() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        let t = new_tenant("u1");
+        let m = TenantMember {
+            tenant_id: t.id.clone(),
+            user_id: "u1".to_string(),
+            joined_at: Utc::now(),
+        };
+        insert_tenant_with_creator(&pool, &t, &m).await.unwrap();
+        assert!(get_tenant(&pool, &t.id).await.unwrap().is_some());
+        assert!(is_tenant_member(&pool, &t.id, "u1").await.unwrap());
+
+        // Reusing the same slug must fail and — because the helper uses a
+        // transaction — must not create a new member row either.
+        let t2 = Tenant {
+            id: Uuid::new_v4().to_string(),
+            slug: t.slug.clone(),
+            ..new_tenant("u1")
+        };
+        let m2 = TenantMember {
+            tenant_id: t2.id.clone(),
+            user_id: "u1".to_string(),
+            joined_at: Utc::now(),
+        };
+        assert!(insert_tenant_with_creator(&pool, &t2, &m2).await.is_err());
+        assert!(get_tenant(&pool, &t2.id).await.unwrap().is_none());
+        assert!(!is_tenant_member(&pool, &t2.id, "u1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn count_projects_for_installation_blocks_delete() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        let t = new_tenant("u1");
+        insert_tenant(&pool, &t).await.unwrap();
+
+        let install = GitHubAppInstallation {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            install_id: 99,
+            account_login: "acme".to_string(),
+            account_type: GitHubAccountType::Organization,
+            created_at: Utc::now(),
+        };
+        insert_github_app_installation(&pool, &install, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            count_projects_for_installation(&pool, &install.id)
+                .await
+                .unwrap(),
+            0
+        );
+
+        let project = Project {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            github_app_installation_id: install.id.clone(),
+            repo_owner: "acme".to_string(),
+            repo_name: "widgets".to_string(),
+            default_branch: "main".to_string(),
+            created_at: Utc::now(),
+        };
+        insert_project(&pool, &project).await.unwrap();
+
+        assert_eq!(
+            count_projects_for_installation(&pool, &install.id)
+                .await
+                .unwrap(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use crate::core::{Node, NodeStatus, Session, SessionState, User};
+use crate::core::{
+    GitHubAppInstallation, Node, NodeStatus, Project, Session, SessionState, Tenant, TenantMember,
+    User,
+};
 use chrono::Utc;
 use sqlx::pool::PoolOptions;
 use sqlx::AnyPool;
@@ -187,6 +190,87 @@ async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     )
     .execute(pool)
     .await?;
+
+    // ── Tenant / membership / GitHub App / project tables (issue #59) ──
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS tenants (
+            id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS tenant_members (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            joined_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, user_id)
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_tenant_members_user_id ON tenant_members (user_id)",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS github_app_installations (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            install_id BIGINT NOT NULL UNIQUE,
+            account_login TEXT NOT NULL,
+            account_type TEXT NOT NULL,
+            webhook_secret_cipher TEXT,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_github_app_installations_tenant_id \
+         ON github_app_installations (tenant_id)",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            github_app_installation_id TEXT NOT NULL,
+            repo_owner TEXT NOT NULL,
+            repo_name TEXT NOT NULL,
+            default_branch TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(tenant_id, repo_owner, repo_name)
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_projects_tenant_id ON projects (tenant_id)")
+        .execute(pool)
+        .await?;
+
+    // Attach sessions to projects (nullable; pre-existing sessions stay personal).
+    // Same swallow-on-duplicate ALTER pattern as earlier migrations for
+    // cross-backend compatibility.
+    let _ = sqlx::query("ALTER TABLE sessions ADD COLUMN project_id TEXT")
+        .execute(pool)
+        .await;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions (project_id)")
+        .execute(pool)
+        .await?;
 
     Ok(())
 }
@@ -731,10 +815,23 @@ pub async fn insert_session_with_user(
     session: &Session,
     user_id: Option<&str>,
 ) -> anyhow::Result<()> {
+    insert_session_with_user_and_project(pool, session, user_id, None).await
+}
+
+/// Variant that also binds a `project_id` when the session is scoped to a
+/// tenant-owned project (issue #59). Pre-existing sessions with a null
+/// `project_id` remain personal sessions forever.
+pub async fn insert_session_with_user_and_project(
+    pool: &AnyPool,
+    session: &Session,
+    user_id: Option<&str>,
+    project_id: Option<&str>,
+) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO sessions (id, task_id, node_id, state, prompt, output, working_dir, \
-                               user_id, artifact_id, artifact_version, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+                               user_id, project_id, artifact_id, artifact_version, \
+                               created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
     )
     .bind(&session.id)
     .bind(&session.task_id)
@@ -744,6 +841,7 @@ pub async fn insert_session_with_user(
     .bind(&session.output)
     .bind(&session.working_dir)
     .bind(user_id)
+    .bind(project_id)
     .bind(&session.artifact_id)
     .bind(session.artifact_version)
     .bind(session.created_at.to_rfc3339())
@@ -902,4 +1000,573 @@ struct UserCredentialRow {
 struct CredentialKvRow {
     name: String,
     encrypted_value: String,
+}
+
+// ── Tenant / membership / installation / project CRUD (issue #59) ──
+
+pub async fn insert_tenant(pool: &AnyPool, tenant: &Tenant) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO tenants (id, slug, name, created_by, created_at) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(&tenant.id)
+    .bind(&tenant.slug)
+    .bind(&tenant.name)
+    .bind(&tenant.created_by)
+    .bind(tenant.created_at.to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn get_tenant(pool: &AnyPool, tenant_id: &str) -> anyhow::Result<Option<Tenant>> {
+    let row = sqlx::query_as::<_, TenantRow>(
+        "SELECT id, slug, name, created_by, created_at FROM tenants WHERE id = $1",
+    )
+    .bind(tenant_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn list_tenants_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Result<Vec<Tenant>> {
+    let rows = sqlx::query_as::<_, TenantRow>(
+        "SELECT t.id, t.slug, t.name, t.created_by, t.created_at \
+         FROM tenants t \
+         JOIN tenant_members m ON t.id = m.tenant_id \
+         WHERE m.user_id = $1 \
+         ORDER BY t.created_at ASC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn insert_tenant_member(pool: &AnyPool, member: &TenantMember) -> anyhow::Result<()> {
+    sqlx::query("INSERT INTO tenant_members (tenant_id, user_id, joined_at) VALUES ($1, $2, $3)")
+        .bind(&member.tenant_id)
+        .bind(&member.user_id)
+        .bind(member.joined_at.to_rfc3339())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn is_tenant_member(
+    pool: &AnyPool,
+    tenant_id: &str,
+    user_id: &str,
+) -> anyhow::Result<bool> {
+    let row = sqlx::query_scalar::<_, String>(
+        "SELECT user_id FROM tenant_members WHERE tenant_id = $1 AND user_id = $2",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.is_some())
+}
+
+pub async fn list_tenant_members(
+    pool: &AnyPool,
+    tenant_id: &str,
+) -> anyhow::Result<Vec<TenantMember>> {
+    let rows = sqlx::query_as::<_, TenantMemberRow>(
+        "SELECT tenant_id, user_id, joined_at \
+         FROM tenant_members WHERE tenant_id = $1 ORDER BY joined_at ASC",
+    )
+    .bind(tenant_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn insert_github_app_installation(
+    pool: &AnyPool,
+    install: &GitHubAppInstallation,
+    webhook_secret_cipher: Option<&str>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO github_app_installations (id, tenant_id, install_id, account_login, \
+                                               account_type, webhook_secret_cipher, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(&install.id)
+    .bind(&install.tenant_id)
+    .bind(install.install_id)
+    .bind(&install.account_login)
+    .bind(install.account_type.to_string())
+    .bind(webhook_secret_cipher)
+    .bind(install.created_at.to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn list_github_app_installations_for_tenant(
+    pool: &AnyPool,
+    tenant_id: &str,
+) -> anyhow::Result<Vec<GitHubAppInstallation>> {
+    let rows = sqlx::query_as::<_, GitHubAppInstallationRow>(
+        "SELECT id, tenant_id, install_id, account_login, account_type, created_at \
+         FROM github_app_installations WHERE tenant_id = $1 ORDER BY created_at ASC",
+    )
+    .bind(tenant_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn get_github_app_installation(
+    pool: &AnyPool,
+    install_id: &str,
+) -> anyhow::Result<Option<GitHubAppInstallation>> {
+    let row = sqlx::query_as::<_, GitHubAppInstallationRow>(
+        "SELECT id, tenant_id, install_id, account_login, account_type, created_at \
+         FROM github_app_installations WHERE id = $1",
+    )
+    .bind(install_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn delete_github_app_installation(
+    pool: &AnyPool,
+    install_id: &str,
+) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM github_app_installations WHERE id = $1")
+        .bind(install_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn insert_project(pool: &AnyPool, project: &Project) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO projects (id, tenant_id, github_app_installation_id, repo_owner, \
+                               repo_name, default_branch, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(&project.id)
+    .bind(&project.tenant_id)
+    .bind(&project.github_app_installation_id)
+    .bind(&project.repo_owner)
+    .bind(&project.repo_name)
+    .bind(&project.default_branch)
+    .bind(project.created_at.to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn get_project(pool: &AnyPool, project_id: &str) -> anyhow::Result<Option<Project>> {
+    let row = sqlx::query_as::<_, ProjectRow>(
+        "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, \
+                default_branch, created_at \
+         FROM projects WHERE id = $1",
+    )
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn list_projects_for_tenant(
+    pool: &AnyPool,
+    tenant_id: &str,
+) -> anyhow::Result<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, \
+                default_branch, created_at \
+         FROM projects WHERE tenant_id = $1 ORDER BY created_at ASC",
+    )
+    .bind(tenant_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn list_projects_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Result<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        "SELECT p.id, p.tenant_id, p.github_app_installation_id, p.repo_owner, p.repo_name, \
+                p.default_branch, p.created_at \
+         FROM projects p \
+         JOIN tenant_members m ON p.tenant_id = m.tenant_id \
+         WHERE m.user_id = $1 \
+         ORDER BY p.created_at ASC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn delete_project(pool: &AnyPool, project_id: &str) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM projects WHERE id = $1")
+        .bind(project_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Count sessions attached to a project that are not in a terminal state.
+/// Used to block project deletion while live sessions reference it (no
+/// cascade, no soft-delete in v1).
+pub async fn count_live_sessions_for_project(
+    pool: &AnyPool,
+    project_id: &str,
+) -> anyhow::Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sessions \
+         WHERE project_id = $1 AND state NOT IN ('done', 'failed')",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
+// ── Row types (Tenant / membership / installation / project) ──
+
+#[derive(sqlx::FromRow)]
+struct TenantRow {
+    id: String,
+    slug: String,
+    name: String,
+    created_by: String,
+    created_at: String,
+}
+
+impl TryFrom<TenantRow> for Tenant {
+    type Error = anyhow::Error;
+
+    fn try_from(row: TenantRow) -> anyhow::Result<Self> {
+        Ok(Tenant {
+            id: row.id,
+            slug: row.slug,
+            name: row.name,
+            created_by: row.created_by,
+            created_at: chrono::DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct TenantMemberRow {
+    tenant_id: String,
+    user_id: String,
+    joined_at: String,
+}
+
+impl TryFrom<TenantMemberRow> for TenantMember {
+    type Error = anyhow::Error;
+
+    fn try_from(row: TenantMemberRow) -> anyhow::Result<Self> {
+        Ok(TenantMember {
+            tenant_id: row.tenant_id,
+            user_id: row.user_id,
+            joined_at: chrono::DateTime::parse_from_rfc3339(&row.joined_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct GitHubAppInstallationRow {
+    id: String,
+    tenant_id: String,
+    install_id: i64,
+    account_login: String,
+    account_type: String,
+    created_at: String,
+}
+
+impl TryFrom<GitHubAppInstallationRow> for GitHubAppInstallation {
+    type Error = anyhow::Error;
+
+    fn try_from(row: GitHubAppInstallationRow) -> anyhow::Result<Self> {
+        Ok(GitHubAppInstallation {
+            id: row.id,
+            tenant_id: row.tenant_id,
+            install_id: row.install_id,
+            account_login: row.account_login,
+            account_type: row
+                .account_type
+                .parse()
+                .map_err(|e: crate::core::StiglabError| anyhow::anyhow!(e))?,
+            created_at: chrono::DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct ProjectRow {
+    id: String,
+    tenant_id: String,
+    github_app_installation_id: String,
+    repo_owner: String,
+    repo_name: String,
+    default_branch: String,
+    created_at: String,
+}
+
+impl TryFrom<ProjectRow> for Project {
+    type Error = anyhow::Error;
+
+    fn try_from(row: ProjectRow) -> anyhow::Result<Self> {
+        Ok(Project {
+            id: row.id,
+            tenant_id: row.tenant_id,
+            github_app_installation_id: row.github_app_installation_id,
+            repo_owner: row.repo_owner,
+            repo_name: row.repo_name,
+            default_branch: row.default_branch,
+            created_at: chrono::DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{GitHubAccountType, Project, Session, SessionState, Tenant, TenantMember};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    async fn test_pool() -> AnyPool {
+        sqlx::any::install_default_drivers();
+        let pool = PoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("failed to connect to sqlite in-memory");
+        run_migrations(&pool)
+            .await
+            .expect("migrations should succeed");
+        pool
+    }
+
+    async fn seed_user(pool: &AnyPool, user_id: &str) {
+        // Derive a stable non-colliding github_id from the user_id bytes.
+        let github_id: i64 = user_id.bytes().fold(0i64, |acc, b| acc * 131 + b as i64);
+        sqlx::query(
+            "INSERT INTO users (id, github_id, github_login, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $4)",
+        )
+        .bind(user_id)
+        .bind(github_id)
+        .bind(user_id)
+        .bind(Utc::now().to_rfc3339())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn new_tenant(created_by: &str) -> Tenant {
+        Tenant {
+            id: Uuid::new_v4().to_string(),
+            slug: format!("tenant-{}", Uuid::new_v4().simple()),
+            name: "Test Tenant".to_string(),
+            created_by: created_by.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_crud_roundtrip() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+
+        let tenant = new_tenant("u1");
+        insert_tenant(&pool, &tenant).await.unwrap();
+
+        let fetched = get_tenant(&pool, &tenant.id).await.unwrap().unwrap();
+        assert_eq!(fetched.id, tenant.id);
+        assert_eq!(fetched.slug, tenant.slug);
+    }
+
+    #[tokio::test]
+    async fn membership_query_and_list_tenants_for_user() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        seed_user(&pool, "u2").await;
+
+        let t = new_tenant("u1");
+        insert_tenant(&pool, &t).await.unwrap();
+        insert_tenant_member(
+            &pool,
+            &TenantMember {
+                tenant_id: t.id.clone(),
+                user_id: "u1".to_string(),
+                joined_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(is_tenant_member(&pool, &t.id, "u1").await.unwrap());
+        assert!(!is_tenant_member(&pool, &t.id, "u2").await.unwrap());
+
+        let u1_tenants = list_tenants_for_user(&pool, "u1").await.unwrap();
+        assert_eq!(u1_tenants.len(), 1);
+        assert_eq!(u1_tenants[0].id, t.id);
+
+        let u2_tenants = list_tenants_for_user(&pool, "u2").await.unwrap();
+        assert!(u2_tenants.is_empty());
+    }
+
+    #[tokio::test]
+    async fn installation_and_project_crud() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        let t = new_tenant("u1");
+        insert_tenant(&pool, &t).await.unwrap();
+
+        let install = GitHubAppInstallation {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            install_id: 42,
+            account_login: "acme".to_string(),
+            account_type: GitHubAccountType::Organization,
+            created_at: Utc::now(),
+        };
+        insert_github_app_installation(&pool, &install, Some("ciphertext"))
+            .await
+            .unwrap();
+
+        let installs = list_github_app_installations_for_tenant(&pool, &t.id)
+            .await
+            .unwrap();
+        assert_eq!(installs.len(), 1);
+        assert_eq!(installs[0].install_id, 42);
+
+        let project = Project {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            github_app_installation_id: install.id.clone(),
+            repo_owner: "acme".to_string(),
+            repo_name: "widgets".to_string(),
+            default_branch: "main".to_string(),
+            created_at: Utc::now(),
+        };
+        insert_project(&pool, &project).await.unwrap();
+
+        let projects = list_projects_for_tenant(&pool, &t.id).await.unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].repo_name, "widgets");
+    }
+
+    #[tokio::test]
+    async fn delete_project_blocks_on_live_sessions() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        let t = new_tenant("u1");
+        insert_tenant(&pool, &t).await.unwrap();
+
+        let install = GitHubAppInstallation {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            install_id: 7,
+            account_login: "acme".to_string(),
+            account_type: GitHubAccountType::Organization,
+            created_at: Utc::now(),
+        };
+        insert_github_app_installation(&pool, &install, None)
+            .await
+            .unwrap();
+
+        let project = Project {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t.id.clone(),
+            github_app_installation_id: install.id.clone(),
+            repo_owner: "acme".to_string(),
+            repo_name: "widgets".to_string(),
+            default_branch: "main".to_string(),
+            created_at: Utc::now(),
+        };
+        insert_project(&pool, &project).await.unwrap();
+
+        let session = Session {
+            id: Uuid::new_v4().to_string(),
+            task_id: Uuid::new_v4().to_string(),
+            node_id: "node-1".to_string(),
+            state: SessionState::Running,
+            prompt: "hello".to_string(),
+            output: None,
+            working_dir: None,
+            artifact_id: None,
+            artifact_version: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        insert_session_with_user_and_project(&pool, &session, Some("u1"), Some(&project.id))
+            .await
+            .unwrap();
+
+        let live = count_live_sessions_for_project(&pool, &project.id)
+            .await
+            .unwrap();
+        assert_eq!(live, 1);
+
+        // Transition to a terminal state — live count should drop to zero.
+        update_session_state(&pool, &session.id, SessionState::Done)
+            .await
+            .unwrap();
+        let live = count_live_sessions_for_project(&pool, &project.id)
+            .await
+            .unwrap();
+        assert_eq!(live, 0);
+
+        delete_project(&pool, &project.id).await.unwrap();
+        assert!(get_project(&pool, &project.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_projects_for_user_follows_membership() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        seed_user(&pool, "u2").await;
+
+        let t1 = new_tenant("u1");
+        insert_tenant(&pool, &t1).await.unwrap();
+        insert_tenant_member(
+            &pool,
+            &TenantMember {
+                tenant_id: t1.id.clone(),
+                user_id: "u1".to_string(),
+                joined_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let install = GitHubAppInstallation {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t1.id.clone(),
+            install_id: 1,
+            account_login: "acme".to_string(),
+            account_type: GitHubAccountType::User,
+            created_at: Utc::now(),
+        };
+        insert_github_app_installation(&pool, &install, None)
+            .await
+            .unwrap();
+        let project = Project {
+            id: Uuid::new_v4().to_string(),
+            tenant_id: t1.id.clone(),
+            github_app_installation_id: install.id.clone(),
+            repo_owner: "acme".to_string(),
+            repo_name: "widgets".to_string(),
+            default_branch: "main".to_string(),
+            created_at: Utc::now(),
+        };
+        insert_project(&pool, &project).await.unwrap();
+
+        let u1_projects = list_projects_for_user(&pool, "u1").await.unwrap();
+        assert_eq!(u1_projects.len(), 1);
+
+        let u2_projects = list_projects_for_user(&pool, "u2").await.unwrap();
+        assert!(u2_projects.is_empty());
+    }
 }

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -53,6 +53,36 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/credentials/{name}",
             put(routes::credentials::set_credential).delete(routes::credentials::delete_credential),
         )
+        // Tenant / workspace routes (issue #59 — Phase 0)
+        .route(
+            "/api/tenants",
+            get(routes::tenants::list_tenants).post(routes::tenants::create_tenant),
+        )
+        .route("/api/tenants/{id}", get(routes::tenants::get_tenant))
+        .route(
+            "/api/tenants/{id}/members",
+            get(routes::tenants::list_members),
+        )
+        .route(
+            "/api/tenants/{id}/github-installations",
+            get(routes::tenants::list_installations).post(routes::tenants::register_installation),
+        )
+        .route(
+            "/api/tenants/{id}/github-installations/{install_id}",
+            axum::routing::delete(routes::tenants::delete_installation),
+        )
+        .route(
+            "/api/tenants/{id}/projects",
+            get(routes::tenants::list_projects).post(routes::tenants::add_project),
+        )
+        .route(
+            "/api/projects",
+            get(routes::tenants::list_all_projects_for_user),
+        )
+        .route(
+            "/api/projects/{id}",
+            get(routes::tenants::get_project).delete(routes::tenants::delete_project),
+        )
         // Governance proxy — forwards to synodic on internal port
         .route("/api/governance/{*path}", any(routes::governance::proxy))
         // Spine API — exposes shared event spine data to the dashboard

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -7,3 +7,4 @@ pub mod sessions;
 pub mod shaping;
 pub mod spine;
 pub mod tasks;
+pub mod tenants;

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -102,7 +102,52 @@ pub async fn create_task(
         Some(auth_user.user_id.as_str())
     };
 
-    if let Err(e) = db::insert_session_with_user(&state.db, &session, user_id).await {
+    // Validate project membership if the caller scoped the session to a
+    // tenant-owned project (issue #59). Non-members get 404 via
+    // `assert_tenant_member` so project IDs can't be enumerated.
+    if let Some(ref project_id) = request.project_id {
+        let Some(caller_id) = user_id else {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "authentication required to scope a session to a project"
+                })),
+            )
+                .into_response();
+        };
+        let project = match db::get_project(&state.db, project_id).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "project not found" })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("failed to look up project: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+        };
+        if let Err(r) = crate::server::routes::tenants::assert_tenant_member(
+            &state.db,
+            caller_id,
+            &project.tenant_id,
+        )
+        .await
+        {
+            return r;
+        }
+    }
+
+    if let Err(e) = db::insert_session_with_user_and_project(
+        &state.db,
+        &session,
+        user_id,
+        request.project_id.as_deref(),
+    )
+    .await
+    {
         tracing::error!("failed to insert session: {e}");
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -1,0 +1,563 @@
+//! Tenant / workspace, membership, GitHub App installation, and project
+//! CRUD routes (issue #59 — Phase 0).
+//!
+//! All tenant-scoped endpoints go through [`require_tenant_member`] which
+//! returns **404 (not 403)** for non-members. Matching GitHub's private-
+//! resource behaviour means the tenant-enumeration surface stays private —
+//! no invite-acceptance UI needed for v1.
+//!
+//! Project deletion blocks with a clear error when live sessions reference
+//! the project; there is no cascade and no soft-delete in v1.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use serde::Deserialize;
+use sqlx::AnyPool;
+use uuid::Uuid;
+
+use crate::core::{GitHubAccountType, GitHubAppInstallation, Project, Tenant, TenantMember};
+use crate::server::auth::{encrypt_credential, AuthUser};
+use crate::server::db;
+use crate::server::state::AppState;
+
+// ── Auth helper ──
+
+/// Ensure the authenticated user is a member of the tenant. Returns
+/// **404** (not 403) for non-members — callers get the same response for
+/// "tenant doesn't exist" and "you're not a member", so tenant IDs can't be
+/// enumerated.
+#[allow(clippy::result_large_err)]
+async fn require_tenant_member(
+    pool: &AnyPool,
+    user_id: &str,
+    tenant_id: &str,
+) -> Result<(), Response> {
+    match db::is_tenant_member(pool, tenant_id, user_id).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(not_found("tenant not found")),
+        Err(e) => {
+            tracing::error!("failed to check tenant membership: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+    }
+}
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+#[allow(clippy::result_large_err)]
+fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
+    if auth_user.user_id == "anonymous" {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "authentication required" })),
+        )
+            .into_response())
+    } else {
+        Ok(auth_user.user_id.as_str())
+    }
+}
+
+// ── Tenant CRUD ──
+
+#[derive(Debug, Deserialize)]
+pub struct CreateTenantBody {
+    pub slug: String,
+    pub name: String,
+}
+
+/// POST /api/tenants — Create a workspace. Creator is auto-inserted as a
+/// member (no role column in v1).
+pub async fn create_tenant(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(body): Json<CreateTenantBody>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+
+    let slug = body.slug.trim();
+    let name = body.name.trim();
+    if slug.is_empty() || name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "slug and name are required" })),
+        )
+            .into_response();
+    }
+    if !slug
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "slug must be lowercase alphanumeric with hyphens"
+            })),
+        )
+            .into_response();
+    }
+
+    let now = Utc::now();
+    let tenant = Tenant {
+        id: Uuid::new_v4().to_string(),
+        slug: slug.to_string(),
+        name: name.to_string(),
+        created_by: user_id.clone(),
+        created_at: now,
+    };
+
+    if let Err(e) = db::insert_tenant(&state.db, &tenant).await {
+        tracing::error!("failed to insert tenant: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(
+                serde_json::json!({ "error": "failed to create tenant (slug may already exist)" }),
+            ),
+        )
+            .into_response();
+    }
+
+    let member = TenantMember {
+        tenant_id: tenant.id.clone(),
+        user_id: user_id.clone(),
+        joined_at: now,
+    };
+    if let Err(e) = db::insert_tenant_member(&state.db, &member).await {
+        tracing::error!("failed to auto-insert creator as member: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "tenant": tenant })),
+    )
+        .into_response()
+}
+
+/// GET /api/tenants — List workspaces the current user belongs to.
+pub async fn list_tenants(State(state): State<AppState>, auth_user: AuthUser) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    match db::list_tenants_for_user(&state.db, user_id).await {
+        Ok(tenants) => Json(serde_json::json!({ "tenants": tenants })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list tenants: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+/// GET /api/tenants/:id — Fetch a workspace. 404 for non-members.
+pub async fn get_tenant(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+    match db::get_tenant(&state.db, &tenant_id).await {
+        Ok(Some(t)) => Json(serde_json::json!({ "tenant": t })).into_response(),
+        Ok(None) => not_found("tenant not found"),
+        Err(e) => {
+            tracing::error!("failed to get tenant: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+/// GET /api/tenants/:id/members — List members (read-only in v1).
+pub async fn list_members(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+    match db::list_tenant_members(&state.db, &tenant_id).await {
+        Ok(members) => Json(serde_json::json!({ "members": members })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list members: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+// ── GitHub App installations ──
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterInstallationBody {
+    pub install_id: i64,
+    pub account_login: String,
+    pub account_type: GitHubAccountType,
+    /// Webhook shared-secret for signature verification. Stored encrypted
+    /// at rest using the existing credential key. Optional so tenants can
+    /// register an installation before wiring up webhooks.
+    pub webhook_secret: Option<String>,
+}
+
+/// POST /api/tenants/:id/github-installations — Register a GitHub App
+/// installation linked to this tenant.
+///
+/// In Phase 0 this is a manual-entry endpoint (caller supplies the
+/// installation ID and webhook secret). The full OAuth App-callback flow
+/// that mints these automatically is a follow-up spec; the data model and
+/// API shape are frozen here so the callback is purely additive.
+pub async fn register_installation(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+    Json(body): Json<RegisterInstallationBody>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+        return r;
+    }
+
+    let secret_cipher = match body.webhook_secret.as_deref() {
+        None | Some("") => None,
+        Some(plaintext) => {
+            let Some(ref key) = state.config.credential_key else {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({
+                        "error": "credential storage not configured (set STIGLAB_CREDENTIAL_KEY)"
+                    })),
+                )
+                    .into_response();
+            };
+            match encrypt_credential(key, plaintext) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    tracing::error!("failed to encrypt webhook secret: {e}");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "encryption failed")
+                        .into_response();
+                }
+            }
+        }
+    };
+
+    let install = GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        tenant_id: tenant_id.clone(),
+        install_id: body.install_id,
+        account_login: body.account_login.clone(),
+        account_type: body.account_type,
+        created_at: Utc::now(),
+    };
+
+    if let Err(e) =
+        db::insert_github_app_installation(&state.db, &install, secret_cipher.as_deref()).await
+    {
+        tracing::error!("failed to insert installation: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed to register installation (install_id may already be linked)"
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "installation": install })),
+    )
+        .into_response()
+}
+
+/// GET /api/tenants/:id/github-installations — List installations linked
+/// to a tenant.
+pub async fn list_installations(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+    match db::list_github_app_installations_for_tenant(&state.db, &tenant_id).await {
+        Ok(installations) => {
+            Json(serde_json::json!({ "installations": installations })).into_response()
+        }
+        Err(e) => {
+            tracing::error!("failed to list installations: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+/// DELETE /api/tenants/:id/github-installations/:install_id — Unlink an
+/// installation. Projects that reference it are blocked from deletion
+/// via FK — callers should delete projects first in v1.
+pub async fn delete_installation(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((tenant_id, install_id)): Path<(String, String)>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+
+    match db::get_github_app_installation(&state.db, &install_id).await {
+        Ok(Some(inst)) if inst.tenant_id == tenant_id => {}
+        Ok(_) => return not_found("installation not found"),
+        Err(e) => {
+            tracing::error!("failed to get installation: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+
+    if let Err(e) = db::delete_github_app_installation(&state.db, &install_id).await {
+        tracing::error!("failed to delete installation: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+// ── Projects ──
+
+#[derive(Debug, Deserialize)]
+pub struct AddProjectBody {
+    pub github_app_installation_id: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    /// Optional. Inferring from GitHub at create-time requires an
+    /// installation access token the Phase 0 stub can't mint; callers may
+    /// supply a branch or let the server fall back to `"main"`.
+    pub default_branch: Option<String>,
+}
+
+/// POST /api/tenants/:id/projects — Add a project (opt-in per repo; no
+/// auto-mirroring).
+pub async fn add_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+    Json(body): Json<AddProjectBody>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+
+    // Validate the installation belongs to this tenant.
+    match db::get_github_app_installation(&state.db, &body.github_app_installation_id).await {
+        Ok(Some(inst)) if inst.tenant_id == tenant_id => {}
+        Ok(_) => return not_found("installation not found"),
+        Err(e) => {
+            tracing::error!("failed to get installation: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+
+    let repo_owner = body.repo_owner.trim();
+    let repo_name = body.repo_name.trim();
+    if repo_owner.is_empty() || repo_name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "repo_owner and repo_name are required" })),
+        )
+            .into_response();
+    }
+
+    let default_branch = body
+        .default_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("main")
+        .to_string();
+
+    let project = Project {
+        id: Uuid::new_v4().to_string(),
+        tenant_id: tenant_id.clone(),
+        github_app_installation_id: body.github_app_installation_id.clone(),
+        repo_owner: repo_owner.to_string(),
+        repo_name: repo_name.to_string(),
+        default_branch,
+        created_at: Utc::now(),
+    };
+
+    if let Err(e) = db::insert_project(&state.db, &project).await {
+        tracing::error!("failed to insert project: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed to add project (repo may already be onboarded)"
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "project": project })),
+    )
+        .into_response()
+}
+
+/// GET /api/tenants/:id/projects — List projects in a workspace.
+pub async fn list_projects(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(tenant_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+        return r;
+    }
+    match db::list_projects_for_tenant(&state.db, &tenant_id).await {
+        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list projects: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+/// GET /api/projects — List every project the current user can access,
+/// across all their workspaces. Powers the cross-workspace project
+/// selector in `CreateSessionSheet`.
+pub async fn list_all_projects_for_user(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    match db::list_projects_for_user(&state.db, user_id).await {
+        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list projects: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+/// GET /api/projects/:id — Fetch a project by ID. 404 for users who are
+/// not members of the owning tenant.
+pub async fn get_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    let project = match db::get_project(&state.db, &project_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return not_found("project not found"),
+        Err(e) => {
+            tracing::error!("failed to get project: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &project.tenant_id).await {
+        return r;
+    }
+    Json(serde_json::json!({ "project": project })).into_response()
+}
+
+/// DELETE /api/projects/:id — Delete a project. Blocks with a clear
+/// error when any attached session is not in a terminal state (no
+/// cascade, no soft-delete in v1).
+pub async fn delete_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    let project = match db::get_project(&state.db, &project_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return not_found("project not found"),
+        Err(e) => {
+            tracing::error!("failed to get project: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_tenant_member(&state.db, user_id, &project.tenant_id).await {
+        return r;
+    }
+
+    match db::count_live_sessions_for_project(&state.db, &project_id).await {
+        Ok(n) if n > 0 => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "cannot delete project: {n} live session(s) still reference it. \
+                         Wait for them to finish or abort them first."
+                    )
+                })),
+            )
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!("failed to count live sessions: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+
+    if let Err(e) = db::delete_project(&state.db, &project_id).await {
+        tracing::error!("failed to delete project: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+/// Public helper re-exported so `routes::tasks` can reuse the same 404
+/// semantics when creating a session scoped to a project.
+#[allow(clippy::result_large_err)]
+pub async fn assert_tenant_member(
+    pool: &AnyPool,
+    user_id: &str,
+    tenant_id: &str,
+) -> Result<(), Response> {
+    require_tenant_member(pool, user_id, tenant_id).await
+}

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -116,9 +116,16 @@ pub async fn create_tenant(
         created_by: user_id.clone(),
         created_at: now,
     };
+    let member = TenantMember {
+        tenant_id: tenant.id.clone(),
+        user_id: user_id.clone(),
+        joined_at: now,
+    };
 
-    if let Err(e) = db::insert_tenant(&state.db, &tenant).await {
-        tracing::error!("failed to insert tenant: {e}");
+    // Transactional so a failed member insert can't leave an orphan
+    // tenant row that permanently consumes the slug.
+    if let Err(e) = db::insert_tenant_with_creator(&state.db, &tenant, &member).await {
+        tracing::error!("failed to insert tenant + creator-member: {e}");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(
@@ -126,16 +133,6 @@ pub async fn create_tenant(
             ),
         )
             .into_response();
-    }
-
-    let member = TenantMember {
-        tenant_id: tenant.id.clone(),
-        user_id: user_id.clone(),
-        joined_at: now,
-    };
-    if let Err(e) = db::insert_tenant_member(&state.db, &member).await {
-        tracing::error!("failed to auto-insert creator as member: {e}");
-        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
 
     (
@@ -239,6 +236,15 @@ pub async fn register_installation(
         return r;
     }
 
+    let account_login = body.account_login.trim();
+    if account_login.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "account_login is required" })),
+        )
+            .into_response();
+    }
+
     let secret_cipher = match body.webhook_secret.as_deref() {
         None | Some("") => None,
         Some(plaintext) => {
@@ -266,7 +272,7 @@ pub async fn register_installation(
         id: Uuid::new_v4().to_string(),
         tenant_id: tenant_id.clone(),
         install_id: body.install_id,
-        account_login: body.account_login.clone(),
+        account_login: account_login.to_string(),
         account_type: body.account_type,
         created_at: Utc::now(),
     };
@@ -317,8 +323,10 @@ pub async fn list_installations(
 }
 
 /// DELETE /api/tenants/:id/github-installations/:install_id — Unlink an
-/// installation. Projects that reference it are blocked from deletion
-/// via FK — callers should delete projects first in v1.
+/// installation. Blocked with 409 when projects still reference it
+/// (app-layer check — the tables do not declare FK constraints, in
+/// keeping with the rest of stiglab's schema). Callers must delete the
+/// projects first in v1.
 pub async fn delete_installation(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -337,6 +345,26 @@ pub async fn delete_installation(
         Ok(_) => return not_found("installation not found"),
         Err(e) => {
             tracing::error!("failed to get installation: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+
+    match db::count_projects_for_installation(&state.db, &install_id).await {
+        Ok(n) if n > 0 => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "cannot unlink installation: {n} project(s) still reference it. \
+                         Delete the projects first."
+                    )
+                })),
+            )
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!("failed to count projects for installation: {e}");
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     }


### PR DESCRIPTION
Part of #58 — implements #59 (Phase 0).

## Summary

Lays the organizational foundation needed to onboard any repo as a
first-class factory tenant. Four tables plus a `sessions.project_id`
column land together so future enterprise features (roles, invites,
billing) are purely additive — no auth-table migration later.

- **Schema**: `tenants`, `tenant_members`, `github_app_installations`,
  `projects`; nullable `sessions.project_id`. Pre-existing sessions stay
  as null-project personal sessions forever (no migration UI).
- **Domain types** in `crates/stiglab/src/core/`: `Tenant`,
  `TenantMember`, `GitHubAppInstallation`, `Project`.
- **Routes** (`crates/stiglab/src/server/routes/tenants.rs`):
  `/api/tenants`, `/api/tenants/{id}/members`,
  `/api/tenants/{id}/github-installations[/{install_id}]`,
  `/api/tenants/{id}/projects`, `/api/projects`, `/api/projects/{id}`.
  All tenant-scoped endpoints funnel through `require_tenant_member`,
  which returns **404 (not 403)** for non-members so tenant IDs can't be
  enumerated.
- **Session creation** now accepts `project_id`; non-members get 404
  via the same helper so they can't create sessions against projects
  they don't own.
- **Webhook secrets** stored encrypted at rest using the existing
  credential-key AES-256-GCM path.
- **Dashboard**: new "Workspaces" Settings card with nested Members
  (read-only), Installations, and Projects; `CreateSessionSheet`
  gains a workspace → project cascade selector.

## v1 simplifications (per spec alignment on #58)

- No `role` column, no invite flow, no RBAC — `tenant_members` is
  bare (joined_at only). The follow-up spec can `ALTER TABLE ADD
  COLUMN role` with zero backfill.
- No cascades, no soft-delete. Project delete blocks with a clear
  error when any attached session is not in a terminal state.
- **Opt-in per repo** — installing the App on an org never
  auto-mirrors its repos.
- Non-members see 404 on tenant-scoped endpoints.
- `default_branch` defaults to `"main"` when not supplied (GitHub
  API inference requires an installation access token that the Phase 0
  stub can't mint — frozen API shape means the callback flow lands
  additively).

## Intentional follow-ups (not this PR)

- Full GitHub App OAuth callback flow with the modal workspace
  picker. Phase 0 ships the manual-entry endpoint
  (`POST /api/tenants/:id/github-installations`) with identical shape
  so the callback is purely additive. Listed in #58's deferred items.
- `default_branch` inference via installation access tokens.
- "Add Project" dropdown scoped to the installation's accessible
  repos (requires the same installation access token path).
- Full `tenant_members.role` + invite flow.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (5 new DB CRUD tests cover
      tenant round-trip, membership queries, installation + project
      CRUD, `delete_project_blocks_on_live_sessions`, and
      `list_projects_for_user` membership scoping; 2 new core tests
      cover `GitHubAccountType` display/parse/serde)
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds
- [x] `pnpm test` (41 tests pass)
- [ ] Manual smoke on dev stack: create a Workspace, register an
      installation, add a Project, create a session scoped to it,
      verify non-members get 404 on tenant-scoped routes.
