### PR TITLE
fix(stiglab): repair GitHub App install flow on Railway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ project does not yet publish numbered releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Stiglab + Dashboard**: GitHub App install callback now registers at
+  `/api/github-app/callback` (was `/api/github-app/install-callback`),
+  matching the Setup URL typically configured on the GitHub App. Post-
+  install redirect lands on `/workspaces?github_app_linked=…` instead of
+  `/settings` so `WorkspaceCard`'s existing effect can invalidate the
+  installations query and the workspace reflects the new installation
+  without a manual refresh. The redundant "Install via GitHub App"
+  button in `InstallationsSection` is suppressed on the empty state —
+  the `NextStepCallout` now owns the sole install CTA, and the section
+  only renders an "Add another installation" button once the workspace
+  already has one. Fixes the four GitHub-integration bugs reported on
+  the Railway deploy (callback 404 → install never recorded, duplicate
+  CTAs, no post-install redirect, stale "not installed" state).
+
 ### Added
 - **Architecture**: ADR 0002 frames design as two loops — inner
   (spec → PR → merge) and outer (observe drift → propose rule → activate

--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -395,15 +395,19 @@ function InstallationsSection({
           <GitBranch className="h-3 w-3" />
           GitHub installations ({installations.length})
         </p>
-        {appConfig?.enabled && (
+        {/* Empty state is driven by the parent's NextStepCallout so the
+            primary CTA stays unambiguous. Only offer the "add another"
+            button once the workspace already has an installation. */}
+        {appConfig?.enabled && installations.length > 0 && (
           <Button
             size="sm"
+            variant="outline"
             onClick={() => {
               window.location.href = `/api/github-app/install-start?tenant_id=${encodeURIComponent(workspaceId)}`
             }}
           >
             <Plus className="mr-1 h-3 w-3" />
-            Install via GitHub App
+            Add another installation
           </Button>
         )}
       </div>

--- a/apps/dashboard/tests/smoke/workspaces-card.test.tsx
+++ b/apps/dashboard/tests/smoke/workspaces-card.test.tsx
@@ -126,7 +126,7 @@ describe("WorkspaceCard — OAuth-first Add project flow", () => {
   it("never renders a 'Link manually' button", async () => {
     await primeMocks({ repos: [] })
     renderCard()
-    await screen.findByRole("button", { name: /install via github app/i })
+    await screen.findByRole("button", { name: /add another installation/i })
     expect(
       screen.queryByRole("button", { name: /link manually/i }),
     ).not.toBeInTheDocument()
@@ -147,6 +147,9 @@ describe("WorkspaceCard — OAuth-first Add project flow", () => {
       screen.queryByRole("button", { name: /install via github app/i }),
     ).not.toBeInTheDocument()
     expect(
+      screen.queryByRole("button", { name: /add another installation/i }),
+    ).not.toBeInTheDocument()
+    expect(
       screen.queryByRole("button", { name: /link manually/i }),
     ).not.toBeInTheDocument()
   })
@@ -163,6 +166,14 @@ describe("WorkspaceCard — step-by-step NextStepCallout", () => {
       "/api/github-app/install-start?tenant_id=ws1",
     )
     expect(screen.getByText(/step 2 of 3/i)).toBeInTheDocument()
+    // Empty-state CTA must be unambiguous — the InstallationsSection
+    // must not duplicate the callout's install button.
+    expect(
+      screen.queryByRole("button", { name: /install via github app/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /add another installation/i }),
+    ).not.toBeInTheDocument()
   })
 
   it("blocks setup with an admin-action callout when the GitHub App is unavailable", async () => {

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -85,7 +85,7 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             get(routes::tenants::github_app_install_start),
         )
         .route(
-            "/api/github-app/install-callback",
+            "/api/github-app/callback",
             get(routes::tenants::github_app_install_callback),
         )
         .route(

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -763,12 +763,14 @@ pub struct InstallCallbackQuery {
     pub state: Option<String>,
 }
 
-/// GET /api/github-app/install-callback?installation_id=N&setup_action=install&state=...
+/// GET /api/github-app/callback?installation_id=N&setup_action=install&state=...
 ///
-/// GitHub redirects here after the user installs the App. We verify the
-/// state cookie, mint an App JWT to look up the install's account, persist
-/// the installation row under the originating tenant, and redirect the
-/// browser back to `/settings?github_app_linked={id}`.
+/// GitHub redirects here after the user installs the App (this path is the
+/// App's Setup URL on GitHub). We verify the state cookie, mint an App JWT
+/// to look up the install's account, persist the installation row under
+/// the originating tenant, and redirect the browser back to
+/// `/workspaces?github_app_linked={id}` so `WorkspaceCard`'s useEffect can
+/// invalidate the installations query without a manual refresh.
 pub async fn github_app_install_callback(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -891,7 +893,7 @@ pub async fn github_app_install_callback(
     let clear =
         format!("stiglab_github_app_state=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0{sec}");
     let location = format!(
-        "/settings?github_app_linked={}&tenant_id={}",
+        "/workspaces?github_app_linked={}&tenant_id={}",
         query.installation_id, tenant_id
     );
 


### PR DESCRIPTION
## Summary

Four linked defects broke the GitHub App install path on the Railway-deployed dashboard. Each fix is small; together they restore the install flow end-to-end.

1. **Callback path mismatch.** Backend registered the Setup URL at `/api/github-app/install-callback`, but the GitHub App's Setup URL on github.com is `/api/github-app/callback`. The callback 404'd into the SPA → the installation was never persisted → the rest of the flow (redirect, "installed" state) had nothing to reflect. Renamed the route.
2. **Duplicated install buttons.** `InstallationsSection` rendered "Install via GitHub App" whenever the App was enabled, including the empty state where `NextStepCallout` already shows an "Install GitHub App" CTA. Matched the `ProjectsSection` pattern: suppress the section button until the workspace has ≥1 installation, relabel it "Add another installation".
3. **Post-install redirect target.** Callback redirected to `/settings`, which does not mount `WorkspaceCard` and therefore never invalidates the installations query — so the UI looked stale even after the DB was updated. Redirect to `/workspaces` so the existing `useEffect` fires.
4. **"Not installed" persists.** Symptom of (1); once the callback actually persists the install, `useSetupProgress`'s refetch-on-mount picks it up. No additional change needed.

> Note on issue #1 raised by the reporter: `/api/auth/github/callback` and `/api/github-app/callback` are **not** duplicates — the first is user OAuth login (GitHub as identity provider), the second is the GitHub App Setup URL (post-install webhook). They serve distinct purposes and both are required.

## Test plan

- [x] `cargo build --workspace` with `RUSTFLAGS="-D warnings"`
- [x] `cargo test --workspace --lib` with `RUSTFLAGS="-D warnings"` (113 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `pnpm --filter dashboard lint`
- [x] `pnpm --filter dashboard test -- --run workspaces-card` (10 tests, incl. new regression test for empty-state CTA)
- [ ] Manual: Railway deploy preview → click "Install GitHub App" in an empty workspace → complete install on github.com → lands on `/workspaces?github_app_linked=…` → installation row appears without manual refresh
- [ ] Manual: after install, revisit `https://app.onsager.ai/` → "GitHub connected" checked, NextStepCallout advances to "Step 3 of 3 · Add a project"

https://claude.ai/code/session_01KLjWEspM8hiDCm6bc3Mydc