### PR TITLE
fix(stiglab): implement missing repo labels endpoint

### DIFF
--- a/crates/stiglab/src/server/github_app.rs
+++ b/crates/stiglab/src/server/github_app.rs
@@ -263,9 +263,8 @@ pub async fn list_repo_labels(
 ) -> anyhow::Result<Vec<RepoLabel>> {
     let mut out = Vec::new();
     for page in 1..=2 {
-        let url = format!(
-            "https://api.github.com/repos/{owner}/{repo}/labels?per_page=100&page={page}"
-        );
+        let url =
+            format!("https://api.github.com/repos/{owner}/{repo}/labels?per_page=100&page={page}");
         let resp = gh_client()?
             .get(&url)
             .bearer_auth(&token.token)

--- a/crates/stiglab/src/server/github_app.rs
+++ b/crates/stiglab/src/server/github_app.rs
@@ -238,6 +238,60 @@ pub async fn list_installation_repos(
     Ok(out)
 }
 
+#[derive(Debug, Deserialize)]
+struct LabelJson {
+    name: String,
+    color: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoLabel {
+    pub name: String,
+    pub color: Option<String>,
+    pub description: Option<String>,
+}
+
+/// List the labels defined on a repo. Paginated up to 200 (two 100-item
+/// pages) — same budget as `list_installation_repos`. Repos with more
+/// labels than that are rare; the combobox's free-text "create label"
+/// path still works when a label isn't in the returned set.
+pub async fn list_repo_labels(
+    token: &InstallationToken,
+    owner: &str,
+    repo: &str,
+) -> anyhow::Result<Vec<RepoLabel>> {
+    let mut out = Vec::new();
+    for page in 1..=2 {
+        let url = format!(
+            "https://api.github.com/repos/{owner}/{repo}/labels?per_page=100&page={page}"
+        );
+        let resp = gh_client()?
+            .get(&url)
+            .bearer_auth(&token.token)
+            .header("Accept", "application/vnd.github+json")
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("list_repo_labels failed ({status}): {body}");
+        }
+        let parsed: Vec<LabelJson> = resp.json().await?;
+        let count = parsed.len();
+        out.extend(parsed.into_iter().map(|l| RepoLabel {
+            name: l.name,
+            color: l.color,
+            description: l.description,
+        }));
+        if count < 100 {
+            break;
+        }
+    }
+    Ok(out)
+}
+
 /// Fetch a repo's default branch via the installation token. Used by
 /// `add_project` to populate `default_branch` automatically.
 pub async fn get_repo_default_branch(

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -80,6 +80,10 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             get(routes::tenants::list_accessible_repos),
         )
         .route(
+            "/api/tenants/{id}/github-installations/{install_id}/repos/{owner}/{repo}/labels",
+            get(routes::tenants::list_repo_labels),
+        )
+        .route(
             "/api/github-app/config",
             get(routes::tenants::github_app_config),
         )

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -704,10 +704,10 @@ pub async fn list_repo_labels(
     Path((tenant_id, install_id, owner, repo)): Path<(String, String, String, String)>,
 ) -> Response {
     let user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id.to_string(),
+        Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
         return r;
     }
     match db::get_github_app_installation(&state.db, &install_id).await {

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -695,6 +695,60 @@ pub async fn list_accessible_repos(
     }
 }
 
+/// GET /api/tenants/:id/github-installations/:install_id/repos/:owner/:repo/labels
+/// — list labels defined on a repo, so workflow triggers can offer a
+/// combobox of existing labels instead of free-text entry.
+pub async fn list_repo_labels(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((tenant_id, install_id, owner, repo)): Path<(String, String, String, String)>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+        return r;
+    }
+    match db::get_github_app_installation(&state.db, &install_id).await {
+        Ok(Some(inst)) if inst.tenant_id == tenant_id => {}
+        Ok(_) => return not_found("installation not found"),
+        Err(e) => {
+            tracing::error!("failed to get installation: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+
+    match installation_token_for(&state.db, &install_id).await {
+        Ok(Some(token)) => match github_app::list_repo_labels(&token, &owner, &repo).await {
+            Ok(labels) => Json(serde_json::json!({ "labels": labels })).into_response(),
+            Err(e) => {
+                tracing::warn!("list_repo_labels failed: {e}");
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({ "error": "GitHub API request failed" })),
+                )
+                    .into_response()
+            }
+        },
+        Ok(None) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "GitHub App is not configured on this server"
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("failed to mint installation token: {e}");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub App auth failed" })),
+            )
+                .into_response()
+        }
+    }
+}
+
 // ── Install-flow routes ──
 
 #[derive(Debug, Deserialize)]

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -251,13 +251,12 @@ pub async fn get_workflow_install_target(
     pool: &AnyPool,
     workflow_id: &str,
 ) -> anyhow::Result<Option<(i64, String, String)>> {
-    let row: Option<(i64, String, String)> =
-        sqlx::query_as(
-            "SELECT install_id, repo_owner, repo_name FROM tenant_workflows WHERE id = $1",
-        )
-            .bind(workflow_id)
-            .fetch_optional(pool)
-            .await?;
+    let row: Option<(i64, String, String)> = sqlx::query_as(
+        "SELECT install_id, repo_owner, repo_name FROM tenant_workflows WHERE id = $1",
+    )
+    .bind(workflow_id)
+    .fetch_optional(pool)
+    .await?;
     Ok(row)
 }
 


### PR DESCRIPTION
Part of #79 (completes the backend half of the label-combobox UX called out in #81 / #82 — the frontend shipped expecting this endpoint, but the route was never wired up).

## Summary

The workflow trigger config's `LabelCombobox` calls
`/tenants/:id/github-installations/:install_id/repos/:owner/:repo/labels`,
but the backend route was never wired up. Selecting a label in a trigger
always surfaced `Couldn't load labels. Check the GitHub install.`
even when the install was healthy (repos and everything else loaded fine).

- Add `github_app::list_repo_labels` — thin wrapper around GitHub's
  `GET /repos/:owner/:repo/labels`, paginated up to 200 like
  `list_installation_repos`.
- Add `routes::tenants::list_repo_labels` handler that validates tenant
  membership + install ownership before minting a token.
- Register the new route in `server/mod.rs`.

Response shape matches the frontend's `GitHubLabel` type
(`{ labels: [{ name, color, description }] }`).

## Test plan

- [x] `cargo build -p stiglab` — passes
- [x] `cargo clippy -p stiglab --all-targets -- -D warnings` — passes
- [x] `cargo test -p stiglab --lib server::github_app` — 6 tests pass
- [ ] Manual: open a workflow trigger, pick an install + repo, confirm labels load in the combobox
