### PR TITLE
fix(stiglab): surface missing GitHub App permission on workflow activate

### DIFF
--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -481,11 +481,25 @@ fn map_activation_error(e: ActivationError) -> Response {
         ActivationError::RepoOutOfScope { owner, repo } => bad_request(format!(
             "repo {owner}/{repo} is outside the workspace install scope"
         )),
+        ActivationError::MissingGithubPermission { action, details } => {
+            tracing::warn!("activation missing github permission: {action}");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": details,
+                    "code": "github_permission_missing",
+                })),
+            )
+                .into_response()
+        }
         ActivationError::GitHub(msg) => {
             tracing::warn!("activation github error: {msg}");
             (
                 StatusCode::BAD_GATEWAY,
-                Json(serde_json::json!({ "error": "github api error" })),
+                Json(serde_json::json!({
+                    "error": format!("github api error: {msg}"),
+                    "code": "github_api_error",
+                })),
             )
                 .into_response()
         }

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -481,13 +481,24 @@ fn map_activation_error(e: ActivationError) -> Response {
         ActivationError::RepoOutOfScope { owner, repo } => bad_request(format!(
             "repo {owner}/{repo} is outside the workspace install scope"
         )),
-        ActivationError::MissingGithubPermission { action, details } => {
-            tracing::warn!("activation missing github permission: {action}");
+        ActivationError::MissingGithubPermission {
+            action,
+            permission,
+            details,
+            upstream,
+        } => {
+            tracing::warn!(
+                action = %action,
+                permission = %permission,
+                upstream = %upstream,
+                "activation missing github permission"
+            );
             (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
                     "error": details,
                     "code": "github_permission_missing",
+                    "permission": permission,
                 })),
             )
                 .into_response()

--- a/crates/stiglab/src/server/workflow_activation.rs
+++ b/crates/stiglab/src/server/workflow_activation.rs
@@ -28,10 +28,36 @@ use crate::server::github_app::{list_installation_repos, InstallationToken};
 pub enum ActivationError {
     #[error("workflow target repo {owner}/{repo} is outside the workspace install scope")]
     RepoOutOfScope { owner: String, repo: String },
+    /// The GitHub App install responded with a 403 "Resource not accessible by
+    /// integration" — the App manifest is missing the permission required for
+    /// `action` (or the install hasn't accepted an updated permission set).
+    /// The CRUD route maps this to a user-visible 4xx so the dashboard can
+    /// prompt the operator to update the App's permissions, rather than the
+    /// generic 502 we use for opaque upstream failures.
+    #[error("github app install is missing permission for {action}")]
+    MissingGithubPermission { action: String, details: String },
     #[error("github api error: {0}")]
     GitHub(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+/// Classify a non-2xx response from the GitHub REST API. Returns a
+/// `MissingGithubPermission` when the status + body match the signature of a
+/// missing App permission (so the caller surfaces a dashboard-actionable 4xx);
+/// otherwise falls back to the opaque `GitHub` variant.
+fn classify_github_error(action: &str, status: reqwest::StatusCode, body: &str) -> ActivationError {
+    if status.as_u16() == 403 && body.contains("Resource not accessible by integration") {
+        return ActivationError::MissingGithubPermission {
+            action: action.to_string(),
+            details: format!(
+                "GitHub App install is missing the 'Repository webhooks: Read & write' \
+                 permission required to {action}. Update the App's permissions on GitHub \
+                 and accept the new permission request on the installation, then retry."
+            ),
+        };
+    }
+    ActivationError::GitHub(format!("{action} failed ({status}): {body}"))
 }
 
 /// Event types the webhook receiver cares about. Registered together so one
@@ -110,9 +136,7 @@ pub async fn ensure_label_exists(
     if resp.status().as_u16() != 404 {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(ActivationError::GitHub(format!(
-            "label lookup failed ({status}): {body}"
-        )));
+        return Err(classify_github_error("look up repo labels", status, &body));
     }
 
     // Create the label. GitHub requires a `color` field; pick a neutral grey.
@@ -138,9 +162,11 @@ pub async fn ensure_label_exists(
     }
     let status = resp.status();
     let body = resp.text().await.unwrap_or_default();
-    Err(ActivationError::GitHub(format!(
-        "label create failed ({status}): {body}"
-    )))
+    Err(classify_github_error(
+        "create the trigger label",
+        status,
+        &body,
+    ))
 }
 
 #[derive(Debug, Serialize)]
@@ -184,9 +210,11 @@ pub async fn ensure_webhook_registered(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(ActivationError::GitHub(format!(
-            "list hooks failed ({status}): {body}"
-        )));
+        return Err(classify_github_error(
+            "list the repo webhooks",
+            status,
+            &body,
+        ));
     }
     let hooks: Vec<serde_json::Value> = resp
         .json()
@@ -237,9 +265,11 @@ pub async fn ensure_webhook_registered(
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(ActivationError::GitHub(format!(
-                "update hook failed ({status}): {body}"
-            )));
+            return Err(classify_github_error(
+                "update the repo webhook",
+                status,
+                &body,
+            ));
         }
         return Ok(existing_id);
     }
@@ -268,9 +298,11 @@ pub async fn ensure_webhook_registered(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(ActivationError::GitHub(format!(
-            "create hook failed ({status}): {body}"
-        )));
+        return Err(classify_github_error(
+            "create the repo webhook",
+            status,
+            &body,
+        ));
     }
     let created: serde_json::Value = resp
         .json()
@@ -392,5 +424,59 @@ mod tests {
         assert!(REQUIRED_WEBHOOK_EVENTS.contains(&"check_suite"));
         assert!(REQUIRED_WEBHOOK_EVENTS.contains(&"check_run"));
         assert!(REQUIRED_WEBHOOK_EVENTS.contains(&"status"));
+    }
+
+    #[test]
+    fn classify_403_not_accessible_as_missing_permission() {
+        let body = r#"{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/repos/webhooks#list-repository-webhooks","status":"403"}"#;
+        let err = classify_github_error(
+            "list the repo webhooks",
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+        );
+        match err {
+            ActivationError::MissingGithubPermission { action, details } => {
+                assert_eq!(action, "list the repo webhooks");
+                assert!(details.contains("Repository webhooks"));
+                assert!(details.contains("list the repo webhooks"));
+            }
+            other => panic!("expected MissingGithubPermission, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_403_without_integration_phrase_falls_back_to_github_error() {
+        // Some 403s are rate-limit or org-SSO ones — don't mis-classify them
+        // as a missing App permission.
+        let body = r#"{"message":"API rate limit exceeded"}"#;
+        let err = classify_github_error(
+            "list the repo webhooks",
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+        );
+        match err {
+            ActivationError::GitHub(msg) => {
+                assert!(msg.contains("list the repo webhooks failed"));
+                assert!(msg.contains("rate limit"));
+            }
+            other => panic!("expected GitHub, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_non_403_is_opaque_github_error() {
+        let err = classify_github_error(
+            "create the repo webhook",
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            "boom",
+        );
+        match err {
+            ActivationError::GitHub(msg) => {
+                assert!(msg.contains("create the repo webhook failed"));
+                assert!(msg.contains("422"));
+                assert!(msg.contains("boom"));
+            }
+            other => panic!("expected GitHub, got {other:?}"),
+        }
     }
 }

--- a/crates/stiglab/src/server/workflow_activation.rs
+++ b/crates/stiglab/src/server/workflow_activation.rs
@@ -33,9 +33,16 @@ pub enum ActivationError {
     /// `action` (or the install hasn't accepted an updated permission set).
     /// The CRUD route maps this to a user-visible 4xx so the dashboard can
     /// prompt the operator to update the App's permissions, rather than the
-    /// generic 502 we use for opaque upstream failures.
+    /// generic 502 we use for opaque upstream failures. `upstream` carries
+    /// the raw `status: body` pair so operator logs keep the breadcrumb the
+    /// 502 path previously had.
     #[error("github app install is missing permission for {action}")]
-    MissingGithubPermission { action: String, details: String },
+    MissingGithubPermission {
+        action: String,
+        permission: &'static str,
+        details: String,
+        upstream: String,
+    },
     #[error("github api error: {0}")]
     GitHub(String),
     #[error(transparent)]
@@ -45,16 +52,25 @@ pub enum ActivationError {
 /// Classify a non-2xx response from the GitHub REST API. Returns a
 /// `MissingGithubPermission` when the status + body match the signature of a
 /// missing App permission (so the caller surfaces a dashboard-actionable 4xx);
-/// otherwise falls back to the opaque `GitHub` variant.
-fn classify_github_error(action: &str, status: reqwest::StatusCode, body: &str) -> ActivationError {
+/// otherwise falls back to the opaque `GitHub` variant. `permission` is the
+/// human-readable name the caller knows the endpoint needs (e.g.
+/// `"Repository webhooks: Read & write"` or `"Issues: Read & write"`) — GitHub
+/// returns the same opaque 403 for any missing App permission, so we can't
+/// derive it from the response.
+fn classify_github_error(
+    action: &str,
+    permission: &'static str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> ActivationError {
     if status.as_u16() == 403 && body.contains("Resource not accessible by integration") {
         return ActivationError::MissingGithubPermission {
             action: action.to_string(),
+            permission,
             details: format!(
-                "GitHub App install is missing the 'Repository webhooks: Read & write' \
-                 permission required to {action}. Update the App's permissions on GitHub \
-                 and accept the new permission request on the installation, then retry."
+                "GitHub App install is missing the '{permission}' permission required to {action}. Update the App's permissions on GitHub and accept the new permission request on the installation, then retry."
             ),
+            upstream: format!("{status}: {body}"),
         };
     }
     ActivationError::GitHub(format!("{action} failed ({status}): {body}"))
@@ -136,7 +152,12 @@ pub async fn ensure_label_exists(
     if resp.status().as_u16() != 404 {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(classify_github_error("look up repo labels", status, &body));
+        return Err(classify_github_error(
+            "look up repo labels",
+            "Issues: Read & write",
+            status,
+            &body,
+        ));
     }
 
     // Create the label. GitHub requires a `color` field; pick a neutral grey.
@@ -164,6 +185,7 @@ pub async fn ensure_label_exists(
     let body = resp.text().await.unwrap_or_default();
     Err(classify_github_error(
         "create the trigger label",
+        "Issues: Read & write",
         status,
         &body,
     ))
@@ -212,6 +234,7 @@ pub async fn ensure_webhook_registered(
         let body = resp.text().await.unwrap_or_default();
         return Err(classify_github_error(
             "list the repo webhooks",
+            "Repository webhooks: Read & write",
             status,
             &body,
         ));
@@ -267,6 +290,7 @@ pub async fn ensure_webhook_registered(
             let body = resp.text().await.unwrap_or_default();
             return Err(classify_github_error(
                 "update the repo webhook",
+                "Repository webhooks: Read & write",
                 status,
                 &body,
             ));
@@ -300,6 +324,7 @@ pub async fn ensure_webhook_registered(
         let body = resp.text().await.unwrap_or_default();
         return Err(classify_github_error(
             "create the repo webhook",
+            "Repository webhooks: Read & write",
             status,
             &body,
         ));
@@ -431,14 +456,52 @@ mod tests {
         let body = r#"{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/repos/webhooks#list-repository-webhooks","status":"403"}"#;
         let err = classify_github_error(
             "list the repo webhooks",
+            "Repository webhooks: Read & write",
             reqwest::StatusCode::FORBIDDEN,
             body,
         );
         match err {
-            ActivationError::MissingGithubPermission { action, details } => {
+            ActivationError::MissingGithubPermission {
+                action,
+                permission,
+                details,
+                upstream,
+            } => {
                 assert_eq!(action, "list the repo webhooks");
-                assert!(details.contains("Repository webhooks"));
+                assert_eq!(permission, "Repository webhooks: Read & write");
+                assert!(details.contains("Repository webhooks: Read & write"));
                 assert!(details.contains("list the repo webhooks"));
+                // No hard wraps embedded in the user-visible string.
+                assert!(!details.contains("  "));
+                // Upstream breadcrumb preserved for operator logs.
+                assert!(upstream.contains("403"));
+                assert!(upstream.contains("Resource not accessible by integration"));
+            }
+            other => panic!("expected MissingGithubPermission, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_403_label_path_mentions_issues_permission() {
+        // The same opaque 403 on a label endpoint must point at the Issues
+        // permission — not the webhooks one — since the caller knows which
+        // permission the endpoint needs.
+        let body = r#"{"message":"Resource not accessible by integration"}"#;
+        let err = classify_github_error(
+            "look up repo labels",
+            "Issues: Read & write",
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+        );
+        match err {
+            ActivationError::MissingGithubPermission {
+                permission,
+                details,
+                ..
+            } => {
+                assert_eq!(permission, "Issues: Read & write");
+                assert!(details.contains("Issues: Read & write"));
+                assert!(!details.contains("Repository webhooks"));
             }
             other => panic!("expected MissingGithubPermission, got {other:?}"),
         }
@@ -451,6 +514,7 @@ mod tests {
         let body = r#"{"message":"API rate limit exceeded"}"#;
         let err = classify_github_error(
             "list the repo webhooks",
+            "Repository webhooks: Read & write",
             reqwest::StatusCode::FORBIDDEN,
             body,
         );
@@ -467,6 +531,7 @@ mod tests {
     fn classify_non_403_is_opaque_github_error() {
         let err = classify_github_error(
             "create the repo webhook",
+            "Repository webhooks: Read & write",
             reqwest::StatusCode::UNPROCESSABLE_ENTITY,
             "boom",
         );


### PR DESCRIPTION
Closes #99.

## Summary

Saving a workflow from the "Start the factory" card on `/workflows/start` was
failing with a dead-end toast: `Saving workflow failed with "github api
error"` and a 502 from `POST /api/workflows`. The stiglab logs showed the
real cause:

```
list hooks failed (403 Forbidden): {message:"Resource not accessible by
integration", documentation_url:".../webhooks#list-repository-webhooks"}
```

The GitHub App install on the target repo is missing the required permission
(`Repository webhooks` for hook endpoints, `Issues` for label endpoints), so
activation's idempotent hook/label calls fail. We were flattening every
upstream failure to a generic 502 with the body `{"error":"github api
error"}`, which gave the user nothing to act on and left no breadcrumb in
the browser devtools either.

- Classify 403 + "Resource not accessible by integration" as a new
  `ActivationError::MissingGithubPermission` variant and map it to a 400
  with an actionable message the dashboard renders verbatim ("install is
  missing the 'X: Read & write' permission…").
- Each call site supplies the permission name it knows the endpoint needs
  (Issues for labels, Repository webhooks for hooks) — GitHub returns the
  same opaque 403 for every missing permission, so the classifier can't
  derive it from the response.
- Preserve the raw `status: body` as an `upstream` field on the variant
  and include it in the structured log, so operators keep the breadcrumb
  the 502 path previously had.
- For any other non-2xx from GitHub, keep the 502 but include the real
  `status + body` in the JSON response so the failure mode is also
  diagnosable from the client.
- Helper + variant live behind a single `classify_github_error` so every
  label / webhook call site goes through one place.

## Test plan

- [x] `cargo test -p stiglab --lib server::workflow_activation` — classifier
  cases cover webhook-path 403, label-path 403 (distinct permission name),
  403 rate-limit fallback to the opaque GitHub variant, and non-403 opaque.
- [x] `cargo test -p stiglab --lib server::routes::workflows` — existing
  route tests still pass.
- [x] `cargo clippy -p stiglab --all-targets -- -D warnings`
- [x] `cargo fmt -p stiglab -- --check`
- [ ] Manually: re-trigger "Run factory" on the affected install — expect
  the card to show the "install is missing the 'Repository webhooks: Read
  & write' permission…" message instead of "github api error", and
  stiglab logs to keep the `activation missing github permission` warning
  with the original upstream `status: body`.
