### PR TITLE
perf(dashboard): compress, split, and skeleton the initial load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -81,6 +102,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -223,6 +256,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +371,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +476,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -558,6 +639,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1341,6 +1432,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2224,6 +2325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2965,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "any", "pos
 # HTTP / Web
 axum = { version = "0.8", features = ["ws"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
+tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "cors", "trace", "compression-gzip", "compression-br", "set-header"] }
 reqwest = { version = "0.12", features = ["json"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "any", "pos
 # HTTP / Web
 axum = { version = "0.8", features = ["ws"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
-tower-http = { version = "0.6", features = ["fs", "cors", "trace"] }
+tower-http = { version = "0.6", features = ["fs", "cors", "trace", "compression-gzip", "compression-br", "set-header"] }
 reqwest = { version = "0.12", features = ["json"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,25 +1,56 @@
-import { useEffect } from "react"
+import { lazy, Suspense, useEffect } from "react"
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query"
 import { ThemeProvider } from "@/components/providers/ThemeProvider"
 import { AuthProvider, useAuth } from "@/lib/auth"
 import { AppLayout } from "@/components/layout/AppLayout"
-import { FactoryOverviewPage } from "@/pages/FactoryOverviewPage"
-import { ArtifactDetailPage } from "@/pages/ArtifactDetailPage"
-import { NodesPage } from "@/pages/NodesPage"
-import { SessionsPage } from "@/pages/SessionsPage"
-import { SessionDetailPage } from "@/pages/SessionDetailPage"
+import { AppShellSkeleton } from "@/components/layout/AppShellSkeleton"
+import { PageSkeleton } from "@/components/layout/PageSkeleton"
+// Login stays eager so the unauthenticated first-paint path doesn't
+// pay for an extra chunk fetch. Every other page is lazy.
 import { LoginPage } from "@/pages/LoginPage"
-import { SettingsPage } from "@/pages/SettingsPage"
-import { GovernancePage } from "@/pages/GovernancePage"
-import { SpinePage } from "@/pages/SpinePage"
-import { ArtifactsPage } from "@/pages/ArtifactsPage"
-import { WorkspacesPage } from "@/pages/WorkspacesPage"
-import { WorkflowsPage } from "@/pages/WorkflowsPage"
-import { WorkflowStartPage } from "@/pages/WorkflowStartPage"
-import { WorkflowDetailPage } from "@/pages/WorkflowDetailPage"
 import { api } from "@/lib/api"
 import type { ReactNode } from "react"
+
+const FactoryOverviewPage = lazy(() =>
+  import("@/pages/FactoryOverviewPage").then((m) => ({ default: m.FactoryOverviewPage })),
+)
+const ArtifactsPage = lazy(() =>
+  import("@/pages/ArtifactsPage").then((m) => ({ default: m.ArtifactsPage })),
+)
+const ArtifactDetailPage = lazy(() =>
+  import("@/pages/ArtifactDetailPage").then((m) => ({ default: m.ArtifactDetailPage })),
+)
+const SpinePage = lazy(() =>
+  import("@/pages/SpinePage").then((m) => ({ default: m.SpinePage })),
+)
+const GovernancePage = lazy(() =>
+  import("@/pages/GovernancePage").then((m) => ({ default: m.GovernancePage })),
+)
+const SessionsPage = lazy(() =>
+  import("@/pages/SessionsPage").then((m) => ({ default: m.SessionsPage })),
+)
+const SessionDetailPage = lazy(() =>
+  import("@/pages/SessionDetailPage").then((m) => ({ default: m.SessionDetailPage })),
+)
+const NodesPage = lazy(() =>
+  import("@/pages/NodesPage").then((m) => ({ default: m.NodesPage })),
+)
+const WorkspacesPage = lazy(() =>
+  import("@/pages/WorkspacesPage").then((m) => ({ default: m.WorkspacesPage })),
+)
+const WorkflowsPage = lazy(() =>
+  import("@/pages/WorkflowsPage").then((m) => ({ default: m.WorkflowsPage })),
+)
+const WorkflowStartPage = lazy(() =>
+  import("@/pages/WorkflowStartPage").then((m) => ({ default: m.WorkflowStartPage })),
+)
+const WorkflowDetailPage = lazy(() =>
+  import("@/pages/WorkflowDetailPage").then((m) => ({ default: m.WorkflowDetailPage })),
+)
+const SettingsPage = lazy(() =>
+  import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,11 +65,7 @@ function ProtectedRoute({ children }: { children: ReactNode }) {
   const { user, loading, authEnabled } = useAuth()
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-muted-foreground">Loading...</p>
-      </div>
-    )
+    return <AppShellSkeleton />
   }
 
   // If auth is not enabled, allow access
@@ -52,6 +79,19 @@ function ProtectedRoute({ children }: { children: ReactNode }) {
   }
 
   return <>{children}</>
+}
+
+// Wraps a lazy page's element in a Suspense with a variant-appropriate
+// skeleton. Chunk loads are typically sub-second but on slow connections
+// this keeps the main area non-empty while the JS streams in.
+function LazyRoute({
+  variant = "default",
+  children,
+}: {
+  variant?: "list" | "detail" | "default"
+  children: ReactNode
+}) {
+  return <Suspense fallback={<PageSkeleton variant={variant} />}>{children}</Suspense>
 }
 
 // Redirects users with zero workspaces to /workspaces?welcome=1 on their
@@ -111,6 +151,10 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
   const location = useLocation()
   const gateEnabled = authEnabled && !!user
 
+  // Fire both queries in parallel — the old code chained `workflows` on
+  // `hasWorkspace`, which serialized two RTTs. The workflows endpoint is
+  // safe to call without a workspace (it filters by the current user's
+  // membership); we only *use* the result when `hasWorkspace` is true.
   const { data: workspacesData } = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
@@ -119,11 +163,11 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
   })
   const hasWorkspace = (workspacesData?.tenants?.length ?? 0) > 0
 
-  const { data: workflowsData, isLoading } = useQuery({
+  const { data: workflowsData, isLoading: workflowsLoading } = useQuery({
     queryKey: ["workflows", "user"],
     queryFn: () => api.listWorkflowsForUser(),
     staleTime: 30_000,
-    enabled: gateEnabled && hasWorkspace,
+    enabled: gateEnabled,
   })
   const workflowsCount = workflowsData?.workflows?.length ?? 0
 
@@ -144,7 +188,7 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
   if (
     gateEnabled &&
     hasWorkspace &&
-    !isLoading &&
+    !workflowsLoading &&
     workflowsCount === 0 &&
     !seen &&
     location.pathname === "/"
@@ -159,11 +203,7 @@ function AppRoutes() {
   const { user, loading, authEnabled } = useAuth()
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-muted-foreground">Loading...</p>
-      </div>
-    )
+    return <AppShellSkeleton />
   }
 
   return (
@@ -183,19 +223,58 @@ function AppRoutes() {
               <OnboardingGate>
                 <WorkflowsFirstRunGate>
                   <Routes>
-                    <Route path="/" element={<FactoryOverviewPage />} />
-                    <Route path="/artifacts" element={<ArtifactsPage />} />
-                    <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
-                    <Route path="/spine" element={<SpinePage />} />
-                    <Route path="/governance" element={<GovernancePage />} />
-                    <Route path="/sessions" element={<SessionsPage />} />
-                    <Route path="/sessions/:id" element={<SessionDetailPage />} />
-                    <Route path="/nodes" element={<NodesPage />} />
-                    <Route path="/workspaces" element={<WorkspacesPage />} />
-                    <Route path="/workflows" element={<WorkflowsPage />} />
-                    <Route path="/workflows/start" element={<WorkflowStartPage />} />
-                    <Route path="/workflows/:id" element={<WorkflowDetailPage />} />
-                    <Route path="/settings" element={<SettingsPage />} />
+                    <Route
+                      path="/"
+                      element={<LazyRoute><FactoryOverviewPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/artifacts"
+                      element={<LazyRoute variant="list"><ArtifactsPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/artifacts/:id"
+                      element={<LazyRoute variant="detail"><ArtifactDetailPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/spine"
+                      element={<LazyRoute variant="list"><SpinePage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/governance"
+                      element={<LazyRoute><GovernancePage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/sessions"
+                      element={<LazyRoute variant="list"><SessionsPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/sessions/:id"
+                      element={<LazyRoute variant="detail"><SessionDetailPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/nodes"
+                      element={<LazyRoute variant="list"><NodesPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/workspaces"
+                      element={<LazyRoute variant="list"><WorkspacesPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/workflows"
+                      element={<LazyRoute variant="list"><WorkflowsPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/workflows/start"
+                      element={<LazyRoute><WorkflowStartPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/workflows/:id"
+                      element={<LazyRoute variant="detail"><WorkflowDetailPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/settings"
+                      element={<LazyRoute><SettingsPage /></LazyRoute>}
+                    />
                   </Routes>
                 </WorkflowsFirstRunGate>
               </OnboardingGate>

--- a/apps/dashboard/src/components/layout/AppShellSkeleton.tsx
+++ b/apps/dashboard/src/components/layout/AppShellSkeleton.tsx
@@ -51,7 +51,7 @@ export function AppShellSkeleton() {
             <Skeleton className="h-9 w-9 rounded-full" />
           </div>
         </header>
-        <main className="flex-1 p-4 md:p-6">
+        <main className="flex-1 p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] md:p-6 md:pb-6">
           <PageSkeleton />
         </main>
       </div>

--- a/apps/dashboard/src/components/layout/AppShellSkeleton.tsx
+++ b/apps/dashboard/src/components/layout/AppShellSkeleton.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { PageSkeleton } from "./PageSkeleton"
+
+/**
+ * Full-page shell placeholder rendered before auth resolves or while a
+ * lazy route chunk is loading. Static — no hooks, no context, no
+ * network. Mirrors the geometry of AppLayout (sidebar width, header
+ * height, main padding) so swapping to the real UI causes no layout
+ * shift.
+ */
+export function AppShellSkeleton() {
+  return (
+    <div className="flex min-h-screen w-full" aria-busy="true" aria-live="polite">
+      {/* Sidebar — hidden on mobile to match SidebarProvider default */}
+      <aside className="hidden w-64 shrink-0 border-r bg-sidebar md:flex md:flex-col">
+        <div className="flex h-[60px] items-center gap-2 border-b px-6">
+          <Skeleton className="h-6 w-6 rounded-md" />
+          <Skeleton className="h-5 w-24" />
+        </div>
+        <div className="flex-1 space-y-6 px-3 py-4">
+          {Array.from({ length: 4 }).map((_, s) => (
+            <div key={s} className="space-y-2">
+              <Skeleton className="mx-2 h-3 w-20" />
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-2 rounded-md px-2 py-2">
+                  <Skeleton className="h-4 w-4 rounded-sm" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className="border-t p-4">
+          <Skeleton className="h-3 w-12" />
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* Mobile header */}
+        <header className="sticky top-0 z-30 flex h-14 items-center gap-2 border-b bg-background/95 px-3 backdrop-blur md:hidden">
+          <Skeleton className="h-9 w-9 rounded-md" />
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="ml-auto h-9 w-9 rounded-full" />
+          <Skeleton className="h-9 w-9 rounded-full" />
+        </header>
+        {/* Desktop header */}
+        <header className="hidden h-14 items-center gap-2 border-b px-6 md:flex">
+          <Skeleton className="h-7 w-7 rounded-md" />
+          <div className="ml-auto flex items-center gap-2">
+            <Skeleton className="h-9 w-28 rounded-md" />
+            <Skeleton className="h-9 w-9 rounded-full" />
+          </div>
+        </header>
+        <main className="flex-1 p-4 md:p-6">
+          <PageSkeleton />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/layout/PageSkeleton.tsx
+++ b/apps/dashboard/src/components/layout/PageSkeleton.tsx
@@ -1,0 +1,106 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+
+type Variant = "list" | "detail" | "default"
+
+export function PageSkeleton({
+  variant = "default",
+  className,
+}: {
+  variant?: Variant
+  className?: string
+}) {
+  if (variant === "detail") {
+    return <DetailSkeleton className={className} />
+  }
+  if (variant === "list") {
+    return <ListSkeleton className={className} />
+  }
+  return <DefaultSkeleton className={className} />
+}
+
+function PageHeaderSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-4 w-72" />
+    </div>
+  )
+}
+
+function ListSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)} aria-busy="true" aria-live="polite">
+      <PageHeaderSkeleton />
+      <div className="rounded-lg border">
+        <div className="flex items-center gap-4 border-b px-4 py-3">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="ml-auto h-4 w-20" />
+        </div>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b px-4 py-4 last:border-b-0">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="ml-auto h-4 w-24" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DetailSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)} aria-busy="true" aria-live="polite">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border p-4 space-y-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-7 w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg border p-6 space-y-3">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-11/12" />
+        <Skeleton className="h-4 w-10/12" />
+      </div>
+    </div>
+  )
+}
+
+function DefaultSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)} aria-busy="true" aria-live="polite">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border p-4 space-y-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-7 w-24" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg border">
+        <div className="border-b p-4">
+          <Skeleton className="h-5 w-40" />
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/ui/skeleton.tsx
+++ b/apps/dashboard/src/components/ui/skeleton.tsx
@@ -5,7 +5,7 @@ function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("animate-shimmer rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -130,3 +130,25 @@
     @apply font-sans;
     }
 }
+
+/* Shimmer used by <Skeleton> — a moving highlight bar feels less static
+   than tailwind's pulse and signals "this is loading" more clearly. */
+@keyframes onsager-shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.animate-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    var(--muted) 0%,
+    color-mix(in oklch, var(--muted-foreground) 18%, var(--muted)) 50%,
+    var(--muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: onsager-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer { animation: none; }
+}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -19,4 +19,23 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    // Stable vendor chunks — these libs rarely change, so splitting them
+    // lets the browser keep them cached across deploys while the app
+    // entry invalidates on each release.
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (/\/(react|react-dom|react-router|react-router-dom|scheduler)\//.test(id)) {
+            return 'react-vendor'
+          }
+          if (id.includes('@tanstack/react-query')) {
+            return 'query-vendor'
+          }
+          return undefined
+        },
+      },
+    },
+  },
 })

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -33,7 +33,7 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
-tower = "0.5"
+tower = { workspace = true }
 tower-http = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -33,6 +33,7 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
+tower = "0.5"
 tower-http = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
@@ -49,4 +50,3 @@ clap = { workspace = true }
 hostname = "0.4"
 
 [dev-dependencies]
-tower = "0.5"

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -13,10 +13,14 @@ pub mod ws;
 
 pub use sqlx::AnyPool;
 
+use axum::http::{header, HeaderValue};
 use axum::routing::{any, get, post, put};
 use axum::Router;
+use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
+use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 
 use config::ServerConfig;
@@ -176,11 +180,43 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 
-    // Serve static UI files if configured
+    // Serve static UI files if configured.
+    //
+    // Vite emits two classes of output into `static_dir`:
+    //   * `/assets/*` — content-hashed JS/CSS/fonts; safe to cache forever.
+    //   * `index.html` (plus the SPA fallback) — must revalidate so a new
+    //     deploy is picked up on the next navigation without a manual
+    //     refresh; an ETag keeps the wire cost minimal when unchanged.
+    //
+    // Both branches are wrapped in gzip+br compression. The compression
+    // layer respects `Accept-Encoding` and skips already-compressed
+    // content-types, so PNGs/woff2 aren't double-compressed.
     if let Some(ref static_dir) = config.static_dir {
         tracing::info!("serving static files from {static_dir}");
         let index_file = format!("{static_dir}/index.html");
-        app = app.fallback_service(ServeDir::new(static_dir).fallback(ServeFile::new(index_file)));
+        let assets_dir = format!("{static_dir}/assets");
+
+        let compression = CompressionLayer::new().gzip(true).br(true);
+
+        let assets_service = ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ))
+            .layer(compression.clone())
+            .service(ServeDir::new(assets_dir));
+
+        let shell_service = ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("no-cache"),
+            ))
+            .layer(compression)
+            .service(ServeDir::new(static_dir).fallback(ServeFile::new(index_file)));
+
+        app = app
+            .nest_service("/assets", assets_service)
+            .fallback_service(shell_service);
     }
 
     app

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -198,10 +198,23 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
 
         let compression = CompressionLayer::new().gzip(true).br(true);
 
+        // Status-aware: only apply `immutable` to successful responses so a
+        // 404 during a bad deploy or partial rollout isn't cached for a
+        // year by clients and intermediaries. The closure is generic over
+        // the response body type (compression wraps it); returning `None`
+        // leaves the header off.
         let assets_service = ServiceBuilder::new()
             .layer(SetResponseHeaderLayer::overriding(
                 header::CACHE_CONTROL,
-                HeaderValue::from_static("public, max-age=31536000, immutable"),
+                |response: &axum::http::Response<_>| -> Option<HeaderValue> {
+                    if response.status().is_success() {
+                        Some(HeaderValue::from_static(
+                            "public, max-age=31536000, immutable",
+                        ))
+                    } else {
+                        None
+                    }
+                },
             ))
             .layer(compression.clone())
             .service(ServeDir::new(assets_dir));


### PR DESCRIPTION
## Summary

Closes #95. Cuts time-to-interactive on `https://app.onsager.ai` and
removes the blank-screen feel on cold loads.

### What changed
- **stiglab** (`crates/stiglab/src/server/mod.rs`): wrap static serving in gzip+br compression and add `Cache-Control` headers — `public, max-age=31536000, immutable` on hashed `/assets/*`, `no-cache` on `index.html` so deploys are picked up on next navigation while hashed chunks stay cached.
- **dashboard** (`apps/dashboard/src/App.tsx`): every page route is now `React.lazy` + `<Suspense>`. Login stays eager so the unauthenticated first-paint path doesn't pay for an extra chunk fetch.
- **dashboard** (`vite.config.ts`): `manualChunks` isolates `react` / `react-dom` / `react-router-dom` into `react-vendor` and `@tanstack/react-query` into `query-vendor`. These rarely change, so browsers keep them cached across deploys.
- **dashboard**: shimmer-animated skeletons replace the three `<p>Loading...</p>` placeholders. `AppShellSkeleton` renders while auth resolves; `PageSkeleton` (list / detail / default variants) is the `<Suspense>` fallback for lazy routes. Honors `prefers-reduced-motion`.
- **dashboard**: `WorkflowsFirstRunGate` no longer chains its workflows query on `hasWorkspace` — both fire in parallel, removing one RTT before first interaction.

### Measured impact (build output)

Main entry now splits cleanly:

```
react-vendor-*.js        413.26 kB │ gzip: 132.59 kB  ← cached across deploys
query-vendor-*.js         38.67 kB │ gzip:  12.09 kB  ← cached across deploys
index-*.js                47.36 kB │ gzip:  13.95 kB  ← app entry only
page chunks                2–18 kB │ gzip: 1–5 kB ea  ← loaded on demand
```

First paint on a route now pulls only `index` + `react-vendor` + the
route chunk instead of the full ~500 KB monolith. Compression cuts
wire bytes roughly in half on top of that.

## Test plan

- [x] `cargo clippy -p stiglab --all-targets -- -D warnings` — clean
- [x] `cargo test -p stiglab --lib` — 85 passed
- [x] `cargo fmt -p stiglab -- --check` — clean
- [x] `pnpm --filter dashboard build` — succeeds, chunks look right
- [x] `pnpm --filter dashboard lint` — clean
- [x] `pnpm --filter dashboard test` — 75 passed
- [ ] Manual: `curl -H 'Accept-Encoding: gzip' https://app.onsager.ai/assets/<hashed>.js` returns `Content-Encoding: gzip`
- [ ] Manual: `/assets/*` response includes `Cache-Control: max-age=31536000, immutable`; `/` and `/index.html` include `Cache-Control: no-cache`
- [ ] Manual (Chrome DevTools, Fast 3G): shimmer shell visible before any data call completes, no layout shift when real UI renders
- [ ] Manual: new deploy invalidates `index.html` on next visit, hashed asset cache survives

https://claude.ai/code/session_01FeYvryazBPKraRySEyBA4B
