### PR TITLE
feat(dashboard): workspace creation + navigation UX overhaul

### DIFF
--- a/.claude/skills/dashboard-ui/SKILL.md
+++ b/.claude/skills/dashboard-ui/SKILL.md
@@ -177,3 +177,50 @@ on desktop, and definitely not on mobile.
 
 When in doubt, open Railway/Vercel, walk through the analogous flow, and
 copy the pattern.
+
+## New primitive = new surface
+
+When the dashboard grows a new user-facing resource (workspace, project,
+credential, node type — anything a user can create), shipping just the
+CRUD UI isn't enough. A primitive without entry points is functionally
+invisible: users land on empty pages with no hint that the resource
+exists, and the feature ships as dead code.
+
+**This is the product-side complement to the `issue-spec` "Reach ships
+with the primitive" principle** — the spec scopes these in, the UI
+implementation checks them off. If a spec lands on your desk without
+them, push back at the spec stage. Don't quietly defer.
+
+**Before a PR that introduces a new primitive is ready:**
+
+- [ ] **Sidebar entry** in `AppSidebar.tsx` under the right group. Create
+  a new group (e.g. "Organization") if the category doesn't exist —
+  don't bury under "System" or "Settings."
+- [ ] **Dedicated page** at `/<primitive>s`, not just a card inside
+  Settings. Lists, create flow, and the empty state all live here.
+- [ ] **First-run redirect** for authenticated users with zero
+  instances. Pattern: `OnboardingGate` in `App.tsx`. Session-scoped
+  dismissal via `sessionStorage` so navigating away doesn't loop.
+- [ ] **Stepped onboarding hero** on the dedicated page when empty.
+  Two or three numbered steps, active CTA on step one.
+- [ ] **Empty-state CTA** on *other* pages that expect instances to
+  exist (e.g. a workspace-setup banner on Factory Overview). Always a
+  button linking to the primitive's page — never a paragraph of
+  instructions.
+- [ ] **`QuickCreateMenu` entry** if the resource is create-intensive.
+- [ ] **Auth gating on every query and entry point**
+  (`enabled: authEnabled && !!user`). Anonymous / L1-smoke contexts
+  must not 401 or render a dead CTA. If the primitive requires auth,
+  hide the sidebar entry too — a visible link to a broken page is
+  worse than no link.
+- [ ] **Client validation mirrors server rules** (slug regex, length,
+  etc.). Normalize on input or show an inline error before submit —
+  helper text that can't prevent a 400 is a lie.
+
+**The cheap option is usually wrong.** It's tempting to ship just the
+list + create card inside Settings and plan the surface as a follow-up.
+In practice the follow-up PR is bigger than building it up front, the
+primitive is invisible in the meantime, and reviewers/users start
+reporting "there's no way to do X" despite the code being live.
+See #70 / `/workspaces` as the canonical example of what this shape
+looks like when done right.

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -30,6 +30,14 @@ Three principles from lean-spec:
 2. **Intent Over Implementation** — Document the *why* and *what*, not the *how*. Implementation details belong in PRs, not spec issues. The spec captures human intent that isn't in the code.
 3. **Living Documents** — Specs evolve via issue comments and edits. Status labels track lifecycle. The issue thread becomes the decision record.
 
+Plus one Onsager-specific principle:
+
+4. **Reach ships with the primitive.** A spec that introduces a new user-facing resource (workspace, project, credential, session type — anything a user must create to use) must scope in the discovery surface: primary navigation entry, first-run flow for zero-instance users, empty-state CTAs on pages that expect instances, and auth gating on every touchpoint. Without those, the primitive is functionally present but invisible — users land in dead-empty states with no way to recover. This principle also applies to backend primitives that are only usable via a UI affordance (e.g. a new governance action needs the button that triggers it).
+
+   **The "minimal v1" trap.** It's tempting to defer the surface ("we'll add the sidebar entry later"). That choice is almost always wrong. The cheap option — ship CRUD behind a Settings card, call it done — looks complete and is functionally invisible. The follow-up spec to add the surface ends up bigger than building it up front, and between the two PRs the feature ships as dead code. **Most of the time the cheap option is the bad decision.** Explicitly-scoped-out UX (a workspace switcher, role editor, invite flow) is fine to defer; *discoverability is not deferrable*.
+
+   See [references/reach-checklist.md](references/reach-checklist.md) for the per-spec Plan items this implies.
+
 ## When to use this skill
 
 Use when:

--- a/.claude/skills/issue-spec/references/reach-checklist.md
+++ b/.claude/skills/issue-spec/references/reach-checklist.md
@@ -1,0 +1,92 @@
+# Reach checklist
+
+When a spec introduces a new user-facing primitive — a resource a user
+must create (workspace, project, credential) or a new capability with a
+UI entry point (governance action, artifact type, session kind) — the
+spec's Plan section must include the discovery surface, not just the
+CRUD.
+
+Without this, the primitive ships as dead code: functionally live but
+invisible. The cheap option (ship the API + a hidden Settings card,
+defer the surface to a follow-up spec) is almost always the wrong call —
+see the workspace onboarding case in #70 for the canonical example.
+
+## Items to scope into the spec Plan
+
+Copy the applicable items into the spec's Plan section. Not every
+primitive needs every item — a governance action probably doesn't need
+a sidebar entry — but a *user-created resource* typically needs all of
+them.
+
+### Discovery
+
+- [ ] **Primary navigation entry** in `AppSidebar.tsx` under the right
+  group. Create a new group if the category doesn't exist — don't bury
+  under "System" or "Settings."
+- [ ] **Dedicated page** (`/<primitive>s`), not just a card inside
+  another page. Lists, create flow, and empty state live here.
+- [ ] **First-run redirect** for authenticated users with zero
+  instances. See `OnboardingGate` in `App.tsx` as the canonical pattern.
+  Session-scoped dismissal via `sessionStorage` so subsequent navigation
+  doesn't loop.
+
+### Empty states
+
+- [ ] **Stepped onboarding hero** on the primitive's own page when the
+  user has zero instances. Two or three numbered steps max, with an
+  active CTA on step one.
+- [ ] **Empty-state CTA** on any *other* page that expects instances to
+  exist (e.g. Factory Overview shows a "Set up workspace" banner when
+  the user has no workspaces). Always a button linking to the primitive's
+  page, not a paragraph of instructions.
+
+### Create affordances
+
+- [ ] **`QuickCreateMenu` entry** if the resource is create-intensive.
+- [ ] **Create affordance where the user already looks** — if the primitive
+  is typically created in the flow of another action (e.g. linking a
+  GitHub install from the workspace page), wire that path, not just the
+  standalone modal.
+
+### Hygiene
+
+- [ ] **Auth gating.** Every query and entry point gated on
+  `authEnabled && user`. Anonymous/L1 contexts must not 401 or surface a
+  dead CTA. If the primitive's visibility depends on auth, hide the
+  sidebar entry too — a visible link to a broken page is worse than no
+  link.
+- [ ] **Client validation mirrors server rules.** If the backend rejects
+  a pattern (slug regex, length, reserved words), the client normalizes
+  or shows an inline error before submit. Helper text that can't prevent
+  a 400 is a lie.
+- [ ] **Secondary link-out** from related surfaces (e.g. Settings page
+  links to `/workspaces`) for users who search in the old place. One
+  link out, not an embedded copy of the UI.
+
+## What's explicitly deferrable
+
+These are fine to scope *out* with a Non-goals section, as long as the
+items above are in:
+
+- Switcher / active-instance context indicator (only when ≥1 page
+  consumes the context globally).
+- Role editors, invites, billing, quotas.
+- Bulk operations, templates, import/export.
+- Cascading delete / archive flows.
+
+If the spec's Non-goals covers these explicitly, a follow-up spec is
+legible. What's *not* fine to defer: the user's ability to find the
+primitive at all.
+
+## How to verify
+
+Before marking the spec `planned`:
+
+1. Walk through the flow as a brand-new user with empty database state.
+2. If at any point there's a page with no content and no actionable
+   CTA, you're missing a Reach item.
+3. Repeat with `authEnabled=false` — anonymous / L1 mode must not
+   surface dead entry points.
+
+The `web-testing` skill exercises both states in its exploratory pass
+and will catch regressions.

--- a/.claude/skills/onsager-dev-process/SKILL.md
+++ b/.claude/skills/onsager-dev-process/SKILL.md
@@ -223,6 +223,15 @@ merge. If the merged-progress routine is disabled, the
   spec, split the PR.
 - **Skipping `onsager-pre-push`.** CI failures cost more time than the
   checklist does.
+- **Shipping a primitive without its discovery surface.** Specs that
+  introduce a new user-facing resource (workspace, project, credential —
+  anything a user must create to use) must scope in navigation entry,
+  first-run flow, empty-state CTAs, and auth gating in the *same* spec.
+  Deferring the surface to a follow-up ships dead code in the interim
+  and usually costs more overall. See `issue-spec`'s
+  [reach-checklist](../issue-spec/references/reach-checklist.md).
+  The cheap option (ship CRUD behind a hidden Settings card) is almost
+  always the wrong one.
 
 ## Delegation map
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useEffect } from "react"
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom"
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query"
 import { ThemeProvider } from "@/components/providers/ThemeProvider"
 import { AuthProvider, useAuth } from "@/lib/auth"
 import { AppLayout } from "@/components/layout/AppLayout"
@@ -13,6 +14,8 @@ import { SettingsPage } from "@/pages/SettingsPage"
 import { GovernancePage } from "@/pages/GovernancePage"
 import { SpinePage } from "@/pages/SpinePage"
 import { ArtifactsPage } from "@/pages/ArtifactsPage"
+import { WorkspacesPage } from "@/pages/WorkspacesPage"
+import { api } from "@/lib/api"
 import type { ReactNode } from "react"
 
 const queryClient = new QueryClient({
@@ -48,6 +51,52 @@ function ProtectedRoute({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+// Redirects users with zero workspaces to /workspaces?welcome=1 on their
+// first visit of the session. Once we've shown the welcome hero, mark the
+// onboarding as seen so the user can navigate freely without being bounced
+// back — they'll still see the empty-state banner on pages that render one.
+const ONBOARDING_SEEN_KEY = "onsager.onboarding_seen"
+
+function OnboardingGate({ children }: { children: ReactNode }) {
+  const { user, authEnabled } = useAuth()
+  const location = useLocation()
+  // Only run the onboarding redirect for authenticated users — anonymous
+  // mode (auth disabled or no session) has no workspace concept to gate.
+  const gateEnabled = authEnabled && !!user
+  const { data, isLoading } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+    staleTime: 30_000,
+    enabled: gateEnabled,
+  })
+  const workspaces = data?.tenants ?? []
+  const seen =
+    typeof window !== "undefined" &&
+    window.sessionStorage.getItem(ONBOARDING_SEEN_KEY) === "1"
+
+  const onWorkspaces =
+    location.pathname === "/workspaces" ||
+    location.pathname.startsWith("/workspaces/")
+
+  useEffect(() => {
+    if (onWorkspaces && typeof window !== "undefined") {
+      window.sessionStorage.setItem(ONBOARDING_SEEN_KEY, "1")
+    }
+  }, [onWorkspaces])
+
+  if (
+    gateEnabled &&
+    !isLoading &&
+    workspaces.length === 0 &&
+    !seen &&
+    !onWorkspaces
+  ) {
+    return <Navigate to="/workspaces?welcome=1" replace />
+  }
+
+  return <>{children}</>
+}
+
 function AppRoutes() {
   const { user, loading, authEnabled } = useAuth()
 
@@ -73,17 +122,20 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <AppLayout>
-              <Routes>
-                <Route path="/" element={<FactoryOverviewPage />} />
-                <Route path="/artifacts" element={<ArtifactsPage />} />
-                <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
-                <Route path="/spine" element={<SpinePage />} />
-                <Route path="/governance" element={<GovernancePage />} />
-                <Route path="/sessions" element={<SessionsPage />} />
-                <Route path="/sessions/:id" element={<SessionDetailPage />} />
-                <Route path="/nodes" element={<NodesPage />} />
-                <Route path="/settings" element={<SettingsPage />} />
-              </Routes>
+              <OnboardingGate>
+                <Routes>
+                  <Route path="/" element={<FactoryOverviewPage />} />
+                  <Route path="/artifacts" element={<ArtifactsPage />} />
+                  <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
+                  <Route path="/spine" element={<SpinePage />} />
+                  <Route path="/governance" element={<GovernancePage />} />
+                  <Route path="/sessions" element={<SessionsPage />} />
+                  <Route path="/sessions/:id" element={<SessionDetailPage />} />
+                  <Route path="/nodes" element={<NodesPage />} />
+                  <Route path="/workspaces" element={<WorkspacesPage />} />
+                  <Route path="/settings" element={<SettingsPage />} />
+                </Routes>
+              </OnboardingGate>
             </AppLayout>
           </ProtectedRoute>
         }

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -60,6 +60,13 @@ export function AppSidebar() {
   const { user, authEnabled } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
 
+  // The Organization section (workspaces) requires authentication; /api/tenants
+  // returns 401 otherwise. Hide the group entirely in anonymous/L1 mode.
+  const authed = authEnabled && !!user
+  const visibleSections = navSections.filter(
+    (s) => s.label !== "Organization" || authed,
+  )
+
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false)
   }
@@ -73,7 +80,7 @@ export function AppSidebar() {
         </Link>
       </SidebarHeader>
       <SidebarContent>
-        {navSections.map((section) => (
+        {visibleSections.map((section) => (
           <SidebarGroup key={section.label}>
             <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
             <SidebarGroupContent>

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Factory, Plus, Server, Terminal, Settings, Shield, Package, Activity } from "lucide-react"
+import { Building2, Factory, Plus, Server, Terminal, Settings, Shield, Package, Activity } from "lucide-react"
 import { OnsagerLogo } from "./OnsagerLogo"
 import { Link, useLocation } from "react-router-dom"
 import {
@@ -20,6 +20,12 @@ import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
 import { Button } from "@/components/ui/button"
 
 const navSections = [
+  {
+    label: "Organization",
+    items: [
+      { title: "Workspaces", icon: Building2, path: "/workspaces" },
+    ],
+  },
   {
     label: "Factory",
     items: [

--- a/apps/dashboard/src/components/layout/QuickCreateMenu.tsx
+++ b/apps/dashboard/src/components/layout/QuickCreateMenu.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react"
-import { Package, Plus, Terminal } from "lucide-react"
+import { Building2, Package, Plus, Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { CreateSessionSheet } from "@/components/sessions/CreateSessionSheet"
 import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
+import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
 
 export function QuickCreateMenu() {
   const [sessionOpen, setSessionOpen] = useState(false)
   const [artifactOpen, setArtifactOpen] = useState(false)
+  const [workspaceOpen, setWorkspaceOpen] = useState(false)
 
   return (
     <>
@@ -30,6 +33,11 @@ export function QuickCreateMenu() {
           <Plus className="h-5 w-5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem onClick={() => setWorkspaceOpen(true)}>
+            <Building2 className="mr-2 h-4 w-4" />
+            New Workspace
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setSessionOpen(true)}>
             <Terminal className="mr-2 h-4 w-4" />
             New Session
@@ -47,6 +55,10 @@ export function QuickCreateMenu() {
       {artifactOpen && (
         <CreateArtifactSheet open={artifactOpen} onOpenChange={setArtifactOpen} />
       )}
+      <NewWorkspaceDialog
+        open={workspaceOpen}
+        onOpenChange={setWorkspaceOpen}
+      />
     </>
   )
 }

--- a/apps/dashboard/src/components/layout/QuickCreateMenu.tsx
+++ b/apps/dashboard/src/components/layout/QuickCreateMenu.tsx
@@ -11,8 +11,11 @@ import {
 import { CreateSessionSheet } from "@/components/sessions/CreateSessionSheet"
 import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
 import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
+import { useAuth } from "@/lib/auth"
 
 export function QuickCreateMenu() {
+  const { user, authEnabled } = useAuth()
+  const canCreateWorkspace = authEnabled && !!user
   const [sessionOpen, setSessionOpen] = useState(false)
   const [artifactOpen, setArtifactOpen] = useState(false)
   const [workspaceOpen, setWorkspaceOpen] = useState(false)
@@ -33,11 +36,15 @@ export function QuickCreateMenu() {
           <Plus className="h-5 w-5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem onClick={() => setWorkspaceOpen(true)}>
-            <Building2 className="mr-2 h-4 w-4" />
-            New Workspace
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
+          {canCreateWorkspace && (
+            <>
+              <DropdownMenuItem onClick={() => setWorkspaceOpen(true)}>
+                <Building2 className="mr-2 h-4 w-4" />
+                New Workspace
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
           <DropdownMenuItem onClick={() => setSessionOpen(true)}>
             <Terminal className="mr-2 h-4 w-4" />
             New Session
@@ -55,10 +62,12 @@ export function QuickCreateMenu() {
       {artifactOpen && (
         <CreateArtifactSheet open={artifactOpen} onOpenChange={setArtifactOpen} />
       )}
-      <NewWorkspaceDialog
-        open={workspaceOpen}
-        onOpenChange={setWorkspaceOpen}
-      />
+      {canCreateWorkspace && (
+        <NewWorkspaceDialog
+          open={workspaceOpen}
+          onOpenChange={setWorkspaceOpen}
+        />
+      )}
     </>
   )
 }

--- a/apps/dashboard/src/components/workspaces/NewWorkspaceDialog.tsx
+++ b/apps/dashboard/src/components/workspaces/NewWorkspaceDialog.tsx
@@ -98,7 +98,7 @@ export function NewWorkspaceDialog({
             <Input
               placeholder="acme"
               value={slug}
-              onChange={(e) => setCustomSlug(e.target.value.toLowerCase())}
+              onChange={(e) => setCustomSlug(slugify(e.target.value))}
               className="font-mono"
             />
             <span className="text-xs text-muted-foreground">

--- a/apps/dashboard/src/components/workspaces/NewWorkspaceDialog.tsx
+++ b/apps/dashboard/src/components/workspaces/NewWorkspaceDialog.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+}
+
+/**
+ * Modal for creating a new workspace. Auto-suggests a slug from the display
+ * name until the user overrides it.
+ */
+export function NewWorkspaceDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated?: (id: string) => void
+}) {
+  const queryClient = useQueryClient()
+  const [name, setName] = useState("")
+  const [customSlug, setCustomSlug] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Auto-derive slug from the display name until the user edits the slug
+  // field directly; then keep their override.
+  const slug = customSlug ?? slugify(name)
+
+  const reset = () => {
+    setName("")
+    setCustomSlug(null)
+    setError(null)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const create = useMutation({
+    mutationFn: () => api.createWorkspace({ slug, name }),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ["workspaces"] })
+      reset()
+      onOpenChange(false)
+      onCreated?.(res.tenant.id)
+    },
+    onError: (err) =>
+      setError(err instanceof Error ? err.message : "Failed to create workspace"),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a workspace</DialogTitle>
+          <DialogDescription>
+            A workspace groups the GitHub projects and agent sessions that share
+            credentials and governance. You can create more later.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          id="new-workspace-form"
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (create.isPending) return
+            if (slug && name) create.mutate()
+          }}
+          className="space-y-3"
+        >
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Display name</span>
+            <Input
+              placeholder="Acme Inc."
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Slug</span>
+            <Input
+              placeholder="acme"
+              value={slug}
+              onChange={(e) => setCustomSlug(e.target.value.toLowerCase())}
+              className="font-mono"
+            />
+            <span className="text-xs text-muted-foreground">
+              Lowercase letters, numbers, and hyphens. Used in URLs and APIs.
+            </span>
+          </label>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </form>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="new-workspace-form"
+            disabled={!slug || !name || create.isPending}
+          >
+            {create.isPending ? "Creating…" : "Create workspace"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -7,9 +7,9 @@ import {
   type GitHubAppInstallation,
   type Project,
 } from "@/lib/api"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Button, buttonVariants } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
 import {
   Select,
   SelectContent,
@@ -32,142 +32,23 @@ import {
 } from "@/components/ui/command"
 import {
   Building2,
+  Check,
   ChevronsUpDown,
+  Circle,
   GitBranch,
+  Package,
   Plus,
   Trash2,
+  Users,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 /**
- * Settings card that lists the user's Workspaces and the nested
- * Members / GitHub installations / Projects for each.
- *
- * v1 is intentionally minimal (issue #59): no roles, no invites, no
- * cascades, no auto-mirror. GitHub App installations are registered
- * manually here — the full OAuth callback flow lands in a follow-up.
+ * Card rendering a single workspace with its GitHub installations, projects,
+ * and members. Setup state is surfaced up top so users can tell at a glance
+ * where they are in the onboarding sequence.
  */
-export function WorkspacesCard() {
-  const [creating, setCreating] = useState(false)
-  const [newSlug, setNewSlug] = useState("")
-  const [newName, setNewName] = useState("")
-  const [createError, setCreateError] = useState<string | null>(null)
-  const queryClient = useQueryClient()
-
-  const { data: wsData } = useQuery({
-    queryKey: ["workspaces"],
-    queryFn: api.listWorkspaces,
-  })
-
-  const createMutation = useMutation({
-    mutationFn: (body: { slug: string; name: string }) => api.createWorkspace(body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["workspaces"] })
-      setCreating(false)
-      setNewSlug("")
-      setNewName("")
-      setCreateError(null)
-    },
-    onError: (err) => {
-      setCreateError(err instanceof Error ? err.message : "Failed to create workspace")
-    },
-  })
-
-  const workspaces = wsData?.tenants ?? []
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-          <Building2 className="h-4 w-4" />
-          Workspaces
-        </CardTitle>
-        <CardDescription>
-          A workspace owns GitHub App installations and projects. Projects are
-          opt-in per repo — installing the App on an organization does not
-          auto-mirror its repositories.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {workspaces.length === 0 && !creating && (
-          <p className="text-sm text-muted-foreground">
-            You have no workspaces yet. Create one to onboard GitHub projects.
-          </p>
-        )}
-
-        {workspaces.map((ws) => (
-          <WorkspaceRow key={ws.id} workspace={ws} />
-        ))}
-
-        {creating ? (
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              if (createMutation.isPending) return
-              if (newSlug && newName)
-                createMutation.mutate({ slug: newSlug, name: newName })
-            }}
-            className="space-y-2 rounded-md border border-dashed p-3"
-          >
-            <p className="text-sm font-medium">New workspace</p>
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[auto_1fr]">
-              <Input
-                placeholder="slug (e.g. acme)"
-                value={newSlug}
-                onChange={(e) => setNewSlug(e.target.value.toLowerCase())}
-                className="sm:w-48"
-              />
-              <Input
-                placeholder="Display name"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-              />
-            </div>
-            {createError && (
-              <p className="text-xs text-destructive">{createError}</p>
-            )}
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                type="submit"
-                disabled={!newSlug || !newName || createMutation.isPending}
-              >
-                Create
-              </Button>
-              <Button
-                size="sm"
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setCreating(false)
-                  setNewSlug("")
-                  setNewName("")
-                  setCreateError(null)
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        ) : (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setCreating(true)
-              setCreateError(null)
-            }}
-          >
-            <Plus className="mr-1 h-3 w-3" />
-            New workspace
-          </Button>
-        )}
-      </CardContent>
-    </Card>
-  )
-}
-
-function WorkspaceRow({ workspace }: { workspace: Workspace }) {
+export function WorkspaceCard({ workspace }: { workspace: Workspace }) {
   const { data: membersData } = useQuery({
     queryKey: ["workspace-members", workspace.id],
     queryFn: () => api.listWorkspaceMembers(workspace.id),
@@ -185,38 +66,108 @@ function WorkspaceRow({ workspace }: { workspace: Workspace }) {
   const installations = installsData?.installations ?? []
   const projects = projectsData?.projects ?? []
 
+  const hasInstalls = installations.length > 0
+  const hasProjects = projects.length > 0
+  const fullySetUp = hasInstalls && hasProjects
+
   return (
-    <div className="space-y-3 rounded-md border p-3">
-      <div>
-        <p className="font-medium">{workspace.name}</p>
-        <p className="text-xs text-muted-foreground">
-          Slug: <span className="font-mono">{workspace.slug}</span> · Created{" "}
-          {new Date(workspace.created_at).toLocaleDateString()}
-        </p>
-      </div>
+    <Card>
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+              <h2 className="truncate text-lg font-semibold">{workspace.name}</h2>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              <span className="font-mono">{workspace.slug}</span> · Created{" "}
+              {new Date(workspace.created_at).toLocaleDateString()}
+            </p>
+          </div>
+          {fullySetUp ? (
+            <Badge variant="outline" className="shrink-0">
+              <Check className="mr-1 h-3 w-3" />
+              Ready
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="shrink-0">
+              Setup needed
+            </Badge>
+          )}
+        </div>
 
-      {/* Members (read-only in v1) */}
-      <div className="space-y-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Members ({members.length})
-        </p>
-        <p className="text-xs text-muted-foreground">
-          {members.map((m) => m.user_id).join(", ") || "—"}
-        </p>
-      </div>
+        <SetupProgress
+          hasInstalls={hasInstalls}
+          hasProjects={hasProjects}
+        />
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <MembersSection members={members} />
 
-      {/* GitHub installations */}
-      <InstallationsSection
-        workspaceId={workspace.id}
-        installations={installations}
-      />
+        <InstallationsSection
+          workspaceId={workspace.id}
+          installations={installations}
+        />
 
-      {/* Projects */}
-      <ProjectsSection
-        workspaceId={workspace.id}
-        installations={installations}
-        projects={projects}
-      />
+        <ProjectsSection
+          workspaceId={workspace.id}
+          installations={installations}
+          projects={projects}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function SetupProgress({
+  hasInstalls,
+  hasProjects,
+}: {
+  hasInstalls: boolean
+  hasProjects: boolean
+}) {
+  const steps = [
+    { label: "Workspace created", done: true },
+    { label: "GitHub connected", done: hasInstalls },
+    { label: "Project linked", done: hasProjects },
+  ]
+  return (
+    <ol className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+      {steps.map((s, i) => (
+        <li key={s.label} className="flex items-center gap-1.5">
+          {s.done ? (
+            <Check className="h-3.5 w-3.5 text-emerald-500" aria-hidden />
+          ) : (
+            <Circle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+          )}
+          <span
+            className={cn(
+              "font-medium",
+              s.done ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {i + 1}. {s.label}
+          </span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function MembersSection({
+  members,
+}: {
+  members: { user_id: string }[]
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <Users className="h-3 w-3" />
+        Members ({members.length})
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {members.map((m) => m.user_id).join(", ") || "—"}
+      </p>
     </div>
   )
 }
@@ -266,11 +217,13 @@ function InstallationsSection({
     },
   })
 
+  const appMissing = appConfig && !appConfig.enabled
+
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          <GitBranch className="mr-1 inline h-3 w-3" />
+      <div className="flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <GitBranch className="h-3 w-3" />
           GitHub installations ({installations.length})
         </p>
         {appConfig?.enabled && (
@@ -286,10 +239,17 @@ function InstallationsSection({
         )}
       </div>
 
-      {appConfig && !appConfig.enabled && installations.length === 0 && (
+      {appMissing && installations.length === 0 && (
         <p className="rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
           GitHub App is not configured on this server. Ask an administrator to
           set up the Onsager GitHub App before linking a repository.
+        </p>
+      )}
+
+      {!appMissing && installations.length === 0 && (
+        <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+          No GitHub installations yet. Install the Onsager GitHub App on a
+          user or organization to let this workspace manage its repositories.
         </p>
       )}
 
@@ -300,7 +260,10 @@ function InstallationsSection({
         >
           <div className="min-w-0 flex-1">
             <p className="truncate font-mono">
-              {inst.account_login} <span className="text-muted-foreground">({inst.account_type})</span>
+              {inst.account_login}{" "}
+              <span className="text-muted-foreground">
+                ({inst.account_type})
+              </span>
             </p>
             <p className="text-muted-foreground">
               Installation #{inst.install_id}
@@ -338,10 +301,6 @@ function ProjectsSection({
   const [error, setError] = useState<string | null>(null)
   const queryClient = useQueryClient()
 
-  // Accessible-repos dropdown population. Only queried when the user has
-  // started adding a project and selected an installation — the endpoint
-  // returns 503 when the App isn't configured, which falls us through to
-  // manual entry automatically.
   const { data: reposData, isLoading: reposLoading, isError: reposError } = useQuery({
     queryKey: ["installation-repos", workspaceId, installationId],
     queryFn: () =>
@@ -397,8 +356,9 @@ function ProjectsSection({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <Package className="h-3 w-3" />
           Projects ({projects.length})
         </p>
         {!adding && canAdd && (
@@ -418,8 +378,16 @@ function ProjectsSection({
       </div>
 
       {!canAdd && (
-        <p className="text-xs text-muted-foreground">
-          Link a GitHub installation first to add projects.
+        <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+          Link a GitHub installation first — projects are picked from repos the
+          Onsager GitHub App can see.
+        </p>
+      )}
+
+      {canAdd && projects.length === 0 && !adding && (
+        <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+          No projects yet. Add a repo to start running agent sessions against
+          it.
         </p>
       )}
 
@@ -455,7 +423,7 @@ function ProjectsSection({
             if (add.isPending) return
             if (installationId && repoOwner && repoName) add.mutate()
           }}
-          className="space-y-2 rounded-md border border-dashed p-2"
+          className="space-y-2 rounded-md border border-dashed p-3"
           data-testid="add-project-form"
         >
           <Select

--- a/apps/dashboard/src/components/workspaces/WorkspaceOnboarding.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceOnboarding.tsx
@@ -1,0 +1,101 @@
+import { Building2, GitBranch, Package, Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+/**
+ * Hero shown when the user has zero workspaces. Walks them through the
+ * three-step setup (create workspace → connect GitHub → pick a repo) and
+ * opens the creation dialog on click.
+ */
+export function WorkspaceOnboarding({ onCreate }: { onCreate: () => void }) {
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="space-y-6 p-6 md:p-8">
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+            <Sparkles className="h-3 w-3" />
+            Welcome to Onsager
+          </div>
+          <h2 className="text-xl font-semibold md:text-2xl">
+            Let's set up your first workspace
+          </h2>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            A workspace is where Onsager runs agent sessions against your
+            GitHub repositories. It owns your GitHub App installations, the
+            projects you onboard, and the credentials your agents use.
+          </p>
+        </div>
+
+        <ol className="grid gap-4 md:grid-cols-3">
+          <Step
+            n={1}
+            title="Create a workspace"
+            description="Name it after your team, org, or personal scope. You can create more later."
+            icon={Building2}
+            active
+          />
+          <Step
+            n={2}
+            title="Connect GitHub"
+            description="Install the Onsager GitHub App on a user or org you own."
+            icon={GitBranch}
+          />
+          <Step
+            n={3}
+            title="Add a project"
+            description="Pick a repo the App can see. Agent sessions run against it."
+            icon={Package}
+          />
+        </ol>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={onCreate} size="lg">
+            Create workspace
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Takes under a minute.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Step({
+  n,
+  title,
+  description,
+  icon: Icon,
+  active,
+}: {
+  n: number
+  title: string
+  description: string
+  icon: React.ComponentType<{ className?: string }>
+  active?: boolean
+}) {
+  return (
+    <li
+      className={
+        "rounded-md border p-4 " +
+        (active ? "border-primary/40 bg-primary/5" : "bg-muted/30")
+      }
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={
+            "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold " +
+            (active
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground")
+          }
+        >
+          {n}
+        </span>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <p className="text-sm font-medium">{title}</p>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">{description}</p>
+    </li>
+  )
+}

--- a/apps/dashboard/src/components/workspaces/WorkspaceOnboarding.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceOnboarding.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react"
 import { Building2, GitBranch, Package, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -71,7 +72,7 @@ function Step({
   n: number
   title: string
   description: string
-  icon: React.ComponentType<{ className?: string }>
+  icon: ComponentType<{ className?: string }>
   active?: boolean
 }) {
   return (

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -24,6 +24,8 @@ import {
 } from "lucide-react"
 import { Link } from "react-router-dom"
 import type { SessionSpend, SpineArtifact, SpineEvent } from "@/lib/api"
+import { Building2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
 
 const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -116,6 +118,12 @@ export function FactoryOverviewPage() {
     queryFn: () => api.getSessionSpend(100),
     refetchInterval: 30000,
   })
+  const { data: workspacesData } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+    staleTime: 30_000,
+  })
+  const noWorkspaces = (workspacesData?.tenants?.length ?? 0) === 0
 
   const artifacts = artifactsData?.artifacts ?? []
   const events = spineData?.events ?? []
@@ -160,6 +168,28 @@ export function FactoryOverviewPage() {
           Production pipeline overview — artifacts, events, and factory health.
         </p>
       </div>
+
+      {noWorkspaces && (
+        <Card className="border-primary/30 bg-primary/5">
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+            <div className="flex items-start gap-3">
+              <Building2 className="mt-0.5 h-5 w-5 text-primary" />
+              <div>
+                <p className="text-sm font-medium">
+                  You don't have a workspace yet
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Create one to onboard a GitHub project and start running
+                  agent sessions.
+                </p>
+              </div>
+            </div>
+            <Button render={<Link to="/workspaces?welcome=1" />}>
+              Set up workspace
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
         {stats.map((stat) => (

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -26,6 +26,7 @@ import { Link } from "react-router-dom"
 import type { SessionSpend, SpineArtifact, SpineEvent } from "@/lib/api"
 import { Building2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { useAuth } from "@/lib/auth"
 
 const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -90,6 +91,9 @@ function PipelineStats({ artifacts }: { artifacts: SpineArtifact[] }) {
 }
 
 export function FactoryOverviewPage() {
+  const { user, authEnabled } = useAuth()
+  const canLoadWorkspaces = Boolean(authEnabled && user)
+
   const { data: artifactsData } = useQuery({
     queryKey: ["artifacts"],
     queryFn: api.getArtifacts,
@@ -122,8 +126,10 @@ export function FactoryOverviewPage() {
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
     staleTime: 30_000,
+    enabled: canLoadWorkspaces,
   })
-  const noWorkspaces = (workspacesData?.tenants?.length ?? 0) === 0
+  const noWorkspaces =
+    canLoadWorkspaces && (workspacesData?.tenants?.length ?? 0) === 0
 
   const artifacts = artifactsData?.artifacts ?? []
   const events = spineData?.events ?? []

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react"
+import { Link } from "react-router-dom"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useAuth } from "@/lib/auth"
 import { api } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Trash2, Plus, KeyRound, User } from "lucide-react"
-import { WorkspacesCard } from "@/components/settings/WorkspacesCard"
+import { ArrowRight, Building2, Trash2, Plus, KeyRound, User } from "lucide-react"
 
 const KNOWN_CREDENTIALS = [
   {
@@ -96,8 +96,25 @@ export function SettingsPage() {
         </Card>
       )}
 
-      {/* Workspaces */}
-      <WorkspacesCard />
+      {/* Workspaces link-out — the full management UI lives at /workspaces. */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Building2 className="h-4 w-4" />
+            Workspaces
+          </CardTitle>
+          <CardDescription>
+            Manage the GitHub installations, projects, and members for each
+            workspace.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button render={<Link to="/workspaces" />} variant="outline">
+            Go to Workspaces
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        </CardContent>
+      </Card>
 
       {/* Credentials */}
       <Card>

--- a/apps/dashboard/src/pages/WorkspacesPage.tsx
+++ b/apps/dashboard/src/pages/WorkspacesPage.tsx
@@ -2,7 +2,9 @@ import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useSearchParams } from "react-router-dom"
 import { api } from "@/lib/api"
+import { useAuth } from "@/lib/auth"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Plus } from "lucide-react"
 import { WorkspaceCard } from "@/components/workspaces/WorkspaceCard"
@@ -14,9 +16,12 @@ import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
  * first-run onboarding hero. Replaces the former Settings → Workspaces card.
  */
 export function WorkspacesPage() {
+  const { user, authEnabled } = useAuth()
+  const canLoadWorkspaces = Boolean(authEnabled && user)
   const { data, isLoading } = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
+    enabled: canLoadWorkspaces,
   })
   const workspaces = useMemo(() => data?.tenants ?? [], [data])
   const [createOpen, setCreateOpen] = useState(false)
@@ -31,7 +36,7 @@ export function WorkspacesPage() {
   }
 
   const showOnboarding =
-    !isLoading && (workspaces.length === 0 || welcome)
+    canLoadWorkspaces && !isLoading && (workspaces.length === 0 || welcome)
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -46,7 +51,7 @@ export function WorkspacesPage() {
             auto-mirror repos — projects are opt-in per repo.
           </p>
         </div>
-        {workspaces.length > 0 && (
+        {canLoadWorkspaces && workspaces.length > 0 && (
           <Button
             onClick={() => {
               setCreateOpen(true)
@@ -59,7 +64,16 @@ export function WorkspacesPage() {
         )}
       </div>
 
-      {isLoading && (
+      {!canLoadWorkspaces && (
+        <Card>
+          <CardContent className="p-6 text-sm text-muted-foreground">
+            Workspaces require authentication. Sign in to create one and
+            manage GitHub installations, projects, and members.
+          </CardContent>
+        </Card>
+      )}
+
+      {canLoadWorkspaces && isLoading && (
         <div className="space-y-3">
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
@@ -75,7 +89,8 @@ export function WorkspacesPage() {
         />
       )}
 
-      {!isLoading &&
+      {canLoadWorkspaces &&
+        !isLoading &&
         workspaces.map((ws) => <WorkspaceCard key={ws.id} workspace={ws} />)}
 
       <NewWorkspaceDialog

--- a/apps/dashboard/src/pages/WorkspacesPage.tsx
+++ b/apps/dashboard/src/pages/WorkspacesPage.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useSearchParams } from "react-router-dom"
+import { api } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Plus } from "lucide-react"
+import { WorkspaceCard } from "@/components/workspaces/WorkspaceCard"
+import { WorkspaceOnboarding } from "@/components/workspaces/WorkspaceOnboarding"
+import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
+
+/**
+ * Top-level Workspaces page. Owns the list, the create flow, and the
+ * first-run onboarding hero. Replaces the former Settings → Workspaces card.
+ */
+export function WorkspacesPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+  })
+  const workspaces = useMemo(() => data?.tenants ?? [], [data])
+  const [createOpen, setCreateOpen] = useState(false)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const welcome = searchParams.get("welcome") === "1"
+
+  const dismissWelcome = () => {
+    if (!welcome) return
+    const next = new URLSearchParams(searchParams)
+    next.delete("welcome")
+    setSearchParams(next, { replace: true })
+  }
+
+  const showOnboarding =
+    !isLoading && (workspaces.length === 0 || welcome)
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">
+            Workspaces
+          </h1>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            A workspace owns GitHub App installations and projects, and scopes
+            the sessions your agents run. Installing the App does not
+            auto-mirror repos — projects are opt-in per repo.
+          </p>
+        </div>
+        {workspaces.length > 0 && (
+          <Button
+            onClick={() => {
+              setCreateOpen(true)
+              dismissWelcome()
+            }}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            New workspace
+          </Button>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="space-y-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      )}
+
+      {showOnboarding && (
+        <WorkspaceOnboarding
+          onCreate={() => {
+            setCreateOpen(true)
+            dismissWelcome()
+          }}
+        />
+      )}
+
+      {!isLoading &&
+        workspaces.map((ws) => <WorkspaceCard key={ws.id} workspace={ws} />)}
+
+      <NewWorkspaceDialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          setCreateOpen(open)
+          if (!open) dismissWelcome()
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/dashboard/tests/smoke/settings-credentials.test.tsx
+++ b/apps/dashboard/tests/smoke/settings-credentials.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
 import { SettingsPage } from "@/pages/SettingsPage"
 
 // Minimal mocks so SettingsPage renders without network
@@ -20,7 +21,9 @@ function renderSettings() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <SettingsPage />
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>
     </QueryClientProvider>,
   )
 }

--- a/apps/dashboard/tests/smoke/workspaces-card.test.tsx
+++ b/apps/dashboard/tests/smoke/workspaces-card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { WorkspacesCard } from "@/components/settings/WorkspacesCard"
+import { WorkspaceCard } from "@/components/workspaces/WorkspaceCard"
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -35,30 +35,36 @@ const orgInstall = {
   created_at: "2026-01-01",
 }
 
-async function primeMocks(opts: { repos: unknown[] }) {
+async function primeMocks(opts: {
+  repos: unknown[]
+  installations?: unknown[]
+  appEnabled?: boolean
+}) {
   const { api } = await import("@/lib/api")
   vi.mocked(api.listWorkspaces).mockResolvedValue({ tenants: [ws] })
   vi.mocked(api.listWorkspaceMembers).mockResolvedValue({ members: [] })
   vi.mocked(api.listWorkspaceInstallations).mockResolvedValue({
-    installations: [orgInstall],
+    installations: (opts.installations ?? [orgInstall]) as never,
   })
   vi.mocked(api.listWorkspaceProjects).mockResolvedValue({ projects: [] })
   vi.mocked(api.listInstallationRepos).mockResolvedValue({
     repos: opts.repos as never,
   })
-  vi.mocked(api.getGitHubAppConfig).mockResolvedValue({ enabled: true })
+  vi.mocked(api.getGitHubAppConfig).mockResolvedValue({
+    enabled: opts.appEnabled ?? true,
+  })
 }
 
 function renderCard() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <WorkspacesCard />
+      <WorkspaceCard workspace={ws} />
     </QueryClientProvider>,
   )
 }
 
-describe("WorkspacesCard — OAuth-first Add project flow", () => {
+describe("WorkspaceCard — OAuth-first Add project flow", () => {
   beforeEach(() => vi.clearAllMocks())
 
   it("deep-links to GitHub install settings when the install has no accessible repos", async () => {
@@ -124,14 +130,7 @@ describe("WorkspacesCard — OAuth-first Add project flow", () => {
   })
 
   it("tells the user to contact an admin when the GitHub App is not configured", async () => {
-    const { api } = await import("@/lib/api")
-    vi.mocked(api.listWorkspaces).mockResolvedValue({ tenants: [ws] })
-    vi.mocked(api.listWorkspaceMembers).mockResolvedValue({ members: [] })
-    vi.mocked(api.listWorkspaceInstallations).mockResolvedValue({
-      installations: [],
-    })
-    vi.mocked(api.listWorkspaceProjects).mockResolvedValue({ projects: [] })
-    vi.mocked(api.getGitHubAppConfig).mockResolvedValue({ enabled: false })
+    await primeMocks({ repos: [], installations: [], appEnabled: false })
     renderCard()
     await waitFor(() =>
       expect(


### PR DESCRIPTION
## Summary

Surfaces org/workspace onboarding as a first-class product flow. The Phase 0
workspace APIs + `WorkspacesCard` shipped in #59 but the entry point was
buried inside Settings with no sidebar affordance and no first-run guidance
— a new user landed on an empty Factory Overview with no way to discover
that they needed a workspace before anything else could happen.

Closes #70

### What's new

- **Dedicated `/workspaces` page** replaces the Settings → Workspaces card.
  Features a stepped welcome hero (create → connect GitHub → add project)
  for zero-workspace users and per-workspace setup-progress indicators
  (`1. Workspace created · 2. GitHub connected · 3. Project linked`) with
  a "Setup needed" / "Ready" status badge.
- **OnboardingGate** (`apps/dashboard/src/App.tsx`): authenticated users with
  zero workspaces are redirected to `/workspaces?welcome=1` once per session.
  Gated on `authEnabled && user` so anonymous/L1 contexts are untouched.
- **Sidebar**: new top-level `Organization → Workspaces` entry
  (`apps/dashboard/src/components/layout/AppSidebar.tsx`).
- **QuickCreateMenu**: "New Workspace" action backed by a modal with
  auto-derived slug (`apps/dashboard/src/components/workspaces/NewWorkspaceDialog.tsx`).
- **Factory Overview**: workspace-setup CTA banner when the user has no
  workspaces.
- **Settings**: link-out card to `/workspaces` for secondary discoverability.

### File layout

```
apps/dashboard/src/
├── components/
│   ├── workspaces/
│   │   ├── WorkspaceCard.tsx          (extracted from settings/WorkspacesCard)
│   │   ├── WorkspaceOnboarding.tsx    (new — stepped welcome hero)
│   │   └── NewWorkspaceDialog.tsx     (new — create modal)
│   └── settings/
│       └── WorkspacesCard.tsx         (deleted)
└── pages/
    └── WorkspacesPage.tsx              (new)
```

## Test plan

- [x] `pnpm --filter dashboard lint` clean
- [x] `pnpm --filter dashboard build` clean (tsc + vite)
- [x] `pnpm --filter dashboard test` — 46/46 tests pass (workspaces-card smoke
      test migrated to import `WorkspaceCard` directly; settings-credentials
      test wrapped in `MemoryRouter` for the new link-out)
- [ ] L1 e2e smoke still lands on `/` (gated off for anonymous sessions)
- [ ] Manually verify `/workspaces?welcome=1` redirect fires once per session
      and doesn't loop after navigating away

https://claude.ai/code/session_01EihKSWdcXkXurEHtRXDRxQ