### PR TITLE
feat(dashboard): sidebar setup checklist + progressive nav disclosure

### DIFF
--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -67,7 +67,10 @@ export function AppSidebar() {
   const location = useLocation()
   const { user, authEnabled } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
-  const { hasWorkspace, loading: progressLoading } = useSetupProgress()
+  // Call the progress hook once at the sidebar root and thread the result
+  // down — avoids a second observer/render path when SetupChecklist mounts.
+  const setupProgress = useSetupProgress()
+  const { hasWorkspace, workspacesLoading } = setupProgress
 
   // The Organization section (workspaces) requires authentication; /api/tenants
   // returns 401 otherwise. Hide the group entirely in anonymous/L1 mode.
@@ -76,8 +79,10 @@ export function AppSidebar() {
   // the Organization + System groups. Anonymous users see everything except
   // Organization (same as before). Once the first workspace is created the
   // full nav unlocks — and the SetupChecklist takes over as outer-loop
-  // guidance until GitHub is connected and a project is added.
-  const gateNav = authed && !progressLoading && !hasWorkspace
+  // guidance until GitHub is connected and a project is added. Gate on
+  // workspacesLoading only (not the aggregate `loading`) so the nav decision
+  // doesn't wait for the slower projects/installs queries.
+  const gateNav = authed && !workspacesLoading && !hasWorkspace
   const visibleSections = navSections.filter((s) => {
     if (s.label === "Organization" && !authed) return false
     if (gateNav && !PRE_WORKSPACE_SECTIONS.has(s.label)) return false
@@ -121,7 +126,7 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         ))}
-        <SetupChecklist />
+        <SetupChecklist progress={setupProgress} />
         {!gateNav && (
           <SidebarGroup>
             <SidebarGroupContent>

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -18,6 +18,8 @@ import { ThemeToggle } from "./ThemeToggle"
 import { useAuth } from "@/lib/auth"
 import { CreateArtifactSheet } from "@/components/factory/CreateArtifactSheet"
 import { Button } from "@/components/ui/button"
+import { SetupChecklist } from "@/components/workspaces/SetupChecklist"
+import { useSetupProgress } from "@/hooks/useSetupProgress"
 
 const navSections = [
   {
@@ -55,17 +57,32 @@ const navSections = [
   },
 ]
 
+// Sections kept visible before the user has created their first workspace.
+// Everything else (factory, governance, infrastructure) shows empty tables in
+// that state and distracts from the setup path, so we hide it until the user
+// has at least one workspace.
+const PRE_WORKSPACE_SECTIONS = new Set(["Organization", "System"])
+
 export function AppSidebar() {
   const location = useLocation()
   const { user, authEnabled } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
+  const { hasWorkspace, loading: progressLoading } = useSetupProgress()
 
   // The Organization section (workspaces) requires authentication; /api/tenants
   // returns 401 otherwise. Hide the group entirely in anonymous/L1 mode.
   const authed = authEnabled && !!user
-  const visibleSections = navSections.filter(
-    (s) => s.label !== "Organization" || authed,
-  )
+  // Progressive disclosure: authenticated users with zero workspaces only see
+  // the Organization + System groups. Anonymous users see everything except
+  // Organization (same as before). Once the first workspace is created the
+  // full nav unlocks — and the SetupChecklist takes over as outer-loop
+  // guidance until GitHub is connected and a project is added.
+  const gateNav = authed && !progressLoading && !hasWorkspace
+  const visibleSections = navSections.filter((s) => {
+    if (s.label === "Organization" && !authed) return false
+    if (gateNav && !PRE_WORKSPACE_SECTIONS.has(s.label)) return false
+    return true
+  })
 
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false)
@@ -104,16 +121,19 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         ))}
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <CreateArtifactSheet>
-              <Button variant="outline" className="w-full justify-start gap-2">
-                <Plus className="h-4 w-4" />
-                <span>Register Artifact</span>
-              </Button>
-            </CreateArtifactSheet>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        <SetupChecklist />
+        {!gateNav && (
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <CreateArtifactSheet>
+                <Button variant="outline" className="w-full justify-start gap-2">
+                  <Plus className="h-4 w-4" />
+                  <span>Register Artifact</span>
+                </Button>
+              </CreateArtifactSheet>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter className="border-t p-4 space-y-3">
         {authEnabled && user && (

--- a/apps/dashboard/src/components/workspaces/SetupChecklist.tsx
+++ b/apps/dashboard/src/components/workspaces/SetupChecklist.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Check, ChevronRight, Circle, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useSetupProgress } from "@/hooks/useSetupProgress"
+import type { SetupProgress } from "@/hooks/useSetupProgress"
 
 // Session-scoped dismissal — the user chose to hide the checklist for this
 // session; we still re-show it on the next session so unfinished setup isn't
@@ -15,17 +15,13 @@ const DISMISS_KEY = "onsager.setup_checklist_dismissed"
  * Complements the progressive nav disclosure: pre-workspace users only see
  * "Workspaces" in the sidebar, but once they've created a workspace the full
  * nav unlocks and this checklist takes over as outer-loop guidance.
+ *
+ * Progress is passed in from `AppSidebar` rather than read via the hook to
+ * keep a single observer/render path across sidebar + checklist.
  */
-export function SetupChecklist() {
-  const {
-    authed,
-    loading,
-    hasWorkspace,
-    hasInstall,
-    hasProject,
-    complete,
-    firstWorkspaceSlug,
-  } = useSetupProgress()
+export function SetupChecklist({ progress }: { progress: SetupProgress }) {
+  const { authed, loading, hasWorkspace, hasInstall, hasProject, complete } =
+    progress
   const [dismissed, setDismissed] = useState(
     () =>
       typeof window !== "undefined" &&
@@ -41,26 +37,21 @@ export function SetupChecklist() {
     }
   }
 
-  const steps: { done: boolean; title: string; href: string; active?: boolean }[] = [
-    {
-      done: hasWorkspace,
-      title: "Create a workspace",
-      href: "/workspaces?welcome=1",
-    },
-    {
-      done: hasInstall,
-      title: "Connect GitHub",
-      href: firstWorkspaceSlug ? `/workspaces#${firstWorkspaceSlug}` : "/workspaces",
-    },
-    {
-      done: hasProject,
-      title: "Add a project",
-      href: firstWorkspaceSlug ? `/workspaces#${firstWorkspaceSlug}` : "/workspaces",
-    },
+  // All steps link to /workspaces — the page owns the setup flow (create
+  // workspace, connect GitHub App, pick a repo). Deep-linking to a specific
+  // workspace would need the page to read `location.hash` and scroll, which
+  // it doesn't today; plain routes stay honest.
+  const steps: { done: boolean; title: string; active?: boolean }[] = [
+    { done: hasWorkspace, title: "Create a workspace" },
+    { done: hasInstall, title: "Connect GitHub" },
+    { done: hasProject, title: "Add a project" },
   ]
   const activeIndex = steps.findIndex((s) => !s.done)
   if (activeIndex >= 0) steps[activeIndex].active = true
   const doneCount = steps.filter((s) => s.done).length
+  // Zero-workspace users land on /workspaces?welcome=1 to get the full hero;
+  // everyone else just needs the page itself.
+  const href = hasWorkspace ? "/workspaces" : "/workspaces?welcome=1"
 
   return (
     <div className="mx-2 mb-2 rounded-md border bg-sidebar-accent/40 p-3">
@@ -85,7 +76,7 @@ export function SetupChecklist() {
         {steps.map((step, i) => (
           <li key={i}>
             <Link
-              to={step.href}
+              to={href}
               className={
                 "group flex items-center gap-2 rounded px-1.5 py-1 text-xs transition-colors " +
                 (step.active

--- a/apps/dashboard/src/components/workspaces/SetupChecklist.tsx
+++ b/apps/dashboard/src/components/workspaces/SetupChecklist.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { Check, ChevronRight, Circle, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useSetupProgress } from "@/hooks/useSetupProgress"
+
+// Session-scoped dismissal — the user chose to hide the checklist for this
+// session; we still re-show it on the next session so unfinished setup isn't
+// permanently invisible.
+const DISMISS_KEY = "onsager.setup_checklist_dismissed"
+
+/**
+ * Sidebar-embedded onboarding checklist. Shown whenever the user has started
+ * but not finished workspace setup; auto-hides once all three steps are done.
+ * Complements the progressive nav disclosure: pre-workspace users only see
+ * "Workspaces" in the sidebar, but once they've created a workspace the full
+ * nav unlocks and this checklist takes over as outer-loop guidance.
+ */
+export function SetupChecklist() {
+  const {
+    authed,
+    loading,
+    hasWorkspace,
+    hasInstall,
+    hasProject,
+    complete,
+    firstWorkspaceSlug,
+  } = useSetupProgress()
+  const [dismissed, setDismissed] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(DISMISS_KEY) === "1",
+  )
+
+  if (!authed || loading || complete || dismissed) return null
+
+  const dismiss = () => {
+    setDismissed(true)
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(DISMISS_KEY, "1")
+    }
+  }
+
+  const steps: { done: boolean; title: string; href: string; active?: boolean }[] = [
+    {
+      done: hasWorkspace,
+      title: "Create a workspace",
+      href: "/workspaces?welcome=1",
+    },
+    {
+      done: hasInstall,
+      title: "Connect GitHub",
+      href: firstWorkspaceSlug ? `/workspaces#${firstWorkspaceSlug}` : "/workspaces",
+    },
+    {
+      done: hasProject,
+      title: "Add a project",
+      href: firstWorkspaceSlug ? `/workspaces#${firstWorkspaceSlug}` : "/workspaces",
+    },
+  ]
+  const activeIndex = steps.findIndex((s) => !s.done)
+  if (activeIndex >= 0) steps[activeIndex].active = true
+  const doneCount = steps.filter((s) => s.done).length
+
+  return (
+    <div className="mx-2 mb-2 rounded-md border bg-sidebar-accent/40 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div>
+          <p className="text-xs font-semibold">Getting started</p>
+          <p className="text-[10px] text-muted-foreground">
+            {doneCount} of {steps.length} complete
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={dismiss}
+          aria-label="Dismiss checklist"
+          className="h-6 w-6 text-muted-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <ol className="space-y-1">
+        {steps.map((step, i) => (
+          <li key={i}>
+            <Link
+              to={step.href}
+              className={
+                "group flex items-center gap-2 rounded px-1.5 py-1 text-xs transition-colors " +
+                (step.active
+                  ? "bg-primary/10 text-foreground"
+                  : "text-muted-foreground hover:bg-sidebar-accent")
+              }
+            >
+              {step.done ? (
+                <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
+              ) : (
+                <Circle
+                  className={
+                    "h-3.5 w-3.5 shrink-0 " +
+                    (step.active ? "text-primary" : "text-muted-foreground")
+                  }
+                />
+              )}
+              <span
+                className={
+                  "flex-1 " +
+                  (step.done ? "line-through opacity-60" : "")
+                }
+              >
+                {step.title}
+              </span>
+              {step.active && (
+                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-primary opacity-0 transition-opacity group-hover:opacity-100" />
+              )}
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/apps/dashboard/src/hooks/useSetupProgress.ts
+++ b/apps/dashboard/src/hooks/useSetupProgress.ts
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { useAuth } from "@/lib/auth"
+
+export interface SetupProgress {
+  authed: boolean
+  loading: boolean
+  hasWorkspace: boolean
+  hasInstall: boolean
+  hasProject: boolean
+  complete: boolean
+  firstWorkspaceSlug: string | null
+}
+
+/**
+ * Shared source of truth for workspace onboarding progress. Used by the
+ * sidebar's progressive nav disclosure (hide Factory/Governance/Infra until
+ * a workspace exists) and the SetupChecklist that surfaces the remaining
+ * setup steps. Co-locating the queries keeps the React Query cache honest
+ * and avoids double-fetching across the two callers.
+ */
+export function useSetupProgress(): SetupProgress {
+  const { user, authEnabled } = useAuth()
+  const authed = Boolean(authEnabled && user)
+
+  const { data: wsData, isLoading: wsLoading } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+    enabled: authed,
+    staleTime: 30_000,
+  })
+  const workspaces = wsData?.tenants ?? []
+  const firstWs = workspaces[0]
+
+  const { data: installsData, isLoading: installsLoading } = useQuery({
+    queryKey: ["workspace-installations", firstWs?.id],
+    queryFn: () => api.listWorkspaceInstallations(firstWs!.id),
+    enabled: authed && !!firstWs,
+    staleTime: 30_000,
+  })
+  const installs = installsData?.installations ?? []
+
+  const { data: projectsData, isLoading: projectsLoading } = useQuery({
+    queryKey: ["all-projects"],
+    queryFn: api.listAllProjects,
+    enabled: authed,
+    staleTime: 30_000,
+  })
+  const projects = projectsData?.projects ?? []
+
+  const hasWorkspace = workspaces.length > 0
+  // A project implies an install somewhere, even if not in the first workspace.
+  const hasInstall = installs.length > 0 || projects.length > 0
+  const hasProject = projects.length > 0
+
+  return {
+    authed,
+    loading: authed && (wsLoading || installsLoading || projectsLoading),
+    hasWorkspace,
+    hasInstall,
+    hasProject,
+    complete: hasWorkspace && hasInstall && hasProject,
+    firstWorkspaceSlug: firstWs?.slug ?? null,
+  }
+}

--- a/apps/dashboard/src/hooks/useSetupProgress.ts
+++ b/apps/dashboard/src/hooks/useSetupProgress.ts
@@ -1,9 +1,17 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQueries, useQuery } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { useAuth } from "@/lib/auth"
 
 export interface SetupProgress {
   authed: boolean
+  /**
+   * True while the *workspaces* query is still loading. This is the only
+   * signal the sidebar's progressive nav disclosure needs — gating nav on
+   * the full `loading` would keep the nav visible while `/projects` is
+   * still in-flight and cause a flash before hiding.
+   */
+  workspacesLoading: boolean
+  /** True while any of the underlying queries are still loading. */
   loading: boolean
   hasWorkspace: boolean
   hasInstall: boolean
@@ -17,7 +25,7 @@ export interface SetupProgress {
  * sidebar's progressive nav disclosure (hide Factory/Governance/Infra until
  * a workspace exists) and the SetupChecklist that surfaces the remaining
  * setup steps. Co-locating the queries keeps the React Query cache honest
- * and avoids double-fetching across the two callers.
+ * and avoids double-fetching across callers.
  */
 export function useSetupProgress(): SetupProgress {
   const { user, authEnabled } = useAuth()
@@ -32,13 +40,22 @@ export function useSetupProgress(): SetupProgress {
   const workspaces = wsData?.tenants ?? []
   const firstWs = workspaces[0]
 
-  const { data: installsData, isLoading: installsLoading } = useQuery({
-    queryKey: ["workspace-installations", firstWs?.id],
-    queryFn: () => api.listWorkspaceInstallations(firstWs!.id),
-    enabled: authed && !!firstWs,
-    staleTime: 30_000,
+  // Installations live per-tenant; a user may install the App in any of
+  // their workspaces. Fan out one query per workspace so the checklist
+  // reflects the truth regardless of which workspace got the install.
+  // React Query shares the cache with `WorkspaceCard`'s per-id queries.
+  const installQueries = useQueries({
+    queries: workspaces.map((ws) => ({
+      queryKey: ["workspace-installations", ws.id],
+      queryFn: () => api.listWorkspaceInstallations(ws.id),
+      enabled: authed,
+      staleTime: 30_000,
+    })),
   })
-  const installs = installsData?.installations ?? []
+  const installsLoading = installQueries.some((q) => q.isLoading)
+  const anyInstallExists = installQueries.some(
+    (q) => (q.data?.installations.length ?? 0) > 0,
+  )
 
   const { data: projectsData, isLoading: projectsLoading } = useQuery({
     queryKey: ["all-projects"],
@@ -49,12 +66,14 @@ export function useSetupProgress(): SetupProgress {
   const projects = projectsData?.projects ?? []
 
   const hasWorkspace = workspaces.length > 0
-  // A project implies an install somewhere, even if not in the first workspace.
-  const hasInstall = installs.length > 0 || projects.length > 0
+  // A project implies an install somewhere; otherwise fall back to the
+  // aggregated install check across all workspaces.
+  const hasInstall = projects.length > 0 || anyInstallExists
   const hasProject = projects.length > 0
 
   return {
     authed,
+    workspacesLoading: authed && wsLoading,
     loading: authed && (wsLoading || installsLoading || projectsLoading),
     hasWorkspace,
     hasInstall,

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -24,9 +24,6 @@ import {
 } from "lucide-react"
 import { Link } from "react-router-dom"
 import type { SessionSpend, SpineArtifact, SpineEvent } from "@/lib/api"
-import { Building2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { useAuth } from "@/lib/auth"
 
 const STATE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -91,9 +88,6 @@ function PipelineStats({ artifacts }: { artifacts: SpineArtifact[] }) {
 }
 
 export function FactoryOverviewPage() {
-  const { user, authEnabled } = useAuth()
-  const canLoadWorkspaces = Boolean(authEnabled && user)
-
   const { data: artifactsData } = useQuery({
     queryKey: ["artifacts"],
     queryFn: api.getArtifacts,
@@ -122,14 +116,6 @@ export function FactoryOverviewPage() {
     queryFn: () => api.getSessionSpend(100),
     refetchInterval: 30000,
   })
-  const { data: workspacesData } = useQuery({
-    queryKey: ["workspaces"],
-    queryFn: api.listWorkspaces,
-    staleTime: 30_000,
-    enabled: canLoadWorkspaces,
-  })
-  const noWorkspaces =
-    canLoadWorkspaces && (workspacesData?.tenants?.length ?? 0) === 0
 
   const artifacts = artifactsData?.artifacts ?? []
   const events = spineData?.events ?? []
@@ -174,28 +160,6 @@ export function FactoryOverviewPage() {
           Production pipeline overview — artifacts, events, and factory health.
         </p>
       </div>
-
-      {noWorkspaces && (
-        <Card className="border-primary/30 bg-primary/5">
-          <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
-            <div className="flex items-start gap-3">
-              <Building2 className="mt-0.5 h-5 w-5 text-primary" />
-              <div>
-                <p className="text-sm font-medium">
-                  You don't have a workspace yet
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Create one to onboard a GitHub project and start running
-                  agent sessions.
-                </p>
-              </div>
-            </div>
-            <Button render={<Link to="/workspaces?welcome=1" />}>
-              Set up workspace
-            </Button>
-          </CardContent>
-        </Card>
-      )}
 
       <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
         {stats.map((stat) => (


### PR DESCRIPTION
Closes #72

## Summary

Today the workspace onboarding CTA only lives on Factory Overview and
`/workspaces`. Every other page (Sessions, Nodes, Artifacts, Governance,
Spine) shows a blank table for a zero-workspace user with no path back to
setup. This PR lifts onboarding into the sidebar so it follows the user
across routes.

Two-part pattern:

- **Progressive nav disclosure** (`AppSidebar.tsx`) — authenticated users
  with zero workspaces only see the Organization (Workspaces) + System
  (Settings) groups. Factory / Governance / Infrastructure and the
  "Register Artifact" CTA unlock once a workspace is created. Anonymous
  users still see everything except Organization (existing behavior).

- **Setup checklist** (`SetupChecklist.tsx` + `useSetupProgress.ts`) —
  compact three-step checklist pinned to the sidebar that tracks live
  progress (workspace → GitHub → project), is session-dismissible, and
  auto-hides once all three steps are done. Shared hook keeps the React
  Query cache honest across the sidebar + checklist.

The stale zero-workspace banner on `FactoryOverviewPage` is removed since
the sidebar covers the same ground everywhere.

## Test plan

- [x] `pnpm run build` succeeds
- [x] `pnpm run lint` clean
- [x] `pnpm run test` — 46 tests pass
- [ ] Visual: authed user with 0 workspaces → sidebar shows only
      Organization + System + checklist (step 1 active)
- [ ] Visual: 1 workspace, 0 installs → full nav unlocked, checklist step 2
      active
- [ ] Visual: 1 workspace, install, 1+ project → checklist auto-hides
- [ ] Visual: dismiss checklist → stays hidden for the session, returns
      next session
- [ ] Anonymous / auth-disabled mode → sidebar behaves as before (no
      Organization group, no checklist)

https://claude.ai/code/session_018w9dnYrgLKtf9SdoPeFEqN