### PR TITLE
docs(preview-env): drop ephemeral-postgres toggle, clarify default

### DIFF
--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -59,9 +59,14 @@ project tokens are environment-locked and can't see ephemeral PR envs.
 
 2. **Enable PR environments**
    Railway dashboard → Project Settings → *Pull Request Environments* → **Enabled**
-   - Ephemeral Postgres: **Enabled** (do not clone prod data)
    - Wait-for-check: `deploy-ready`
    - Environment TTL: leave default (tears down with PR)
+
+   Railway forks the Postgres plugin as a fresh empty instance per PR by
+   default — volume data is not copied unless you explicitly opt in. If
+   you see prod data leaking into a preview DB, look for a
+   "Copy volume contents to new environments" toggle on the Postgres
+   service's volume settings and turn it off; otherwise, no action.
 
 3. **Verify**
    Open a throwaway PR. When Railway's PR-env deploy finishes, the

--- a/railway.toml
+++ b/railway.toml
@@ -85,8 +85,9 @@ numReplicas = 1
 #
 # Enable once in the Railway dashboard:
 #   Project Settings → Pull Request Environments → Enabled
-#                    → Ephemeral Postgres: enabled (do NOT clone prod data)
 #                    → Wait for check: deploy-ready
+# Postgres forks as a fresh empty instance per PR by default — volume data
+# is not copied unless explicitly opted in.
 #
 # After enabling, `.github/workflows/preview-environment.yml` reacts to the
 # `deployment_status` event Railway's GitHub App emits on successful deploy


### PR DESCRIPTION
## Summary

Follow-up to #90. The "Ephemeral Postgres: Enabled (do not clone prod data)" step was misleading: there's no such toggle in Railway's dashboard — volume data simply isn't copied into PR-env forks unless you explicitly opt in. Replace it with a short note on the actual default and where to look if prod data ever does show up in a preview DB.

Doc-only, no behavior change. Label as `trivial` please.

## Test plan

- [ ] Skim the updated `docs/preview-environments.md` — setup steps match what's actually clickable in the Railway dashboard.

https://claude.ai/code/session_01N9xPaRKEFUWpqSDM1ATjoS