### PR TITLE
fix(dashboard): render DropdownMenuLabel as plain div to avoid Base UI error #31

### DIFF
--- a/apps/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/apps/dashboard/src/components/ui/dropdown-menu.tsx
@@ -55,11 +55,11 @@ function DropdownMenuLabel({
   className,
   inset,
   ...props
-}: MenuPrimitive.GroupLabel.Props & {
+}: React.ComponentProps<"div"> & {
   inset?: boolean
 }) {
   return (
-    <MenuPrimitive.GroupLabel
+    <div
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(


### PR DESCRIPTION
## Summary

- Clicking the top-right user avatar crashed the dashboard on Railway with `Uncaught Error: Base UI error #31` and a blank page.
- Root cause: Base UI's `Menu.GroupLabel` requires a `Menu.Group` ancestor. Our `DropdownMenuLabel` wrapper delegated to `MenuPrimitive.GroupLabel`, but `UserMenu` uses it standalone (account header + "Theme" section header) — Base UI throws `useMenuGroupRootContext` / error #31 when the context is missing.
- Fix: render `DropdownMenuLabel` as a styled `<div>` (matches shadcn/ui's standard semantics where the label is decorative and can appear anywhere in the menu). No API change for call sites.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 51/51 pass
- [ ] Manually click the avatar on the deployed app; dropdown opens without throwing and the account/Theme headers render.
