### PR TITLE
feat(dashboard): step-by-step CTAs in WorkspaceCard onboarding

### DIFF
--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useState } from "react"
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import { Link } from "react-router-dom"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   api,
@@ -31,6 +39,7 @@ import {
   CommandList,
 } from "@/components/ui/command"
 import {
+  ArrowRight,
   Building2,
   Check,
   ChevronsUpDown,
@@ -38,6 +47,7 @@ import {
   GitBranch,
   Package,
   Plus,
+  Sparkles,
   Trash2,
   Users,
 } from "lucide-react"
@@ -70,6 +80,21 @@ export function WorkspaceCard({ workspace }: { workspace: Workspace }) {
   const hasProjects = projects.length > 0
   const fullySetUp = hasInstalls && hasProjects
 
+  const projectsScrollRef = useRef<HTMLDivElement>(null)
+  const projectsSectionRef = useRef<ProjectsSectionHandle>(null)
+
+  const handleAddProject = () => {
+    projectsSectionRef.current?.openAdd()
+    requestAnimationFrame(() => {
+      const el = projectsScrollRef.current
+      // jsdom (used in unit tests) doesn't implement scrollIntoView; production
+      // browsers do. Feature-detect rather than prototype-pollute the test env.
+      if (el && typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ behavior: "smooth", block: "center" })
+      }
+    })
+  }
+
   return (
     <Card>
       <CardHeader className="gap-3">
@@ -100,6 +125,13 @@ export function WorkspaceCard({ workspace }: { workspace: Workspace }) {
           hasInstalls={hasInstalls}
           hasProjects={hasProjects}
         />
+
+        <NextStepCallout
+          workspaceId={workspace.id}
+          hasInstalls={hasInstalls}
+          hasProjects={hasProjects}
+          onAddProject={handleAddProject}
+        />
       </CardHeader>
       <CardContent className="space-y-5">
         <MembersSection members={members} />
@@ -109,13 +141,147 @@ export function WorkspaceCard({ workspace }: { workspace: Workspace }) {
           installations={installations}
         />
 
-        <ProjectsSection
-          workspaceId={workspace.id}
-          installations={installations}
-          projects={projects}
-        />
+        <div ref={projectsScrollRef}>
+          <ProjectsSection
+            ref={projectsSectionRef}
+            workspaceId={workspace.id}
+            installations={installations}
+            projects={projects}
+          />
+        </div>
       </CardContent>
     </Card>
+  )
+}
+
+/**
+ * Step-by-step CTA: surfaces the single next action the user needs to take
+ * to drive a workspace from "Setup needed" to running an agent session.
+ * Replaces the previous experience where the only progress signal was the
+ * dotted SetupProgress checklist with no buttons attached.
+ */
+function NextStepCallout({
+  workspaceId,
+  hasInstalls,
+  hasProjects,
+  onAddProject,
+}: {
+  workspaceId: string
+  hasInstalls: boolean
+  hasProjects: boolean
+  onAddProject: () => void
+}) {
+  const { data: appConfig } = useQuery({
+    queryKey: ["github-app-config"],
+    queryFn: api.getGitHubAppConfig,
+    staleTime: 5 * 60_000,
+  })
+
+  if (!hasInstalls) {
+    if (appConfig && !appConfig.enabled) {
+      return (
+        <div
+          className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3"
+          role="status"
+        >
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
+            Setup blocked: GitHub App unavailable
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Ask an administrator to register the Onsager GitHub App on this
+            server before continuing setup.
+          </p>
+        </div>
+      )
+    }
+    return (
+      <NextStepRow
+        label="Step 2 of 3 · Connect GitHub"
+        description="Install the Onsager GitHub App on a user or org you own so this workspace can read its repositories."
+        action={
+          <Button
+            size="sm"
+            onClick={() => {
+              window.location.href = `/api/github-app/install-start?tenant_id=${encodeURIComponent(workspaceId)}`
+            }}
+            disabled={!appConfig?.enabled}
+          >
+            <GitBranch className="mr-1 h-3 w-3" />
+            Install GitHub App
+            <ArrowRight className="ml-1 h-3 w-3" />
+          </Button>
+        }
+      />
+    )
+  }
+
+  if (!hasProjects) {
+    return (
+      <NextStepRow
+        label="Step 3 of 3 · Add a project"
+        description="Pick a repository the App can see — agent sessions will run against it."
+        action={
+          <Button size="sm" onClick={onAddProject}>
+            <Package className="mr-1 h-3 w-3" />
+            Add project
+            <ArrowRight className="ml-1 h-3 w-3" />
+          </Button>
+        }
+      />
+    )
+  }
+
+  return (
+    <NextStepRow
+      tone="success"
+      label="You're set up"
+      description="Start your first agent session against a project in this workspace."
+      action={
+        <Link to="/sessions" className={buttonVariants({ size: "sm" })}>
+          <Sparkles className="mr-1 h-3 w-3" />
+          Start a session
+          <ArrowRight className="ml-1 h-3 w-3" />
+        </Link>
+      }
+    />
+  )
+}
+
+function NextStepRow({
+  label,
+  description,
+  action,
+  tone = "primary",
+}: {
+  label: string
+  description: string
+  action: ReactNode
+  tone?: "primary" | "success"
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3",
+        tone === "primary"
+          ? "border-primary/30 bg-primary/5"
+          : "border-emerald-500/30 bg-emerald-500/5",
+      )}
+    >
+      <div className="min-w-0">
+        <p
+          className={cn(
+            "text-xs font-semibold uppercase tracking-wide",
+            tone === "primary"
+              ? "text-primary"
+              : "text-emerald-700 dark:text-emerald-400",
+          )}
+        >
+          {label}
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0 self-start sm:self-auto">{action}</div>
+    </div>
   )
 }
 
@@ -284,15 +450,23 @@ function InstallationsSection({
   )
 }
 
-function ProjectsSection({
-  workspaceId,
-  installations,
-  projects,
-}: {
+/**
+ * Imperative handle the parent's NextStepCallout uses to open the add-project
+ * form without having to lift every form field upward. Keeps form state local
+ * to the section while letting the step-by-step CTA drive the user forward.
+ */
+export interface ProjectsSectionHandle {
+  openAdd: () => void
+}
+
+interface ProjectsSectionProps {
   workspaceId: string
   installations: GitHubAppInstallation[]
   projects: Project[]
-}) {
+}
+
+const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(
+  function ProjectsSection({ workspaceId, installations, projects }, ref) {
   const [adding, setAdding] = useState(false)
   const [installationId, setInstallationId] = useState("")
   const [repoOwner, setRepoOwner] = useState("")
@@ -300,6 +474,19 @@ function ProjectsSection({
   const [defaultBranch, setDefaultBranch] = useState("")
   const [error, setError] = useState<string | null>(null)
   const queryClient = useQueryClient()
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAdd: () => {
+        if (installations.length === 0) return
+        setAdding(true)
+        setError(null)
+        setInstallationId((current) => current || installations[0]?.id || "")
+      },
+    }),
+    [installations],
+  )
 
   const { data: reposData, isLoading: reposLoading, isError: reposError } = useQuery({
     queryKey: ["installation-repos", workspaceId, installationId],
@@ -361,7 +548,11 @@ function ProjectsSection({
           <Package className="h-3 w-3" />
           Projects ({projects.length})
         </p>
-        {!adding && canAdd && (
+        {/* Empty state is driven by the parent's NextStepCallout; this
+            section button only appears once the user has at least one project
+            and wants to add another. Keeps the empty-state CTA single and
+            unambiguous. */}
+        {!adding && canAdd && projects.length > 0 && (
           <Button
             size="sm"
             variant="outline"
@@ -372,7 +563,7 @@ function ProjectsSection({
             }}
           >
             <Plus className="mr-1 h-3 w-3" />
-            Add project
+            Add another project
           </Button>
         )}
       </div>
@@ -381,13 +572,6 @@ function ProjectsSection({
         <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
           Link a GitHub installation first — projects are picked from repos the
           Onsager GitHub App can see.
-        </p>
-      )}
-
-      {canAdd && projects.length === 0 && !adding && (
-        <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
-          No projects yet. Add a repo to start running agent sessions against
-          it.
         </p>
       )}
 
@@ -511,7 +695,7 @@ function ProjectsSection({
       )}
     </div>
   )
-}
+})
 
 function RepoCombobox({
   repos,

--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -194,22 +194,25 @@ function NextStepCallout({
         </div>
       )
     }
+    // Use a real anchor so keyboard activation, right-click → "open in new
+    // tab", and screen-reader semantics match user expectations for what is
+    // ultimately a server-rendered redirect to GitHub. The disabled-while-
+    // loading case from the previous Button impl is handled by the early
+    // return above — by the time we get here, appConfig is either still
+    // loading (treat optimistically) or has confirmed `enabled: true`.
     return (
       <NextStepRow
         label="Step 2 of 3 · Connect GitHub"
         description="Install the Onsager GitHub App on a user or org you own so this workspace can read its repositories."
         action={
-          <Button
-            size="sm"
-            onClick={() => {
-              window.location.href = `/api/github-app/install-start?tenant_id=${encodeURIComponent(workspaceId)}`
-            }}
-            disabled={!appConfig?.enabled}
+          <a
+            href={`/api/github-app/install-start?tenant_id=${encodeURIComponent(workspaceId)}`}
+            className={buttonVariants({ size: "sm" })}
           >
             <GitBranch className="mr-1 h-3 w-3" />
             Install GitHub App
             <ArrowRight className="ml-1 h-3 w-3" />
-          </Button>
+          </a>
         }
       />
     )

--- a/apps/dashboard/tests/smoke/workspaces-card.test.tsx
+++ b/apps/dashboard/tests/smoke/workspaces-card.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
 import { WorkspaceCard } from "@/components/workspaces/WorkspaceCard"
 
 vi.mock("@/lib/api", () => ({
@@ -38,6 +39,7 @@ const orgInstall = {
 async function primeMocks(opts: {
   repos: unknown[]
   installations?: unknown[]
+  projects?: unknown[]
   appEnabled?: boolean
 }) {
   const { api } = await import("@/lib/api")
@@ -46,7 +48,9 @@ async function primeMocks(opts: {
   vi.mocked(api.listWorkspaceInstallations).mockResolvedValue({
     installations: (opts.installations ?? [orgInstall]) as never,
   })
-  vi.mocked(api.listWorkspaceProjects).mockResolvedValue({ projects: [] })
+  vi.mocked(api.listWorkspaceProjects).mockResolvedValue({
+    projects: (opts.projects ?? []) as never,
+  })
   vi.mocked(api.listInstallationRepos).mockResolvedValue({
     repos: opts.repos as never,
   })
@@ -58,9 +62,11 @@ async function primeMocks(opts: {
 function renderCard() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={qc}>
-      <WorkspaceCard workspace={ws} />
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <WorkspaceCard workspace={ws} />
+      </QueryClientProvider>
+    </MemoryRouter>,
   )
 }
 
@@ -143,5 +149,88 @@ describe("WorkspaceCard — OAuth-first Add project flow", () => {
     expect(
       screen.queryByRole("button", { name: /link manually/i }),
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("WorkspaceCard — step-by-step NextStepCallout", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("shows a Connect GitHub CTA when no installations are linked yet", async () => {
+    await primeMocks({ repos: [], installations: [] })
+    renderCard()
+    expect(
+      await screen.findByRole("button", { name: /install github app/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/step 2 of 3/i)).toBeInTheDocument()
+  })
+
+  it("blocks setup with an admin-action callout when the GitHub App is unavailable", async () => {
+    await primeMocks({ repos: [], installations: [], appEnabled: false })
+    renderCard()
+    expect(
+      await screen.findByText(/setup blocked: github app unavailable/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /install github app/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows an Add project CTA once GitHub is connected but no project is linked", async () => {
+    await primeMocks({
+      repos: [
+        { owner: "onsager-ai", name: "onsager", default_branch: "main", private: false },
+      ],
+    })
+    renderCard()
+    const cta = await screen.findByRole("button", { name: /^add project/i })
+    expect(cta).toBeInTheDocument()
+    expect(screen.getByText(/step 3 of 3/i)).toBeInTheDocument()
+    // The empty-state button in the section is suppressed; only the callout
+    // CTA drives the user forward.
+    expect(
+      screen.queryByRole("button", { name: /add another project/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("clicking the Add project CTA opens the add-project form", async () => {
+    await primeMocks({
+      repos: [
+        { owner: "onsager-ai", name: "onsager", default_branch: "main", private: false },
+      ],
+    })
+    renderCard()
+    const cta = await screen.findByRole("button", { name: /^add project/i })
+    fireEvent.click(cta)
+    await waitFor(() =>
+      expect(screen.getByTestId("add-project-form")).toBeInTheDocument(),
+    )
+    expect(
+      await screen.findByRole("button", { name: /select a repository/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("invites the user to start a session once setup is complete", async () => {
+    await primeMocks({
+      repos: [],
+      projects: [
+        {
+          id: "p1",
+          tenant_id: "ws1",
+          github_app_installation_id: "inst1",
+          repo_owner: "onsager-ai",
+          repo_name: "onsager",
+          default_branch: "main",
+          created_at: "2026-01-01",
+        },
+      ],
+    })
+    renderCard()
+    const link = await screen.findByRole("link", { name: /start a session/i })
+    expect(link.getAttribute("href")).toBe("/sessions")
+    expect(screen.getByText(/you're set up/i)).toBeInTheDocument()
+    // "Add another project" appears now that there's an existing project.
+    expect(
+      screen.getByRole("button", { name: /add another project/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/apps/dashboard/tests/smoke/workspaces-card.test.tsx
+++ b/apps/dashboard/tests/smoke/workspaces-card.test.tsx
@@ -158,9 +158,10 @@ describe("WorkspaceCard — step-by-step NextStepCallout", () => {
   it("shows a Connect GitHub CTA when no installations are linked yet", async () => {
     await primeMocks({ repos: [], installations: [] })
     renderCard()
-    expect(
-      await screen.findByRole("button", { name: /install github app/i }),
-    ).toBeInTheDocument()
+    const link = await screen.findByRole("link", { name: /install github app/i })
+    expect(link.getAttribute("href")).toBe(
+      "/api/github-app/install-start?tenant_id=ws1",
+    )
     expect(screen.getByText(/step 2 of 3/i)).toBeInTheDocument()
   })
 
@@ -171,7 +172,7 @@ describe("WorkspaceCard — step-by-step NextStepCallout", () => {
       await screen.findByText(/setup blocked: github app unavailable/i),
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: /install github app/i }),
+      screen.queryByRole("link", { name: /install github app/i }),
     ).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
Closes #74.

## Summary
- After creating their first workspace, users were left with a "Setup needed" badge and no obvious next action — install/add buttons were tucked into section headers, and an unconfigured GitHub App produced no callout at all. The flow read as a checklist of things that had happened to the user, not a path forward.
- Add a `NextStepCallout` in the `WorkspaceCard` header that surfaces the single next action (Install GitHub App → Add project → Start a session) as a primary CTA with step-of-3 framing, and a distinct success state once setup is complete.
- Wire the Add project CTA through an imperative ref handle (`ProjectsSectionHandle`) so it opens the existing add-project form and scrolls it into view — no need to lift form state. Suppress the section-level "+ Add project" button in the empty state so the callout drives the flow unambiguously, then restore it as "Add another project" once a project exists.
- When the GitHub App is unavailable on this server, render an amber "Setup blocked" callout that names the unblocking action (contact an administrator) instead of leaving the user in dead silence.

## Test plan
- [x] `pnpm test` — 51 passed (5 new step-by-step CTA tests cover Connect GitHub, App-unavailable amber state, Add project CTA, form-opens-on-click, and post-setup "Start a session" link).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — clean.
- [ ] Manual smoke on the deployed dashboard: create a workspace → confirm "Step 2 of 3 · Connect GitHub" appears with primary CTA → install the App → confirm "Step 3 of 3 · Add a project" CTA appears and opens the add form → confirm the "You're set up · Start a session" success callout after a project lands.

https://claude.ai/code/session_013TdC8RYjrTrdRHJofxiwfo