### PR TITLE
fix(dashboard): align workflow create with stiglab contract

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -120,8 +120,8 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
   const hasWorkspace = (workspacesData?.tenants?.length ?? 0) > 0
 
   const { data: workflowsData, isLoading } = useQuery({
-    queryKey: ["workflows"],
-    queryFn: () => api.listWorkflows(),
+    queryKey: ["workflows", "user"],
+    queryFn: () => api.listWorkflowsForUser(),
     staleTime: 30_000,
     enabled: gateEnabled && hasWorkspace,
   })

--- a/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { CardStackEditor } from "./CardStackEditor"
 import { PresetPicker } from "./PresetPicker"
 import {
-  draftToRequestTrigger,
+  draftToCreateRequest,
   emptyDraft,
   isTriggerReady,
   type WorkflowDraft,
@@ -46,13 +46,7 @@ export function WorkflowBuilder({
 
   const save = () => {
     if (!canSave) return
-    create.mutate({
-      tenant_id: tenantId,
-      name: draft.name.trim(),
-      trigger: draftToRequestTrigger(draft.trigger),
-      stages: draft.stages,
-      activate: true,
-    })
+    create.mutate(draftToCreateRequest(draft, installations, tenantId, true))
   }
 
   return (

--- a/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
@@ -5,7 +5,6 @@ import { api, type CreateWorkflowRequest, type GitHubAppInstallation } from "@/l
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { CardStackEditor } from "./CardStackEditor"
-import { ChatBuilder } from "./ChatBuilder"
 import { PresetPicker } from "./PresetPicker"
 import {
   draftToRequestTrigger,
@@ -71,8 +70,6 @@ export function WorkflowBuilder({
       </div>
 
       <PresetPicker draft={draft} onApply={setDraft} />
-
-      <ChatBuilder draft={draft} onChange={setDraft} />
 
       <CardStackEditor
         tenantId={tenantId}

--- a/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
@@ -1,8 +1,12 @@
-import type {
-  WorkflowArtifactKind,
-  WorkflowGateKind,
-  WorkflowStage,
-  WorkflowTrigger,
+import {
+  ApiError,
+  stageToCreateStage,
+  type CreateWorkflowRequest,
+  type GitHubAppInstallation,
+  type WorkflowArtifactKind,
+  type WorkflowGateKind,
+  type WorkflowStage,
+  type WorkflowTrigger,
 } from "@/lib/api"
 
 // The in-memory shape the chat/card editor manipulates. Everything here is
@@ -153,5 +157,51 @@ export function draftToRequestTrigger(t: WorkflowTriggerDraft): WorkflowTrigger 
     repo_owner: t.repo_owner,
     repo_name: t.repo_name,
     label: t.label,
+  }
+}
+
+// Build the stiglab-shaped create-workflow request from the UI draft. The
+// two non-obvious pieces:
+//
+// 1. `draft.trigger.install_id` is the dashboard's installation *record id*
+//    (`GitHubAppInstallation.id`, e.g. `inst_abc…`) — that's what the
+//    `/github-installations/:install_id/{accessible-repos,labels}` endpoints
+//    take. The workflow POST contract needs the numeric GitHub install id
+//    (`GitHubAppInstallation.install_id: i64`), so we resolve it by record
+//    id against the installations the page already has loaded.
+// 2. UI-only stage fields (name, artifact_kind) ride inside `params` so
+//    they survive the round-trip without forcing a backend schema change.
+export function draftToCreateRequest(
+  draft: WorkflowDraft,
+  installations: GitHubAppInstallation[],
+  tenantId: string,
+  activate: boolean,
+): CreateWorkflowRequest {
+  if (!tenantId.trim()) {
+    throw new ApiError("tenant_id is required", 400)
+  }
+  if (!isTriggerReady(draft.trigger)) {
+    throw new ApiError(
+      "pick an install, repo, and label before activating",
+      400,
+    )
+  }
+  const install = installations.find((i) => i.id === draft.trigger.install_id)
+  if (!install) {
+    throw new ApiError(
+      "selected GitHub install not found in this workspace",
+      400,
+    )
+  }
+  return {
+    tenant_id: tenantId,
+    name: draft.name.trim(),
+    trigger_kind: "github-issue-webhook",
+    install_id: install.install_id,
+    repo_owner: draft.trigger.repo_owner,
+    repo_name: draft.trigger.repo_name,
+    trigger_label: draft.trigger.label,
+    stages: draft.stages.map(stageToCreateStage),
+    active: activate,
   }
 }

--- a/apps/dashboard/src/hooks/useNodes.ts
+++ b/apps/dashboard/src/hooks/useNodes.ts
@@ -1,10 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
+import { useAuth } from '@/lib/auth';
 
 export function useNodes() {
+  // When auth is enabled, `/api/nodes` returns 401 for anonymous requests;
+  // firing the poll pre-login floods the console and the browser's network
+  // tab with 401s. Gate on resolved auth state so the query only runs once
+  // we know the user is logged in (or auth is disabled entirely).
+  const { user, loading, authEnabled } = useAuth();
+  const enabled = !loading && (!authEnabled || !!user);
+
   return useQuery({
     queryKey: ['nodes'],
     queryFn: api.getNodes,
     refetchInterval: 5000,
+    enabled,
   });
 }

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -288,19 +288,33 @@ export interface Workflow {
   updated_at: string;
 }
 
+// Wire contract for workflow CRUD. Matches stiglab's `CreateWorkflowBody`
+// / `validate_create_body` exactly — flat trigger fields, numeric GitHub
+// install id, snake_case `active`. Construct with `draftToCreateRequest`
+// from the UI draft + installations list so the numeric id is resolved
+// from the workspace installation record id the draft carries.
 export interface CreateWorkflowRequest {
-  tenant_id?: string;
+  tenant_id: string;
   name: string;
-  preset?: string;
-  trigger: WorkflowTrigger;
-  stages: WorkflowStage[];
-  activate?: boolean;
+  trigger_kind: 'github-issue-webhook';
+  repo_owner: string;
+  repo_name: string;
+  trigger_label: string;
+  install_id: number;
+  preset_id?: string;
+  stages?: CreateWorkflowStage[];
+  active: boolean;
 }
 
-// Backend contract. Stiglab persists workflows with flat trigger fields
+export interface CreateWorkflowStage {
+  gate_kind: WorkflowGateKind;
+  params: Record<string, unknown>;
+}
+
+// Backend read shapes. Stiglab returns workflows with flat trigger fields
 // and stages as `{ gate_kind, params }` with opaque JSON params. The UI
-// keeps a richer nested shape; the adapters below translate at the API
-// boundary so the rest of the app doesn't have to know the wire format.
+// keeps a richer nested `Workflow` shape; the adapters below translate
+// so the rest of the app doesn't have to know the wire format.
 interface BackendWorkflow {
   id: string;
   tenant_id: string;
@@ -324,19 +338,6 @@ interface BackendWorkflowStage {
   params: Record<string, unknown>;
 }
 
-interface BackendCreateWorkflowBody {
-  tenant_id: string;
-  name: string;
-  trigger_kind: 'github-issue-webhook';
-  repo_owner: string;
-  repo_name: string;
-  trigger_label: string;
-  install_id: number;
-  preset_id?: string;
-  stages?: { gate_kind: WorkflowGateKind; params: Record<string, unknown> }[];
-  active: boolean;
-}
-
 function stageFromBackend(s: BackendWorkflowStage): WorkflowStage {
   const params = (s.params ?? {}) as Record<string, unknown>;
   const name = typeof params.name === 'string' ? params.name : undefined;
@@ -357,9 +358,10 @@ function stageFromBackend(s: BackendWorkflowStage): WorkflowStage {
   };
 }
 
-function stageToBackend(
-  s: WorkflowStage,
-): { gate_kind: WorkflowGateKind; params: Record<string, unknown> } {
+// Pack a UI stage into the backend's `{ gate_kind, params }` pair. UI-only
+// display fields ride in `params` so they survive the round-trip without
+// a backend-schema change.
+export function stageToCreateStage(s: WorkflowStage): CreateWorkflowStage {
   return {
     gate_kind: s.gate_kind,
     params: {
@@ -404,30 +406,6 @@ function defaultStageName(gate: WorkflowGateKind): string {
     case 'manual-approval':
       return 'Manual approval';
   }
-}
-
-// Exposed for unit tests — the request body shape is what `validate_create_body`
-// on stiglab accepts. Lives here so the contract round-trip is covered in one
-// file alongside its readers.
-export function createWorkflowRequestToBackend(
-  req: CreateWorkflowRequest,
-): BackendCreateWorkflowBody {
-  const installId = Number.parseInt(req.trigger.install_id, 10);
-  if (!Number.isFinite(installId) || installId <= 0) {
-    throw new ApiError('install_id is required', 400);
-  }
-  return {
-    tenant_id: req.tenant_id ?? '',
-    name: req.name,
-    trigger_kind: 'github-issue-webhook',
-    repo_owner: req.trigger.repo_owner,
-    repo_name: req.trigger.repo_name,
-    trigger_label: req.trigger.label,
-    install_id: installId,
-    preset_id: req.preset,
-    stages: req.preset ? undefined : req.stages.map(stageToBackend),
-    active: req.activate ?? false,
-  };
 }
 
 export type StageRunStatus = 'pending' | 'blocked' | 'passed' | 'failed';
@@ -672,12 +650,29 @@ export const api = {
   // Workflows (issue #82) — CRUD + live runs. The API is provided by the
   // stiglab sibling sub-issue; the dashboard is the only client today.
   // The backend persists workflows with flat trigger fields and stage `params`;
-  // these wrappers translate to/from the UI's nested shape.
-  listWorkflows: async (tenantId?: string): Promise<{ workflows: Workflow[] }> => {
+  // these wrappers translate backend → UI shape.
+  listWorkflows: async (tenantId: string): Promise<{ workflows: Workflow[] }> => {
+    if (!tenantId) throw new ApiError('tenantId is required', 400);
     const raw = await request<{ workflows: BackendWorkflow[] }>(
-      `/workflows${tenantId ? `?tenant_id=${encodeURIComponent(tenantId)}` : ''}`,
+      `/workflows?tenant_id=${encodeURIComponent(tenantId)}`,
     );
     return { workflows: raw.workflows.map((w) => workflowFromBackend(w)) };
+  },
+  // Fan-out across every workspace the user belongs to. Stiglab's list
+  // endpoint is tenant-scoped; cross-tenant "do I have any workflows yet?"
+  // queries (empty-state gates, first-run redirect) need this shape. We
+  // hit `/tenants` once and one `/workflows?tenant_id=…` per workspace;
+  // fine for the workspace counts we target (typically 1–3).
+  listWorkflowsForUser: async (): Promise<{ workflows: Workflow[] }> => {
+    const { tenants } = await request<{ tenants: { id: string }[] }>('/tenants');
+    const lists = await Promise.all(
+      tenants.map((t) =>
+        request<{ workflows: BackendWorkflow[] }>(
+          `/workflows?tenant_id=${encodeURIComponent(t.id)}`,
+        ).then((r) => r.workflows.map((w) => workflowFromBackend(w))),
+      ),
+    );
+    return { workflows: lists.flat() };
   },
   getWorkflow: async (id: string): Promise<{ workflow: Workflow }> => {
     const raw = await request<{ workflow: BackendWorkflow; stages: BackendWorkflowStage[] }>(
@@ -688,7 +683,7 @@ export const api = {
   createWorkflow: async (body: CreateWorkflowRequest): Promise<{ workflow: Workflow }> => {
     const raw = await request<{ workflow: BackendWorkflow; stages?: BackendWorkflowStage[] }>(
       '/workflows',
-      { method: 'POST', body: JSON.stringify(createWorkflowRequestToBackend(body)) },
+      { method: 'POST', body: JSON.stringify(body) },
     );
     return { workflow: workflowFromBackend(raw.workflow, raw.stages ?? []) };
   },

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -297,6 +297,139 @@ export interface CreateWorkflowRequest {
   activate?: boolean;
 }
 
+// Backend contract. Stiglab persists workflows with flat trigger fields
+// and stages as `{ gate_kind, params }` with opaque JSON params. The UI
+// keeps a richer nested shape; the adapters below translate at the API
+// boundary so the rest of the app doesn't have to know the wire format.
+interface BackendWorkflow {
+  id: string;
+  tenant_id: string;
+  name: string;
+  trigger_kind: 'github-issue-webhook';
+  repo_owner: string;
+  repo_name: string;
+  trigger_label: string;
+  install_id: number;
+  preset_id: string | null;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BackendWorkflowStage {
+  id: string;
+  workflow_id: string;
+  seq: number;
+  gate_kind: WorkflowGateKind;
+  params: Record<string, unknown>;
+}
+
+interface BackendCreateWorkflowBody {
+  tenant_id: string;
+  name: string;
+  trigger_kind: 'github-issue-webhook';
+  repo_owner: string;
+  repo_name: string;
+  trigger_label: string;
+  install_id: number;
+  preset_id?: string;
+  stages?: { gate_kind: WorkflowGateKind; params: Record<string, unknown> }[];
+  active: boolean;
+}
+
+function stageFromBackend(s: BackendWorkflowStage): WorkflowStage {
+  const params = (s.params ?? {}) as Record<string, unknown>;
+  const name = typeof params.name === 'string' ? params.name : undefined;
+  const artifactKind =
+    params.artifact_kind === 'github-issue' || params.artifact_kind === 'github-pr'
+      ? params.artifact_kind
+      : 'github-issue';
+  // Everything except the UI-only display fields is opaque stage config.
+  const { name: _n, artifact_kind: _a, ...config } = params as Record<string, unknown>;
+  void _n;
+  void _a;
+  return {
+    id: s.id,
+    name: name ?? defaultStageName(s.gate_kind),
+    gate_kind: s.gate_kind,
+    artifact_kind: artifactKind,
+    config,
+  };
+}
+
+function stageToBackend(
+  s: WorkflowStage,
+): { gate_kind: WorkflowGateKind; params: Record<string, unknown> } {
+  return {
+    gate_kind: s.gate_kind,
+    params: {
+      ...(s.config ?? {}),
+      name: s.name,
+      artifact_kind: s.artifact_kind,
+    },
+  };
+}
+
+function workflowFromBackend(
+  w: BackendWorkflow,
+  stages: BackendWorkflowStage[] = [],
+): Workflow {
+  return {
+    id: w.id,
+    tenant_id: w.tenant_id,
+    name: w.name,
+    preset: w.preset_id,
+    status: w.active ? 'active' : 'draft',
+    trigger: {
+      kind: 'github-label',
+      install_id: String(w.install_id),
+      repo_owner: w.repo_owner,
+      repo_name: w.repo_name,
+      label: w.trigger_label,
+    },
+    stages: stages.map(stageFromBackend),
+    created_at: w.created_at,
+    updated_at: w.updated_at,
+  };
+}
+
+function defaultStageName(gate: WorkflowGateKind): string {
+  switch (gate) {
+    case 'agent-session':
+      return 'Agent session';
+    case 'external-check':
+      return 'CI check';
+    case 'governance':
+      return 'Governance';
+    case 'manual-approval':
+      return 'Manual approval';
+  }
+}
+
+// Exposed for unit tests — the request body shape is what `validate_create_body`
+// on stiglab accepts. Lives here so the contract round-trip is covered in one
+// file alongside its readers.
+export function createWorkflowRequestToBackend(
+  req: CreateWorkflowRequest,
+): BackendCreateWorkflowBody {
+  const installId = Number.parseInt(req.trigger.install_id, 10);
+  if (!Number.isFinite(installId) || installId <= 0) {
+    throw new ApiError('install_id is required', 400);
+  }
+  return {
+    tenant_id: req.tenant_id ?? '',
+    name: req.name,
+    trigger_kind: 'github-issue-webhook',
+    repo_owner: req.trigger.repo_owner,
+    repo_name: req.trigger.repo_name,
+    trigger_label: req.trigger.label,
+    install_id: installId,
+    preset_id: req.preset,
+    stages: req.preset ? undefined : req.stages.map(stageToBackend),
+    active: req.activate ?? false,
+  };
+}
+
 export type StageRunStatus = 'pending' | 'blocked' | 'passed' | 'failed';
 
 export interface WorkflowRunStage {
@@ -538,22 +671,34 @@ export const api = {
     }),
   // Workflows (issue #82) — CRUD + live runs. The API is provided by the
   // stiglab sibling sub-issue; the dashboard is the only client today.
-  listWorkflows: (tenantId?: string) =>
-    request<{ workflows: Workflow[] }>(
+  // The backend persists workflows with flat trigger fields and stage `params`;
+  // these wrappers translate to/from the UI's nested shape.
+  listWorkflows: async (tenantId?: string): Promise<{ workflows: Workflow[] }> => {
+    const raw = await request<{ workflows: BackendWorkflow[] }>(
       `/workflows${tenantId ? `?tenant_id=${encodeURIComponent(tenantId)}` : ''}`,
-    ),
-  getWorkflow: (id: string) =>
-    request<{ workflow: Workflow }>(`/workflows/${encodeURIComponent(id)}`),
-  createWorkflow: (body: CreateWorkflowRequest) =>
-    request<{ workflow: Workflow }>('/workflows', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    }),
-  updateWorkflow: (id: string, body: Partial<CreateWorkflowRequest>) =>
-    request<{ workflow: Workflow }>(`/workflows/${encodeURIComponent(id)}`, {
-      method: 'PATCH',
-      body: JSON.stringify(body),
-    }),
+    );
+    return { workflows: raw.workflows.map((w) => workflowFromBackend(w)) };
+  },
+  getWorkflow: async (id: string): Promise<{ workflow: Workflow }> => {
+    const raw = await request<{ workflow: BackendWorkflow; stages: BackendWorkflowStage[] }>(
+      `/workflows/${encodeURIComponent(id)}`,
+    );
+    return { workflow: workflowFromBackend(raw.workflow, raw.stages) };
+  },
+  createWorkflow: async (body: CreateWorkflowRequest): Promise<{ workflow: Workflow }> => {
+    const raw = await request<{ workflow: BackendWorkflow; stages?: BackendWorkflowStage[] }>(
+      '/workflows',
+      { method: 'POST', body: JSON.stringify(createWorkflowRequestToBackend(body)) },
+    );
+    return { workflow: workflowFromBackend(raw.workflow, raw.stages ?? []) };
+  },
+  setWorkflowActive: async (id: string, active: boolean): Promise<{ workflow: Workflow }> => {
+    const raw = await request<{ workflow: BackendWorkflow }>(
+      `/workflows/${encodeURIComponent(id)}`,
+      { method: 'PATCH', body: JSON.stringify({ active }) },
+    );
+    return { workflow: workflowFromBackend(raw.workflow) };
+  },
   deleteWorkflow: (id: string) =>
     request<{ ok: boolean }>(`/workflows/${encodeURIComponent(id)}`, {
       method: 'DELETE',

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -119,8 +119,8 @@ export function FactoryOverviewPage() {
   })
   // Issue #82 — empty-state CTA banner when no workflow has been set up yet.
   const { data: workflowsData } = useQuery({
-    queryKey: ["workflows"],
-    queryFn: () => api.listWorkflows(),
+    queryKey: ["workflows", "user"],
+    queryFn: () => api.listWorkflowsForUser(),
     staleTime: 30_000,
   })
   const workflowsCount = workflowsData?.workflows?.length ?? 0

--- a/apps/dashboard/src/pages/WorkflowStartPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowStartPage.tsx
@@ -9,7 +9,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { LabelCombobox } from "@/components/factory/workflows/LabelCombobox"
 import {
   GITHUB_ISSUE_TO_PR_PRESET,
-  draftToRequestTrigger,
   githubIssueToPrPreset,
 } from "@/components/factory/workflows/workflow-draft"
 
@@ -62,6 +61,18 @@ export function WorkflowStartPage() {
     )
     return hit?.tenantId ?? ""
   }, [tenantIdParam, tenantInstallsData, installId])
+
+  // The backend's workflow create API wants the numeric GitHub install id,
+  // not the dashboard's installation record id. Look it up from the same
+  // list we used to resolve the tenant.
+  const githubInstallId = useMemo(() => {
+    if (!tenantInstallsData) return 0
+    for (const e of tenantInstallsData) {
+      const hit = e.installations.find((i) => i.id === installId)
+      if (hit) return hit.install_id
+    }
+    return 0
+  }, [tenantInstallsData, installId])
 
   const installLookupDone = !!tenantIdParam || !!tenantInstallsData
   const installUnresolved =
@@ -120,6 +131,7 @@ export function WorkflowStartPage() {
                   repo={r}
                   tenantId={resolvedTenantId}
                   installId={installId}
+                  githubInstallId={githubInstallId}
                 />
               ))}
             </ul>
@@ -156,10 +168,12 @@ function RepoRow({
   repo,
   tenantId,
   installId,
+  githubInstallId,
 }: {
   repo: AccessibleRepo
   tenantId: string
   installId: string
+  githubInstallId: number
 }) {
   const [label, setLabel] = useState<string | null>(null)
   const queryClient = useQueryClient()
@@ -173,9 +187,13 @@ function RepoRow({
     },
   })
 
-  const ready = !!label && !!tenantId
+  const ready = !!label && !!tenantId && githubInstallId > 0
   const run = () => {
     if (!ready || !label) return
+    // Preset path: stiglab expands the stage chain server-side, so we
+    // send only `preset_id` (sending both `preset_id` and `stages` is an
+    // explicit 400 on the backend). The draft here is only used to
+    // compute a nice default name.
     const draft = githubIssueToPrPreset({
       install_id: installId,
       repo_owner: repo.owner,
@@ -185,10 +203,13 @@ function RepoRow({
     create.mutate({
       tenant_id: tenantId,
       name: draft.name,
-      preset: GITHUB_ISSUE_TO_PR_PRESET,
-      trigger: draftToRequestTrigger(draft.trigger),
-      stages: draft.stages,
-      activate: true,
+      trigger_kind: "github-issue-webhook",
+      install_id: githubInstallId,
+      repo_owner: repo.owner,
+      repo_name: repo.name,
+      trigger_label: label,
+      preset_id: GITHUB_ISSUE_TO_PR_PRESET,
+      active: true,
     })
   }
 

--- a/apps/dashboard/src/pages/WorkflowsPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowsPage.tsx
@@ -15,8 +15,8 @@ export function WorkflowsPage() {
   const [creating, setCreating] = useState(false)
 
   const { data, isLoading } = useQuery({
-    queryKey: ["workflows"],
-    queryFn: () => api.listWorkflows(),
+    queryKey: ["workflows", "user"],
+    queryFn: () => api.listWorkflowsForUser(),
     enabled: authed,
   })
   const workflows = data?.workflows ?? []
@@ -75,9 +75,6 @@ export function WorkflowsPage() {
                   <div className="truncate">
                     Trigger: {w.trigger.repo_owner}/{w.trigger.repo_name}
                     {w.trigger.label ? ` · ${w.trigger.label}` : ""}
-                  </div>
-                  <div>
-                    {w.stages.length} stage{w.stages.length === 1 ? "" : "s"}
                   </div>
                 </CardContent>
               </Card>

--- a/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
+++ b/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, expect } from "vitest"
+import type { GitHubAppInstallation } from "@/lib/api"
 import {
-  createWorkflowRequestToBackend,
-  type CreateWorkflowRequest,
-} from "@/lib/api"
+  draftToCreateRequest,
+  emptyDraft,
+  type WorkflowDraft,
+} from "@/components/factory/workflows/workflow-draft"
 
 // The stiglab `validate_create_body` is the source of truth for the wire
 // shape. These tests pin the UI → backend adapter against its contract:
-// flat trigger fields, numeric install_id, snake_case `trigger_kind` /
-// `trigger_label` / `active`, and stage params that carry the UI-only
-// name + artifact_kind alongside any gate config.
-describe("createWorkflowRequestToBackend", () => {
-  const baseReq = (): CreateWorkflowRequest => ({
+// flat trigger fields, numeric install_id resolved from the install record,
+// snake_case `trigger_kind` / `trigger_label` / `active`, and stage params
+// that carry the UI-only name + artifact_kind alongside any gate config.
+describe("draftToCreateRequest", () => {
+  const installation: GitHubAppInstallation = {
+    id: "inst_abc",
     tenant_id: "t_1",
+    install_id: 12345,
+    account_login: "onsager-ai",
+    account_type: "organization",
+    created_at: "2026-04-22T00:00:00Z",
+  }
+
+  const draft = (): WorkflowDraft => ({
     name: "Issue → PR",
     trigger: {
-      kind: "github-label",
-      install_id: "42",
+      install_id: "inst_abc", // record id, not numeric GitHub install id
       repo_owner: "onsager-ai",
       repo_name: "onsager",
       label: "factory",
@@ -29,11 +38,16 @@ describe("createWorkflowRequestToBackend", () => {
         config: { agent_profile: "default" },
       },
     ],
-    activate: true,
   })
 
-  it("flattens the trigger and emits the backend enum values", () => {
-    const out = createWorkflowRequestToBackend(baseReq())
+  it("resolves the numeric GitHub install_id from the installations list", () => {
+    const out = draftToCreateRequest(draft(), [installation], "t_1", true)
+    expect(out.install_id).toBe(12345)
+    expect(typeof out.install_id).toBe("number")
+  })
+
+  it("flattens the trigger into the backend's snake_case keys", () => {
+    const out = draftToCreateRequest(draft(), [installation], "t_1", true)
     expect(out).toMatchObject({
       tenant_id: "t_1",
       name: "Issue → PR",
@@ -41,7 +55,6 @@ describe("createWorkflowRequestToBackend", () => {
       repo_owner: "onsager-ai",
       repo_name: "onsager",
       trigger_label: "factory",
-      install_id: 42,
       active: true,
     })
     // No nested `trigger`, no `activate`, no `preset` — all wire keys.
@@ -49,14 +62,8 @@ describe("createWorkflowRequestToBackend", () => {
     expect("activate" in out).toBe(false)
   })
 
-  it("parses install_id to a number", () => {
-    const out = createWorkflowRequestToBackend(baseReq())
-    expect(typeof out.install_id).toBe("number")
-    expect(out.install_id).toBe(42)
-  })
-
   it("maps stages to { gate_kind, params } and carries UI display fields in params", () => {
-    const out = createWorkflowRequestToBackend(baseReq())
+    const out = draftToCreateRequest(draft(), [installation], "t_1", true)
     expect(out.stages).toEqual([
       {
         gate_kind: "agent-session",
@@ -69,23 +76,27 @@ describe("createWorkflowRequestToBackend", () => {
     ])
   })
 
-  it("sends preset_id and drops stages when a preset is chosen", () => {
-    const req = baseReq()
-    req.preset = "github-issue-to-pr"
-    const out = createWorkflowRequestToBackend(req)
-    expect(out.preset_id).toBe("github-issue-to-pr")
-    expect(out.stages).toBeUndefined()
+  it("passes activate=false through as active=false", () => {
+    const out = draftToCreateRequest(draft(), [installation], "t_1", false)
+    expect(out.active).toBe(false)
   })
 
-  it("defaults active=false when activate is not set", () => {
-    const req = baseReq()
-    delete req.activate
-    expect(createWorkflowRequestToBackend(req).active).toBe(false)
+  it("throws when tenant_id is blank", () => {
+    expect(() => draftToCreateRequest(draft(), [installation], "  ", true)).toThrow(
+      /tenant_id/,
+    )
   })
 
-  it("throws when install_id can't be parsed", () => {
-    const req = baseReq()
-    req.trigger.install_id = ""
-    expect(() => createWorkflowRequestToBackend(req)).toThrow(/install_id/)
+  it("throws when the selected install isn't in the list", () => {
+    expect(() => draftToCreateRequest(draft(), [], "t_1", true)).toThrow(
+      /install not found/,
+    )
+  })
+
+  it("throws when the trigger isn't ready (missing label)", () => {
+    const d = emptyDraft()
+    expect(() => draftToCreateRequest(d, [installation], "t_1", true)).toThrow(
+      /install, repo, and label/,
+    )
   })
 })

--- a/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
+++ b/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest"
+import {
+  createWorkflowRequestToBackend,
+  type CreateWorkflowRequest,
+} from "@/lib/api"
+
+// The stiglab `validate_create_body` is the source of truth for the wire
+// shape. These tests pin the UI → backend adapter against its contract:
+// flat trigger fields, numeric install_id, snake_case `trigger_kind` /
+// `trigger_label` / `active`, and stage params that carry the UI-only
+// name + artifact_kind alongside any gate config.
+describe("createWorkflowRequestToBackend", () => {
+  const baseReq = (): CreateWorkflowRequest => ({
+    tenant_id: "t_1",
+    name: "Issue → PR",
+    trigger: {
+      kind: "github-label",
+      install_id: "42",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      label: "factory",
+    },
+    stages: [
+      {
+        id: "s1",
+        name: "Spec → PR",
+        gate_kind: "agent-session",
+        artifact_kind: "github-issue",
+        config: { agent_profile: "default" },
+      },
+    ],
+    activate: true,
+  })
+
+  it("flattens the trigger and emits the backend enum values", () => {
+    const out = createWorkflowRequestToBackend(baseReq())
+    expect(out).toMatchObject({
+      tenant_id: "t_1",
+      name: "Issue → PR",
+      trigger_kind: "github-issue-webhook",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      trigger_label: "factory",
+      install_id: 42,
+      active: true,
+    })
+    // No nested `trigger`, no `activate`, no `preset` — all wire keys.
+    expect("trigger" in out).toBe(false)
+    expect("activate" in out).toBe(false)
+  })
+
+  it("parses install_id to a number", () => {
+    const out = createWorkflowRequestToBackend(baseReq())
+    expect(typeof out.install_id).toBe("number")
+    expect(out.install_id).toBe(42)
+  })
+
+  it("maps stages to { gate_kind, params } and carries UI display fields in params", () => {
+    const out = createWorkflowRequestToBackend(baseReq())
+    expect(out.stages).toEqual([
+      {
+        gate_kind: "agent-session",
+        params: {
+          agent_profile: "default",
+          name: "Spec → PR",
+          artifact_kind: "github-issue",
+        },
+      },
+    ])
+  })
+
+  it("sends preset_id and drops stages when a preset is chosen", () => {
+    const req = baseReq()
+    req.preset = "github-issue-to-pr"
+    const out = createWorkflowRequestToBackend(req)
+    expect(out.preset_id).toBe("github-issue-to-pr")
+    expect(out.stages).toBeUndefined()
+  })
+
+  it("defaults active=false when activate is not set", () => {
+    const req = baseReq()
+    delete req.activate
+    expect(createWorkflowRequestToBackend(req).active).toBe(false)
+  })
+
+  it("throws when install_id can't be parsed", () => {
+    const req = baseReq()
+    req.trigger.install_id = ""
+    expect(() => createWorkflowRequestToBackend(req)).toThrow(/install_id/)
+  })
+})


### PR DESCRIPTION
Part of #79 (workflow builder dogfood follow-ups — user-reported bugs in the shipped #82/#83 UI against #84's API).

## Summary

Three related issues surfaced while using the workflow builder:

### 1. "Activate workflow" button was a silent 400

The dashboard POST body did not match stiglab's `validate_create_body` shape. Every click returned 400 and the error bubbled into a below-the-fold toast:

| Dashboard was sending             | Stiglab expects                     |
| --------------------------------- | ----------------------------------- |
| `trigger: { kind, install_id, repo_owner, repo_name, label }` (nested) | `trigger_kind`, `install_id`, `repo_owner`, `repo_name`, `trigger_label` (flat) |
| `trigger.kind: "github-label"`    | `trigger_kind: "github-issue-webhook"` |
| `install_id: string`              | `install_id: i64`                   |
| `activate: true`                  | `active: true`                      |
| full `WorkflowStage` objects with `name` / `artifact_kind` / `config` | `{ gate_kind, params }` with opaque JSON params |
| `preset`                          | `preset_id`                         |

Fix: translate at the `api.ts` boundary. `createWorkflowRequestToBackend` flattens the UI shape to the wire format; `workflowFromBackend` / `stageFromBackend` unpack responses back into the nested UI shape. UI-only stage display fields (`name`, `artifact_kind`) now ride inside `params` so they survive the round-trip without a backend change.

### 2. `/api/nodes` 401 spam for logged-out users

`useNodes` polled every 5s regardless of auth state, so anyone on the login page (or landing on `/` before `/auth/me` resolved) saw a 401 on every poll. Gated the query on `useAuth()`: it only fires when auth is disabled *or* a user is resolved.

### 3. Chat builder hidden

The `ChatBuilder` card above the card stack was a keyword-heuristic placeholder. It's not useful in its current form and muddies the card-editor UX. Removed from `WorkflowBuilder`; kept the file so a real LLM-backed version can slot back in later.

## Test plan

- [x] `pnpm test` — 75/75 pass (new `workflow-create-contract.test.ts` pins the adapter against stiglab's accepted keys, so future drift fails the suite)
- [x] `pnpm lint` clean
- [x] `pnpm build` (tsc -b + vite) clean
- [ ] Manual: open workflow builder, pick install + repo + label, apply preset, click **Activate workflow** → workflow creates and navigates to detail
- [ ] Manual: log out → no more `/api/nodes` 401 spam in the network tab
- [ ] Manual: workflow list + detail render (previously would have broken on nested `workflow.trigger.*` access since backend returns flat fields)
