### PR TITLE
deploy(portal): co-deploy onsager-portal in the unified container

### DIFF
--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -16,16 +16,30 @@ WORKDIR /app
 # Cargo.toml before it can resolve the workspace — missing manifests cause
 # "no such file or directory" errors even when building a single crate (-p).
 COPY Cargo.toml Cargo.lock ./
-COPY crates/onsager-spine/Cargo.toml crates/onsager-spine/Cargo.toml
-COPY crates/onsager/Cargo.toml       crates/onsager/Cargo.toml
-COPY crates/forge/Cargo.toml         crates/forge/Cargo.toml
-COPY crates/ising/Cargo.toml         crates/ising/Cargo.toml
-COPY crates/stiglab/Cargo.toml       crates/stiglab/Cargo.toml
-COPY crates/synodic/Cargo.toml       crates/synodic/Cargo.toml
+COPY crates/onsager-spine/Cargo.toml    crates/onsager-spine/Cargo.toml
+COPY crates/onsager-artifact/Cargo.toml crates/onsager-artifact/Cargo.toml
+COPY crates/onsager-protocol/Cargo.toml crates/onsager-protocol/Cargo.toml
+COPY crates/onsager-warehouse/Cargo.toml crates/onsager-warehouse/Cargo.toml
+COPY crates/onsager-delivery/Cargo.toml crates/onsager-delivery/Cargo.toml
+COPY crates/onsager-registry/Cargo.toml crates/onsager-registry/Cargo.toml
+COPY crates/onsager-portal/Cargo.toml   crates/onsager-portal/Cargo.toml
+COPY crates/refract/Cargo.toml          crates/refract/Cargo.toml
+COPY crates/onsager/Cargo.toml          crates/onsager/Cargo.toml
+COPY crates/forge/Cargo.toml            crates/forge/Cargo.toml
+COPY crates/ising/Cargo.toml            crates/ising/Cargo.toml
+COPY crates/stiglab/Cargo.toml          crates/stiglab/Cargo.toml
+COPY crates/synodic/Cargo.toml          crates/synodic/Cargo.toml
 # Create dummy source files so Cargo can compile each crate stub.
 # Crates with [lib] need src/lib.rs; crates with [[bin]] need src/main.rs.
 RUN mkdir -p \
       crates/onsager-spine/src \
+      crates/onsager-artifact/src \
+      crates/onsager-protocol/src \
+      crates/onsager-warehouse/src \
+      crates/onsager-delivery/src \
+      crates/onsager-registry/src \
+      crates/onsager-portal/src \
+      crates/refract/src \
       crates/onsager/src \
       crates/forge/src \
       crates/ising/src \
@@ -33,6 +47,13 @@ RUN mkdir -p \
       crates/synodic/src \
     && touch \
       crates/onsager-spine/src/lib.rs \
+      crates/onsager-artifact/src/lib.rs \
+      crates/onsager-protocol/src/lib.rs \
+      crates/onsager-warehouse/src/lib.rs \
+      crates/onsager-delivery/src/lib.rs \
+      crates/onsager-registry/src/lib.rs \
+      crates/onsager-portal/src/lib.rs \
+      crates/refract/src/lib.rs \
       crates/forge/src/lib.rs \
       crates/ising/src/lib.rs \
       crates/stiglab/src/lib.rs \
@@ -43,14 +64,20 @@ RUN mkdir -p \
       crates/ising/src/main.rs \
       crates/stiglab/src/main.rs \
       crates/synodic/src/main.rs \
-    && cargo build --release -p stiglab -p synodic --features synodic/postgres 2>/dev/null || true
+      crates/onsager-portal/src/main.rs \
+      crates/refract/src/main.rs \
+    && cargo build --release \
+         -p stiglab -p synodic -p onsager-portal \
+         --features synodic/postgres 2>/dev/null || true
 # Copy actual source and rebuild.
 # Touch all .rs files so their mtime is newer than the dummy-build artifacts —
 # Docker's COPY preserves git timestamps which may predate the dummy build,
 # causing Cargo to skip recompilation and deploy the stub binary instead.
 COPY crates/ crates/
 RUN find crates -name "*.rs" | xargs touch \
-    && cargo build --release -p stiglab -p synodic --features synodic/postgres
+    && cargo build --release \
+         -p stiglab -p synodic -p onsager-portal \
+         --features synodic/postgres
 
 # ---- Stage 3: Node.js for runtime (glibc-compatible) ----
 FROM node:20-bookworm-slim AS node-runtime
@@ -83,8 +110,9 @@ RUN printf '#!/bin/sh\necho "username=x-access-token\npassword=${GITHUB_TOKEN}"\
 RUN useradd -m -s /bin/bash onsager
 
 WORKDIR /app
-COPY --from=rust-builder /app/target/release/stiglab /app/stiglab
-COPY --from=rust-builder /app/target/release/synodic /app/synodic
+COPY --from=rust-builder /app/target/release/stiglab        /app/stiglab
+COPY --from=rust-builder /app/target/release/synodic        /app/synodic
+COPY --from=rust-builder /app/target/release/onsager-portal /app/onsager-portal
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static
 # Spine migrations — applied on startup when ONSAGER_DATABASE_URL is set
 COPY crates/onsager-spine/migrations/ /app/spine-migrations/

--- a/crates/stiglab/deploy/entrypoint.sh
+++ b/crates/stiglab/deploy/entrypoint.sh
@@ -29,6 +29,26 @@ SYNODIC_PORT="${SYNODIC_PORT:-3001}"
 echo "Starting synodic on :${SYNODIC_PORT}..."
 gosu onsager sh -c "while true; do DATABASE_URL=\"$ONSAGER_DATABASE_URL\" /app/synodic serve --port $SYNODIC_PORT 2>&1; echo 'synodic exited, restarting in 1s...'; sleep 1; done" &
 
+# Start onsager-portal (GitHub webhook ingress) on an internal port.
+# Not exposed by Railway — stiglab reverse-proxies /webhooks/github to it so
+# the public surface stays a single service. Skipped entirely when the spine
+# DB isn't configured (useful for local smoke tests without portal wiring).
+if [ -n "$ONSAGER_DATABASE_URL" ]; then
+    PORTAL_PORT="${PORTAL_PORT:-3002}"
+    PORTAL_BIND="${PORTAL_BIND:-127.0.0.1:${PORTAL_PORT}}"
+    echo "Starting onsager-portal on ${PORTAL_BIND}..."
+    gosu onsager sh -c "\
+        while true; do \
+            PORTAL_BIND=\"$PORTAL_BIND\" \
+            DATABASE_URL=\"$ONSAGER_DATABASE_URL\" \
+            ONSAGER_CREDENTIAL_KEY=\"${STIGLAB_CREDENTIAL_KEY:-${ONSAGER_CREDENTIAL_KEY:-}}\" \
+            SYNODIC_URL=\"${SYNODIC_URL:-http://127.0.0.1:$SYNODIC_PORT}\" \
+            /app/onsager-portal serve 2>&1; \
+            echo 'onsager-portal exited, restarting in 1s...'; \
+            sleep 1; \
+        done" &
+fi
+
 # Drop from root to unprivileged user and start stiglab.
 # Claude Code CLI refuses --permission-mode bypassPermissions under root.
 exec gosu onsager /app/stiglab "$@"

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -85,6 +85,10 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         )
         // Governance proxy — forwards to synodic on internal port
         .route("/api/governance/{*path}", any(routes::governance::proxy))
+        // Portal webhook proxy — forwards `/webhooks/github` to the
+        // onsager-portal binary running on an internal port so the
+        // Railway service exposes a single external origin.
+        .route("/webhooks/github", any(routes::portal::proxy))
         // Spine API — exposes shared event spine data to the dashboard
         .route("/api/spine/events", get(routes::spine::list_events))
         .route(

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -3,6 +3,7 @@ pub mod credentials;
 pub mod governance;
 pub mod health;
 pub mod nodes;
+pub mod portal;
 pub mod sessions;
 pub mod shaping;
 pub mod spine;

--- a/crates/stiglab/src/server/routes/portal.rs
+++ b/crates/stiglab/src/server/routes/portal.rs
@@ -1,0 +1,89 @@
+//! Reverse proxy for the onsager-portal webhook ingress.
+//!
+//! Forwards `/webhooks/github` to the portal running on an internal port so
+//! the Railway service exposes a single external origin. GitHub webhook
+//! signatures are computed over the raw request body, so this proxy must
+//! forward bytes untouched and preserve the `X-Hub-Signature-256`,
+//! `X-GitHub-Event`, and `X-GitHub-Delivery` headers.
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// GitHub caps individual webhook payloads at 25 MiB; match that here so we
+/// don't reject legitimate deliveries at the proxy.
+const MAX_BODY_BYTES: usize = 25 * 1024 * 1024;
+
+/// Base URL for the portal webhook server (internal, not exposed by Railway).
+fn portal_base_url() -> String {
+    if let Ok(url) = std::env::var("PORTAL_URL") {
+        return url;
+    }
+    let port = std::env::var("PORTAL_PORT").unwrap_or_else(|_| "3002".to_string());
+    format!("http://127.0.0.1:{port}")
+}
+
+/// Proxy handler: forward `/webhooks/github` to the portal, preserving
+/// headers and raw body bytes.
+pub async fn proxy(req: Request) -> Response {
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let headers = req.headers().clone();
+
+    let path = uri.path();
+    let query = uri.query().map(|q| format!("?{q}")).unwrap_or_default();
+    let target = format!("{}{path}{query}", portal_base_url());
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!("failed to read portal proxy request body: {e}");
+            return (StatusCode::BAD_REQUEST, "bad request body").into_response();
+        }
+    };
+
+    let client = reqwest::Client::new();
+    let mut upstream = client.request(method, &target);
+    // Forward every incoming header — signature verification in the portal
+    // depends on `X-Hub-Signature-256` + the exact body bytes, and event
+    // dispatch depends on `X-GitHub-Event`. Stripping `host` avoids leaking
+    // the stiglab origin into the upstream request.
+    for (name, value) in headers.iter() {
+        if name == axum::http::header::HOST {
+            continue;
+        }
+        upstream = upstream.header(name, value);
+    }
+    if !body_bytes.is_empty() {
+        upstream = upstream.body(body_bytes);
+    }
+
+    match upstream.send().await {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+            let content_type = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("application/json")
+                .to_string();
+            let bytes = resp.bytes().await.unwrap_or_default();
+
+            Response::builder()
+                .status(status)
+                .header("content-type", content_type)
+                .body(Body::from(bytes))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+        Err(e) => {
+            tracing::error!("portal proxy error: {e}");
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("portal service unavailable: {e}"),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/stiglab/src/server/routes/portal.rs
+++ b/crates/stiglab/src/server/routes/portal.rs
@@ -6,6 +6,9 @@
 //! forward bytes untouched and preserve the `X-Hub-Signature-256`,
 //! `X-GitHub-Event`, and `X-GitHub-Delivery` headers.
 
+use std::sync::OnceLock;
+use std::time::Duration;
+
 use axum::body::Body;
 use axum::extract::Request;
 use axum::http::StatusCode;
@@ -14,6 +17,35 @@ use axum::response::{IntoResponse, Response};
 /// GitHub caps individual webhook payloads at 25 MiB; match that here so we
 /// don't reject legitimate deliveries at the proxy.
 const MAX_BODY_BYTES: usize = 25 * 1024 * 1024;
+
+/// Hop-by-hop headers per RFC 7230 §6.1 that must not be forwarded by a
+/// proxy. `content-length` and `host` are also stripped — reqwest derives
+/// both from the body and target URL.
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "content-length",
+    "host",
+];
+
+/// Process-wide `reqwest::Client` — pooled connections + bounded timeouts
+/// so a stalled portal can't tie up stiglab request capacity indefinitely.
+fn shared_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("failed to build portal proxy client")
+    })
+}
 
 /// Base URL for the portal webhook server (internal, not exposed by Railway).
 fn portal_base_url() -> String {
@@ -25,7 +57,7 @@ fn portal_base_url() -> String {
 }
 
 /// Proxy handler: forward `/webhooks/github` to the portal, preserving
-/// headers and raw body bytes.
+/// non-hop-by-hop headers and raw body bytes.
 pub async fn proxy(req: Request) -> Response {
     let method = req.method().clone();
     let uri = req.uri().clone();
@@ -43,14 +75,12 @@ pub async fn proxy(req: Request) -> Response {
         }
     };
 
-    let client = reqwest::Client::new();
-    let mut upstream = client.request(method, &target);
-    // Forward every incoming header — signature verification in the portal
-    // depends on `X-Hub-Signature-256` + the exact body bytes, and event
-    // dispatch depends on `X-GitHub-Event`. Stripping `host` avoids leaking
-    // the stiglab origin into the upstream request.
+    let mut upstream = shared_client().request(method, &target);
+    // HeaderName is normalized to lowercase, so a direct `.contains` works.
+    // Signature verification depends on the GitHub headers falling through;
+    // event dispatch depends on `x-github-event`.
     for (name, value) in headers.iter() {
-        if name == axum::http::header::HOST {
+        if HOP_BY_HOP.contains(&name.as_str()) {
             continue;
         }
         upstream = upstream.header(name, value);
@@ -78,12 +108,10 @@ pub async fn proxy(req: Request) -> Response {
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         }
         Err(e) => {
+            // Keep upstream detail in logs only — the webhook endpoint is
+            // public, and error strings can reveal internal topology.
             tracing::error!("portal proxy error: {e}");
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("portal service unavailable: {e}"),
-            )
-                .into_response()
+            (StatusCode::BAD_GATEWAY, "portal service unavailable").into_response()
         }
     }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -2,24 +2,31 @@
 #
 # Unified single-container deployment. All subsystems run in one service:
 #
-#   Process       | Description                          | Port
-#   ------------- | ------------------------------------ | ----
-#   stiglab       | Sessions, agents, dashboard, API     | 3000 (exposed)
-#   synodic       | Governance API (internal)            | 3001 (proxied)
-#   PostgreSQL    | Shared event spine (Railway plugin)  | 5432
+#   Process         | Description                               | Port
+#   --------------- | ----------------------------------------- | ----
+#   stiglab         | Sessions, agents, dashboard, API          | 3000 (exposed)
+#   synodic         | Governance API (internal)                 | 3001 (proxied)
+#   onsager-portal  | GitHub webhook ingress (internal)         | 3002 (proxied)
+#   PostgreSQL      | Shared event spine (Railway plugin)       | 5432
 #
 # Stiglab is the front door — it serves the dashboard, its own API, and
-# reverse-proxies /api/governance/* to synodic on localhost:3001.
+# reverse-proxies /api/governance/* to synodic on localhost:3001 and
+# /webhooks/github to onsager-portal on localhost:3002. The portal runs its
+# own migrations (factory_tasks, pr_gate_verdicts, pr_branch_links) at
+# startup.
 #
 # Quick start:
 #   1. Create a Railway project and connect this repo
 #   2. Add a PostgreSQL plugin (auto-provides DATABASE_URL)
-#   3. Default service uses this config (builds stiglab + synodic)
+#   3. Default service uses this config (builds stiglab + synodic + portal)
 #   4. Set required variables (see [deploy] section below)
+#   5. Point your GitHub App webhook at
+#      https://<app>.up.railway.app/webhooks/github
 #
 # Migrations:
-#   The entrypoint auto-applies both onsager-spine and synodic migrations
-#   on startup when ONSAGER_DATABASE_URL is set.
+#   The entrypoint auto-applies onsager-spine and synodic migrations on
+#   startup when ONSAGER_DATABASE_URL is set. The portal applies its own
+#   tables when it boots.
 
 # =============================================================================
 # Stiglab — primary service (sessions + dashboard + agent runner)
@@ -30,6 +37,9 @@ builder = "DOCKERFILE"
 dockerfilePath = "crates/stiglab/deploy/Dockerfile"
 watchPatterns = [
     "crates/onsager-spine/**",
+    "crates/onsager-artifact/**",
+    "crates/onsager-portal/**",
+    "crates/refract/**",
     "crates/stiglab/**",
     "crates/synodic/**",
     "apps/dashboard/**",
@@ -60,3 +70,8 @@ numReplicas = 1
 #   STIGLAB_PUBLIC_URL        — public URL for OAuth callbacks (e.g. https://<app>.up.railway.app)
 #   GITHUB_CLIENT_ID          — GitHub OAuth app client ID
 #   GITHUB_CLIENT_SECRET      — GitHub OAuth app client secret
+#   SYNODIC_PORT              — internal port for synodic (default: 3001)
+#   PORTAL_PORT               — internal port for onsager-portal (default: 3002)
+#   GITHUB_TOKEN              — optional PAT used by the portal for posting
+#                               check runs / comments when installation-token
+#                               signing isn't wired up yet

--- a/railway.toml
+++ b/railway.toml
@@ -36,12 +36,10 @@
 builder = "DOCKERFILE"
 dockerfilePath = "crates/stiglab/deploy/Dockerfile"
 watchPatterns = [
-    "crates/onsager-spine/**",
-    "crates/onsager-artifact/**",
-    "crates/onsager-portal/**",
-    "crates/refract/**",
-    "crates/stiglab/**",
-    "crates/synodic/**",
+    # All crates — every workspace member is linked into at least one of
+    # the binaries shipped in this unified container (stiglab, synodic,
+    # onsager-portal), so any change can affect the deploy.
+    "crates/**",
     "apps/dashboard/**",
     "Cargo.toml",
     "Cargo.lock",


### PR DESCRIPTION
Part of #58.

## Summary

Collapse `onsager-portal` back into the unified Railway container instead
of running it as its own service. The spec's "webhooks are bursty,
latency-sensitive" argument is theoretical until there's real traffic —
for v1 dogfooding, one service = one DB secret, one domain, one deploy
pipeline, and the shared credential key no longer has to be duplicated
across services. Architectural invariant is still honored at the binary
level: portal stays its own crate + binary with no cross-imports. Splitting
into its own Railway service later is a cheap migration if webhook volume
ever starves the stiglab loop.

## Changes

- **`crates/stiglab/deploy/Dockerfile`** — add `onsager-portal` to the
  cargo build (plus the remaining workspace members that were previously
  missing from the cache-warmup layer) and copy the binary into the
  runtime image.
- **`crates/stiglab/deploy/entrypoint.sh`** — supervise
  `onsager-portal serve` as a background process on an internal port
  (default `3002`). Shares `STIGLAB_CREDENTIAL_KEY` (or
  `ONSAGER_CREDENTIAL_KEY`) and resolves synodic at
  `http://127.0.0.1:$SYNODIC_PORT`.
- **`crates/stiglab/src/server/routes/portal.rs`** (new) — reverse proxy
  that forwards `/webhooks/github` to `http://127.0.0.1:$PORTAL_PORT`
  mirroring the existing governance proxy pattern. Forwards every header
  untouched (signature verification depends on
  `X-Hub-Signature-256` + raw body bytes) and lifts the body cap to
  25 MiB to match GitHub's webhook payload limit.
- **`railway.toml`** — documents the three-process layout, webhook URL,
  and new env vars (`PORTAL_PORT`, `GITHUB_TOKEN`); extends
  `watchPatterns` so portal / artifact / refract edits retrigger builds.

## Deploy shape

```
Process         | Port
--------------- | ----
stiglab         | 3000 (exposed) — also proxies /api/governance/* and /webhooks/github
synodic         | 3001 (internal)
onsager-portal  | 3002 (internal)
```

After deploy, the GitHub App webhook URL is
`https://<app>.up.railway.app/webhooks/github`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` passes (stiglab: 46 tests; no regressions elsewhere)
- [x] `cargo build -p stiglab -p synodic -p onsager-portal --features synodic/postgres` — matches the Dockerfile build command
- [ ] Manual: deploy to Railway, point a GitHub App webhook at
      `/webhooks/github`, verify signed delivery reaches the portal
      (check the supervised portal log line) and a rule-less project
      produces the no-op Allow `forge.gate_verdict` event.

https://claude.ai/code/session_01W27v8qUphHxjMirzF9Mjhy