### PR TITLE
fix(dashboard): render @login + account_login instead of UUIDs in WorkspaceCard

### DIFF
--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -14,6 +14,7 @@ import {
   type Workspace,
   type GitHubAppInstallation,
   type Project,
+  type WorkspaceMember,
 } from "@/lib/api"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -326,18 +327,71 @@ function SetupProgress({
 function MembersSection({
   members,
 }: {
-  members: { user_id: string }[]
+  members: WorkspaceMember[]
 }) {
   return (
-    <div className="space-y-1">
+    <div className="space-y-1.5">
       <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         <Users className="h-3 w-3" />
         Members ({members.length})
       </p>
-      <p className="text-xs text-muted-foreground">
-        {members.map((m) => m.user_id).join(", ") || "—"}
-      </p>
+      {members.length === 0 ? (
+        <p className="text-xs text-muted-foreground">—</p>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {members.map((m) => (
+            <li key={m.user_id}>
+              <MemberChip member={m} />
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
+  )
+}
+
+function MemberChip({ member }: { member: WorkspaceMember }) {
+  const label = member.github_login ?? member.user_id
+  const href = member.github_login
+    ? `https://github.com/${member.github_login}`
+    : undefined
+  const inner = (
+    <>
+      {member.github_avatar_url ? (
+        <img
+          src={member.github_avatar_url}
+          alt=""
+          className="h-5 w-5 rounded-full"
+        />
+      ) : (
+        <span
+          aria-hidden
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] font-medium uppercase text-muted-foreground"
+        >
+          {label.slice(0, 1)}
+        </span>
+      )}
+      <span className="truncate font-mono">
+        {member.github_login ? `@${member.github_login}` : member.user_id}
+      </span>
+    </>
+  )
+  const className =
+    "inline-flex items-center gap-1.5 rounded-full border bg-muted/50 py-0.5 pr-2 pl-0.5 text-xs"
+  return href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(className, "hover:bg-muted")}
+      title={member.github_name ?? member.github_login ?? undefined}
+    >
+      {inner}
+    </a>
+  ) : (
+    <span className={className} title={member.user_id}>
+      {inner}
+    </span>
   )
 }
 
@@ -622,7 +676,19 @@ const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(
             onValueChange={(v) => setInstallationId(v ?? "")}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select installation" />
+              {/* Base UI's `<Select.Value>` renders the raw `value` (here an
+                  installation UUID) unless given an explicit mapping. Pass a
+                  render function so the trigger shows `{account_login}
+                  ({account_type})` even before the popup has registered its
+                  items. */}
+              <SelectValue placeholder="Select installation">
+                {(value) => {
+                  const inst = installations.find((i) => i.id === value)
+                  return inst
+                    ? `${inst.account_login} (${inst.account_type})`
+                    : ""
+                }}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {installations.map((i) => (

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -84,6 +84,9 @@ export interface WorkspaceMember {
   tenant_id: string;
   user_id: string;
   joined_at: string;
+  github_login: string | null;
+  github_name: string | null;
+  github_avatar_url: string | null;
 }
 
 export type GitHubAccountType = 'user' | 'organization';

--- a/apps/dashboard/tests/smoke/workspaces-card.test.tsx
+++ b/apps/dashboard/tests/smoke/workspaces-card.test.tsx
@@ -41,10 +41,13 @@ async function primeMocks(opts: {
   installations?: unknown[]
   projects?: unknown[]
   appEnabled?: boolean
+  members?: unknown[]
 }) {
   const { api } = await import("@/lib/api")
   vi.mocked(api.listWorkspaces).mockResolvedValue({ tenants: [ws] })
-  vi.mocked(api.listWorkspaceMembers).mockResolvedValue({ members: [] })
+  vi.mocked(api.listWorkspaceMembers).mockResolvedValue({
+    members: (opts.members ?? []) as never,
+  })
   vi.mocked(api.listWorkspaceInstallations).mockResolvedValue({
     installations: (opts.installations ?? [orgInstall]) as never,
   })
@@ -244,5 +247,75 @@ describe("WorkspaceCard — step-by-step NextStepCallout", () => {
     expect(
       screen.getByRole("button", { name: /add another project/i }),
     ).toBeInTheDocument()
+  })
+})
+
+describe("WorkspaceCard — human-readable member + installation labels", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders members as @login links to GitHub, not raw user UUIDs", async () => {
+    await primeMocks({
+      repos: [],
+      members: [
+        {
+          tenant_id: "ws1",
+          user_id: "133d228a-be10-492b-8035-bdb984d20721",
+          joined_at: "2026-01-01",
+          github_login: "octocat",
+          github_name: "Octo Cat",
+          github_avatar_url: "https://example.test/octocat.png",
+        },
+      ],
+    })
+    renderCard()
+    const link = await screen.findByRole("link", { name: /@octocat/i })
+    expect(link.getAttribute("href")).toBe("https://github.com/octocat")
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(
+      screen.queryByText(/133d228a-be10-492b-8035-bdb984d20721/),
+    ).not.toBeInTheDocument()
+  })
+
+  it("falls back to user_id when the joined users row has no github profile", async () => {
+    await primeMocks({
+      repos: [],
+      members: [
+        {
+          tenant_id: "ws1",
+          user_id: "orphaned-user-id",
+          joined_at: "2026-01-01",
+          github_login: null,
+          github_name: null,
+          github_avatar_url: null,
+        },
+      ],
+    })
+    renderCard()
+    // No @login → no link; chip renders a plain span with the raw user_id
+    // so operators can still see something instead of an empty box.
+    await screen.findByText(/orphaned-user-id/)
+    expect(
+      screen.queryByRole("link", { name: /orphaned-user-id/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows the installation account_login in the Select trigger, not the UUID", async () => {
+    await primeMocks({
+      repos: [
+        { owner: "onsager-ai", name: "onsager", default_branch: "main", private: false },
+      ],
+    })
+    const { container } = renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /add project/i }))
+    await screen.findByTestId("add-project-form")
+    // Grab the SelectValue span inside the Select trigger (the [data-slot]
+    // attribute is stamped by the shadcn wrapper). It must render the
+    // installation's account_login after the form auto-selects the first
+    // installation, not the raw installation UUID `inst1`.
+    await waitFor(() => {
+      const selectValue = container.querySelector('[data-slot="select-value"]')
+      expect(selectValue?.textContent).toMatch(/onsager-ai/i)
+      expect(selectValue?.textContent).not.toMatch(/inst1/)
+    })
   })
 })

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -1135,6 +1135,64 @@ pub async fn list_tenant_members(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// `TenantMember` enriched with the member's GitHub profile so the
+/// dashboard can render `@login` + avatar instead of the opaque user UUID.
+/// `LEFT JOIN` so a member row whose `users` row was somehow removed still
+/// surfaces (with nullable GitHub fields) rather than silently disappearing
+/// from the workspace's member list.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TenantMemberWithUser {
+    pub tenant_id: String,
+    pub user_id: String,
+    pub joined_at: chrono::DateTime<Utc>,
+    pub github_login: Option<String>,
+    pub github_name: Option<String>,
+    pub github_avatar_url: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct TenantMemberWithUserRow {
+    tenant_id: String,
+    user_id: String,
+    joined_at: String,
+    github_login: Option<String>,
+    github_name: Option<String>,
+    github_avatar_url: Option<String>,
+}
+
+impl TryFrom<TenantMemberWithUserRow> for TenantMemberWithUser {
+    type Error = anyhow::Error;
+
+    fn try_from(row: TenantMemberWithUserRow) -> anyhow::Result<Self> {
+        Ok(TenantMemberWithUser {
+            tenant_id: row.tenant_id,
+            user_id: row.user_id,
+            joined_at: chrono::DateTime::parse_from_rfc3339(&row.joined_at)?.with_timezone(&Utc),
+            github_login: row.github_login,
+            github_name: row.github_name,
+            github_avatar_url: row.github_avatar_url,
+        })
+    }
+}
+
+pub async fn list_tenant_members_with_users(
+    pool: &AnyPool,
+    tenant_id: &str,
+) -> anyhow::Result<Vec<TenantMemberWithUser>> {
+    let rows = sqlx::query_as::<_, TenantMemberWithUserRow>(
+        "SELECT m.tenant_id, m.user_id, m.joined_at, \
+                u.github_login, u.github_name, u.github_avatar_url \
+         FROM tenant_members m \
+         LEFT JOIN users u ON u.id = m.user_id \
+         WHERE m.tenant_id = $1 \
+         ORDER BY m.joined_at ASC",
+    )
+    .bind(tenant_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 pub async fn insert_github_app_installation(
     pool: &AnyPool,
     install: &GitHubAppInstallation,
@@ -1503,6 +1561,31 @@ mod tests {
 
         let u2_tenants = list_tenants_for_user(&pool, "u2").await.unwrap();
         assert!(u2_tenants.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_tenant_members_with_users_joins_github_profile() {
+        let pool = test_pool().await;
+        seed_user(&pool, "u1").await;
+        let t = new_tenant("u1");
+        insert_tenant(&pool, &t).await.unwrap();
+        insert_tenant_member(
+            &pool,
+            &TenantMember {
+                tenant_id: t.id.clone(),
+                user_id: "u1".to_string(),
+                joined_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let members = list_tenant_members_with_users(&pool, &t.id).await.unwrap();
+        assert_eq!(members.len(), 1);
+        // `seed_user` writes `github_login = user_id`, so this exercises the
+        // JOIN without needing to fixture a realistic avatar URL.
+        assert_eq!(members[0].user_id, "u1");
+        assert_eq!(members[0].github_login.as_deref(), Some("u1"));
     }
 
     #[tokio::test]

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -194,7 +194,7 @@ pub async fn list_members(
     if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
         return r;
     }
-    match db::list_tenant_members(&state.db, &tenant_id).await {
+    match db::list_tenant_members_with_users(&state.db, &tenant_id).await {
         Ok(members) => Json(serde_json::json!({ "members": members })).into_response(),
         Err(e) => {
             tracing::error!("failed to list members: {e}");


### PR DESCRIPTION
## Summary

`WorkspaceCard` was leaking two raw UUIDs into the UI — screenshots from prod showed `Members: 133d228a-be10-…` and an installation select that read `8c881c45-5ac5-…` instead of the actual account login. Both fixed on this PR.

### 1. Members → @login + avatar

`GET /api/tenants/:id/members` was returning only the `tenant_members` join-table columns (`tenant_id`, `user_id`, `joined_at`), so the client had nothing but the UUID to render. Added `list_tenant_members_with_users` which `LEFT JOIN`s `users` and returns `TenantMemberWithUser` with `github_login`, `github_name`, `github_avatar_url`. The frontend now renders each member as a chip: avatar + `@login` linking out to the GitHub profile.

The `LEFT JOIN` (rather than inner) keeps orphaned `tenant_members` visible — if the `users` row is ever missing we still surface the `user_id` in the chip rather than silently dropping the member.

### 2. Installation Select → account_login (organization)

The Add Project form's `<Select value={installationId}>` showed the raw installation UUID in its closed state. Base UI's `<Select.Value>` falls back to rendering the raw `value` when items aren't registered (e.g. before the popup has opened). Pass a children render function that maps the selected id to `{account_login} ({account_type})` so the trigger is legible from first paint.

## Test plan

- [x] `cargo test -p stiglab list_tenant_members_with_users` — new DB test covering the JOIN
- [x] `cargo test --workspace --lib` (113 tests) — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `pnpm --filter dashboard test -- --run workspaces-card` — 13 tests incl. three new ones: members chip rendering, orphaned-user fallback, Select trigger label
- [x] `pnpm --filter dashboard lint`
- [ ] Manual: visit `/workspaces` on a deploy preview → member row shows avatar + `@login`; open Add Project form → trigger shows `onsager-ai (organization)` not `inst1`; click through to GitHub from the member chip.

https://claude.ai/code/session_01KLjWEspM8hiDCm6bc3Mydc