### PR TITLE
feat(portal,ising,stiglab,spine): land Phases 1-3 of issue #58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "onsager-portal"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "base64",
+ "chrono",
+ "clap",
+ "hex",
+ "onsager-artifact",
+ "onsager-spine",
+ "refract",
+ "regex",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "onsager-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/onsager-protocol",
     "crates/onsager-spine",
     "crates/onsager",
+    "crates/onsager-portal",
     "crates/forge",
     "crates/ising",
     "crates/refract",

--- a/crates/forge/src/core/session_listener.rs
+++ b/crates/forge/src/core/session_listener.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 
-/// A parsed stiglab.session_completed event (issue #14 phase 2, #39).
+/// A parsed stiglab.session_completed event (issue #14 phase 2, #39, #60).
 #[derive(Debug, Clone)]
 pub struct SessionCompleted {
     pub event_id: i64,
@@ -32,6 +32,13 @@ pub struct SessionCompleted {
     pub artifact_id: Option<String>,
     /// LLM token usage, if the producing runtime reported it (issue #39).
     pub token_usage: Option<onsager_spine::factory_event::TokenUsage>,
+    /// Working-tree branch the agent pushed (issue #60), used by the portal
+    /// for PR↔session vertical lineage. `None` when the agent didn't write
+    /// to a git working dir.
+    pub branch: Option<String>,
+    /// PR number known at session completion (issue #60). Optional for the
+    /// same reason as `branch`.
+    pub pr_number: Option<u64>,
 }
 
 /// Caller-supplied callback invoked for every session completion.
@@ -92,6 +99,8 @@ impl<H: SessionCompletedHandler> Dispatcher<H> {
             duration_ms,
             artifact_id,
             token_usage,
+            branch,
+            pr_number,
         } = kind
         else {
             return Ok(None);
@@ -104,6 +113,8 @@ impl<H: SessionCompletedHandler> Dispatcher<H> {
             duration_ms,
             artifact_id,
             token_usage,
+            branch,
+            pr_number,
         }))
     }
 }
@@ -160,6 +171,8 @@ mod tests {
                 duration_ms: 42,
                 artifact_id: Some("art_test".into()),
                 token_usage: None,
+                branch: None,
+                pr_number: None,
             })
             .await
             .unwrap();

--- a/crates/ising/src/analyzers/gate_deny_rate.rs
+++ b/crates/ising/src/analyzers/gate_deny_rate.rs
@@ -1,0 +1,213 @@
+//! `gate_deny_rate` analyzer (issue #62).
+//!
+//! Sister of `gate_override`, but inverted: when *forge*-emitted Deny
+//! verdicts dominate within a rolling window, the rule producing them is a
+//! candidate for *Rewrite* (relax the condition) rather than `Retire`
+//! (drop entirely). Keeps Phase 3 honest about runaway gates that block
+//! every PR — a healthy factory has both Allow and Deny outcomes.
+
+use chrono::Duration;
+use onsager_artifact::Kind;
+use onsager_protocol::{FactoryEventRef, Insight};
+use onsager_spine::factory_event::{InsightKind, InsightScope, VerdictSummary};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+pub const SIGNAL_KIND: &str = "gate_deny_rate";
+
+#[derive(Debug, Clone)]
+pub struct GateDenyRateConfig {
+    pub window: Duration,
+    /// Minimum verdicts in the window before a rate is computed.
+    pub min_samples: usize,
+    /// Deny rate at or above which the kind is flagged. Default 0.40 mirrors
+    /// the spec's worked example (`>40% over last 20 PRs`).
+    pub min_deny_rate: f64,
+}
+
+impl Default for GateDenyRateConfig {
+    fn default() -> Self {
+        Self {
+            window: Duration::days(7),
+            min_samples: 20,
+            min_deny_rate: 0.40,
+        }
+    }
+}
+
+pub struct GateDenyRateAnalyzer {
+    config: GateDenyRateConfig,
+}
+
+impl GateDenyRateAnalyzer {
+    pub fn new(config: GateDenyRateConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for GateDenyRateAnalyzer {
+    fn default() -> Self {
+        Self::new(GateDenyRateConfig::default())
+    }
+}
+
+impl Analyzer for GateDenyRateAnalyzer {
+    fn name(&self) -> &str {
+        SIGNAL_KIND
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let cutoff = chrono::Utc::now() - self.config.window;
+        let mut by_kind: std::collections::HashMap<Kind, Vec<i64>> = Default::default();
+        let mut totals: std::collections::HashMap<Kind, usize> = Default::default();
+        let mut deny_ids: std::collections::HashMap<Kind, Vec<i64>> = Default::default();
+
+        for r in model
+            .gate_verdict_records
+            .iter()
+            .filter(|r| r.recorded_at >= cutoff)
+        {
+            let Some(art) = model.artifacts.get(r.artifact_id.as_str()) else {
+                continue;
+            };
+            *totals.entry(art.kind.clone()).or_default() += 1;
+            by_kind
+                .entry(art.kind.clone())
+                .or_default()
+                .push(r.event_id);
+            if matches!(r.verdict, VerdictSummary::Deny) {
+                deny_ids
+                    .entry(art.kind.clone())
+                    .or_default()
+                    .push(r.event_id);
+            }
+        }
+
+        totals
+            .into_iter()
+            .filter_map(|(kind, total)| {
+                if total < self.config.min_samples {
+                    return None;
+                }
+                let denies = deny_ids.get(&kind).map(|v| v.len()).unwrap_or(0);
+                let rate = denies as f64 / total as f64;
+                if rate < self.config.min_deny_rate {
+                    return None;
+                }
+                let mut evidence_ids = deny_ids.get(&kind).cloned().unwrap_or_default();
+                evidence_ids.sort_unstable_by(|a, b| b.cmp(a));
+                evidence_ids.truncate(5);
+                let evidence: Vec<FactoryEventRef> = evidence_ids
+                    .into_iter()
+                    .map(|event_id| FactoryEventRef {
+                        event_id,
+                        event_type: "forge.gate_verdict".into(),
+                    })
+                    .collect();
+                let kind_label = kind.to_string();
+                let denom = self.config.min_deny_rate.max(0.01);
+                let excess = ((rate - self.config.min_deny_rate) / denom).max(0.0);
+                let confidence = (0.6 + excess * 0.3).min(0.95);
+                Some(Insight {
+                    insight_id: format!("ins_gdr_{kind_label}_{denies}_{total}"),
+                    kind: InsightKind::Failure,
+                    scope: InsightScope::ArtifactKind(kind_label.clone()),
+                    observation: format!(
+                        "{kind_label}: {denies}/{total} ({:.0}%) verdicts denied over the last \
+                         {} day(s) — the gate may be too strict; review the rule before it \
+                         becomes friction overhead",
+                        rate * 100.0,
+                        self.config.window.num_days(),
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::ArtifactId;
+    use onsager_spine::factory_event::{FactoryEventKind, GatePoint};
+
+    fn register(model: &mut FactoryModel, id: &ArtifactId, kind: Kind, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ArtifactRegistered {
+                artifact_id: id.clone(),
+                kind,
+                name: "x".into(),
+                owner: "marvin".into(),
+            },
+        );
+    }
+
+    fn verdict(model: &mut FactoryModel, id: &ArtifactId, v: VerdictSummary, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::ForgeGateVerdict {
+                artifact_id: id.clone(),
+                gate_point: GatePoint::StateTransition,
+                verdict: v,
+            },
+        );
+    }
+
+    #[test]
+    fn fires_when_deny_rate_exceeds_threshold() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_code");
+        register(&mut model, &id, Kind::Code, 1);
+        for i in 0..10 {
+            verdict(&mut model, &id, VerdictSummary::Deny, i + 2);
+        }
+        for i in 0..10 {
+            verdict(&mut model, &id, VerdictSummary::Allow, i + 12);
+        }
+        // 10/20 = 50% > 40% threshold, exactly 20 samples = at threshold.
+        let insights = GateDenyRateAnalyzer::default().run(&model);
+        assert_eq!(insights.len(), 1);
+        assert_eq!(insights[0].evidence.len(), 5);
+        assert!(insights[0]
+            .evidence
+            .iter()
+            .all(|e| e.event_type == "forge.gate_verdict"));
+    }
+
+    #[test]
+    fn does_not_fire_below_threshold() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_code");
+        register(&mut model, &id, Kind::Code, 1);
+        // 4 denies / 20 total = 20% — under 40%.
+        for i in 0..4 {
+            verdict(&mut model, &id, VerdictSummary::Deny, i + 2);
+        }
+        for i in 0..16 {
+            verdict(&mut model, &id, VerdictSummary::Allow, i + 6);
+        }
+        assert!(GateDenyRateAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn does_not_fire_below_min_samples() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_code");
+        register(&mut model, &id, Kind::Code, 1);
+        for i in 0..5 {
+            verdict(&mut model, &id, VerdictSummary::Deny, i + 2);
+        }
+        // 5 denies, 5 total — far above threshold rate but below min_samples.
+        assert!(GateDenyRateAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn analyzer_name_is_signal_kind() {
+        assert_eq!(GateDenyRateAnalyzer::default().name(), SIGNAL_KIND);
+    }
+}

--- a/crates/ising/src/analyzers/mod.rs
+++ b/crates/ising/src/analyzers/mod.rs
@@ -2,12 +2,16 @@
 //!
 //! v0.1 ships with heuristic analyzers, not learned models (ising-v0.1 §6).
 
+pub mod gate_deny_rate;
 pub mod gate_override;
+pub mod pr_churn;
 pub mod repeated_failures;
 pub mod shape_retry_spike;
 pub mod stuck_artifacts;
 
+pub use gate_deny_rate::GateDenyRateAnalyzer;
 pub use gate_override::GateOverrideAnalyzer;
+pub use pr_churn::PrChurnAnalyzer;
 pub use repeated_failures::RepeatedFailuresAnalyzer;
 pub use shape_retry_spike::ShapeRetrySpikeAnalyzer;
 pub use stuck_artifacts::StuckArtifactsAnalyzer;
@@ -20,4 +24,6 @@ pub fn register_defaults(registry: &mut AnalyzerRegistry) {
     registry.register(Box::new(StuckArtifactsAnalyzer::default()));
     registry.register(Box::new(GateOverrideAnalyzer::default()));
     registry.register(Box::new(ShapeRetrySpikeAnalyzer::default()));
+    registry.register(Box::new(PrChurnAnalyzer::default()));
+    registry.register(Box::new(GateDenyRateAnalyzer::default()));
 }

--- a/crates/ising/src/analyzers/pr_churn.rs
+++ b/crates/ising/src/analyzers/pr_churn.rs
@@ -12,6 +12,7 @@
 //! threshold the root sits.
 
 use chrono::Duration;
+use onsager_artifact::ArtifactId;
 use onsager_protocol::{FactoryEventRef, Insight};
 use onsager_spine::factory_event::{InsightKind, InsightScope};
 
@@ -90,7 +91,11 @@ impl Analyzer for PrChurnAnalyzer {
                 Some(Insight {
                     insight_id: format!("ins_prc_{root}_{opened}"),
                     kind: InsightKind::Waste,
-                    scope: InsightScope::ArtifactKind(root.clone()),
+                    // `root` is the PR artifact id today (lineage-root
+                    // widening is a future follow-up) — use the specific
+                    // artifact scope so the emitter routes it correctly,
+                    // rather than mislabelling it as a `Kind`.
+                    scope: InsightScope::SpecificArtifact(ArtifactId::new(root.clone())),
                     observation: format!(
                         "{root}: {opened} PR opens vs {merged} merges over the last {} days — \
                          the spec or PreDispatch gate may be too loose, letting under-baked \

--- a/crates/ising/src/analyzers/pr_churn.rs
+++ b/crates/ising/src/analyzers/pr_churn.rs
@@ -1,0 +1,194 @@
+//! `pr_churn` analyzer (issue #62).
+//!
+//! Surfaces lineage roots where the factory has opened many PRs without a
+//! corresponding merge. The intuition: if the same artifact keeps
+//! re-opening PRs the gate or the spec is mis-shaped — the right downstream
+//! response is a `PreDispatch` rule that requires (e.g.) passing tests
+//! before opening the PR, or a tighter design-review hop.
+//!
+//! Emission shape: `signal_kind = "pr_churn"`, `subject_ref` is the lineage
+//! root (today the PR artifact id), `evidence` is up to five recent
+//! `git.pr_opened` event ids, `confidence` scales with how far above the
+//! threshold the root sits.
+
+use chrono::Duration;
+use onsager_protocol::{FactoryEventRef, Insight};
+use onsager_spine::factory_event::{InsightKind, InsightScope};
+
+use crate::core::analyzer::Analyzer;
+use crate::core::model::FactoryModel;
+
+/// Stable signal identifier emitted on the spine for this analyzer's output.
+pub const SIGNAL_KIND: &str = "pr_churn";
+
+/// Configuration for the PR-churn analyzer.
+#[derive(Debug, Clone)]
+pub struct PrChurnConfig {
+    /// Lookback window over which PR records are considered.
+    pub window: Duration,
+    /// Minimum number of opened PRs against the same lineage root that
+    /// triggers a proposal. Three is conservative — too low produces noise
+    /// on small projects, too high never fires on healthy projects.
+    pub min_opens: usize,
+}
+
+impl Default for PrChurnConfig {
+    fn default() -> Self {
+        Self {
+            window: Duration::days(14),
+            min_opens: 3,
+        }
+    }
+}
+
+/// Detects lineage roots with elevated PR-churn (many opens before a merge).
+pub struct PrChurnAnalyzer {
+    config: PrChurnConfig,
+}
+
+impl PrChurnAnalyzer {
+    pub fn new(config: PrChurnConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for PrChurnAnalyzer {
+    fn default() -> Self {
+        Self::new(PrChurnConfig::default())
+    }
+}
+
+impl Analyzer for PrChurnAnalyzer {
+    fn name(&self) -> &str {
+        SIGNAL_KIND
+    }
+
+    fn run(&self, model: &FactoryModel) -> Vec<Insight> {
+        let activity = model.pr_activity_by_root(self.config.window);
+        activity
+            .into_iter()
+            .filter_map(|(root, (opened, merged, evidence))| {
+                if opened < self.config.min_opens {
+                    return None;
+                }
+                // If everything merged, there's no churn; require at least
+                // one un-merged open to fire (otherwise a healthy stream of
+                // five quick PRs would look like churn).
+                if merged >= opened {
+                    return None;
+                }
+                let evidence: Vec<FactoryEventRef> = evidence
+                    .into_iter()
+                    .map(|event_id| FactoryEventRef {
+                        event_id,
+                        event_type: "git.pr_opened".into(),
+                    })
+                    .collect();
+                let denom = self.config.min_opens.max(1) as f64;
+                let excess = ((opened as f64 - self.config.min_opens as f64) / denom).max(0.0);
+                let confidence = (0.6 + excess * 0.3).min(0.95);
+                Some(Insight {
+                    insight_id: format!("ins_prc_{root}_{opened}"),
+                    kind: InsightKind::Waste,
+                    scope: InsightScope::ArtifactKind(root.clone()),
+                    observation: format!(
+                        "{root}: {opened} PR opens vs {merged} merges over the last {} days — \
+                         the spec or PreDispatch gate may be too loose, letting under-baked \
+                         PRs reach review",
+                        self.config.window.num_days(),
+                    ),
+                    evidence,
+                    suggested_action: None,
+                    confidence,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::ArtifactId;
+    use onsager_spine::factory_event::FactoryEventKind;
+
+    fn open(model: &mut FactoryModel, id: &ArtifactId, pr: u64, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::GitPrOpened {
+                artifact_id: id.clone(),
+                repo: "x/y".into(),
+                pr_number: pr,
+                url: format!("https://example.com/pr/{pr}"),
+            },
+        );
+    }
+
+    fn merge(model: &mut FactoryModel, id: &ArtifactId, pr: u64, seq: i64) {
+        model.ingest(
+            seq,
+            &FactoryEventKind::GitPrMerged {
+                artifact_id: id.clone(),
+                pr_number: pr,
+                merge_sha: "deadbeef".into(),
+            },
+        );
+    }
+
+    #[test]
+    fn fires_on_three_opens_no_merge() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_pr_root");
+        for i in 0..3 {
+            open(&mut model, &id, i + 1, (i as i64) + 1);
+        }
+        let insights = PrChurnAnalyzer::default().run(&model);
+        assert_eq!(insights.len(), 1);
+        assert_eq!(insights[0].evidence.len(), 3);
+        assert!(insights[0]
+            .evidence
+            .iter()
+            .all(|e| e.event_type == "git.pr_opened"));
+    }
+
+    #[test]
+    fn does_not_fire_on_one_clean_pr() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_pr_root");
+        open(&mut model, &id, 1, 1);
+        merge(&mut model, &id, 1, 2);
+        assert!(PrChurnAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn does_not_fire_when_all_merged() {
+        let mut model = FactoryModel::new();
+        let id = ArtifactId::new("art_pr_root");
+        for i in 0..3 {
+            open(&mut model, &id, i + 1, (i as i64) + 1);
+            merge(&mut model, &id, i + 1, (i as i64) + 1);
+        }
+        assert!(PrChurnAnalyzer::default().run(&model).is_empty());
+    }
+
+    #[test]
+    fn confidence_climbs_with_open_count() {
+        let mut model_low = FactoryModel::new();
+        let mut model_high = FactoryModel::new();
+        let id = ArtifactId::new("art_pr_root");
+        for i in 0..3 {
+            open(&mut model_low, &id, i + 1, (i as i64) + 1);
+        }
+        for i in 0..10 {
+            open(&mut model_high, &id, i + 1, (i as i64) + 1);
+        }
+        let low = &PrChurnAnalyzer::default().run(&model_low)[0];
+        let high = &PrChurnAnalyzer::default().run(&model_high)[0];
+        assert!(high.confidence >= low.confidence);
+    }
+
+    #[test]
+    fn analyzer_name_is_signal_kind() {
+        assert_eq!(PrChurnAnalyzer::default().name(), SIGNAL_KIND);
+    }
+}

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -138,22 +138,26 @@ async fn run_tick(
 }
 
 /// Rebuild an in-memory [`FactoryModel`] from the recent-events window in
-/// `events_ext`. Parses the hand-coded JSON payloads Forge / Stiglab write
-/// today — once events are emitted through a typed spine helper this parser
-/// collapses to `serde_json::from_value`.
+/// `events_ext`. Parses the hand-coded JSON payloads Forge / Stiglab / the
+/// portal write today — once events are emitted through a typed spine helper
+/// this parser collapses to `serde_json::from_value`.
 async fn build_model(spine: &EventStore) -> Result<FactoryModel, anyhow::Error> {
     let cutoff = Utc::now() - LOOKBACK;
-    let rows = spine
+    // Pull both the `forge` and `git` namespaces — Phase 3 analyzers
+    // (`pr_churn`, `gate_deny_rate`) need the full PR + verdict stream.
+    let mut rows = spine
         .query_ext_events(None, Some("forge"), EVENT_FETCH_LIMIT)
         .await?;
+    let git_rows = spine
+        .query_ext_events(None, Some("git"), EVENT_FETCH_LIMIT)
+        .await?;
+    rows.extend(git_rows);
 
-    // If we pulled the whole fetch cap and the oldest row we got is still
-    // inside the lookback window, there are events we didn't load. The
-    // override rate is then computed from a truncated slice — surface it
-    // loudly rather than silently under-count. A DB-side `created_at >=
-    // cutoff` filter is the structural fix and belongs in the EventStore
-    // API; this warning is the cheap forcing function to get us there.
-    if rows.len() as i64 >= EVENT_FETCH_LIMIT
+    // If we pulled the whole fetch cap on either namespace and the oldest
+    // row we got is still inside the lookback window, there are events we
+    // didn't load. The override rate is then computed from a truncated
+    // slice — surface it loudly rather than silently under-count.
+    if rows.len() as i64 >= EVENT_FETCH_LIMIT * 2
         && rows
             .iter()
             .map(|r| r.created_at)
@@ -163,14 +167,13 @@ async fn build_model(spine: &EventStore) -> Result<FactoryModel, anyhow::Error> 
         tracing::warn!(
             event_fetch_limit = EVENT_FETCH_LIMIT,
             lookback_days = LOOKBACK.num_days(),
-            "ising: forge event fetch cap reached before lookback cutoff; \
+            "ising: spine fetch cap reached before lookback cutoff; \
              model window may be incomplete"
         );
     }
 
     // Rows come back newest-first; ingest oldest-first so event_id ordering
     // inside the model matches spine order.
-    let mut rows = rows;
     rows.sort_by_key(|r| r.id);
 
     let mut model = FactoryModel::new();
@@ -228,6 +231,43 @@ fn parse_forge_event(event_type: &str, data: &serde_json::Value) -> Option<Facto
                 artifact_id: ArtifactId::new(artifact_id),
                 gate_point,
                 verdict,
+            })
+        }
+        // `git.pr_*` events arrive from `onsager-portal` (issue #60). Phase
+        // 3 analyzers (`pr_churn`, `gate_deny_rate`) are the consumers; the
+        // model already knows how to ingest these variants.
+        "git.pr_opened" => {
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let pr_number = data.get("pr_number")?.as_u64()?;
+            let repo = data
+                .get("repo")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let url = data
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(FactoryEventKind::GitPrOpened {
+                artifact_id: ArtifactId::new(artifact_id),
+                repo,
+                pr_number,
+                url,
+            })
+        }
+        "git.pr_merged" => {
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let pr_number = data.get("pr_number")?.as_u64()?;
+            let merge_sha = data
+                .get("merge_sha")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(FactoryEventKind::GitPrMerged {
+                artifact_id: ArtifactId::new(artifact_id),
+                pr_number,
+                merge_sha,
             })
         }
         "forge.shaping_returned" => {

--- a/crates/ising/src/core/emission.rs
+++ b/crates/ising/src/core/emission.rs
@@ -87,6 +87,24 @@ pub fn insight_to_rule_proposal(signal_kind: &str, insight: &Insight) -> Option<
                 "cap rework on `{subject_ref}` artifacts (e.g. max_shapings_per_artifact)"
             )),
         },
+        "pr_churn" => RuleProposalAction::Introduce {
+            // Churn means PRs land before they're ready. Suggest a
+            // `PreDispatch` gate that requires evidence (passing tests,
+            // human design-review) before the PR opens.
+            subject_ref: subject_ref.clone(),
+            suggested_condition: Some(format!(
+                "require PreDispatch evidence for `{subject_ref}` (passing tests + design review)"
+            )),
+        },
+        "gate_deny_rate" => RuleProposalAction::Rewrite {
+            // High deny rate often means the rule is over-strict, not the
+            // contributors. Rewrite — relax the predicate — rather than
+            // retire it outright.
+            rule_id: subject_ref.clone(),
+            suggested_condition: Some(format!(
+                "relax gate predicate for `{subject_ref}`; current rule denies > 40% of PRs"
+            )),
+        },
         _ => return None,
     };
 

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -54,6 +54,24 @@ pub struct TrackedArtifact {
     pub last_updated: DateTime<Utc>,
 }
 
+/// One PR observation derived from the spine `git.*` stream (issue #62).
+/// `lineage_root` collapses to the artifact id today — once Forge writes
+/// horizontal lineage between specs and PRs, the analyzer can climb to the
+/// real root. Until then, "PRs that share a lineage root" means "PRs that
+/// touch the same PR artifact" — enough for the churn signal because every
+/// reopened-with-new-branch attempt creates a fresh PR row.
+#[derive(Debug, Clone)]
+pub struct PrRecord {
+    pub event_id: i64,
+    pub artifact_id: ArtifactId,
+    pub pr_number: u64,
+    /// Logical bucket key for the churn analyzer. Today equals
+    /// `artifact_id.as_str()`; future lineage walking can rewrite this.
+    pub lineage_root: String,
+    pub merged: bool,
+    pub recorded_at: DateTime<Utc>,
+}
+
 /// Accumulated factory model — the internal state Ising maintains.
 #[derive(Debug)]
 pub struct FactoryModel {
@@ -66,6 +84,9 @@ pub struct FactoryModel {
     /// Gate verdict records observed by the model (same retention contract
     /// as `shaping_records`).
     pub gate_verdict_records: Vec<GateVerdictRecord>,
+    /// PR records derived from `git.pr_*` events (issue #62). Same retention
+    /// contract as `shaping_records` — caller windows by `recorded_at`.
+    pub pr_records: Vec<PrRecord>,
     /// Total events processed.
     pub events_processed: u64,
     /// Last processed event ID (for catch-up).
@@ -78,6 +99,7 @@ impl FactoryModel {
             artifacts: HashMap::new(),
             shaping_records: Vec::new(),
             gate_verdict_records: Vec::new(),
+            pr_records: Vec::new(),
             events_processed: 0,
             last_event_id: None,
         }
@@ -179,6 +201,52 @@ impl FactoryModel {
                     verdict: verdict.clone(),
                     recorded_at,
                 });
+            }
+
+            // PR lifecycle (issue #62) — every git.pr_opened becomes one
+            // record; git.pr_merged flips the most recent matching open
+            // record to `merged=true` so the churn analyzer can count
+            // un-merged opens vs. merged outcomes.
+            FactoryEventKind::GitPrOpened {
+                artifact_id,
+                pr_number,
+                ..
+            } => {
+                let lineage_root = artifact_id.as_str().to_owned();
+                self.pr_records.push(PrRecord {
+                    event_id,
+                    artifact_id: artifact_id.clone(),
+                    pr_number: *pr_number,
+                    lineage_root,
+                    merged: false,
+                    recorded_at,
+                });
+            }
+            FactoryEventKind::GitPrMerged {
+                artifact_id,
+                pr_number,
+                ..
+            } => {
+                if let Some(record) = self
+                    .pr_records
+                    .iter_mut()
+                    .rev()
+                    .find(|r| r.artifact_id == *artifact_id && r.pr_number == *pr_number)
+                {
+                    record.merged = true;
+                    record.recorded_at = recorded_at;
+                } else {
+                    // Merged with no observed open — backfill loaded the merge
+                    // event but missed the open. Track it as a merged record.
+                    self.pr_records.push(PrRecord {
+                        event_id,
+                        artifact_id: artifact_id.clone(),
+                        pr_number: *pr_number,
+                        lineage_root: artifact_id.as_str().to_owned(),
+                        merged: true,
+                        recorded_at,
+                    });
+                }
             }
 
             _ => {}
@@ -328,6 +396,44 @@ impl FactoryModel {
             .map(|a| {
                 let records = self.shaping_history(&a.artifact_id);
                 (a, records)
+            })
+            .collect()
+    }
+
+    /// PR records observed within `window`, grouped by `lineage_root`.
+    /// Caller chooses what to do with merged-vs-unmerged distribution per
+    /// group (the `pr_churn` analyzer counts unmerged opens before the
+    /// first merge).
+    pub fn pr_records_since(&self, cutoff: DateTime<Utc>) -> Vec<&PrRecord> {
+        self.pr_records
+            .iter()
+            .filter(|r| r.recorded_at >= cutoff)
+            .collect()
+    }
+
+    /// Per-`lineage_root` (artifact id today, future: spec lineage root)
+    /// summary of PR activity within `window`. Returns
+    /// `(opened_count, merged_count, evidence event ids)` so analyzers can
+    /// reason about churn (many opens before a merge) or regression (many
+    /// merges in close succession).
+    pub fn pr_activity_by_root(
+        &self,
+        window: Duration,
+    ) -> HashMap<String, (usize, usize, Vec<i64>)> {
+        let cutoff = Utc::now() - window;
+        let mut buckets: HashMap<String, Vec<&PrRecord>> = HashMap::new();
+        for r in self.pr_records_since(cutoff) {
+            buckets.entry(r.lineage_root.clone()).or_default().push(r);
+        }
+        buckets
+            .into_iter()
+            .map(|(root, recs)| {
+                let opened = recs.len();
+                let merged = recs.iter().filter(|r| r.merged).count();
+                let mut evidence: Vec<i64> = recs.iter().map(|r| r.event_id).collect();
+                evidence.sort_unstable_by(|a, b| b.cmp(a));
+                evidence.truncate(5);
+                (root, (opened, merged, evidence))
             })
             .collect()
     }

--- a/crates/onsager-portal/Cargo.toml
+++ b/crates/onsager-portal/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "onsager-portal"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "GitHub webhook ingress for the Onsager factory — verifies, resolves, emits"
+
+[lib]
+name = "onsager_portal"
+path = "src/lib.rs"
+
+[[bin]]
+name = "onsager-portal"
+path = "src/main.rs"
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+onsager-spine = { path = "../onsager-spine" }
+refract = { path = "../refract" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+axum = { workspace = true }
+reqwest = { workspace = true }
+sqlx = { workspace = true }
+ring = { workspace = true }
+hex = { workspace = true }
+base64 = { workspace = true }
+regex = "1"

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -1,0 +1,280 @@
+//! Backfill — bulk-ingest a project's existing issues + PRs.
+//!
+//! Three strategies:
+//!
+//! - `recent` (default): the most-recent N items, paginated newest-first.
+//!   Cheap; the right default for onboarding a fresh project.
+//! - `active`: weighted by recent activity — strips stale items so a
+//!   long-tail repo doesn't ingest a thousand year-old issues just to
+//!   reach `cap`.
+//! - `refract`: pipes the candidate set through Refract's prioritization
+//!   scaffolding to surface a useful slice of a VS-Code-scale repo (issue
+//!   #58 / #60 §Backfill).
+//!
+//! Output shape is a `BackfillReport` summarizing per-strategy counts so
+//! the CLI can print a single JSON blob the dashboard can later render.
+
+use std::str::FromStr;
+
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+
+use onsager_artifact::ArtifactId;
+use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::{EventMetadata, EventStore};
+
+use crate::db::{self, PrLifecycleState};
+use crate::github::{Client, Issue, Pull};
+use crate::handlers::issues::SPEC_LABEL;
+
+/// Ingestion strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Strategy {
+    Recent,
+    Active,
+    Refract,
+}
+
+impl FromStr for Strategy {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "recent" => Ok(Strategy::Recent),
+            "active" => Ok(Strategy::Active),
+            "refract" => Ok(Strategy::Refract),
+            other => anyhow::bail!("unknown strategy: {other}"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BackfillReport {
+    pub strategy: String,
+    pub project_id: String,
+    pub repo: String,
+    pub cap: usize,
+    pub prs_ingested: usize,
+    pub tasks_materialized: usize,
+    pub skipped: usize,
+}
+
+/// Drive the chosen strategy against the project's repo. Pulls candidates
+/// from the GitHub REST API, then funnels them through the same write paths
+/// the live webhook handler uses, so backfilled and live-streamed events
+/// have identical shapes.
+pub async fn run(
+    pool: &PgPool,
+    spine: &EventStore,
+    project_id: &str,
+    strategy: Strategy,
+    cap: usize,
+    github_token: Option<String>,
+) -> anyhow::Result<BackfillReport> {
+    let project = db::get_project(pool, project_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("project not found"))?;
+    let client = Client::new(github_token);
+
+    let issues = client
+        .list_recent_issues(&project.repo_owner, &project.repo_name, cap)
+        .await?;
+    let pulls = client
+        .list_recent_pulls(&project.repo_owner, &project.repo_name, cap)
+        .await?;
+
+    let (issues, pulls) = match strategy {
+        Strategy::Recent => (issues, pulls),
+        Strategy::Active => (
+            issues.into_iter().filter(|i| i.state == "open").collect(),
+            pulls
+                .into_iter()
+                .filter(|p| p.state == "open" || p.merged_at.is_some())
+                .collect(),
+        ),
+        Strategy::Refract => {
+            // Reuses Refract's intent decomposer scaffolding as a generic
+            // candidate prioritizer: each backlog item is treated as an
+            // intent, the decomposer ranks them, and we keep the top `cap`.
+            // The exact ranking heuristic lives in
+            // `refract::backlog_prioritize` so future tuning is decoupled
+            // from the portal.
+            (
+                refract_prioritize_issues(issues, cap),
+                refract_prioritize_pulls(pulls, cap),
+            )
+        }
+    };
+
+    let mut report = BackfillReport {
+        strategy: format!("{strategy:?}").to_lowercase(),
+        project_id: project.id.clone(),
+        repo: format!("{}/{}", project.repo_owner, project.repo_name),
+        cap,
+        ..Default::default()
+    };
+
+    let metadata = EventMetadata {
+        actor: "onsager-portal/backfill".into(),
+        ..Default::default()
+    };
+
+    for pr in pulls {
+        let next_state = match (pr.state.as_str(), pr.merged_at.is_some()) {
+            (_, true) => PrLifecycleState::Released,
+            ("closed", false) => PrLifecycleState::Archived,
+            _ => PrLifecycleState::InProgress,
+        };
+        let artifact = db::upsert_pr_artifact(
+            pool,
+            &project.id,
+            pr.number,
+            &pr.title,
+            &pr.user.login,
+            next_state,
+        )
+        .await?;
+        let event = if pr.merged_at.is_some() {
+            FactoryEventKind::GitPrMerged {
+                artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+                pr_number: pr.number,
+                merge_sha: pr.head.sha.clone(),
+            }
+        } else if pr.state == "closed" {
+            FactoryEventKind::GitPrClosed {
+                artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+                pr_number: pr.number,
+            }
+        } else {
+            FactoryEventKind::GitPrOpened {
+                artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+                repo: format!("{}/{}", project.repo_owner, project.repo_name),
+                pr_number: pr.number,
+                url: pr.html_url.clone(),
+            }
+        };
+        let stream_id = crate::handlers::pull_request::pr_stream_id(&project.id, pr.number);
+        spine
+            .append_ext(
+                &stream_id,
+                "git",
+                event.event_type(),
+                serde_json::to_value(&event)?,
+                &metadata,
+                None,
+            )
+            .await?;
+        report.prs_ingested += 1;
+    }
+
+    for issue in issues {
+        if issue.is_pull_request() {
+            // PRs come back through the issues endpoint too; skip — they
+            // were handled in the pulls loop with full PR metadata.
+            continue;
+        }
+        if !issue.has_label(SPEC_LABEL) {
+            report.skipped += 1;
+            continue;
+        }
+        let source_ref = format!(
+            "github:{}/{}:issue#{}",
+            project.repo_owner, project.repo_name, issue.number
+        );
+        db::upsert_factory_task(
+            pool,
+            &project.id,
+            "spec_issue",
+            &source_ref,
+            &issue.title,
+            issue.body.as_deref(),
+        )
+        .await?;
+        report.tasks_materialized += 1;
+    }
+
+    Ok(report)
+}
+
+/// Refract-style prioritization for issues. Today the heuristic is "open
+/// before closed, more labels first" — a placeholder that demonstrates the
+/// shape; the future LLM-backed scorer slots in here without changing the
+/// portal call site.
+fn refract_prioritize_issues(mut issues: Vec<Issue>, cap: usize) -> Vec<Issue> {
+    issues.sort_by(|a, b| {
+        let key = |i: &Issue| {
+            let open = i.state == "open";
+            let labels = i.labels.len();
+            (open as i32, labels as i32)
+        };
+        key(b).cmp(&key(a))
+    });
+    issues.truncate(cap);
+    issues
+}
+
+/// Refract-style prioritization for pulls. Open-then-merged-then-closed,
+/// plus prefer base-branch=main as the most likely workflow signal.
+fn refract_prioritize_pulls(mut pulls: Vec<Pull>, cap: usize) -> Vec<Pull> {
+    pulls.sort_by(|a, b| {
+        let key = |p: &Pull| {
+            let open = p.state == "open";
+            let merged = p.merged_at.is_some();
+            let primary_base = p.base.ref_name == "main" || p.base.ref_name == "master";
+            (open as i32, merged as i32, primary_base as i32)
+        };
+        key(b).cmp(&key(a))
+    });
+    pulls.truncate(cap);
+    pulls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue(number: u64, state: &str, labels: &[&str]) -> Issue {
+        Issue {
+            number,
+            title: format!("issue {number}"),
+            state: state.into(),
+            body: None,
+            labels: labels
+                .iter()
+                .map(|n| crate::github::Label { name: (*n).into() })
+                .collect(),
+            pull_request: None,
+        }
+    }
+
+    #[test]
+    fn refract_orders_open_before_closed() {
+        let mixed = vec![
+            issue(1, "closed", &[]),
+            issue(2, "open", &["bug"]),
+            issue(3, "open", &["bug", "spec"]),
+            issue(4, "closed", &["spec", "perf", "ux"]),
+        ];
+        let prioritized = refract_prioritize_issues(mixed, 4);
+        // Most-labeled open first, then less-labeled open, then most-labeled closed.
+        assert_eq!(prioritized[0].number, 3);
+        assert_eq!(prioritized[1].number, 2);
+        assert_eq!(prioritized[2].number, 4);
+        assert_eq!(prioritized[3].number, 1);
+    }
+
+    #[test]
+    fn refract_respects_cap() {
+        let many: Vec<Issue> = (0..20).map(|n| issue(n, "open", &[])).collect();
+        let cut = refract_prioritize_issues(many, 5);
+        assert_eq!(cut.len(), 5);
+    }
+
+    #[test]
+    fn strategy_parses() {
+        assert_eq!("recent".parse::<Strategy>().unwrap(), Strategy::Recent);
+        assert_eq!("ACTIVE".parse::<Strategy>().unwrap(), Strategy::Active);
+        assert_eq!("Refract".parse::<Strategy>().unwrap(), Strategy::Refract);
+        assert!("nope".parse::<Strategy>().is_err());
+    }
+}

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -4,12 +4,14 @@
 //!
 //! - `recent` (default): the most-recent N items, paginated newest-first.
 //!   Cheap; the right default for onboarding a fresh project.
-//! - `active`: weighted by recent activity — strips stale items so a
-//!   long-tail repo doesn't ingest a thousand year-old issues just to
-//!   reach `cap`.
-//! - `refract`: pipes the candidate set through Refract's prioritization
-//!   scaffolding to surface a useful slice of a VS-Code-scale repo (issue
-//!   #58 / #60 §Backfill).
+//! - `active`: strips stale items (closed-but-unmerged PRs, closed issues)
+//!   so a long-tail repo doesn't spend its cap on year-old chatter.
+//! - `refract`: ranks the candidate set with a local priority heuristic
+//!   (open-before-closed, more labels first) — the in-tree placeholder for
+//!   the future LLM-backed scorer. Today it does NOT dispatch through the
+//!   `refract` crate's intent decomposer; the crate is carried as a
+//!   dependency so the scorer can land additively without a call-site
+//!   refactor (issue #58 / #60 §Backfill).
 //!
 //! Output shape is a `BackfillReport` summarizing per-strategy counts so
 //! the CLI can print a single JSON blob the dashboard can later render.
@@ -93,12 +95,11 @@ pub async fn run(
                 .collect(),
         ),
         Strategy::Refract => {
-            // Reuses Refract's intent decomposer scaffolding as a generic
-            // candidate prioritizer: each backlog item is treated as an
-            // intent, the decomposer ranks them, and we keep the top `cap`.
-            // The exact ranking heuristic lives in
-            // `refract::backlog_prioritize` so future tuning is decoupled
-            // from the portal.
+            // Placeholder ranking: open-before-closed, more-labelled first.
+            // The real LLM-backed scorer slots in here without changing the
+            // portal call site — today there is no `refract` crate API
+            // doing prioritization; the dependency is pre-wired so the
+            // scorer lands additively.
             (
                 refract_prioritize_issues(issues, cap),
                 refract_prioritize_pulls(pulls, cap),
@@ -134,11 +135,19 @@ pub async fn run(
             next_state,
         )
         .await?;
-        let event = if pr.merged_at.is_some() {
+        let event = if let Some(merge_sha) = pr
+            .merge_commit_sha
+            .clone()
+            .filter(|_| pr.merged_at.is_some())
+        {
+            // Only emit `GitPrMerged` when GitHub gave us the mainline merge
+            // commit. `pr.head.sha` is the PR-branch tip, not the merge
+            // commit — consumers correlating against `git log main` would
+            // miss the match.
             FactoryEventKind::GitPrMerged {
                 artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
                 pr_number: pr.number,
-                merge_sha: pr.head.sha.clone(),
+                merge_sha,
             }
         } else if pr.state == "closed" {
             FactoryEventKind::GitPrClosed {
@@ -181,7 +190,7 @@ pub async fn run(
             "github:{}/{}:issue#{}",
             project.repo_owner, project.repo_name, issue.number
         );
-        db::upsert_factory_task(
+        let task = db::upsert_factory_task(
             pool,
             &project.id,
             "spec_issue",
@@ -190,6 +199,27 @@ pub async fn run(
             issue.body.as_deref(),
         )
         .await?;
+        // Emit the same `portal.task_materialized` event the live webhook
+        // handler produces, so dashboard / ising consumers see a uniform
+        // stream whether the task came from backfill or a live `issues.opened`.
+        let stream_id = format!("portal:task:{}", task.id);
+        spine
+            .append_ext(
+                &stream_id,
+                "portal",
+                "portal.task_materialized",
+                serde_json::json!({
+                    "task_id": task.id,
+                    "project_id": project.id,
+                    "source": task.source,
+                    "source_ref": task.source_ref,
+                    "title": task.title,
+                    "backfill": true,
+                }),
+                &metadata,
+                None,
+            )
+            .await?;
         report.tasks_materialized += 1;
     }
 

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -1,0 +1,19 @@
+/// Runtime configuration shared across the webhook server and its handlers.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub bind: String,
+    pub database_url: String,
+    /// AES-256-GCM key (hex), shared with stiglab. When `None`, webhook-secret
+    /// decryption is disabled and only installations with a `NULL`
+    /// `webhook_secret_cipher` (signature verification skipped) are accepted.
+    /// Production deployments must always configure this.
+    pub credential_key: Option<String>,
+    /// Synodic gate URL (`http://host:port`). When `None`, the portal
+    /// short-circuits gate calls to a synthetic `Allow` verdict — useful for
+    /// local development without synodic running, but means real gates never
+    /// evaluate.
+    pub synodic_url: Option<String>,
+    /// Optional fallback GitHub token for posting check runs / comments.
+    /// Per-installation tokens (Phase 2 follow-up) are preferred.
+    pub github_token: Option<String>,
+}

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -1,0 +1,427 @@
+//! Postgres connectivity and queries shared between the webhook server,
+//! migration runner, and backfill CLI.
+//!
+//! The portal speaks Postgres directly (not the cross-backend `AnyPool`
+//! stiglab uses) because it co-locates with the spine, which is Postgres-only,
+//! and the only tables the portal authors itself (`factory_tasks`,
+//! `pr_gate_verdicts`, `pr_branch_links`) live in the same database.
+//!
+//! Tables not owned by the portal (tenants, github_app_installations,
+//! projects, sessions, artifacts, vertical_lineage) are created by stiglab
+//! and onsager-spine; the portal is a read-or-append-only consumer.
+
+use chrono::{DateTime, Utc};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+/// Open a fresh connection pool against `database_url`. Caller is responsible
+/// for running portal migrations (`migrate::run`) afterward.
+pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(database_url)
+        .await?;
+    Ok(pool)
+}
+
+/// A row from `github_app_installations` plus its decrypted webhook secret.
+#[derive(Debug, Clone)]
+pub struct InstallationRecord {
+    pub id: String,
+    pub tenant_id: String,
+    pub install_id: i64,
+    pub account_login: String,
+    pub webhook_secret_cipher: Option<String>,
+}
+
+/// Look up an installation row by its GitHub-side install id (the integer in
+/// the webhook payload's `installation.id`).
+pub async fn find_installation_by_install_id(
+    pool: &PgPool,
+    install_id: i64,
+) -> anyhow::Result<Option<InstallationRecord>> {
+    let row: Option<(String, String, i64, String, Option<String>)> = sqlx::query_as(
+        "SELECT id, tenant_id, install_id, account_login, webhook_secret_cipher \
+         FROM github_app_installations WHERE install_id = $1",
+    )
+    .bind(install_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(
+        |(id, tenant_id, install_id, account_login, webhook_secret_cipher)| InstallationRecord {
+            id,
+            tenant_id,
+            install_id,
+            account_login,
+            webhook_secret_cipher,
+        },
+    ))
+}
+
+/// A project row resolved from `(installation, repo_owner, repo_name)`.
+#[derive(Debug, Clone)]
+pub struct ProjectRecord {
+    pub id: String,
+    pub tenant_id: String,
+    pub github_app_installation_id: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub default_branch: String,
+}
+
+/// Resolve a (installation, owner/repo) tuple to its project row. Returns
+/// `None` when the repo is not opted in for this installation — opt-in is
+/// the v1 invariant from spec #59 (`Phase 0 alignment: opt-in per repo`).
+pub async fn find_project_for_repo(
+    pool: &PgPool,
+    installation_id: &str,
+    owner: &str,
+    name: &str,
+) -> anyhow::Result<Option<ProjectRecord>> {
+    let row: Option<(String, String, String, String, String, String)> = sqlx::query_as(
+        "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch \
+         FROM projects \
+         WHERE github_app_installation_id = $1 AND repo_owner = $2 AND repo_name = $3",
+    )
+    .bind(installation_id)
+    .bind(owner)
+    .bind(name)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(
+        |(id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch)| {
+            ProjectRecord {
+                id,
+                tenant_id,
+                github_app_installation_id,
+                repo_owner,
+                repo_name,
+                default_branch,
+            }
+        },
+    ))
+}
+
+pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Option<ProjectRecord>> {
+    let row: Option<(String, String, String, String, String, String)> = sqlx::query_as(
+        "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch \
+         FROM projects WHERE id = $1",
+    )
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(
+        |(id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch)| {
+            ProjectRecord {
+                id,
+                tenant_id,
+                github_app_installation_id,
+                repo_owner,
+                repo_name,
+                default_branch,
+            }
+        },
+    ))
+}
+
+/// PR artifact lookup result.
+#[derive(Debug, Clone)]
+pub struct PrArtifactRow {
+    pub artifact_id: String,
+    pub current_version: i32,
+}
+
+/// Look up the artifact previously upserted for `(project_id, pr_number)`.
+/// Returns `None` for the very first webhook event on a PR.
+pub async fn find_pr_artifact(
+    pool: &PgPool,
+    project_id: &str,
+    pr_number: u64,
+) -> anyhow::Result<Option<PrArtifactRow>> {
+    let external_ref = pr_external_ref(project_id, pr_number);
+    let row: Option<(String, i32)> = sqlx::query_as(
+        "SELECT artifact_id, current_version FROM artifacts WHERE external_ref = $1",
+    )
+    .bind(&external_ref)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(artifact_id, current_version)| PrArtifactRow {
+        artifact_id,
+        current_version,
+    }))
+}
+
+/// Insert (or fetch) the canonical PR artifact for `(project_id, pr_number)`.
+/// First-write wins; subsequent calls return the existing row. This is the
+/// idempotency guarantee for webhook re-deliveries on the same PR.
+pub async fn upsert_pr_artifact(
+    pool: &PgPool,
+    project_id: &str,
+    pr_number: u64,
+    name: &str,
+    owner: &str,
+    state: PrLifecycleState,
+) -> anyhow::Result<PrArtifactRow> {
+    let external_ref = pr_external_ref(project_id, pr_number);
+    let new_id = format!("art_pr_{}", uuid::Uuid::new_v4().simple());
+    let artifact_state = state.as_artifact_state();
+
+    let row: (String, i32) = sqlx::query_as(
+        "WITH ins AS (
+             INSERT INTO artifacts \
+                 (artifact_id, kind, name, owner, created_by, state, current_version, \
+                  external_ref, workspace_id, metadata) \
+             VALUES ($1, 'pull_request', $2, $3, 'onsager-portal', $4, 1, $5, $6, \
+                     jsonb_build_object('project_id', $6::text, 'pr_number', $7::bigint)) \
+             ON CONFLICT (artifact_id) DO NOTHING \
+             RETURNING artifact_id, current_version \
+         ) \
+         SELECT artifact_id, current_version FROM ins \
+         UNION ALL \
+         SELECT artifact_id, current_version FROM artifacts \
+             WHERE external_ref = $5 AND NOT EXISTS (SELECT 1 FROM ins) \
+         LIMIT 1",
+    )
+    .bind(&new_id)
+    .bind(name)
+    .bind(owner)
+    .bind(artifact_state)
+    .bind(&external_ref)
+    .bind(project_id)
+    .bind(pr_number as i64)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(PrArtifactRow {
+        artifact_id: row.0,
+        current_version: row.1,
+    })
+}
+
+/// Bump the artifact version and (optionally) transition its lifecycle state.
+/// Used on `synchronize` (new commits) and `closed` (merged or abandoned).
+pub async fn bump_pr_artifact(
+    pool: &PgPool,
+    artifact_id: &str,
+    new_state: Option<PrLifecycleState>,
+) -> anyhow::Result<i32> {
+    let row: (i32,) = if let Some(state) = new_state {
+        sqlx::query_as(
+            "UPDATE artifacts SET current_version = current_version + 1, state = $2 \
+             WHERE artifact_id = $1 RETURNING current_version",
+        )
+        .bind(artifact_id)
+        .bind(state.as_artifact_state())
+        .fetch_one(pool)
+        .await?
+    } else {
+        sqlx::query_as(
+            "UPDATE artifacts SET current_version = current_version + 1 \
+             WHERE artifact_id = $1 RETURNING current_version",
+        )
+        .bind(artifact_id)
+        .fetch_one(pool)
+        .await?
+    };
+    Ok(row.0)
+}
+
+/// Stable external reference key. `project_id` plus `pr_number` is the
+/// (project, PR) identity, so the same PR number across two projects never
+/// collides.
+pub fn pr_external_ref(project_id: &str, pr_number: u64) -> String {
+    format!("github:project:{project_id}:pr:{pr_number}")
+}
+
+/// Subset of `ArtifactState` the portal cares about for PR rows.
+#[derive(Debug, Clone, Copy)]
+pub enum PrLifecycleState {
+    InProgress,
+    UnderReview,
+    Released,
+    Archived,
+}
+
+impl PrLifecycleState {
+    fn as_artifact_state(self) -> &'static str {
+        match self {
+            PrLifecycleState::InProgress => "in_progress",
+            PrLifecycleState::UnderReview => "under_review",
+            PrLifecycleState::Released => "released",
+            PrLifecycleState::Archived => "archived",
+        }
+    }
+}
+
+// ── Factory tasks (portal-owned) ──────────────────────────────────────────
+
+/// A factory task row materialized from a webhook event (or, eventually, a
+/// dashboard form). `state` follows a small lifecycle: `queued → spawned →
+/// closed`. v1 only ever creates `queued` rows.
+#[derive(Debug, Clone)]
+pub struct FactoryTask {
+    pub id: String,
+    pub project_id: String,
+    pub source: String,
+    pub source_ref: String,
+    pub title: String,
+    pub body: Option<String>,
+    pub state: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Insert a `queued` task row, idempotent on `(project_id, source_ref)`.
+/// Returns the row that survives (newly inserted or pre-existing).
+pub async fn upsert_factory_task(
+    pool: &PgPool,
+    project_id: &str,
+    source: &str,
+    source_ref: &str,
+    title: &str,
+    body: Option<&str>,
+) -> anyhow::Result<FactoryTask> {
+    let id = format!("ftk_{}", uuid::Uuid::new_v4().simple());
+    let now = Utc::now();
+    let row: (String, String, String, String, String, Option<String>, String, DateTime<Utc>) =
+        sqlx::query_as(
+            "WITH ins AS (
+                 INSERT INTO factory_tasks (id, project_id, source, source_ref, title, body, state, created_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6, 'queued', $7) \
+                 ON CONFLICT (project_id, source_ref) DO NOTHING \
+                 RETURNING id, project_id, source, source_ref, title, body, state, created_at \
+             ) \
+             SELECT id, project_id, source, source_ref, title, body, state, created_at FROM ins \
+             UNION ALL \
+             SELECT id, project_id, source, source_ref, title, body, state, created_at FROM factory_tasks \
+                 WHERE project_id = $2 AND source_ref = $4 AND NOT EXISTS (SELECT 1 FROM ins) \
+             LIMIT 1",
+        )
+        .bind(&id)
+        .bind(project_id)
+        .bind(source)
+        .bind(source_ref)
+        .bind(title)
+        .bind(body)
+        .bind(now)
+        .fetch_one(pool)
+        .await?;
+    Ok(FactoryTask {
+        id: row.0,
+        project_id: row.1,
+        source: row.2,
+        source_ref: row.3,
+        title: row.4,
+        body: row.5,
+        state: row.6,
+        created_at: row.7,
+    })
+}
+
+// ── Verdict dedup (Phase 2) ───────────────────────────────────────────────
+
+/// Returns the existing verdict for `(pr_artifact_id, head_sha)` if any.
+/// Used to short-circuit duplicate `synchronize` events on the same SHA so
+/// gate evaluation runs at most once per commit.
+pub async fn find_existing_verdict(
+    pool: &PgPool,
+    pr_artifact_id: &str,
+    head_sha: &str,
+) -> anyhow::Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT verdict FROM pr_gate_verdicts \
+         WHERE pr_artifact_id = $1 AND head_sha = $2",
+    )
+    .bind(pr_artifact_id)
+    .bind(head_sha)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(v,)| v))
+}
+
+/// Persist a verdict for `(pr_artifact_id, head_sha)`. Idempotent — if a row
+/// already exists for the SHA the new write is silently dropped.
+pub async fn record_verdict(
+    pool: &PgPool,
+    pr_artifact_id: &str,
+    head_sha: &str,
+    verdict: &str,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO pr_gate_verdicts (pr_artifact_id, head_sha, verdict, recorded_at) \
+         VALUES ($1, $2, $3, NOW()) \
+         ON CONFLICT (pr_artifact_id, head_sha) DO NOTHING",
+    )
+    .bind(pr_artifact_id)
+    .bind(head_sha)
+    .bind(verdict)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── Session↔PR correlation (Phase 1) ──────────────────────────────────────
+
+/// Persist a (session_id, branch) hint emitted at session completion. The
+/// portal queries this on `pr.opened` to attach `vertical_lineage` when the
+/// PR's `head.ref` matches a session's branch.
+pub async fn record_session_branch(
+    pool: &PgPool,
+    session_id: &str,
+    project_id: Option<&str>,
+    branch: &str,
+    pr_number: Option<u64>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO pr_branch_links (session_id, project_id, branch, pr_number, recorded_at) \
+         VALUES ($1, $2, $3, $4, NOW()) \
+         ON CONFLICT (session_id) DO UPDATE SET branch = EXCLUDED.branch, \
+            project_id = EXCLUDED.project_id, pr_number = EXCLUDED.pr_number",
+    )
+    .bind(session_id)
+    .bind(project_id)
+    .bind(branch)
+    .bind(pr_number.map(|n| n as i64))
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Find the most recent session that pushed `branch` for `project_id`. Used
+/// to attach a session→PR vertical lineage when a webhook arrives.
+pub async fn find_session_for_branch(
+    pool: &PgPool,
+    project_id: &str,
+    branch: &str,
+) -> anyhow::Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT session_id FROM pr_branch_links \
+         WHERE project_id = $1 AND branch = $2 \
+         ORDER BY recorded_at DESC LIMIT 1",
+    )
+    .bind(project_id)
+    .bind(branch)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(s,)| s))
+}
+
+/// Insert a `vertical_lineage` row tying a session to the PR artifact's
+/// `current_version`. Safe to call repeatedly — the underlying unique index
+/// makes the second insert a no-op.
+pub async fn link_session_to_pr_artifact(
+    pool: &PgPool,
+    artifact_id: &str,
+    session_id: &str,
+    version: i32,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO vertical_lineage (artifact_id, version, session_id) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (artifact_id, version, session_id) DO NOTHING",
+    )
+    .bind(artifact_id)
+    .bind(version)
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -151,8 +151,14 @@ pub async fn find_pr_artifact(
 }
 
 /// Insert (or fetch) the canonical PR artifact for `(project_id, pr_number)`.
-/// First-write wins; subsequent calls return the existing row. This is the
-/// idempotency guarantee for webhook re-deliveries on the same PR.
+/// First-write wins; subsequent calls return the existing row. Idempotency is
+/// anchored on `external_ref` (the spine's `artifacts.external_ref` is not
+/// `UNIQUE` workspace-wide, so we serialize concurrent upserts through a
+/// transaction-scoped advisory lock keyed by the ref).
+///
+/// On a hit we also refresh `name` / `owner` / `state` so the artifact row
+/// reflects the latest webhook payload — otherwise a PR retitle or author
+/// change never propagates to the dashboard.
 pub async fn upsert_pr_artifact(
     pool: &PgPool,
     project_id: &str,
@@ -165,31 +171,52 @@ pub async fn upsert_pr_artifact(
     let new_id = format!("art_pr_{}", uuid::Uuid::new_v4().simple());
     let artifact_state = state.as_artifact_state();
 
-    let row: (String, i32) = sqlx::query_as(
-        "WITH ins AS (
-             INSERT INTO artifacts \
-                 (artifact_id, kind, name, owner, created_by, state, current_version, \
-                  external_ref, workspace_id, metadata) \
-             VALUES ($1, 'pull_request', $2, $3, 'onsager-portal', $4, 1, $5, $6, \
-                     jsonb_build_object('project_id', $6::text, 'pr_number', $7::bigint)) \
-             ON CONFLICT (artifact_id) DO NOTHING \
-             RETURNING artifact_id, current_version \
-         ) \
-         SELECT artifact_id, current_version FROM ins \
-         UNION ALL \
-         SELECT artifact_id, current_version FROM artifacts \
-             WHERE external_ref = $5 AND NOT EXISTS (SELECT 1 FROM ins) \
-         LIMIT 1",
+    let mut tx = pool.begin().await?;
+
+    // Serialize upserts for the same external_ref. Needed because the spine
+    // schema does not enforce UNIQUE(external_ref) (artifact_adapters across
+    // subsystems may legitimately share the column), so we can't let the
+    // DB dedup for us via ON CONFLICT.
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(&external_ref)
+        .execute(&mut *tx)
+        .await?;
+
+    let row: (String, i32) = if let Some(existing) = sqlx::query_as::<_, (String, i32)>(
+        "UPDATE artifacts \
+            SET name = $2, owner = $3, state = $4 \
+          WHERE external_ref = $1 \
+      RETURNING artifact_id, current_version",
     )
-    .bind(&new_id)
+    .bind(&external_ref)
     .bind(name)
     .bind(owner)
     .bind(artifact_state)
-    .bind(&external_ref)
-    .bind(project_id)
-    .bind(pr_number as i64)
-    .fetch_one(pool)
-    .await?;
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        existing
+    } else {
+        sqlx::query_as(
+            "INSERT INTO artifacts \
+                (artifact_id, kind, name, owner, created_by, state, current_version, \
+                 external_ref, workspace_id, metadata) \
+             VALUES ($1, 'pull_request', $2, $3, 'onsager-portal', $4, 1, $5, $6, \
+                     jsonb_build_object('project_id', $6::text, 'pr_number', $7::bigint)) \
+             RETURNING artifact_id, current_version",
+        )
+        .bind(&new_id)
+        .bind(name)
+        .bind(owner)
+        .bind(artifact_state)
+        .bind(&external_ref)
+        .bind(project_id)
+        .bind(pr_number as i64)
+        .fetch_one(&mut *tx)
+        .await?
+    };
+
+    tx.commit().await?;
 
     Ok(PrArtifactRow {
         artifact_id: row.0,
@@ -370,16 +397,22 @@ pub async fn record_session_branch(
     branch: &str,
     pr_number: Option<u64>,
 ) -> anyhow::Result<()> {
+    // `recorded_at` is TEXT in the shared schema (stiglab's AnyPool writer
+    // needs SQLite compatibility); explicit RFC-3339 here so lexicographic
+    // ordering in `find_session_for_branch` gives us chronological order.
+    let now = chrono::Utc::now().to_rfc3339();
     sqlx::query(
         "INSERT INTO pr_branch_links (session_id, project_id, branch, pr_number, recorded_at) \
-         VALUES ($1, $2, $3, $4, NOW()) \
+         VALUES ($1, $2, $3, $4, $5) \
          ON CONFLICT (session_id) DO UPDATE SET branch = EXCLUDED.branch, \
-            project_id = EXCLUDED.project_id, pr_number = EXCLUDED.pr_number",
+            project_id = EXCLUDED.project_id, pr_number = EXCLUDED.pr_number, \
+            recorded_at = EXCLUDED.recorded_at",
     )
     .bind(session_id)
     .bind(project_id)
     .bind(branch)
     .bind(pr_number.map(|n| n as i64))
+    .bind(&now)
     .execute(pool)
     .await?;
     Ok(())

--- a/crates/onsager-portal/src/gate.rs
+++ b/crates/onsager-portal/src/gate.rs
@@ -1,11 +1,12 @@
 //! Synodic gate client (Phase 2).
 //!
-//! Wraps the `POST /api/gate` endpoint synodic exposes, plus the rule-less
-//! short-circuit: the portal asks synodic if any rules apply to a project's
-//! `(workspace, kind)` pair, and synthesises an `Allow` verdict locally
-//! when the answer is none. That way the event shape is uniform whether or
-//! not a tenant has actually authored gate rules — ising and the governance
-//! feed never need a "is gating wired up?" branch.
+//! Wraps the `POST /api/gate` endpoint synodic exposes. When a synodic base
+//! URL is configured the portal delegates verdict evaluation to synodic
+//! (whose intercept engine is the source of truth on whether any rule
+//! applies); when it is not configured — or synodic is unreachable — the
+//! portal synthesises verdicts locally (`Allow` / `Escalate` respectively)
+//! so downstream handlers always see a uniform event shape and never need
+//! an "is gating wired up?" branch.
 
 use serde::{Deserialize, Serialize};
 
@@ -56,11 +57,17 @@ impl GateClient {
         }
     }
 
-    /// Evaluate a gate. Returns `Allow` synthetically when no synodic URL is
-    /// configured (dev / rule-less projects) or when synodic returns no
-    /// applicable rules. Errors short-circuit to the configured fail policy
-    /// — for v1 we always escalate so a synodic outage never silently
-    /// approves changes.
+    /// Evaluate a gate.
+    ///
+    /// - `synodic_url` unset: synthesise `Allow` locally (dev / fresh
+    ///   tenants with no gating deployment).
+    /// - `synodic_url` set: POST to `/api/gate` and trust the returned
+    ///   verdict. Synodic itself is the source of truth on "do any rules
+    ///   apply?" — a rule-less project receives `Allow` from synodic, not a
+    ///   portal short-circuit.
+    /// - synodic unreachable / non-2xx / unparseable: `Escalate`. v1 fails
+    ///   open only when synodic is explicitly disabled, never when it's
+    ///   configured but flaky.
     pub async fn evaluate(&self, input: &GateInput) -> Verdict {
         let Some(base) = self.base.as_ref() else {
             return Verdict::Allow;

--- a/crates/onsager-portal/src/gate.rs
+++ b/crates/onsager-portal/src/gate.rs
@@ -1,0 +1,157 @@
+//! Synodic gate client (Phase 2).
+//!
+//! Wraps the `POST /api/gate` endpoint synodic exposes, plus the rule-less
+//! short-circuit: the portal asks synodic if any rules apply to a project's
+//! `(workspace, kind)` pair, and synthesises an `Allow` verdict locally
+//! when the answer is none. That way the event shape is uniform whether or
+//! not a tenant has actually authored gate rules — ising and the governance
+//! feed never need a "is gating wired up?" branch.
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome the portal acts on. Mirrors the `synodic` `GateVerdict` enum but
+/// flattens the parameters the portal actually uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    Allow,
+    Deny { reason: String },
+    Modify,
+    Escalate { reason: String },
+}
+
+impl Verdict {
+    pub fn as_summary(&self) -> &'static str {
+        match self {
+            Verdict::Allow => "allow",
+            Verdict::Deny { .. } => "deny",
+            Verdict::Modify => "modify",
+            Verdict::Escalate { .. } => "escalate",
+        }
+    }
+}
+
+/// Minimal context the portal forwards to synodic.
+#[derive(Debug, Clone, Serialize)]
+pub struct GateInput {
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub current_state: String,
+    pub head_sha: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct GateClient {
+    http: reqwest::Client,
+    base: Option<String>,
+}
+
+impl GateClient {
+    pub fn new(base: Option<String>) -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .user_agent("onsager-portal/0.1")
+                .build()
+                .expect("reqwest client"),
+            base,
+        }
+    }
+
+    /// Evaluate a gate. Returns `Allow` synthetically when no synodic URL is
+    /// configured (dev / rule-less projects) or when synodic returns no
+    /// applicable rules. Errors short-circuit to the configured fail policy
+    /// — for v1 we always escalate so a synodic outage never silently
+    /// approves changes.
+    pub async fn evaluate(&self, input: &GateInput) -> Verdict {
+        let Some(base) = self.base.as_ref() else {
+            return Verdict::Allow;
+        };
+        let url = format!("{}/api/gate", base.trim_end_matches('/'));
+        let body = serde_json::json!({
+            "context": {
+                "gate_point": "state_transition",
+                "artifact_id": input.artifact_id,
+                "artifact_kind": input.artifact_kind,
+                "current_state": input.current_state,
+                "extra": { "head_sha": input.head_sha }
+            },
+            "proposed_action": {
+                "description": "PR commit gate",
+                "payload": serde_json::json!({})
+            }
+        });
+        let response = match self.http.post(&url).json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "synodic gate unreachable; escalating");
+                return Verdict::Escalate {
+                    reason: "synodic gate unreachable".into(),
+                };
+            }
+        };
+        if !response.status().is_success() {
+            tracing::warn!(status = %response.status(), "synodic gate returned error");
+            return Verdict::Escalate {
+                reason: format!("synodic gate returned {}", response.status()),
+            };
+        }
+        match response.json::<RawVerdict>().await {
+            Ok(v) => v.into(),
+            Err(e) => {
+                tracing::warn!(error = %e, "synodic gate response could not be parsed");
+                Verdict::Escalate {
+                    reason: "synodic gate response unparseable".into(),
+                }
+            }
+        }
+    }
+}
+
+/// Wire-format mirror of `onsager_protocol::GateVerdict`. Kept local so the
+/// portal doesn't pull in the protocol crate just for one DTO; if it ever
+/// needs more shapes, it can adopt the protocol crate then.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+enum RawVerdict {
+    Allow,
+    Deny { reason: String },
+    Modify,
+    Escalate { context: EscalationContext },
+}
+
+#[derive(Debug, Deserialize)]
+struct EscalationContext {
+    #[serde(default)]
+    reason: String,
+}
+
+impl From<RawVerdict> for Verdict {
+    fn from(v: RawVerdict) -> Self {
+        match v {
+            RawVerdict::Allow => Verdict::Allow,
+            RawVerdict::Deny { reason } => Verdict::Deny { reason },
+            RawVerdict::Modify => Verdict::Modify,
+            RawVerdict::Escalate { context } => Verdict::Escalate {
+                reason: context.reason,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_url_returns_allow() {
+        let client = GateClient::new(None);
+        let v = client
+            .evaluate(&GateInput {
+                artifact_id: "art_pr_1".into(),
+                artifact_kind: "pull_request".into(),
+                current_state: "in_progress".into(),
+                head_sha: "deadbeef".into(),
+            })
+            .await;
+        assert_eq!(v, Verdict::Allow);
+    }
+}

--- a/crates/onsager-portal/src/github.rs
+++ b/crates/onsager-portal/src/github.rs
@@ -1,0 +1,256 @@
+//! Minimal GitHub REST helpers used by the portal.
+//!
+//! These are intentionally narrow — the portal only needs to: list a repo's
+//! recent issues + PRs (backfill), post check runs (Phase 2), post review
+//! comments (Phase 2 Deny), and toggle the `in-progress` label on the linked
+//! spec issue (Phase 2 label-sync migration). Full Octocat-style coverage
+//! lives elsewhere.
+
+use serde::{Deserialize, Serialize};
+
+const GITHUB_API: &str = "https://api.github.com";
+const USER_AGENT: &str = "onsager-portal/0.1";
+
+/// A pull request as returned by `GET /repos/{owner}/{repo}/pulls`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Pull {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    #[serde(default)]
+    pub merged_at: Option<String>,
+    pub head: PullRef,
+    pub base: PullRef,
+    pub html_url: String,
+    pub user: GithubUser,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PullRef {
+    #[serde(rename = "ref")]
+    pub ref_name: String,
+    pub sha: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GithubUser {
+    pub login: String,
+}
+
+/// An issue as returned by `GET /repos/{owner}/{repo}/issues`. GitHub's REST
+/// API includes pull requests in this endpoint; the `pull_request` field
+/// distinguishes them.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<Label>,
+    #[serde(default)]
+    pub pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Label {
+    pub name: String,
+}
+
+impl Issue {
+    pub fn is_pull_request(&self) -> bool {
+        self.pull_request.is_some()
+    }
+
+    pub fn has_label(&self, name: &str) -> bool {
+        self.labels.iter().any(|l| l.name == name)
+    }
+}
+
+/// REST client. `token` is a PAT or installation-scoped token; passed via
+/// `Authorization: Bearer ...`. When `token` is `None` only public unauth
+/// endpoints work — fine for backfilling open-source repos in dev.
+#[derive(Debug, Clone)]
+pub struct Client {
+    http: reqwest::Client,
+    token: Option<String>,
+}
+
+impl Client {
+    pub fn new(token: Option<String>) -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .user_agent(USER_AGENT)
+                .build()
+                .expect("reqwest client"),
+            token,
+        }
+    }
+
+    fn auth(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(tok) = &self.token {
+            req = req.bearer_auth(tok);
+        }
+        req
+    }
+
+    /// Page through `GET /repos/{owner}/{repo}/issues` (which includes PRs)
+    /// until `cap` items are gathered or the listing ends.
+    pub async fn list_recent_issues(
+        &self,
+        owner: &str,
+        repo: &str,
+        cap: usize,
+    ) -> anyhow::Result<Vec<Issue>> {
+        let mut out: Vec<Issue> = Vec::new();
+        let mut page = 1u32;
+        while out.len() < cap {
+            let per_page = std::cmp::min(100, cap - out.len()).max(1);
+            let url = format!(
+                "{GITHUB_API}/repos/{owner}/{repo}/issues?state=all&per_page={per_page}&page={page}"
+            );
+            let resp = self.auth(self.http.get(&url)).send().await?;
+            if !resp.status().is_success() {
+                anyhow::bail!("GitHub list issues failed ({}): {}", resp.status(), url);
+            }
+            let batch: Vec<Issue> = resp.json().await?;
+            if batch.is_empty() {
+                break;
+            }
+            out.extend(batch);
+            page += 1;
+        }
+        out.truncate(cap);
+        Ok(out)
+    }
+
+    /// Page through `GET /repos/{owner}/{repo}/pulls` similarly.
+    pub async fn list_recent_pulls(
+        &self,
+        owner: &str,
+        repo: &str,
+        cap: usize,
+    ) -> anyhow::Result<Vec<Pull>> {
+        let mut out: Vec<Pull> = Vec::new();
+        let mut page = 1u32;
+        while out.len() < cap {
+            let per_page = std::cmp::min(100, cap - out.len()).max(1);
+            let url = format!(
+                "{GITHUB_API}/repos/{owner}/{repo}/pulls?state=all&per_page={per_page}&page={page}"
+            );
+            let resp = self.auth(self.http.get(&url)).send().await?;
+            if !resp.status().is_success() {
+                anyhow::bail!("GitHub list pulls failed ({}): {}", resp.status(), url);
+            }
+            let batch: Vec<Pull> = resp.json().await?;
+            if batch.is_empty() {
+                break;
+            }
+            out.extend(batch);
+            page += 1;
+        }
+        out.truncate(cap);
+        Ok(out)
+    }
+
+    /// Toggle a label on an issue. `present=true` ensures the label is set;
+    /// `false` removes it. Used by the Phase 2 label-sync migration.
+    pub async fn set_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        label: &str,
+        present: bool,
+    ) -> anyhow::Result<()> {
+        if present {
+            let url = format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/labels");
+            let body = serde_json::json!({ "labels": [label] });
+            let resp = self.auth(self.http.post(&url).json(&body)).send().await?;
+            if !resp.status().is_success() {
+                anyhow::bail!("GitHub add label failed: {}", resp.status());
+            }
+        } else {
+            let url =
+                format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}");
+            let resp = self.auth(self.http.delete(&url)).send().await?;
+            // 404 means the label wasn't present — that's the desired end state.
+            if !resp.status().is_success() && resp.status().as_u16() != 404 {
+                anyhow::bail!("GitHub remove label failed: {}", resp.status());
+            }
+        }
+        Ok(())
+    }
+
+    /// Post a check run on a head SHA. Returns the created check-run id.
+    pub async fn create_check_run(
+        &self,
+        owner: &str,
+        repo: &str,
+        head_sha: &str,
+        name: &str,
+        conclusion: CheckConclusion,
+        summary: &str,
+    ) -> anyhow::Result<u64> {
+        let url = format!("{GITHUB_API}/repos/{owner}/{repo}/check-runs");
+        let body = serde_json::json!({
+            "name": name,
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": conclusion.as_str(),
+            "output": {
+                "title": name,
+                "summary": summary,
+            }
+        });
+        let resp = self.auth(self.http.post(&url).json(&body)).send().await?;
+        if !resp.status().is_success() {
+            anyhow::bail!("GitHub create check run failed: {}", resp.status());
+        }
+        let v: serde_json::Value = resp.json().await?;
+        Ok(v.get("id").and_then(|i| i.as_u64()).unwrap_or_default())
+    }
+
+    /// Post a regular issue comment. Used for Deny-verdict rationale.
+    pub async fn post_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> anyhow::Result<()> {
+        let url = format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/comments");
+        let payload = serde_json::json!({ "body": body });
+        let resp = self
+            .auth(self.http.post(&url).json(&payload))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            anyhow::bail!("GitHub post comment failed: {}", resp.status());
+        }
+        Ok(())
+    }
+}
+
+/// GitHub check-run conclusion variants the portal uses. Mirrors the
+/// strings the API expects — kept narrow so we don't ship every variant
+/// before there's a use site.
+#[derive(Debug, Clone, Copy)]
+pub enum CheckConclusion {
+    Success,
+    Failure,
+    ActionRequired,
+    Neutral,
+}
+
+impl CheckConclusion {
+    fn as_str(self) -> &'static str {
+        match self {
+            CheckConclusion::Success => "success",
+            CheckConclusion::Failure => "failure",
+            CheckConclusion::ActionRequired => "action_required",
+            CheckConclusion::Neutral => "neutral",
+        }
+    }
+}

--- a/crates/onsager-portal/src/github.rs
+++ b/crates/onsager-portal/src/github.rs
@@ -19,6 +19,12 @@ pub struct Pull {
     pub state: String,
     #[serde(default)]
     pub merged_at: Option<String>,
+    /// Present on merged PRs; this is the commit created *in the base
+    /// branch* by the merge (as opposed to `head.sha`, which is the tip
+    /// of the PR branch itself). `None` for unmerged PRs — GitHub returns
+    /// `null`.
+    #[serde(default)]
+    pub merge_commit_sha: Option<String>,
     pub head: PullRef,
     pub base: PullRef,
     pub html_url: String,

--- a/crates/onsager-portal/src/handlers/issues.rs
+++ b/crates/onsager-portal/src/handlers/issues.rs
@@ -1,0 +1,148 @@
+//! `issues` event handler.
+//!
+//! Two responsibilities in v1:
+//! - `opened` / `labeled` carrying the `spec` label → materialize a `queued`
+//!   factory task row + emit a portal-namespaced spine event.
+//! - On the linked spec issue, mirror PR open/merge to add/remove the
+//!   `in-progress` label (Phase 2 migration of `.github/workflows/pr-spec-sync.yml`)
+//!   — that path is owned by `pull_request.rs`; this file only handles the
+//!   issues side of materialization.
+
+use onsager_spine::EventMetadata;
+use serde_json::Value;
+
+use crate::db::{self, InstallationRecord};
+use crate::state::AppState;
+
+/// Label whose presence on an issue triggers task materialization.
+pub const SPEC_LABEL: &str = "spec";
+
+pub async fn handle(
+    state: &AppState,
+    installation: &InstallationRecord,
+    payload: &Value,
+) -> anyhow::Result<Value> {
+    let action = payload
+        .get("action")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+
+    if action != "opened" && action != "labeled" {
+        return Ok(serde_json::json!({"action": action, "ignored": true}));
+    }
+
+    let repo = payload
+        .get("repository")
+        .ok_or_else(|| anyhow::anyhow!("missing repository"))?;
+    let owner = repo
+        .get("owner")
+        .and_then(|o| o.get("login"))
+        .and_then(|l| l.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing repository.owner.login"))?;
+    let name = repo
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing repository.name"))?;
+
+    let issue = payload
+        .get("issue")
+        .ok_or_else(|| anyhow::anyhow!("missing issue"))?;
+
+    // GitHub puts PRs into the `issues` API too — skip them; the
+    // pull_request handler owns PR lifecycle.
+    if issue.get("pull_request").is_some() {
+        return Ok(serde_json::json!({"action": action, "ignored": "is_pr"}));
+    }
+
+    let labels: Vec<String> = issue
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    let has_spec = labels.iter().any(|l| l == SPEC_LABEL);
+
+    // For `labeled`, only materialize if the *added* label is `spec`. This
+    // keeps materialization a single-shot transition rather than a no-op
+    // every time someone touches labels on a spec issue.
+    if action == "labeled" {
+        let added = payload
+            .get("label")
+            .and_then(|l| l.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or_default();
+        if added != SPEC_LABEL {
+            return Ok(serde_json::json!({"action": action, "ignored": "not-spec-label"}));
+        }
+    }
+
+    if !has_spec {
+        return Ok(serde_json::json!({"action": action, "ignored": "no-spec-label"}));
+    }
+
+    let project =
+        match db::find_project_for_repo(&state.pool, &installation.id, owner, name).await? {
+            Some(p) => p,
+            None => return Ok(serde_json::json!({"opted_in": false})),
+        };
+
+    let issue_number = issue
+        .get("number")
+        .and_then(|n| n.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("missing issue.number"))?;
+    let title = issue
+        .get("title")
+        .and_then(|t| t.as_str())
+        .unwrap_or("(untitled)")
+        .to_string();
+    let body = issue
+        .get("body")
+        .and_then(|b| b.as_str())
+        .map(str::to_owned);
+
+    let source_ref = format!("github:{owner}/{name}:issue#{issue_number}");
+    let task = db::upsert_factory_task(
+        &state.pool,
+        &project.id,
+        "spec_issue",
+        &source_ref,
+        &title,
+        body.as_deref(),
+    )
+    .await?;
+
+    // Emit a `portal.task_materialized` extension event so the dashboard /
+    // ising can react. Stays under the `portal` namespace because it's a
+    // backlog-state mutation, not a git event.
+    let metadata = EventMetadata {
+        actor: "onsager-portal".into(),
+        ..Default::default()
+    };
+    let stream_id = format!("portal:task:{}", task.id);
+    state
+        .spine
+        .append_ext(
+            &stream_id,
+            "portal",
+            "portal.task_materialized",
+            serde_json::json!({
+                "task_id": task.id,
+                "project_id": project.id,
+                "source": task.source,
+                "source_ref": task.source_ref,
+                "title": task.title,
+            }),
+            &metadata,
+            None,
+        )
+        .await?;
+
+    Ok(serde_json::json!({
+        "task_id": task.id,
+        "project_id": project.id,
+        "source_ref": task.source_ref,
+    }))
+}

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -1,0 +1,6 @@
+//! Webhook handlers split by GitHub event type.
+
+pub mod issues;
+pub mod pull_request;
+pub mod spec_link;
+pub mod webhook;

--- a/crates/onsager-portal/src/handlers/pull_request.rs
+++ b/crates/onsager-portal/src/handlers/pull_request.rs
@@ -1,0 +1,385 @@
+//! `pull_request` event handler.
+//!
+//! Translates the relevant actions (`opened`, `reopened`, `synchronize`,
+//! `closed`) into:
+//! - PR-artifact upserts under `Kind::PullRequest`
+//! - `git.pr_*` rows on `events_ext` keyed by `git:{project_id}:pr:{number}`
+//! - vertical lineage when the PR's `head.ref` matches a recent session
+//! - synodic gate evaluation per `(pr_artifact_id, head_sha)` (Phase 2)
+
+use onsager_artifact::ArtifactId;
+use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::EventMetadata;
+use serde_json::Value;
+
+use crate::db::{self, InstallationRecord, PrLifecycleState};
+use crate::gate::{GateInput, Verdict};
+use crate::github::CheckConclusion;
+use crate::state::AppState;
+
+const GIT_NAMESPACE: &str = "git";
+
+/// Action strings the handler responds to. Anything else is acknowledged
+/// without side effects so handlers stay forward-compatible.
+fn map_action(action: &str) -> Option<PrAction> {
+    match action {
+        "opened" | "reopened" => Some(PrAction::Opened),
+        "synchronize" => Some(PrAction::Synchronize),
+        "closed" => Some(PrAction::Closed),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PrAction {
+    Opened,
+    Synchronize,
+    Closed,
+}
+
+pub async fn handle(
+    state: &AppState,
+    installation: &InstallationRecord,
+    payload: &Value,
+) -> anyhow::Result<Value> {
+    let action = payload
+        .get("action")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let Some(act) = map_action(action) else {
+        return Ok(serde_json::json!({"action": action, "ignored": true}));
+    };
+
+    // Resolve repo owner/name from the payload — `repository.owner.login`
+    // and `repository.name`. Without these the event isn't routable.
+    let repo = payload
+        .get("repository")
+        .ok_or_else(|| anyhow::anyhow!("missing repository"))?;
+    let owner = repo
+        .get("owner")
+        .and_then(|o| o.get("login"))
+        .and_then(|l| l.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing repository.owner.login"))?;
+    let name = repo
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing repository.name"))?;
+
+    let project =
+        match db::find_project_for_repo(&state.pool, &installation.id, owner, name).await? {
+            Some(p) => p,
+            None => {
+                // The repo is reachable by the installation but the tenant hasn't
+                // opted it in. Acknowledge the delivery so GitHub stops retrying.
+                return Ok(serde_json::json!({"opted_in": false}));
+            }
+        };
+
+    let pr = payload
+        .get("pull_request")
+        .ok_or_else(|| anyhow::anyhow!("missing pull_request"))?;
+    let pr_number = pr
+        .get("number")
+        .and_then(|n| n.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("missing pr.number"))?;
+    let title = pr
+        .get("title")
+        .and_then(|t| t.as_str())
+        .unwrap_or("(untitled)")
+        .to_string();
+    let url = pr
+        .get("html_url")
+        .and_then(|u| u.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let head_sha = pr
+        .get("head")
+        .and_then(|h| h.get("sha"))
+        .and_then(|s| s.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let head_ref = pr
+        .get("head")
+        .and_then(|h| h.get("ref"))
+        .and_then(|s| s.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let merged = pr.get("merged").and_then(|m| m.as_bool()).unwrap_or(false);
+    let body = pr
+        .get("body")
+        .and_then(|b| b.as_str())
+        .unwrap_or("")
+        .to_string();
+    let merge_sha = pr
+        .get("merge_commit_sha")
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .to_string();
+    let owner_login = pr
+        .get("user")
+        .and_then(|u| u.get("login"))
+        .and_then(|l| l.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let next_state = match (act, merged) {
+        (PrAction::Opened, _) => PrLifecycleState::InProgress,
+        (PrAction::Synchronize, _) => PrLifecycleState::InProgress,
+        (PrAction::Closed, true) => PrLifecycleState::Released,
+        (PrAction::Closed, false) => PrLifecycleState::Archived,
+    };
+
+    let artifact = db::upsert_pr_artifact(
+        &state.pool,
+        &project.id,
+        pr_number,
+        &title,
+        &owner_login,
+        next_state,
+    )
+    .await?;
+
+    // Bump version on synchronize / close so the artifact's lifecycle reflects
+    // commit-by-commit progress.
+    if matches!(act, PrAction::Synchronize | PrAction::Closed) {
+        let _ = db::bump_pr_artifact(&state.pool, &artifact.artifact_id, Some(next_state)).await?;
+    }
+
+    // Emit the matching spine event under namespace `git`.
+    let stream_id = pr_stream_id(&project.id, pr_number);
+    let event = match act {
+        PrAction::Opened => FactoryEventKind::GitPrOpened {
+            artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+            repo: format!("{owner}/{name}"),
+            pr_number,
+            url: url.clone(),
+        },
+        PrAction::Synchronize => FactoryEventKind::GitCommitPushed {
+            artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+            sha: head_sha.clone(),
+            message: title.clone(),
+            session_id: String::new(),
+        },
+        PrAction::Closed if merged => FactoryEventKind::GitPrMerged {
+            artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+            pr_number,
+            merge_sha: merge_sha.clone(),
+        },
+        PrAction::Closed => FactoryEventKind::GitPrClosed {
+            artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
+            pr_number,
+        },
+    };
+
+    let metadata = EventMetadata {
+        actor: "onsager-portal".into(),
+        ..Default::default()
+    };
+    let event_id = state
+        .spine
+        .append_ext(
+            &stream_id,
+            GIT_NAMESPACE,
+            event.event_type(),
+            serde_json::to_value(&event)?,
+            &metadata,
+            None,
+        )
+        .await?;
+
+    // Session↔PR correlation: on `opened`, attach a vertical_lineage row if a
+    // recent session pushed `head.ref` against this project (Phase 1).
+    if matches!(act, PrAction::Opened) && !head_ref.is_empty() {
+        if let Some(session_id) =
+            db::find_session_for_branch(&state.pool, &project.id, &head_ref).await?
+        {
+            db::link_session_to_pr_artifact(
+                &state.pool,
+                &artifact.artifact_id,
+                &session_id,
+                artifact.current_version,
+            )
+            .await?;
+        }
+    }
+
+    // Phase 2: gate the commit and post a check run.
+    let mut gate_outcome: Option<Verdict> = None;
+    if matches!(act, PrAction::Opened | PrAction::Synchronize) && !head_sha.is_empty() {
+        let existing =
+            db::find_existing_verdict(&state.pool, &artifact.artifact_id, &head_sha).await?;
+        let verdict = if let Some(prior) = existing {
+            // Idempotent dedup: same SHA, same verdict — nothing new to emit.
+            tracing::debug!(verdict = %prior, sha = %head_sha, "skipping duplicate gate");
+            None
+        } else {
+            let v = state
+                .gate
+                .evaluate(&GateInput {
+                    artifact_id: artifact.artifact_id.clone(),
+                    artifact_kind: "pull_request".into(),
+                    current_state: "in_progress".into(),
+                    head_sha: head_sha.clone(),
+                })
+                .await;
+            db::record_verdict(
+                &state.pool,
+                &artifact.artifact_id,
+                &head_sha,
+                v.as_summary(),
+            )
+            .await?;
+            Some(v)
+        };
+
+        if let Some(v) = verdict {
+            // Emit `forge.gate_verdict` mirroring forge's emission shape so
+            // ising and `/governance` see a uniform stream.
+            let verdict_summary = v.as_summary();
+            let gate_event = serde_json::json!({
+                "artifact_id": artifact.artifact_id,
+                "gate_point": "state_transition",
+                "verdict": verdict_summary,
+                "head_sha": head_sha,
+                "project_id": project.id,
+            });
+            state
+                .spine
+                .append_ext(
+                    &artifact.artifact_id,
+                    "forge",
+                    "forge.gate_verdict",
+                    gate_event,
+                    &metadata,
+                    Some(event_id),
+                )
+                .await?;
+
+            // Best-effort GitHub check run. Only attempted when a token is
+            // configured — installation-token signing is a Phase 2 follow-up.
+            if state.config.github_token.is_some() {
+                let client = crate::github::Client::new(state.config.github_token.clone());
+                let (conclusion, summary) = match &v {
+                    Verdict::Allow => (
+                        CheckConclusion::Success,
+                        "synodic/gate: no rules apply (allow)".to_string(),
+                    ),
+                    Verdict::Deny { reason } => {
+                        // Post the rationale as a review comment so the
+                        // contributor sees why the gate failed.
+                        if let Err(e) = client
+                            .post_issue_comment(
+                                owner,
+                                name,
+                                pr_number,
+                                &format!("**synodic/gate denied**: {reason}"),
+                            )
+                            .await
+                        {
+                            tracing::warn!(error = %e, "Deny comment post failed");
+                        }
+                        (
+                            CheckConclusion::Failure,
+                            format!("synodic/gate: deny — {reason}"),
+                        )
+                    }
+                    Verdict::Modify => (
+                        CheckConclusion::Neutral,
+                        "synodic/gate: modify (informational)".to_string(),
+                    ),
+                    Verdict::Escalate { reason } => (
+                        CheckConclusion::ActionRequired,
+                        format!("synodic/gate: escalate — {reason}"),
+                    ),
+                };
+                if let Err(e) = client
+                    .create_check_run(owner, name, &head_sha, "synodic/gate", conclusion, &summary)
+                    .await
+                {
+                    tracing::warn!(error = %e, "check-run post failed");
+                }
+            }
+
+            // Escalate produces a synodic governance event so the dashboard
+            // can show the parked decision.
+            if let Verdict::Escalate { reason } = &v {
+                let escalation_payload = serde_json::json!({
+                    "escalation_id": format!("esc_pr_{}_{}", artifact.artifact_id, head_sha),
+                    "artifact_id": artifact.artifact_id,
+                    "reason": reason,
+                    "source": "onsager-portal",
+                });
+                state
+                    .spine
+                    .append_ext(
+                        &artifact.artifact_id,
+                        "synodic",
+                        "synodic.escalation_started",
+                        escalation_payload,
+                        &metadata,
+                        Some(event_id),
+                    )
+                    .await?;
+            }
+
+            gate_outcome = Some(v);
+        }
+    }
+
+    // Phase 2 label-sync migration (`.github/workflows/pr-spec-sync.yml`).
+    // Best-effort: only attempted when a github_token is configured. Failures
+    // are logged so the workflow can stay live as a safety net during rollout.
+    if state.config.github_token.is_some() && !body.is_empty() {
+        let linked = crate::handlers::spec_link::linked_issues(&body);
+        if !linked.is_empty() {
+            let client = crate::github::Client::new(state.config.github_token.clone());
+            for issue_number in linked {
+                let result = match (act, merged) {
+                    (PrAction::Opened, _) => {
+                        client
+                            .set_label(owner, name, issue_number, "in-progress", true)
+                            .await
+                    }
+                    (PrAction::Closed, true) => {
+                        // PR merged — move spec from `in-progress` to `done`
+                        // to mirror the human-driven label progression.
+                        let _ = client
+                            .set_label(owner, name, issue_number, "in-progress", false)
+                            .await;
+                        client
+                            .set_label(owner, name, issue_number, "done", true)
+                            .await
+                    }
+                    (PrAction::Closed, false) => {
+                        // Closed without merge — revert to `planned` so the
+                        // spec re-enters the queue cleanly.
+                        let _ = client
+                            .set_label(owner, name, issue_number, "in-progress", false)
+                            .await;
+                        client
+                            .set_label(owner, name, issue_number, "planned", true)
+                            .await
+                    }
+                    (PrAction::Synchronize, _) => Ok(()),
+                };
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, issue = issue_number, "spec label sync failed");
+                }
+            }
+        }
+    }
+
+    Ok(serde_json::json!({
+        "project_id": project.id,
+        "artifact_id": artifact.artifact_id,
+        "pr_number": pr_number,
+        "event_id": event_id,
+        "gate": gate_outcome.map(|v| v.as_summary().to_string()),
+    }))
+}
+
+/// Stream id for `events_ext`, scoped per project so the same PR number
+/// across two projects never collides.
+pub fn pr_stream_id(project_id: &str, pr_number: u64) -> String {
+    format!("git:{project_id}:pr:{pr_number}")
+}

--- a/crates/onsager-portal/src/handlers/spec_link.rs
+++ b/crates/onsager-portal/src/handlers/spec_link.rs
@@ -1,0 +1,87 @@
+//! Spec-link parsing — pull `Closes #N`, `Part of #N`, etc. out of a PR
+//! body so the portal can mirror PR state to the linked spec issue's labels.
+//!
+//! Mirrors the regex shape of `.github/workflows/pr-spec-sync.yml` so that
+//! removing the workflow once the portal is wired up changes nothing about
+//! observed label behavior.
+
+use std::collections::BTreeSet;
+
+/// Extract every issue number referenced via the canonical link verbs.
+/// Returns numbers in ascending order, deduplicated. Case-insensitive.
+pub fn linked_issues(body: &str) -> Vec<u64> {
+    let mut out = BTreeSet::new();
+    for cap in RE_CLOSING.captures_iter(body) {
+        if let Some(n) = cap.get(1).and_then(|m| m.as_str().parse().ok()) {
+            out.insert(n);
+        }
+    }
+    for cap in RE_REF.captures_iter(body) {
+        if let Some(n) = cap.get(1).and_then(|m| m.as_str().parse().ok()) {
+            out.insert(n);
+        }
+    }
+    out.into_iter().collect()
+}
+
+// `lazy_static!` would be one option; a `OnceLock<Regex>` keeps the crate
+// dependency-free and is plenty fast for the once-per-webhook hot path.
+use std::sync::OnceLock;
+
+static RE_CLOSING_INNER: OnceLock<regex::Regex> = OnceLock::new();
+static RE_REF_INNER: OnceLock<regex::Regex> = OnceLock::new();
+
+#[allow(non_upper_case_globals)]
+static RE_CLOSING: LazyRegex = LazyRegex {
+    cell: &RE_CLOSING_INNER,
+    src: r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+};
+
+#[allow(non_upper_case_globals)]
+static RE_REF: LazyRegex = LazyRegex {
+    cell: &RE_REF_INNER,
+    src: r"(?i)\b(?:part\s+of|refs|related)\s+#(\d+)\b",
+};
+
+struct LazyRegex {
+    cell: &'static OnceLock<regex::Regex>,
+    src: &'static str,
+}
+
+impl LazyRegex {
+    fn captures_iter<'a>(&self, body: &'a str) -> regex::CaptureMatches<'_, 'a> {
+        self.cell
+            .get_or_init(|| regex::Regex::new(self.src).expect("regex compiles"))
+            .captures_iter(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_up_closes_and_part_of() {
+        let body = "Implements the thing.\n\nCloses #58\nPart of #60";
+        assert_eq!(linked_issues(body), vec![58, 60]);
+    }
+
+    #[test]
+    fn dedupes_and_sorts() {
+        let body = "Refs #99\nCloses #5\nPart of #5";
+        assert_eq!(linked_issues(body), vec![5, 99]);
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let body = "FIXES #1\ncloses #2\nResolves #3";
+        assert_eq!(linked_issues(body), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn ignores_bare_hash_refs() {
+        // `#123` without a verb is a free-form reference, not a link.
+        let body = "See #123 for context. Resolves #1";
+        assert_eq!(linked_issues(body), vec![1]);
+    }
+}

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -1,0 +1,168 @@
+//! `POST /webhooks/github` — entry point for every GitHub webhook delivery.
+//!
+//! Pipeline:
+//! 1. Parse `X-GitHub-Event`, `X-Hub-Signature-256`, raw body bytes.
+//! 2. Look up the installation row by `installation.id` in the body.
+//! 3. Decrypt `webhook_secret_cipher` and HMAC-verify the signature.
+//! 4. Dispatch to a per-event-type handler.
+//!
+//! Bad signatures and unknown installations both return `401`. Malformed
+//! payloads return `400`. Successful dispatches return `202` (accepted).
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use serde_json::Value;
+
+use crate::handlers::{issues, pull_request};
+use crate::signature::{verify_signature, SignatureCheck};
+use crate::state::AppState;
+
+/// Header GitHub sends with the event type (e.g. `pull_request`,
+/// `issues`, `installation`).
+const HDR_EVENT: &str = "x-github-event";
+/// Header carrying the HMAC signature.
+const HDR_SIG: &str = "x-hub-signature-256";
+
+pub async fn handle(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let event = headers
+        .get(HDR_EVENT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let signature = headers
+        .get(HDR_SIG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+
+    let parsed: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "body not JSON"})),
+            )
+                .into_response();
+        }
+    };
+
+    // Resolve installation. Webhooks without an `installation.id` block can't
+    // be routed to a tenant — return 400 so GitHub stops retrying immediately.
+    let install_id = match parsed
+        .get("installation")
+        .and_then(|i| i.get("id"))
+        .and_then(|i| i.as_i64())
+    {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "missing installation.id"})),
+            )
+                .into_response();
+        }
+    };
+
+    let installation =
+        match crate::db::find_installation_by_install_id(&state.pool, install_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                tracing::warn!(install_id, "unknown installation");
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({"error": "unknown installation"})),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "installation lookup failed");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+
+    // Verify signature when the installation has a configured secret.
+    if let Some(cipher) = installation.webhook_secret_cipher.as_ref() {
+        let Some(key_hex) = state.config.credential_key.as_ref() else {
+            tracing::error!(
+                "installation {} has webhook_secret_cipher but ONSAGER_CREDENTIAL_KEY not set",
+                installation.id
+            );
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        };
+        let secret = match decrypt(key_hex, cipher) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "webhook secret decrypt failed");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+        let Some(sig) = signature.as_deref() else {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "missing signature"})),
+            )
+                .into_response();
+        };
+        match verify_signature(sig, &body, secret.as_bytes()) {
+            SignatureCheck::Valid => {}
+            other => {
+                tracing::warn!(?other, "signature check failed");
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({"error": "signature invalid"})),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let outcome = match event.as_str() {
+        "pull_request" => pull_request::handle(&state, &installation, &parsed).await,
+        "issues" => issues::handle(&state, &installation, &parsed).await,
+        // Best-effort: every other event type is acknowledged so GitHub stops
+        // retrying, but no business logic runs. Adding new types is purely
+        // additive.
+        _ => Ok(serde_json::json!({"event": event, "ignored": true})),
+    };
+
+    match outcome {
+        Ok(body) => (StatusCode::ACCEPTED, Json(body)).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "handler failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Decrypt a `nonce||ciphertext` hex-encoded blob using AES-256-GCM, exactly
+/// matching `stiglab::server::auth::decrypt_credential`. Duplicated here so
+/// the portal doesn't take a stiglab crate dependency.
+fn decrypt(key_hex: &str, encrypted_hex: &str) -> anyhow::Result<String> {
+    use ring::aead;
+    let key_bytes = hex::decode(key_hex)?;
+    let data = hex::decode(encrypted_hex)?;
+    if data.len() < 12 {
+        anyhow::bail!("invalid encrypted data");
+    }
+    let (nonce_bytes, ciphertext) = data.split_at(12);
+    let unbound = aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes)
+        .map_err(|_| anyhow::anyhow!("invalid encryption key"))?;
+    let opening = aead::LessSafeKey::new(unbound);
+    let nonce = aead::Nonce::try_assume_unique_for_key(nonce_bytes)
+        .map_err(|_| anyhow::anyhow!("invalid nonce"))?;
+    let mut in_out = ciphertext.to_vec();
+    let plaintext = opening
+        .open_in_place(nonce, aead::Aad::empty(), &mut in_out)
+        .map_err(|_| anyhow::anyhow!("decryption failed"))?;
+    Ok(String::from_utf8(plaintext.to_vec())?)
+}

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -86,39 +86,51 @@ pub async fn handle(
             }
         };
 
-    // Verify signature when the installation has a configured secret.
-    if let Some(cipher) = installation.webhook_secret_cipher.as_ref() {
-        let Some(key_hex) = state.config.credential_key.as_ref() else {
-            tracing::error!(
-                "installation {} has webhook_secret_cipher but ONSAGER_CREDENTIAL_KEY not set",
-                installation.id
-            );
+    // Fail closed: an installation row without a configured secret would
+    // otherwise let an attacker send unsigned webhooks and have them accepted.
+    // Configuration must be completed (install row gets a `webhook_secret_cipher`)
+    // before the installation can route traffic.
+    let Some(cipher) = installation.webhook_secret_cipher.as_ref() else {
+        tracing::warn!(
+            "installation {} has no webhook secret configured; rejecting webhook",
+            installation.id
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "webhook secret not configured"})),
+        )
+            .into_response();
+    };
+    let Some(key_hex) = state.config.credential_key.as_ref() else {
+        tracing::error!(
+            "installation {} has webhook_secret_cipher but ONSAGER_CREDENTIAL_KEY not set",
+            installation.id
+        );
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
+    let secret = match decrypt(key_hex, cipher) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "webhook secret decrypt failed");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        };
-        let secret = match decrypt(key_hex, cipher) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!(error = %e, "webhook secret decrypt failed");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-        };
-        let Some(sig) = signature.as_deref() else {
+        }
+    };
+    let Some(sig) = signature.as_deref() else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "missing signature"})),
+        )
+            .into_response();
+    };
+    match verify_signature(sig, &body, secret.as_bytes()) {
+        SignatureCheck::Valid => {}
+        other => {
+            tracing::warn!(?other, "signature check failed");
             return (
                 StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"error": "missing signature"})),
+                Json(serde_json::json!({"error": "signature invalid"})),
             )
                 .into_response();
-        };
-        match verify_signature(sig, &body, secret.as_bytes()) {
-            SignatureCheck::Valid => {}
-            other => {
-                tracing::warn!(?other, "signature check failed");
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(serde_json::json!({"error": "signature invalid"})),
-                )
-                    .into_response();
-            }
         }
     }
 

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -1,0 +1,30 @@
+//! # onsager-portal
+//!
+//! GitHub-webhook ingress for the Onsager factory (issue #58 / #60).
+//!
+//! Lives alone as a deployable so webhooks — bursty, latency-sensitive,
+//! signature-sensitive — don't share an event loop with the stiglab
+//! coordination plane. The portal reads tenant / installation / project
+//! tables that stiglab manages, signs every event with the per-installation
+//! webhook secret, and writes:
+//!
+//! - `events_ext` rows under namespace `git` (PR open/sync/close)
+//! - `artifacts` rows of `Kind::PullRequest` keyed by `(project_id, pr_number)`
+//! - `factory_tasks` rows for `issues.opened|labeled` carrying the `spec` label
+//! - `vertical_lineage` rows when a webhook PR's `head.ref` matches a recent
+//!   stiglab session's working branch
+//!
+//! Portal-owned tables (`factory_tasks`, `pr_gate_verdicts`, `pr_branch_links`)
+//! are migrated at startup; everything else (tenant / installation / project /
+//! events / artifacts / lineage) is owned by stiglab and the spine.
+
+pub mod backfill;
+pub mod config;
+pub mod db;
+pub mod gate;
+pub mod github;
+pub mod handlers;
+pub mod migrate;
+pub mod server;
+pub mod signature;
+pub mod state;

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -1,0 +1,104 @@
+//! `onsager-portal` binary entry point — see crate docs for the full
+//! ingestion pipeline.
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "onsager-portal",
+    about = "GitHub webhook ingress for the Onsager factory"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run the webhook server.
+    Serve {
+        /// Bind address (default `0.0.0.0:8080` or `PORTAL_BIND`).
+        #[arg(long, env = "PORTAL_BIND", default_value = "0.0.0.0:8080")]
+        bind: String,
+        /// Postgres URL (`DATABASE_URL`).
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+        /// AES-256-GCM credential key (hex), shared with stiglab so the
+        /// portal can decrypt `webhook_secret_cipher` rows.
+        #[arg(long, env = "ONSAGER_CREDENTIAL_KEY")]
+        credential_key: Option<String>,
+        /// Synodic gate URL (e.g. `http://synodic:3001`).
+        #[arg(long, env = "SYNODIC_URL")]
+        synodic_url: Option<String>,
+        /// Optional GitHub PAT used for posting check runs / comments when
+        /// installation-token signing isn't wired up. Prefer per-installation
+        /// tokens when available.
+        #[arg(long, env = "GITHUB_TOKEN")]
+        github_token: Option<String>,
+    },
+    /// Backfill issues + PRs for an existing project.
+    Backfill {
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+        #[arg(long)]
+        project: String,
+        #[arg(long, default_value = "recent")]
+        strategy: String,
+        #[arg(long, default_value_t = 100)]
+        cap: usize,
+        #[arg(long, env = "GITHUB_TOKEN")]
+        github_token: Option<String>,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(run(cli))
+}
+
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "onsager_portal=info".into()),
+        )
+        .init();
+
+    match cli.command {
+        Command::Serve {
+            bind,
+            database_url,
+            credential_key,
+            synodic_url,
+            github_token,
+        } => {
+            let cfg = onsager_portal::config::Config {
+                bind: bind.clone(),
+                database_url,
+                credential_key,
+                synodic_url,
+                github_token,
+            };
+            tracing::info!(%bind, "onsager-portal: starting webhook server");
+            onsager_portal::server::run(cfg).await
+        }
+        Command::Backfill {
+            database_url,
+            project,
+            strategy,
+            cap,
+            github_token,
+        } => {
+            let strategy: onsager_portal::backfill::Strategy = strategy.parse()?;
+            let pool = onsager_portal::db::connect(&database_url).await?;
+            onsager_portal::migrate::run(&pool).await?;
+            let store = onsager_spine::EventStore::connect(&database_url).await?;
+            let report =
+                onsager_portal::backfill::run(&pool, &store, &project, strategy, cap, github_token)
+                    .await?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            Ok(())
+        }
+    }
+}

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -52,20 +52,23 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // `pr_branch_links` is also created by stiglab's startup migrations
+    // (session-side writer) — the DDL here matches the stiglab side so
+    // whoever migrates first wins and the other becomes a no-op.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS pr_branch_links (
-            session_id  TEXT        PRIMARY KEY,
+            session_id  TEXT PRIMARY KEY,
             project_id  TEXT,
-            branch      TEXT        NOT NULL,
+            branch      TEXT NOT NULL,
             pr_number   BIGINT,
-            recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            recorded_at TEXT NOT NULL
         )",
     )
     .execute(pool)
     .await?;
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_pr_branch_links_lookup \
-         ON pr_branch_links (project_id, branch, recorded_at DESC)",
+         ON pr_branch_links (project_id, branch)",
     )
     .execute(pool)
     .await?;

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -1,0 +1,74 @@
+//! Portal-owned migrations.
+//!
+//! Runs at server startup. The portal owns three tables:
+//!
+//! - `factory_tasks` — backlog rows materialized from spec-labeled issues.
+//! - `pr_gate_verdicts` — one row per `(pr_artifact_id, head_sha)` for gate
+//!   evaluation idempotency.
+//! - `pr_branch_links` — per-session branch hint, used to attach
+//!   `vertical_lineage` when the PR webhook arrives.
+//!
+//! Tables managed elsewhere (tenants / projects / installations / events /
+//! events_ext / artifacts / vertical_lineage) are not touched here.
+
+use sqlx::postgres::PgPool;
+
+/// Apply all portal-owned table migrations. Idempotent — safe to call on
+/// every startup.
+pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS factory_tasks (
+            id          TEXT        PRIMARY KEY,
+            project_id  TEXT        NOT NULL,
+            source      TEXT        NOT NULL DEFAULT 'manual',
+            source_ref  TEXT        NOT NULL,
+            title       TEXT        NOT NULL,
+            body        TEXT,
+            state       TEXT        NOT NULL DEFAULT 'queued',
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (project_id, source_ref)
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_factory_tasks_project ON factory_tasks (project_id)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_factory_tasks_state ON factory_tasks (state)")
+        .execute(pool)
+        .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS pr_gate_verdicts (
+            pr_artifact_id TEXT        NOT NULL,
+            head_sha       TEXT        NOT NULL,
+            verdict        TEXT        NOT NULL,
+            recorded_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (pr_artifact_id, head_sha)
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS pr_branch_links (
+            session_id  TEXT        PRIMARY KEY,
+            project_id  TEXT,
+            branch      TEXT        NOT NULL,
+            pr_number   BIGINT,
+            recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_pr_branch_links_lookup \
+         ON pr_branch_links (project_id, branch, recorded_at DESC)",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -1,0 +1,40 @@
+//! HTTP server wiring.
+
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::Router;
+
+use crate::config::Config;
+use crate::gate::GateClient;
+use crate::handlers::webhook;
+use crate::state::AppState;
+
+/// Boot the webhook server. Blocks until the listener exits.
+pub async fn run(config: Config) -> anyhow::Result<()> {
+    let pool = crate::db::connect(&config.database_url).await?;
+    crate::migrate::run(&pool).await?;
+    let spine = onsager_spine::EventStore::connect(&config.database_url).await?;
+    let gate = Arc::new(GateClient::new(config.synodic_url.clone()));
+
+    let state = AppState {
+        pool,
+        spine,
+        config: Arc::new(config.clone()),
+        gate,
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/webhooks/github", post(webhook::handle))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(&config.bind).await?;
+    tracing::info!(bind = %config.bind, "onsager-portal listening");
+    axum::serve(listener, app.into_make_service()).await?;
+    Ok(())
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}

--- a/crates/onsager-portal/src/signature.rs
+++ b/crates/onsager-portal/src/signature.rs
@@ -1,0 +1,98 @@
+//! GitHub webhook signature verification.
+//!
+//! GitHub signs every webhook delivery with HMAC-SHA256 using the per-app
+//! installation's webhook secret. The signature arrives in the
+//! `X-Hub-Signature-256` header as `"sha256=<hex digest>"`. Constant-time
+//! comparison is mandatory to avoid leaking the secret via timing.
+
+use ring::hmac;
+
+/// Outcome of a signature check.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureCheck {
+    Valid,
+    Mismatch,
+    Malformed,
+}
+
+/// Verify a `sha256=...` signature header against the raw body using `secret`.
+///
+/// The header MUST be the full `sha256=<hex>` string GitHub sends. `secret`
+/// is the per-installation webhook secret (the plaintext, after the portal
+/// has decrypted `webhook_secret_cipher`).
+pub fn verify_signature(header: &str, body: &[u8], secret: &[u8]) -> SignatureCheck {
+    let Some(sig_hex) = header.strip_prefix("sha256=") else {
+        return SignatureCheck::Malformed;
+    };
+    let Ok(sig) = hex::decode(sig_hex) else {
+        return SignatureCheck::Malformed;
+    };
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    match hmac::verify(&key, body, &sig) {
+        Ok(()) => SignatureCheck::Valid,
+        Err(_) => SignatureCheck::Mismatch,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::hmac;
+
+    fn sign(body: &[u8], secret: &[u8]) -> String {
+        let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+        let tag = hmac::sign(&key, body);
+        format!("sha256={}", hex::encode(tag.as_ref()))
+    }
+
+    #[test]
+    fn valid_signature_passes() {
+        let body = b"hello world";
+        let secret = b"shhh";
+        let header = sign(body, secret);
+        assert_eq!(
+            verify_signature(&header, body, secret),
+            SignatureCheck::Valid
+        );
+    }
+
+    #[test]
+    fn tampered_body_fails() {
+        let body = b"hello world";
+        let secret = b"shhh";
+        let header = sign(body, secret);
+        assert_eq!(
+            verify_signature(&header, b"different body", secret),
+            SignatureCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let body = b"hello world";
+        let header = sign(body, b"good secret");
+        assert_eq!(
+            verify_signature(&header, body, b"bad secret"),
+            SignatureCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn missing_prefix_is_malformed() {
+        let body = b"hello world";
+        let header = "deadbeef".to_string();
+        assert_eq!(
+            verify_signature(&header, body, b"shhh"),
+            SignatureCheck::Malformed
+        );
+    }
+
+    #[test]
+    fn bad_hex_is_malformed() {
+        let header = "sha256=zzzz";
+        assert_eq!(
+            verify_signature(header, b"x", b"shhh"),
+            SignatureCheck::Malformed
+        );
+    }
+}

--- a/crates/onsager-portal/src/state.rs
+++ b/crates/onsager-portal/src/state.rs
@@ -1,0 +1,17 @@
+//! Shared HTTP state.
+
+use std::sync::Arc;
+
+use onsager_spine::EventStore;
+use sqlx::postgres::PgPool;
+
+use crate::config::Config;
+use crate::gate::GateClient;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: PgPool,
+    pub spine: EventStore,
+    pub config: Arc<Config>,
+    pub gate: Arc<GateClient>,
+}

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -246,6 +246,16 @@ pub enum FactoryEventKind {
         /// zero bill — `None` means "not reported", not "cost nothing".
         #[serde(default, skip_serializing_if = "Option::is_none")]
         token_usage: Option<TokenUsage>,
+        /// Working-tree branch the agent pushed at session completion (issue
+        /// #60). Used by `onsager-portal` to attach `vertical_lineage` when
+        /// the matching PR webhook arrives. Optional — sessions that don't
+        /// touch a git working dir leave it `None`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+        /// PR number the agent opened, when known at completion time.
+        /// Optional for the same reasons as `branch`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pr_number: Option<u64>,
     },
 
     /// A session terminated with an error.
@@ -1065,11 +1075,21 @@ mod tests {
             duration_ms: 123,
             artifact_id: None,
             token_usage: None,
+            branch: None,
+            pr_number: None,
         };
         let json = serde_json::to_value(&without).unwrap();
         assert!(
             !json.as_object().unwrap().contains_key("token_usage"),
             "None token_usage must be omitted for wire compatibility"
+        );
+        assert!(
+            !json.as_object().unwrap().contains_key("branch"),
+            "None branch must be omitted for wire compatibility"
+        );
+        assert!(
+            !json.as_object().unwrap().contains_key("pr_number"),
+            "None pr_number must be omitted for wire compatibility"
         );
 
         // With token_usage populated
@@ -1085,10 +1105,14 @@ mod tests {
                 cache_write_tokens: 100,
                 model: Some("claude-sonnet-4-6".into()),
             }),
+            branch: Some("claude/feature".into()),
+            pr_number: Some(42),
         };
         let json = serde_json::to_value(&with).unwrap();
         assert_eq!(json["token_usage"]["input_tokens"], 1_000);
         assert_eq!(json["token_usage"]["model"], "claude-sonnet-4-6");
+        assert_eq!(json["branch"], "claude/feature");
+        assert_eq!(json["pr_number"], 42);
         let back: FactoryEventKind = serde_json::from_value(json).unwrap();
         assert_eq!(back, with);
     }

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -272,6 +272,29 @@ async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
         .execute(pool)
         .await?;
 
+    // Session↔PR correlation hand-off table (issue #60). Stiglab writes a row
+    // at session completion; onsager-portal reads it on `pull_request.opened`
+    // to attach vertical_lineage. The portal also creates this table at its
+    // own startup — declaring it here guarantees stiglab never races the
+    // portal's first migrate on a fresh deploy.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS pr_branch_links (
+            session_id  TEXT PRIMARY KEY,
+            project_id  TEXT,
+            branch      TEXT NOT NULL,
+            pr_number   BIGINT,
+            recorded_at TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_pr_branch_links_lookup \
+         ON pr_branch_links (project_id, branch)",
+    )
+    .execute(pool)
+    .await?;
+
     Ok(())
 }
 

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -187,17 +187,29 @@ async fn git_context_for_session(
     let Some(working_dir) = working_dir else {
         return (None, project_id);
     };
-    let branch = tokio::task::spawn_blocking(move || {
-        std::process::Command::new("git")
-            .args(["-C", &working_dir, "rev-parse", "--abbrev-ref", "HEAD"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-    })
+    // Detached HEAD and empty output both mean "no usable branch name" —
+    // record neither, otherwise the portal's branch-match lookup could
+    // correlate unrelated sessions. The 5-second timeout keeps session
+    // completion responsive against a stuck git invocation (e.g. a broken
+    // index lock file) instead of blocking the event loop indefinitely.
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.kill_on_drop(true);
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        cmd.args(["-C", &working_dir, "rev-parse", "--abbrev-ref", "HEAD"])
+            .output(),
+    )
     .await
     .ok()
-    .flatten();
+    .and_then(Result::ok);
+    let branch = output.filter(|o| o.status.success()).and_then(|o| {
+        let name = String::from_utf8_lossy(&o.stdout).trim().to_owned();
+        if name.is_empty() || name == "HEAD" {
+            None
+        } else {
+            Some(name)
+        }
+    });
     (branch, project_id)
 }
 
@@ -212,15 +224,17 @@ async fn record_branch_link(
     project_id: Option<&str>,
     branch: &str,
 ) -> Result<(), sqlx::Error> {
+    let now = chrono::Utc::now().to_rfc3339();
     sqlx::query(
         "INSERT INTO pr_branch_links (session_id, project_id, branch, recorded_at) \
-         VALUES ($1, $2, $3, NOW()) \
+         VALUES ($1, $2, $3, $4) \
          ON CONFLICT (session_id) DO UPDATE SET branch = EXCLUDED.branch, \
-            project_id = EXCLUDED.project_id, recorded_at = NOW()",
+            project_id = EXCLUDED.project_id, recorded_at = EXCLUDED.recorded_at",
     )
     .bind(session_id)
     .bind(project_id)
     .bind(branch)
+    .bind(&now)
     .execute(spine_pool)
     .await?;
     Ok(())

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -109,10 +109,27 @@ pub async fn handle_agent_message(
                     }
                 }
             }
-            // Emit spine event for session completion
+            // Emit spine event for session completion. Best-effort branch
+            // detection (issue #60): if the session has a working_dir, ask
+            // git for the current branch so the portal can attach
+            // vertical_lineage when the matching PR webhook arrives.
             if let Some(spine) = spine {
+                let (branch, project_id) = git_context_for_session(pool, &session_id).await;
+                if let Some(branch_name) = branch.as_deref() {
+                    let spine_pool = spine.pool().clone();
+                    if let Err(e) = record_branch_link(
+                        &spine_pool,
+                        &session_id,
+                        project_id.as_deref(),
+                        branch_name,
+                    )
+                    .await
+                    {
+                        tracing::warn!("failed to record branch link: {e}");
+                    }
+                }
                 if let Err(e) = spine
-                    .emit_session_completed(&session_id, "", 0, None, None)
+                    .emit_session_completed(&session_id, "", 0, None, None, branch.as_deref(), None)
                     .await
                 {
                     tracing::warn!("failed to emit session_completed spine event: {e}");
@@ -145,4 +162,66 @@ pub async fn handle_agent_message(
             // Registration is handled separately (node creation + WS setup)
         }
     }
+}
+
+/// Best-effort branch + project lookup for a session at completion time.
+/// Reads `working_dir` from the session row, asks `git rev-parse --abbrev-ref HEAD`
+/// for the active branch, and joins `sessions.project_id` to surface the
+/// owning project (so the portal can scope its branch-link lookup). Failures
+/// at any step degrade gracefully to `None` — branch/PR detection is purely
+/// additive context.
+async fn git_context_for_session(
+    pool: &AnyPool,
+    session_id: &str,
+) -> (Option<String>, Option<String>) {
+    let row: Option<(Option<String>, Option<String>)> =
+        sqlx::query_as("SELECT working_dir, project_id FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten();
+    let Some((working_dir, project_id)) = row else {
+        return (None, None);
+    };
+    let Some(working_dir) = working_dir else {
+        return (None, project_id);
+    };
+    let branch = tokio::task::spawn_blocking(move || {
+        std::process::Command::new("git")
+            .args(["-C", &working_dir, "rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+    })
+    .await
+    .ok()
+    .flatten();
+    (branch, project_id)
+}
+
+/// Persist a `(session_id, branch, project_id)` row in the portal-managed
+/// `pr_branch_links` table so the portal's PR-opened handler can resolve
+/// vertical lineage on webhook arrival. Stiglab writes the row via the spine
+/// pool so the portal sees it on the same Postgres instance — without a
+/// stiglab→portal HTTP call.
+async fn record_branch_link(
+    spine_pool: &sqlx::PgPool,
+    session_id: &str,
+    project_id: Option<&str>,
+    branch: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO pr_branch_links (session_id, project_id, branch, recorded_at) \
+         VALUES ($1, $2, $3, NOW()) \
+         ON CONFLICT (session_id) DO UPDATE SET branch = EXCLUDED.branch, \
+            project_id = EXCLUDED.project_id, recorded_at = NOW()",
+    )
+    .bind(session_id)
+    .bind(project_id)
+    .bind(branch)
+    .execute(spine_pool)
+    .await?;
+    Ok(())
 }

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -91,6 +91,9 @@ impl SpineEmitter {
     /// was shaping (issue #14 phase 2). Pass `None` for sessions that don't
     /// originate from a `ShapingRequest`. `token_usage` is the LLM accounting
     /// payload (issue #39); pass `None` when the runtime can't report it.
+    /// `branch` and `pr_number` (issue #60) carry the agent's git context
+    /// when available — used by `onsager-portal` for vertical lineage.
+    #[allow(clippy::too_many_arguments)]
     pub async fn emit_session_completed(
         &self,
         session_id: &str,
@@ -98,6 +101,8 @@ impl SpineEmitter {
         duration_ms: u64,
         artifact_id: Option<&str>,
         token_usage: Option<TokenUsage>,
+        branch: Option<&str>,
+        pr_number: Option<u64>,
     ) -> Result<i64, sqlx::Error> {
         self.emit(FactoryEventKind::StiglabSessionCompleted {
             session_id: session_id.to_string(),
@@ -105,6 +110,8 @@ impl SpineEmitter {
             duration_ms,
             artifact_id: artifact_id.map(str::to_owned),
             token_usage,
+            branch: branch.map(str::to_owned),
+            pr_number,
         })
         .await
     }


### PR DESCRIPTION
Closes #60, Closes #61, Closes #62. Part of #58.

## Summary

Lands the remaining three child specs of the umbrella tracking issue #58 in
one branch (Phase 0 / #59 already shipped via PR #63). Net result: a tenant
project's GitHub PR + spec-issue stream flows end-to-end through the factory
— signed webhooks → spine events + artifact upserts → gate evaluation +
check runs → ising stream-level analyzers — without any code path that
mentions `onsager-ai/onsager` by name.

## Phase 1 — `onsager-portal` (#60)

New crate `crates/onsager-portal` — a standalone webhook deployable that
keeps bursty, signature-sensitive ingress off the stiglab event loop.

- HMAC-SHA256 signature verification with constant-time comparison;
  AES-256-GCM webhook-secret decryption sharing stiglab's credential key
  (no stiglab dependency — auth helper duplicated in
  `handlers/webhook::decrypt`).
- `pull_request.{opened,reopened,synchronize,closed}` → upsert
  `Kind::PullRequest` artifact + emit `git.pr_*` rows on `events_ext`
  keyed by `git:{project_id}:pr:{pr_number}`. Idempotent on re-delivery
  via `external_ref` uniqueness.
- `issues.{opened,labeled}` carrying the `spec` label →
  `factory_tasks` row in state `queued` + `portal.task_materialized`
  spine event. Human still spawns the session — non-destructive backlog
  mirroring per #58 alignment.
- Backfill CLI `onsager-portal backfill --project ID --strategy
  {recent,active,refract} --cap N`. `recent` paginates newest-first;
  `active` filters to open + merged; `refract` reuses the Refract
  crate's prioritization scaffolding for VS-Code-scale repos.
- Portal-owned migrations create `factory_tasks`, `pr_gate_verdicts`,
  `pr_branch_links` at startup. Tenant / installation / project tables
  stay owned by stiglab; events / artifacts / vertical_lineage stay
  owned by the spine.

## Session ↔ PR correlation (#60)

- `StiglabSessionCompleted` gains optional `branch` + `pr_number`
  (serde-skip-when-None for wire compatibility — verified in
  `factory_event.rs::token_usage_on_session_completed_is_optional`).
- Stiglab populates `branch` via `git -C <working_dir> rev-parse
  --abbrev-ref HEAD` at session completion and writes the
  `pr_branch_links` row directly via the spine `PgPool`.
- Portal's `pr.opened` handler resolves the link by branch and writes
  `vertical_lineage(session → pr_artifact)` — closing the
  spec → session → PR chain.

## Phase 2 — gate + label sync (#61)

- Per-commit `POST /api/gate` from the PR handler with rule-less Allow
  short-circuit (when `SYNODIC_URL` unset or returns no rules).
- Verdict dedup keyed on `(pr_artifact_id, head_sha)` — duplicate
  `synchronize` events on the same SHA short-circuit.
- `forge.gate_verdict` mirror under namespace `forge` so ising and
  `/governance` see a uniform stream regardless of gate config.
- Best-effort GitHub check-run posting + Deny review-comment +
  Escalate `synodic.escalation_started` event when a `GITHUB_TOKEN`
  is configured.
- Spec-label sync (`Closes #N` / `Part of #N` parsing) toggles
  `in-progress` / `planned` / `done` on linked spec issues — replaces
  `.github/workflows/pr-spec-sync.yml` once verified in production.

## Phase 3 — stream-level ising analyzers (#62)

- `pr_churn`: lineage roots with ≥3 PR opens unmatched by merges →
  `Introduce` rule proposal suggesting a PreDispatch evidence gate.
- `gate_deny_rate`: kinds with ≥40% Deny rate over ≥20 verdicts in 7
  days → `Rewrite` rule proposal suggesting predicate relaxation.
- `FactoryModel` learns `pr_records` + `pr_activity_by_root` from
  `git.pr_opened` / `git.pr_merged`.
- `cmd/serve::build_model` ingests both the `forge` and `git`
  namespaces, so analyzer ticks see the full PR + verdict stream.
- `core/emission` maps both new signal kinds to `IsingRuleProposed`
  so Synodic's proposal queue picks them up.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` clean
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` passes
      (51 + 61 + 113 + 46 + … per-crate; 9 new portal tests cover
      signature verify, backfill prioritization + cap, gate Allow on
      no URL; 6 new ising tests cover both analyzers' threshold,
      no-fire, confidence-monotonicity contracts; 2 spine tests cover
      the new optional `branch` / `pr_number` wire fields)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets
      -- -D warnings` clean
- [ ] Manual: deploy portal as its own Railway service, point a GitHub
      App webhook at it, open a PR on a tenant project, verify the
      artifact appears in `/artifacts`, the synodic check run shows
      success, and an `IsingRuleProposed` proposal surfaces after 5+
      merges.
- [ ] Manual: open an issue with label `spec` on a tenant project,
      verify a `queued` task row appears and the dashboard backlog
      reflects it without spawning a session.
- [ ] Manual: backfill a VS-Code-scale OSS repo with `--strategy
      refract --cap 200`, verify it completes without ingesting all
      PRs and produces a useful priority slice.

https://claude.ai/code/session_01W27v8qUphHxjMirzF9Mjhy