### PR TITLE
feat: Deliverable + registry-backed kinds (closes #100)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,6 +2606,7 @@ dependencies = [
  "jsonwebtoken",
  "onsager-artifact",
  "onsager-protocol",
+ "onsager-registry",
  "onsager-spine",
  "rand 0.8.5",
  "reqwest",

--- a/apps/dashboard/src/components/factory/workflows/ArtifactFlowOverview.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ArtifactFlowOverview.tsx
@@ -1,44 +1,53 @@
 import { ArrowRight, Tag } from "lucide-react"
-import type { WorkflowStage } from "@/lib/api"
-import { ArtifactBadge } from "./ArtifactBadge"
-import { outputArtifactKind } from "./workflow-meta"
+import type { WorkflowGateKind, WorkflowStage } from "@/lib/api"
+import { GATE_KINDS } from "./workflow-meta"
 
 export interface ArtifactFlowOverviewProps {
   triggerLabel: string
   stages: WorkflowStage[]
+  /// Optional current stage index for live runs. The matching pill gets
+  /// the "in-flight" accent; the rest stay muted.
+  currentStageIndex?: number
 }
 
-// A one-line visual summary of what enters each stage and what leaves
-// the workflow — starts with the trigger label pill, then input→output
-// badges for each stage separated by arrows. Scrolls horizontally on
-// mobile rather than wrapping so the pipeline reads left to right.
+// Linear sequence of gate pills: Trigger → Agent → CI → Synodic → Human → …
+//
+// Before #104 this component rendered one pill per stage's input + output
+// artifact kind, which duplicated the same artifact multiple times in a row
+// ("Governed pipeline" showed Issue → PR → PR → PR → PR). Artifact state now
+// lives in a separate `DeliverablePanel`; this strip is strictly "where are
+// we in the process?" One pill per gate, no artifact duplication.
 export function ArtifactFlowOverview({
   triggerLabel,
   stages,
+  currentStageIndex,
 }: ArtifactFlowOverviewProps) {
   if (stages.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        Add a stage to see how artifacts flow.
+        Add a stage to see the pipeline flow.
       </p>
     )
   }
 
+  const gateMeta = Object.fromEntries(
+    GATE_KINDS.map((g) => [g.value, g]),
+  ) as Record<WorkflowGateKind, (typeof GATE_KINDS)[number]>
+
   return (
-    <div className="-mx-1 overflow-x-auto pb-1">
+    <div
+      className="-mx-1 overflow-x-auto pb-1"
+      data-testid="workflow-flow-strip"
+    >
       <div className="flex min-w-max items-center gap-1.5 px-1">
         <span className="inline-flex items-center gap-1 rounded-full border border-dashed border-muted-foreground/30 bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground">
           <Tag aria-hidden focusable={false} className="h-3 w-3" />
           {triggerLabel || "trigger"}
         </span>
         {stages.map((s, i) => {
-          const input = s.artifact_kind
-          const output = outputArtifactKind(s.gate_kind, input)
-          const prevOutput =
-            i === 0
-              ? null
-              : outputArtifactKind(stages[i - 1].gate_kind, stages[i - 1].artifact_kind)
-          const transforms = output !== input
+          const meta = gateMeta[s.gate_kind]
+          const Icon = meta?.icon
+          const isCurrent = i === currentStageIndex
           return (
             <div key={s.id} className="flex items-center gap-1.5">
               <ArrowRight
@@ -46,20 +55,19 @@ export function ArtifactFlowOverview({
                 focusable={false}
                 className="h-3 w-3 shrink-0 text-muted-foreground"
               />
-              <ArtifactBadge
-                kind={input}
-                variant={prevOutput && prevOutput !== input ? "muted" : "default"}
-              />
-              {transforms && (
-                <>
-                  <ArrowRight
-                    aria-hidden
-                    focusable={false}
-                    className="h-3 w-3 shrink-0 text-muted-foreground"
-                  />
-                  <ArtifactBadge kind={output} />
-                </>
-              )}
+              <span
+                className={
+                  isCurrent
+                    ? "inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                    : "inline-flex items-center gap-1 rounded-full border border-muted-foreground/20 bg-muted/60 px-2 py-0.5 text-xs text-foreground"
+                }
+                title={meta?.label ?? s.gate_kind}
+              >
+                {Icon && (
+                  <Icon aria-hidden focusable={false} className="h-3 w-3" />
+                )}
+                {s.name || meta?.label || s.gate_kind}
+              </span>
             </div>
           )
         })}

--- a/apps/dashboard/src/components/factory/workflows/ArtifactKindSelect.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ArtifactKindSelect.tsx
@@ -22,7 +22,8 @@ export function ArtifactKindSelect({ value, onChange, id }: ArtifactKindSelectPr
     <Select
       value={value}
       onValueChange={(v) => {
-        if (v === "github-issue" || v === "github-pr") onChange(v)
+        // Registry-backed kinds (#102) — accept any id the registry emits.
+        if (typeof v === "string" && v.length > 0) onChange(v)
       }}
       items={WORKFLOW_ARTIFACT_KINDS}
     >

--- a/apps/dashboard/src/components/factory/workflows/CardStackEditor.tsx
+++ b/apps/dashboard/src/components/factory/workflows/CardStackEditor.tsx
@@ -2,6 +2,10 @@ import { ArrowDown, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { GitHubAppInstallation, WorkflowStage } from "@/lib/api"
 import { ArtifactFlowOverview } from "./ArtifactFlowOverview"
+import {
+  DeliverablePanel,
+  type DeliverableEntry,
+} from "./DeliverablePanel"
 import { StageCard } from "./StageCard"
 import { TriggerCard } from "./TriggerCard"
 import { makeStage, type WorkflowDraft } from "./workflow-draft"
@@ -11,6 +15,10 @@ export interface CardStackEditorProps {
   installations: GitHubAppInstallation[]
   draft: WorkflowDraft
   onChange: (next: WorkflowDraft) => void
+  /// When set (run-detail view), the flow strip highlights this stage and
+  /// the deliverable panel becomes visible. Editor view leaves both undefined.
+  currentStageIndex?: number
+  deliverable?: DeliverableEntry[]
 }
 
 export function CardStackEditor({
@@ -18,6 +26,8 @@ export function CardStackEditor({
   installations,
   draft,
   onChange,
+  currentStageIndex,
+  deliverable,
 }: CardStackEditorProps) {
   const updateStage = (idx: number, next: WorkflowStage) => {
     const stages = draft.stages.slice()
@@ -46,7 +56,16 @@ export function CardStackEditor({
           <ArtifactFlowOverview
             triggerLabel={draft.trigger.label}
             stages={draft.stages}
+            currentStageIndex={currentStageIndex}
           />
+        </div>
+      )}
+      {deliverable && (
+        <div className="rounded-md border bg-background px-3 py-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Deliverable
+          </div>
+          <DeliverablePanel entries={deliverable} />
         </div>
       )}
       <TriggerCard

--- a/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
+++ b/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
@@ -1,0 +1,152 @@
+import { CircleDot, GitPullRequest } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import type { WorkflowArtifactKind } from "@/lib/api"
+import { artifactKindMeta } from "./workflow-meta"
+
+// The "product" view of a workflow run — a live snapshot of the
+// Deliverable (issue #100/#101). Sits beside the flow strip so the UI
+// answers two different questions: "where are we?" (flow strip) vs.
+// "what have we built?" (this panel).
+//
+// V1 renders a compact card per artifact reference the workflow run
+// currently points at. Per-kind rich summaries (commits count, checks by
+// source) land as the backend starts emitting the intrinsic fields from
+// #103; for now we surface the kind + id, which is already enough to
+// fix the duplicate-PR regression from #100.
+export interface DeliverableEntry {
+  kind: WorkflowArtifactKind
+  artifact_id: string
+  // Optional per-kind intrinsic payload (issue #103). For a PR this holds
+  // `{ target, commits, checks, reviews, merged, closes_issue }`; unknown
+  // kinds pass-through as a generic JSON blob.
+  intrinsic?: Record<string, unknown>
+}
+
+export interface DeliverablePanelProps {
+  entries: DeliverableEntry[]
+  empty?: React.ReactNode
+}
+
+export function DeliverablePanel({ entries, empty }: DeliverablePanelProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/20 px-3 py-3 text-xs text-muted-foreground">
+        {empty ?? "No artifacts yet — the workflow hasn't produced output."}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="space-y-2"
+      data-testid="workflow-deliverable-panel"
+    >
+      {entries.map((entry) => (
+        <DeliverableCard key={`${entry.kind}-${entry.artifact_id}`} entry={entry} />
+      ))}
+    </div>
+  )
+}
+
+function DeliverableCard({ entry }: { entry: DeliverableEntry }) {
+  const meta = artifactKindMeta(entry.kind)
+  const Icon = meta.icon
+
+  if (entry.kind === "PR" || entry.kind === "github-pr") {
+    return <PrCard entry={entry} />
+  }
+
+  return (
+    <div className="rounded-md border bg-card px-3 py-2">
+      <div className="flex items-center gap-2 text-sm">
+        <Icon aria-hidden className="h-4 w-4 text-muted-foreground" />
+        <span className="font-medium">{meta.shortLabel}</span>
+        <code className="ml-auto text-xs text-muted-foreground">
+          {entry.artifact_id}
+        </code>
+      </div>
+    </div>
+  )
+}
+
+function PrCard({ entry }: { entry: DeliverableEntry }) {
+  const pr = (entry.intrinsic ?? {}) as {
+    number?: number
+    target?: { repo?: string; branch?: string }
+    commits?: Array<{ sha?: string; message?: string }>
+    checks?: Record<string, { status?: string; conclusion?: string }>
+    reviews?: Record<string, { state?: string }>
+    merged?: { sha?: string; merged_at?: string } | null
+  }
+
+  const checks = Object.entries(pr.checks ?? {})
+  const reviews = Object.entries(pr.reviews ?? {})
+
+  return (
+    <div className="rounded-md border bg-card px-3 py-2">
+      <div className="flex items-center gap-2">
+        <GitPullRequest aria-hidden className="h-4 w-4 text-muted-foreground" />
+        <span className="font-medium text-sm">
+          PR {pr.number != null ? `#${pr.number}` : ""}
+        </span>
+        {pr.target?.branch && (
+          <span className="text-xs text-muted-foreground">
+            → {pr.target.branch}
+          </span>
+        )}
+        <code className="ml-auto text-xs text-muted-foreground">
+          {entry.artifact_id}
+        </code>
+      </div>
+
+      <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <dt>Commits</dt>
+        <dd className="text-foreground">{pr.commits?.length ?? 0}</dd>
+
+        <dt>Checks</dt>
+        <dd className="flex flex-wrap gap-1">
+          {checks.length === 0 && <span>—</span>}
+          {checks.map(([src, v]) => (
+            <Badge
+              key={src}
+              variant={
+                v.conclusion === "success" || v.conclusion === "pass"
+                  ? "default"
+                  : "secondary"
+              }
+              className="px-1.5 text-[10px]"
+            >
+              {src}: {v.conclusion ?? v.status ?? "?"}
+            </Badge>
+          ))}
+        </dd>
+
+        <dt>Reviews</dt>
+        <dd className="flex flex-wrap gap-1">
+          {reviews.length === 0 && <span>—</span>}
+          {reviews.map(([reviewer, v]) => (
+            <Badge
+              key={reviewer}
+              variant={v.state === "approved" ? "default" : "secondary"}
+              className="px-1.5 text-[10px]"
+            >
+              {reviewer}: {v.state ?? "?"}
+            </Badge>
+          ))}
+        </dd>
+
+        <dt>Merged</dt>
+        <dd className="text-foreground">
+          {pr.merged?.sha ? (
+            <span className="flex items-center gap-1">
+              <CircleDot aria-hidden className="h-3 w-3 text-green-600" />
+              {pr.merged.sha.slice(0, 7)}
+            </span>
+          ) : (
+            "—"
+          )}
+        </dd>
+      </dl>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
+++ b/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { CircleDot, GitPullRequest } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import type { WorkflowArtifactKind } from "@/lib/api"
@@ -24,7 +25,7 @@ export interface DeliverableEntry {
 
 export interface DeliverablePanelProps {
   entries: DeliverableEntry[]
-  empty?: React.ReactNode
+  empty?: ReactNode
 }
 
 export function DeliverablePanel({ entries, empty }: DeliverablePanelProps) {
@@ -48,11 +49,19 @@ export function DeliverablePanel({ entries, empty }: DeliverablePanelProps) {
   )
 }
 
+// Canonical PR kind detection (issue #102). Mirrors the alias map in
+// `workflow-meta.ts` so legacy persisted `github-pr` / `PullRequest`
+// values still get the rich PR card instead of falling through to the
+// generic one.
+function isPrDeliverableKind(kind: WorkflowArtifactKind): boolean {
+  return kind === "PR" || kind === "github-pr" || kind === "PullRequest"
+}
+
 function DeliverableCard({ entry }: { entry: DeliverableEntry }) {
   const meta = artifactKindMeta(entry.kind)
   const Icon = meta.icon
 
-  if (entry.kind === "PR" || entry.kind === "github-pr") {
+  if (isPrDeliverableKind(entry.kind)) {
     return <PrCard entry={entry} />
   }
 

--- a/apps/dashboard/src/components/factory/workflows/propose-workflow.ts
+++ b/apps/dashboard/src/components/factory/workflows/propose-workflow.ts
@@ -9,7 +9,7 @@ export interface ProposeWorkflowCall {
   stages?: {
     name?: string
     gate_kind: WorkflowGateKind
-    artifact_kind?: "github-issue" | "github-pr"
+    artifact_kind?: string
   }[]
 }
 
@@ -23,28 +23,28 @@ export function proposePlaceholder(text: string): ProposeWorkflowCall {
     stages.push({
       name: "Agent session",
       gate_kind: "agent-session",
-      artifact_kind: "github-issue",
+      artifact_kind: "Issue",
     })
   }
   if (/ci|check|build|test/.test(lower)) {
     stages.push({
       name: "CI check",
       gate_kind: "external-check",
-      artifact_kind: "github-pr",
+      artifact_kind: "PR",
     })
   }
   if (/govern/.test(lower)) {
     stages.push({
       name: "Governance",
       gate_kind: "governance",
-      artifact_kind: "github-pr",
+      artifact_kind: "PR",
     })
   }
   if (/merge|approve|manual|human/.test(lower)) {
     stages.push({
       name: "Manual approval",
       gate_kind: "manual-approval",
-      artifact_kind: "github-pr",
+      artifact_kind: "PR",
     })
   }
   return { stages }
@@ -55,7 +55,7 @@ export function applyProposal(
   call: ProposeWorkflowCall,
 ): WorkflowDraft {
   const stages = (call.stages ?? []).map((s) =>
-    makeStage(s.gate_kind, s.artifact_kind ?? "github-issue", s.name),
+    makeStage(s.gate_kind, s.artifact_kind ?? "Issue", s.name),
   )
   return {
     ...draft,

--- a/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
@@ -37,7 +37,7 @@ function newStageId(): string {
 
 export function makeStage(
   gate: WorkflowGateKind,
-  artifactKind: WorkflowArtifactKind = "github-issue",
+  artifactKind: WorkflowArtifactKind = "Issue",
   name?: string,
 ): WorkflowStage {
   return {
@@ -77,9 +77,9 @@ export function githubIssueToPrPreset(
     name: `${trigger.repo_owner}/${trigger.repo_name} — issue to PR`,
     trigger,
     stages: [
-      makeStage("agent-session", "github-issue", "Spec → PR"),
-      makeStage("external-check", "github-pr", "CI check"),
-      makeStage("manual-approval", "github-pr", "Merge approval"),
+      makeStage("agent-session", "Issue", "Spec → PR"),
+      makeStage("external-check", "PR", "CI check"),
+      makeStage("manual-approval", "PR", "Merge approval"),
     ],
   }
 }
@@ -108,7 +108,7 @@ export const WORKFLOW_PRESETS: WorkflowPreset[] = [
     build: (trigger) => ({
       name: `${trigger.repo_owner || "agent"}/${trigger.repo_name || "session"} — agent only`,
       trigger,
-      stages: [makeStage("agent-session", "github-issue", "Agent session")],
+      stages: [makeStage("agent-session", "Issue", "Agent session")],
     }),
   },
   {
@@ -119,8 +119,8 @@ export const WORKFLOW_PRESETS: WorkflowPreset[] = [
       name: `${trigger.repo_owner || "repo"}/${trigger.repo_name || "pr"} — CI to merge`,
       trigger,
       stages: [
-        makeStage("external-check", "github-pr", "CI check"),
-        makeStage("manual-approval", "github-pr", "Merge approval"),
+        makeStage("external-check", "PR", "CI check"),
+        makeStage("manual-approval", "PR", "Merge approval"),
       ],
     }),
   },
@@ -132,10 +132,24 @@ export const WORKFLOW_PRESETS: WorkflowPreset[] = [
       name: `${trigger.repo_owner || "repo"}/${trigger.repo_name || "pipeline"} — governed`,
       trigger,
       stages: [
-        makeStage("agent-session", "github-issue", "Spec → PR"),
-        makeStage("external-check", "github-pr", "CI check"),
-        makeStage("governance", "github-pr", "Synodic gate"),
-        makeStage("manual-approval", "github-pr", "Merge approval"),
+        makeStage("agent-session", "Issue", "Spec → PR"),
+        makeStage("external-check", "PR", "CI check"),
+        makeStage("governance", "PR", "Synodic gate"),
+        makeStage("manual-approval", "PR", "Merge approval"),
+      ],
+    }),
+  },
+  {
+    id: "merge-to-deploy",
+    label: "Merge → Deploy staging",
+    description:
+      "Wait for a PR to merge, then roll the commit to staging. Requires a Deployment adapter.",
+    build: (trigger) => ({
+      name: `${trigger.repo_owner || "repo"}/${trigger.repo_name || "deploy"} — merge to deploy`,
+      trigger,
+      stages: [
+        makeStage("external-check", "PR", "Merge wait"),
+        makeStage("agent-session", "Deployment", "Deploy to staging"),
       ],
     }),
   },

--- a/apps/dashboard/src/components/factory/workflows/workflow-meta.ts
+++ b/apps/dashboard/src/components/factory/workflows/workflow-meta.ts
@@ -4,7 +4,9 @@ import {
   CircleDot,
   Gavel,
   GitPullRequest,
+  Rocket,
   ShieldCheck,
+  Terminal,
 } from "lucide-react"
 import type { WorkflowArtifactKind, WorkflowGateKind } from "@/lib/api"
 
@@ -15,28 +17,56 @@ export interface ArtifactKindMeta {
   icon: typeof Bot
 }
 
+// Static fallback set (issue #102). The canonical list comes from
+// `GET /api/workflow/kinds`; when that fetch fails (offline / dev without
+// stiglab) the UI renders this list so the builder is still usable.
+// Kind ids align with the registry's `workflow_builtin_types()`.
 export const WORKFLOW_ARTIFACT_KINDS: ArtifactKindMeta[] = [
   {
-    value: "github-issue",
+    value: "Issue",
     label: "GitHub Issue",
     shortLabel: "Issue",
     icon: CircleDot,
   },
   {
-    value: "github-pr",
+    value: "PR",
     label: "GitHub Pull Request",
     shortLabel: "PR",
     icon: GitPullRequest,
+  },
+  {
+    value: "Deployment",
+    label: "Deployment",
+    shortLabel: "Deploy",
+    icon: Rocket,
+  },
+  {
+    value: "Session",
+    label: "Agent Session",
+    shortLabel: "Session",
+    icon: Terminal,
   },
 ]
 
 const ARTIFACT_META_BY_VALUE = Object.fromEntries(
   WORKFLOW_ARTIFACT_KINDS.map((k) => [k.value, k]),
-) as Partial<Record<WorkflowArtifactKind, ArtifactKindMeta>>
+) as Record<string, ArtifactKindMeta>
+
+// Legacy kind ids (pre-#102) — older workflows persisted `github-issue`
+// / `github-pr` / `Spec` / `PullRequest` values. Map them onto the v1
+// canonical set so the UI doesn't fall through to the "unknown kind"
+// branch for real workflows that are already on disk.
+const LEGACY_KIND_ALIASES: Record<string, string> = {
+  "github-issue": "Issue",
+  Spec: "Issue",
+  "github-pr": "PR",
+  PullRequest: "PR",
+}
 
 export function artifactKindMeta(value: WorkflowArtifactKind): ArtifactKindMeta {
+  const canonical = LEGACY_KIND_ALIASES[value] ?? value
   return (
-    ARTIFACT_META_BY_VALUE[value] ?? {
+    ARTIFACT_META_BY_VALUE[canonical] ?? {
       value,
       label: value,
       shortLabel: value,
@@ -48,12 +78,16 @@ export function artifactKindMeta(value: WorkflowArtifactKind): ArtifactKindMeta 
 // Derive the artifact kind a stage emits from its gate and input kind.
 // Only agent-session can change the artifact kind (issue → PR). All other
 // gates are inspect-and-forward, so the output kind equals the input.
+//
+// Normalizes legacy `github-issue` on the input side so old persisted
+// workflows keep working through the UI transformation.
 export function outputArtifactKind(
   gate: WorkflowGateKind,
   input: WorkflowArtifactKind,
 ): WorkflowArtifactKind {
-  if (gate === "agent-session" && input === "github-issue") return "github-pr"
-  return input
+  const canonical = LEGACY_KIND_ALIASES[input] ?? input
+  if (gate === "agent-session" && canonical === "Issue") return "PR"
+  return canonical
 }
 
 export const GATE_KINDS: {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -250,7 +250,12 @@ export interface ArtifactLineageEntry {
 //
 // The CRUD API is delivered by a parallel sibling sub-issue of #79; this
 // client is the typed surface the dashboard UI talks to.
-export type WorkflowArtifactKind = 'github-issue' | 'github-pr';
+//
+// Artifact kinds are registry-backed as of #102. `WorkflowArtifactKind` is
+// a string so any kind registered server-side is representable on the wire;
+// the static-fallback list in `workflow-meta.ts` is what the UI renders
+// when the runtime fetch fails (offline / dev without stiglab).
+export type WorkflowArtifactKind = string;
 
 export interface WorkflowTrigger {
   kind: 'github-label';
@@ -265,6 +270,20 @@ export type WorkflowGateKind =
   | 'external-check'
   | 'governance'
   | 'manual-approval';
+
+// Shape returned by `GET /api/workflow/kinds` (issue #102). The registry
+// owns the canonical list; the dashboard's hardcoded set in
+// `workflow-meta.ts` is only a fallback for offline/dev.
+export type WorkflowMergeRule = 'overwrite' | 'merge_by_key' | 'append' | 'deep_merge';
+
+export interface WorkflowKindInfo {
+  id: string;
+  description: string;
+  merge_rule: WorkflowMergeRule;
+  external_kind?: string;
+  aliases: string[];
+  intrinsic_schema: Record<string, unknown>;
+}
 
 export interface WorkflowStage {
   id: string;
@@ -341,10 +360,9 @@ interface BackendWorkflowStage {
 function stageFromBackend(s: BackendWorkflowStage): WorkflowStage {
   const params = (s.params ?? {}) as Record<string, unknown>;
   const name = typeof params.name === 'string' ? params.name : undefined;
-  const artifactKind =
-    params.artifact_kind === 'github-issue' || params.artifact_kind === 'github-pr'
-      ? params.artifact_kind
-      : 'github-issue';
+  // Registry-backed kinds (#102) — accept any string; normalize legacy values.
+  const rawKind = typeof params.artifact_kind === 'string' ? params.artifact_kind : 'Issue';
+  const artifactKind = normalizeWorkflowArtifactKind(rawKind);
   // Everything except the UI-only display fields is opaque stage config.
   const { name: _n, artifact_kind: _a, ...config } = params as Record<string, unknown>;
   void _n;
@@ -356,6 +374,22 @@ function stageFromBackend(s: BackendWorkflowStage): WorkflowStage {
     artifact_kind: artifactKind,
     config,
   };
+}
+
+// Legacy `Spec` / `github-issue` / `PullRequest` / `github-pr` get folded
+// into the canonical `Issue` / `PR` names (issue #102). Anything else
+// passes through unchanged — registered custom kinds keep their id.
+export function normalizeWorkflowArtifactKind(kind: string): WorkflowArtifactKind {
+  switch (kind) {
+    case 'github-issue':
+    case 'Spec':
+      return 'Issue';
+    case 'github-pr':
+    case 'PullRequest':
+      return 'PR';
+    default:
+      return kind;
+  }
 }
 
 // Pack a UI stage into the backend's `{ gate_kind, params }` pair. UI-only
@@ -702,6 +736,12 @@ export const api = {
     request<{ runs: WorkflowRun[] }>(
       `/workflows/${encodeURIComponent(id)}/runs?limit=${limit}`,
     ),
+  // Registry-backed workflow artifact kinds (issue #102). Poll-on-load; the
+  // dashboard caches the result for the session. Falls back to the static
+  // list in `workflow-meta.ts` if the fetch fails (offline / dev without
+  // stiglab).
+  listWorkflowKinds: () =>
+    request<{ kinds: WorkflowKindInfo[] }>('/workflow/kinds'),
   // GitHub labels for a workspace install + repo. Used by the trigger card
   // combobox so the user selects from existing labels (with an inline
   // create-new affordance) instead of free-texting.

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -276,13 +276,25 @@ export type WorkflowGateKind =
 // `workflow-meta.ts` is only a fallback for offline/dev.
 export type WorkflowMergeRule = 'overwrite' | 'merge_by_key' | 'append' | 'deep_merge';
 
+// `intrinsic_schema` arrives as a `serde_json::Value`, which is any JSON
+// value — including `null`, arrays, and primitives. Modelling it as
+// `JsonValue` keeps the wire shape honest so consumers can't assume
+// "always an object".
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
+
 export interface WorkflowKindInfo {
   id: string;
   description: string;
   merge_rule: WorkflowMergeRule;
   external_kind?: string;
   aliases: string[];
-  intrinsic_schema: Record<string, unknown>;
+  intrinsic_schema: JsonValue;
 }
 
 export interface WorkflowStage {

--- a/apps/dashboard/tests/smoke/workflow-artifact-kind-select.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-artifact-kind-select.test.tsx
@@ -3,23 +3,14 @@ import { ArtifactKindSelect } from "@/components/factory/workflows/ArtifactKindS
 import { WORKFLOW_ARTIFACT_KINDS } from "@/components/factory/workflows/workflow-meta"
 
 describe("ArtifactKindSelect", () => {
-  it("only lists the built-in GitHub artifact kinds — no custom kinds", () => {
+  it("ships the v1 builtin artifact kinds as its static fallback (issue #102)", () => {
     const values = WORKFLOW_ARTIFACT_KINDS.map((k) => k.value).sort()
-    expect(values).toEqual(["github-issue", "github-pr"])
-    const hasCustom = WORKFLOW_ARTIFACT_KINDS.some(
-      (k) => k.value === ("custom" as unknown as string),
-    )
-    expect(hasCustom).toBe(false)
+    expect(values).toEqual(["Deployment", "Issue", "PR", "Session"])
   })
 
   it("renders the component without error for each built-in value", () => {
-    // Smoke-check the component module loads with each allowed value —
-    // enforces that the TS union stays synced with the select items.
-    const VALUES: ("github-issue" | "github-pr")[] = ["github-issue", "github-pr"]
-    for (const v of VALUES) {
-      // @ts-expect-no-error — JSX to ensure `value` compiles against the
-      // WorkflowArtifactKind union.
-      const node = <ArtifactKindSelect value={v} onChange={() => {}} />
+    for (const meta of WORKFLOW_ARTIFACT_KINDS) {
+      const node = <ArtifactKindSelect value={meta.value} onChange={() => {}} />
       expect(node).toBeTruthy()
     }
   })

--- a/apps/dashboard/tests/smoke/workflow-flow-strip.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-flow-strip.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+import { render } from "@testing-library/react"
+import { ArtifactFlowOverview } from "@/components/factory/workflows/ArtifactFlowOverview"
+import type { WorkflowStage } from "@/lib/api"
+
+// Issue #100/#104 regression: the pre-#104 flow strip rendered input +
+// output artifact badges per stage, which duplicated "PR" four times on
+// the Governed pipeline preset (`Issue → PR → PR → PR → PR`). Post-#104
+// the strip renders one pill per gate — no artifact duplication.
+describe("ArtifactFlowOverview — gate-only strip (#104)", () => {
+  const stages: WorkflowStage[] = [
+    {
+      id: "s1",
+      name: "Spec → PR",
+      gate_kind: "agent-session",
+      artifact_kind: "Issue",
+      config: {},
+    },
+    {
+      id: "s2",
+      name: "CI check",
+      gate_kind: "external-check",
+      artifact_kind: "PR",
+      config: {},
+    },
+    {
+      id: "s3",
+      name: "Synodic gate",
+      gate_kind: "governance",
+      artifact_kind: "PR",
+      config: {},
+    },
+    {
+      id: "s4",
+      name: "Merge approval",
+      gate_kind: "manual-approval",
+      artifact_kind: "PR",
+      config: {},
+    },
+  ]
+
+  it("renders one pill per stage with no duplicate artifact badges", () => {
+    const { container } = render(
+      <ArtifactFlowOverview triggerLabel="spec" stages={stages} />,
+    )
+    const strip = container.querySelector(
+      '[data-testid="workflow-flow-strip"]',
+    )
+    expect(strip).toBeTruthy()
+    // The four gates we supplied, no more — prior to #104 this would have
+    // been 4 gates + 5 artifact pills.
+    const pills = strip?.querySelectorAll("span.rounded-full") ?? []
+    // Trigger pill (1) + one per stage (4) = 5.
+    expect(pills.length).toBe(5)
+  })
+
+  it("does not render any artifact-kind badge text", () => {
+    const { queryByText } = render(
+      <ArtifactFlowOverview triggerLabel="spec" stages={stages} />,
+    )
+    // Short labels used to appear as standalone pills; they must not.
+    expect(queryByText("Issue")).toBeNull()
+    expect(queryByText("PR")).toBeNull()
+  })
+})

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -370,7 +370,7 @@ pub fn run(database_url: &str, tick_ms: u64) {
         };
 
         // Load existing artifacts from the spine database (issue #30).
-        // `load_artifact_store` restores state, version, and current_bundle_id
+        // `load_artifact_store` restores state, version, and current_version_id
         // so a mid-tick restart resumes at the last persisted transition.
         let artifact_store = match spine.as_ref() {
             Some(s) => match persistence::load_artifact_store(s.pool()).await {

--- a/crates/forge/src/core/artifact_store.rs
+++ b/crates/forge/src/core/artifact_store.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use chrono::Utc;
 
 use onsager_artifact::{
-    Artifact, ArtifactId, ArtifactState, ArtifactVersion, BundleId, ContentRef, Kind,
+    Artifact, ArtifactId, ArtifactState, ArtifactVersion, ArtifactVersionId, ContentRef, Kind,
     VerticalLineage,
 };
 use onsager_protocol::ShapingResult;
@@ -59,7 +59,7 @@ impl ArtifactStore {
     /// update `workflow_id`, `current_stage_index`,
     /// `workflow_parked_reason`, and the artifact state when a stage
     /// declares a `target_state`. Version/bundle/lineage mutations still
-    /// go through `advance` and `record_bundle` so the state-machine and
+    /// go through `advance` and `record_version` so the state-machine and
     /// invariants stay enforced.
     pub fn get_mut(&mut self, id: &ArtifactId) -> Option<&mut Artifact> {
         self.artifacts.get_mut(id.as_str())
@@ -134,15 +134,15 @@ impl ArtifactStore {
         Ok(())
     }
 
-    /// Record a newly sealed bundle on the artifact
+    /// Record a newly sealed artifact version on the artifact
     /// (warehouse-and-delivery-v0.1 §6.3).
     ///
     /// No-op if the artifact is not found (the caller already emits an error
-    /// event for the missing artifact; a missing bundle recording is strictly
+    /// event for the missing artifact; a missing version recording is strictly
     /// subordinate to that).
-    pub fn record_bundle(&mut self, id: &ArtifactId, bundle_id: BundleId) {
+    pub fn record_version(&mut self, id: &ArtifactId, version_id: ArtifactVersionId) {
         if let Some(artifact) = self.artifacts.get_mut(id.as_str()) {
-            artifact.record_bundle(bundle_id);
+            artifact.record_version(version_id);
         }
     }
 

--- a/crates/forge/src/core/persistence.rs
+++ b/crates/forge/src/core/persistence.rs
@@ -10,9 +10,9 @@
 //! This module provides two halves of the projection:
 //!
 //! - [`load_artifact_store`]: on startup, read the `artifacts` table and
-//!   rebuild the in-memory store. Includes `current_bundle_id` so sealed
+//!   rebuild the in-memory store. Includes `current_version_id` so sealed
 //!   releases survive restart (forge invariant: the warehouse pointer on
-//!   each artifact is the tip of its bundle chain).
+//!   each artifact is the tip of its version chain).
 //! - [`persist_artifact_state`]: after a tick produces an
 //!   `ArtifactAdvanced` or `BundleSealed` event and releases the write
 //!   lock, mirror the resulting in-memory state to the `artifacts` row.
@@ -22,7 +22,7 @@
 //! the DB write fails, the next successful transition or a deliberate
 //! reconciliation pass will catch the drift.
 
-use onsager_artifact::{Artifact, ArtifactId, ArtifactState, BundleId, Kind};
+use onsager_artifact::{Artifact, ArtifactId, ArtifactState, ArtifactVersionId, Kind};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 
 use super::artifact_store::ArtifactStore;
@@ -67,7 +67,7 @@ fn kind_from_db(s: &str) -> Kind {
 /// artifacts only (forge-v0.1 §10).
 pub async fn load_artifact_store(pool: &PgPool) -> Result<ArtifactStore, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT artifact_id, kind, name, owner, state, current_version, current_bundle_id, \
+        "SELECT artifact_id, kind, name, owner, state, current_version, current_version_id, \
                 workflow_id, current_stage_index, workflow_parked_reason \
          FROM artifacts \
          WHERE state != 'archived'",
@@ -83,7 +83,7 @@ pub async fn load_artifact_store(pool: &PgPool) -> Result<ArtifactStore, sqlx::E
         let owner: String = row.get("owner");
         let state_str: String = row.get("state");
         let version: i32 = row.get("current_version");
-        let bundle_id: Option<String> = row.get("current_bundle_id");
+        let version_id: Option<String> = row.get("current_version_id");
         let workflow_id: Option<String> = row.try_get("workflow_id").unwrap_or(None);
         let stage_index_raw: Option<i32> = row.try_get("current_stage_index").unwrap_or(None);
         let parked_reason: Option<String> = row.try_get("workflow_parked_reason").unwrap_or(None);
@@ -118,7 +118,7 @@ pub async fn load_artifact_store(pool: &PgPool) -> Result<ArtifactStore, sqlx::E
         artifact.artifact_id = ArtifactId::new(&id);
         artifact.state = state_from_db(&state_str);
         artifact.current_version = version_u32;
-        artifact.current_bundle_id = bundle_id.map(BundleId::new);
+        artifact.current_version_id = version_id.map(ArtifactVersionId::new);
         artifact.workflow_id = workflow_id;
         artifact.current_stage_index = stage_index_u32;
         artifact.workflow_parked_reason = parked_reason;
@@ -162,18 +162,18 @@ pub async fn insert_artifact_row(
 
 /// Mirror the post-tick state of `artifact` to the `artifacts` row.
 ///
-/// Writes `state`, `current_version`, and `current_bundle_id` from the
+/// Writes `state`, `current_version`, and `current_version_id` from the
 /// in-memory snapshot. The trigger in `002_artifacts.sql` refreshes
 /// `updated_at` automatically.
 pub async fn persist_artifact_state(pool: &PgPool, artifact: &Artifact) -> Result<(), sqlx::Error> {
     sqlx::query(
         "UPDATE artifacts \
-            SET state = $1, current_version = $2, current_bundle_id = $3 \
+            SET state = $1, current_version = $2, current_version_id = $3 \
           WHERE artifact_id = $4",
     )
     .bind(state_to_db(artifact.state))
     .bind(artifact.current_version as i32)
-    .bind(artifact.current_bundle_id.as_ref().map(|b| b.as_str()))
+    .bind(artifact.current_version_id.as_ref().map(|b| b.as_str()))
     .bind(artifact.artifact_id.as_str())
     .execute(pool)
     .await?;

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -424,7 +424,7 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
 
                         if let Some(sealed) = sealed {
                             self.store
-                                .record_bundle(&decision.artifact_id, sealed.bundle_id.clone());
+                                .record_version(&decision.artifact_id, sealed.bundle_id.clone());
                             output.events.push(PipelineEvent::BundleSealed {
                                 artifact_id: decision.artifact_id.to_string(),
                                 bundle_id: sealed.bundle_id,
@@ -736,8 +736,8 @@ mod tests {
 
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::Released);
-        assert_eq!(art.current_bundle_id.as_ref(), Some(&evt_bundle));
-        assert_eq!(art.bundle_history.len(), 1);
+        assert_eq!(art.current_version_id.as_ref(), Some(&evt_bundle));
+        assert_eq!(art.version_history.len(), 1);
     }
 
     /// SealSink that always returns a terminal sealing error.
@@ -791,7 +791,7 @@ mod tests {
 
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::UnderReview);
-        assert!(art.current_bundle_id.is_none());
+        assert!(art.current_version_id.is_none());
     }
 
     #[test]
@@ -815,7 +815,7 @@ mod tests {
 
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::Released);
-        assert!(art.current_bundle_id.is_none());
+        assert!(art.current_version_id.is_none());
     }
 
     #[test]

--- a/crates/forge/tests/persistence_restart.rs
+++ b/crates/forge/tests/persistence_restart.rs
@@ -11,7 +11,7 @@
 //! `crates/onsager-warehouse/tests/warehouse_flow.rs`.
 
 use forge::core::persistence;
-use onsager_artifact::{Artifact, ArtifactId, ArtifactState, BundleId, Kind};
+use onsager_artifact::{Artifact, ArtifactId, ArtifactState, ArtifactVersionId, Kind};
 use sqlx::PgPool;
 
 fn db_url() -> Option<String> {
@@ -45,7 +45,7 @@ async fn reset(pool: &PgPool, artifact_id: &str) {
         .execute(pool)
         .await
         .ok();
-    sqlx::query("UPDATE artifacts SET current_bundle_id = NULL WHERE artifact_id = $1")
+    sqlx::query("UPDATE artifacts SET current_version_id = NULL WHERE artifact_id = $1")
         .bind(artifact_id)
         .execute(pool)
         .await
@@ -86,7 +86,7 @@ async fn restart_in_mid_tick_preserves_state_and_bundle() {
     advanced.artifact_id = ArtifactId::new(artifact_id);
     advanced.state = ArtifactState::Released;
     advanced.current_version = 2;
-    advanced.current_bundle_id = Some(BundleId::new("bnd_restart_test_abc"));
+    advanced.current_version_id = Some(ArtifactVersionId::new("ver_restart_test_abc"));
 
     persistence::persist_artifact_state(&pool, &advanced)
         .await
@@ -105,10 +105,10 @@ async fn restart_in_mid_tick_preserves_state_and_bundle() {
     assert_eq!(reloaded_artifact.current_version, 2);
     assert_eq!(
         reloaded_artifact
-            .current_bundle_id
+            .current_version_id
             .as_ref()
             .map(|b| b.as_str()),
-        Some("bnd_restart_test_abc"),
+        Some("ver_restart_test_abc"),
     );
 
     reset(&pool, artifact_id).await;

--- a/crates/onsager-artifact/Cargo.toml
+++ b/crates/onsager-artifact/Cargo.toml
@@ -3,7 +3,7 @@ name = "onsager-artifact"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Artifact value objects — Artifact, ArtifactId, BundleId, lineage, quality signals."
+description = "Artifact value objects — Artifact, ArtifactId, ArtifactVersionId, Deliverable, lineage, quality signals."
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/onsager-artifact/src/artifact.rs
+++ b/crates/onsager-artifact/src/artifact.rs
@@ -46,24 +46,29 @@ impl fmt::Display for ArtifactId {
 }
 
 // ---------------------------------------------------------------------------
-// Bundle identity
+// Artifact version identity
 // ---------------------------------------------------------------------------
 
-/// Content-addressed bundle identifier.
+/// Content-addressed identifier for an artifact version snapshot.
 ///
-/// Format: `bnd_<64-char-hex>`, where the hex is the SHA-256 of
+/// Format: `ver_<64-char-hex>`, where the hex is the SHA-256 of
 /// `(artifact_id, version, canonical_manifest_bytes)`. Two seals of the same
 /// artifact at the same version with identical file contents produce the same
 /// id (idempotent reseal → `VersionConflict`). Two different artifacts with
 /// identical files produce different ids, so they do not collide.
 ///
+/// The legacy `bnd_` prefix is accepted on read for one release cycle; new
+/// ids are minted with `ver_`. The type was previously named `BundleId`; a
+/// deprecated alias remains at the crate root.
+///
 /// This type lives here (not in `onsager-warehouse`) so that `Artifact` can
-/// reference bundles without creating an artifact↔warehouse cycle. Hashing
-/// logic that derives a BundleId from a manifest lives in `onsager-warehouse`.
+/// reference versions without creating an artifact↔warehouse cycle. The
+/// hashing logic that derives an `ArtifactVersionId` from a manifest lives
+/// in `onsager-warehouse`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct BundleId(String);
+pub struct ArtifactVersionId(String);
 
-impl BundleId {
+impl ArtifactVersionId {
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
@@ -73,11 +78,16 @@ impl BundleId {
     }
 }
 
-impl fmt::Display for BundleId {
+impl fmt::Display for ArtifactVersionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
 }
+
+/// Legacy alias for [`ArtifactVersionId`]. Kept so downstream crates that
+/// still talk about "bundles" (`onsager-warehouse`, forge's sealing path,
+/// the `BundleSealed` event) keep compiling while we migrate callers.
+pub type BundleId = ArtifactVersionId;
 
 // ---------------------------------------------------------------------------
 // Kind
@@ -317,13 +327,23 @@ pub struct Artifact {
 
     // Warehouse pointer (warehouse-and-delivery-v0.1 §4.1).
     //
-    // `current_bundle_id` advances on each successful release; a rework does
-    // not clear it until the new bundle is sealed. `bundle_history` is
-    // append-only and records every sealed bundle in order.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub current_bundle_id: Option<BundleId>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub bundle_history: Vec<BundleId>,
+    // `current_version_id` advances on each successful release; a rework does
+    // not clear it until the new version is sealed. `version_history` is
+    // append-only and records every sealed version in order. Serde accepts
+    // the legacy `current_bundle_id` / `bundle_history` keys one release cycle
+    // (issue #101).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "current_bundle_id"
+    )]
+    pub current_version_id: Option<ArtifactVersionId>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "bundle_history"
+    )]
+    pub version_history: Vec<ArtifactVersionId>,
 
     // History (loaded on demand in practice, but modeled here for completeness)
     pub versions: Vec<ArtifactVersion>,
@@ -348,11 +368,28 @@ pub struct Artifact {
 }
 
 impl Artifact {
-    /// Record a newly sealed bundle: advance `current_bundle_id` and append
-    /// to `bundle_history` (warehouse-and-delivery-v0.1 §6.3, invariant §9.4).
-    pub fn record_bundle(&mut self, bundle_id: BundleId) {
-        self.bundle_history.push(bundle_id.clone());
-        self.current_bundle_id = Some(bundle_id);
+    /// Record a newly sealed artifact version: advance `current_version_id`
+    /// and append to `version_history` (warehouse-and-delivery-v0.1 §6.3,
+    /// invariant §9.4).
+    pub fn record_version(&mut self, version_id: ArtifactVersionId) {
+        self.version_history.push(version_id.clone());
+        self.current_version_id = Some(version_id);
+    }
+
+    /// Record an `Issue → PR` referential link on this artifact (issue #103).
+    ///
+    /// Appends a `HorizontalLineage` entry with `role = "closes_issue"` so
+    /// the agent-session → PR flow populates the Deliverable's cross-kind
+    /// lineage without inventing a new lineage type. `source_version` is
+    /// the issue version at the moment the PR was created; if the caller
+    /// doesn't track an issue version, `0` is a conventional placeholder.
+    pub fn record_closes_issue(&mut self, issue_id: ArtifactId, source_version: u32) {
+        self.horizontal_lineage.push(HorizontalLineage {
+            source_artifact_id: issue_id,
+            source_version,
+            role: "closes_issue".into(),
+            recorded_at: Utc::now(),
+        });
     }
 
     /// Create a new artifact in `Draft` state with no versions yet.
@@ -374,8 +411,8 @@ impl Artifact {
             consumers,
             state: ArtifactState::Draft,
             current_version: 0,
-            current_bundle_id: None,
-            bundle_history: Vec::new(),
+            current_version_id: None,
+            version_history: Vec::new(),
             versions: Vec::new(),
             vertical_lineage: Vec::new(),
             horizontal_lineage: Vec::new(),
@@ -469,24 +506,79 @@ mod tests {
         assert!(art.git_context.is_none());
         assert!(art.versions.is_empty());
         assert!(!art.consumers.is_empty());
-        assert!(art.current_bundle_id.is_none());
-        assert!(art.bundle_history.is_empty());
+        assert!(art.current_version_id.is_none());
+        assert!(art.version_history.is_empty());
     }
 
     #[test]
-    fn record_bundle_advances_current_and_history() {
+    fn record_version_advances_current_and_history() {
         let mut art = Artifact::new(Kind::Code, "svc", "marvin", "system", vec![]);
-        let v1 = BundleId::new("bnd_v1");
-        let v2 = BundleId::new("bnd_v2");
+        let v1 = ArtifactVersionId::new("ver_v1");
+        let v2 = ArtifactVersionId::new("ver_v2");
 
-        art.record_bundle(v1.clone());
-        assert_eq!(art.current_bundle_id.as_ref(), Some(&v1));
-        assert_eq!(art.bundle_history, vec![v1.clone()]);
+        art.record_version(v1.clone());
+        assert_eq!(art.current_version_id.as_ref(), Some(&v1));
+        assert_eq!(art.version_history, vec![v1.clone()]);
 
-        art.record_bundle(v2.clone());
+        art.record_version(v2.clone());
         // Current pointer advances to newest; history is append-only.
-        assert_eq!(art.current_bundle_id.as_ref(), Some(&v2));
-        assert_eq!(art.bundle_history, vec![v1, v2]);
+        assert_eq!(art.current_version_id.as_ref(), Some(&v2));
+        assert_eq!(art.version_history, vec![v1, v2]);
+    }
+
+    #[test]
+    fn record_closes_issue_appends_horizontal_lineage_with_role() {
+        let mut pr = Artifact::new(Kind::PullRequest, "feature pr", "marvin", "session", vec![]);
+        let issue_id = ArtifactId::new("art_issue_42");
+        pr.record_closes_issue(issue_id.clone(), 1);
+
+        assert_eq!(pr.horizontal_lineage.len(), 1);
+        let link = &pr.horizontal_lineage[0];
+        assert_eq!(link.source_artifact_id, issue_id);
+        assert_eq!(link.role, "closes_issue");
+        assert_eq!(link.source_version, 1);
+    }
+
+    #[test]
+    fn artifact_version_id_serde_accepts_legacy_prefix() {
+        let legacy = ArtifactVersionId::new("bnd_legacy");
+        let json = serde_json::to_string(&legacy).unwrap();
+        let roundtrip: ArtifactVersionId = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip, legacy);
+
+        let modern = ArtifactVersionId::new("ver_modern");
+        let json = serde_json::to_string(&modern).unwrap();
+        assert_eq!(json, r#""ver_modern""#);
+    }
+
+    #[test]
+    fn artifact_serde_accepts_legacy_bundle_field_names() {
+        let json = serde_json::json!({
+            "artifact_id": "art_01HXYZABC123DEFGHJKMNPQRST",
+            "kind": "code",
+            "name": "svc",
+            "created_at": "2026-04-22T00:00:00Z",
+            "created_by": "system",
+            "owner": "marvin",
+            "consumers": [],
+            "state": "draft",
+            "current_version": 0,
+            "current_bundle_id": "bnd_legacy",
+            "bundle_history": ["bnd_legacy"],
+            "versions": [],
+            "vertical_lineage": [],
+            "horizontal_lineage": [],
+            "quality_signals": []
+        });
+        let art: Artifact = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            art.current_version_id,
+            Some(ArtifactVersionId::new("bnd_legacy"))
+        );
+        assert_eq!(
+            art.version_history,
+            vec![ArtifactVersionId::new("bnd_legacy")]
+        );
     }
 
     #[test]

--- a/crates/onsager-artifact/src/deliverable.rs
+++ b/crates/onsager-artifact/src/deliverable.rs
@@ -1,0 +1,223 @@
+//! Deliverable — the workflow-run output aggregate.
+//!
+//! A [`Deliverable`] is an open-schema map from artifact kind to the
+//! `ArtifactId`s that make up a workflow run's product. It matches the two-level
+//! mental model from issue #100:
+//!
+//! - **WorkflowRun** (process, transient): which graph, current node, history.
+//! - **Deliverable** (product, durable): open map `Kind → Vec<ArtifactId>`.
+//!
+//! Per-kind merge rules live in `onsager-registry` (issue #102, `MergeRule`);
+//! this crate is only the value object.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::ArtifactId;
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/// Globally unique identifier for a [`Deliverable`]. Format: `dlv_<26-char-ulid>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DeliverableId(String);
+
+impl DeliverableId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn generate() -> Self {
+        let ulid = ulid::Ulid::new().to_string();
+        Self(format!("dlv_{ulid}"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DeliverableId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Identifier for the workflow run that produced a deliverable.
+///
+/// Stored as a string so callers can wrap either the stiglab run id or a
+/// forge-side run id without forcing a cross-crate type dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkflowRunId(pub String);
+
+impl WorkflowRunId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WorkflowRunId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Registry-backed artifact kind id, e.g. `"Issue"`, `"PR"`, `"Deployment"`.
+///
+/// Stored as a string; the registry (`onsager-registry::RegistryId`) is the
+/// source of truth for which ids are known. Kept string-typed here so the
+/// value-object crate does not depend on the registry crate.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KindId(pub String);
+
+impl KindId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for KindId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for KindId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for KindId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deliverable
+// ---------------------------------------------------------------------------
+
+/// The aggregate output of a workflow run, keyed by artifact kind.
+///
+/// Entries are referential — the actual artifact records live in their own
+/// storage; the deliverable only points at them. Kinds that accept multiple
+/// concurrent artifacts (e.g. `Commit`) hold a `Vec<ArtifactId>`; kinds with
+/// a single-artifact cardinality (e.g. `Issue`) still use a vec so the shape
+/// is uniform, and the registered `MergeRule` governs what "add" means.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Deliverable {
+    pub id: DeliverableId,
+    pub workflow_run_id: WorkflowRunId,
+    #[serde(default)]
+    pub entries: BTreeMap<KindId, Vec<ArtifactId>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Deliverable {
+    /// Create an empty deliverable bound to a workflow run.
+    pub fn new(workflow_run_id: WorkflowRunId) -> Self {
+        let now = Utc::now();
+        Self {
+            id: DeliverableId::generate(),
+            workflow_run_id,
+            entries: BTreeMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Append an artifact id under a kind. De-duplicates on exact id match so
+    /// replaying the same event is idempotent.
+    pub fn add(&mut self, kind: KindId, artifact_id: ArtifactId) {
+        let slot = self.entries.entry(kind).or_default();
+        if !slot.contains(&artifact_id) {
+            slot.push(artifact_id);
+        }
+        self.updated_at = Utc::now();
+    }
+
+    /// All artifact ids for a given kind, in insertion order.
+    pub fn get(&self, kind: &KindId) -> &[ArtifactId] {
+        self.entries.get(kind).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Total number of artifact references across all kinds.
+    pub fn len(&self) -> usize {
+        self.entries.values().map(Vec::len).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.values().all(Vec::is_empty)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deliverable_id_format() {
+        let id = DeliverableId::generate();
+        assert!(id.as_str().starts_with("dlv_"));
+        assert_eq!(id.as_str().len(), 30);
+    }
+
+    #[test]
+    fn add_is_idempotent_on_exact_id() {
+        let mut d = Deliverable::new(WorkflowRunId::new("run_1"));
+        let aid = ArtifactId::new("art_42");
+        d.add(KindId::from("Issue"), aid.clone());
+        d.add(KindId::from("Issue"), aid.clone());
+        assert_eq!(d.get(&KindId::from("Issue")), &[aid]);
+        assert_eq!(d.len(), 1);
+    }
+
+    #[test]
+    fn add_accumulates_distinct_ids_per_kind() {
+        let mut d = Deliverable::new(WorkflowRunId::new("run_1"));
+        d.add(KindId::from("Commit"), ArtifactId::new("art_a"));
+        d.add(KindId::from("Commit"), ArtifactId::new("art_b"));
+        d.add(KindId::from("PR"), ArtifactId::new("art_pr"));
+        assert_eq!(d.get(&KindId::from("Commit")).len(), 2);
+        assert_eq!(d.get(&KindId::from("PR")).len(), 1);
+        assert_eq!(d.len(), 3);
+    }
+
+    #[test]
+    fn deliverable_serde_roundtrip() {
+        let mut d = Deliverable::new(WorkflowRunId::new("run_abc"));
+        d.add(KindId::from("Issue"), ArtifactId::new("art_issue_1"));
+        d.add(KindId::from("PR"), ArtifactId::new("art_pr_1"));
+
+        let json = serde_json::to_string(&d).unwrap();
+        let back: Deliverable = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, d);
+    }
+
+    #[test]
+    fn deliverable_empty_by_default() {
+        let d = Deliverable::new(WorkflowRunId::new("run_1"));
+        assert!(d.is_empty());
+        assert_eq!(d.len(), 0);
+    }
+}

--- a/crates/onsager-artifact/src/lib.rs
+++ b/crates/onsager-artifact/src/lib.rs
@@ -8,5 +8,7 @@
 //! without pulling in unrelated concerns.
 
 pub mod artifact;
+pub mod deliverable;
 
 pub use artifact::*;
+pub use deliverable::*;

--- a/crates/onsager-registry/src/catalog.rs
+++ b/crates/onsager-registry/src/catalog.rs
@@ -84,8 +84,7 @@ pub fn pr_intrinsic_schema() -> serde_json::Value {
                              },
                              "required": ["state"]
                          } },
-            "merged":  { "type": "object",
-                         "nullable": true,
+            "merged":  { "type": ["object", "null"],
                          "properties": {
                              "sha":       { "type": "string" },
                              "merged_at": { "type": "string",
@@ -229,12 +228,12 @@ pub fn deployment_intrinsic_schema() -> serde_json::Value {
             "status":       { "type": "string",
                               "enum": ["queued", "running", "success",
                                        "failed", "rolled_back"] },
-            "url":          { "type": "string", "nullable": true },
+            "url":          { "type": ["string", "null"] },
             "started_at":   { "type": "string", "format": "date-time" },
-            "completed_at": { "type": "string", "format": "date-time",
-                              "nullable": true },
-            "logs_ref":     { "type": "string", "nullable": true },
-            "from_pr":      { "type": "string", "nullable": true }
+            "completed_at": { "type": ["string", "null"],
+                              "format": "date-time" },
+            "logs_ref":     { "type": ["string", "null"] },
+            "from_pr":      { "type": ["string", "null"] }
         },
         "required": ["env", "sha", "status"]
     })
@@ -249,7 +248,7 @@ pub fn session_intrinsic_schema() -> serde_json::Value {
         "properties": {
             "session_id": { "type": "string" },
             "state":      { "type": "string" },
-            "works_on":   { "type": "string", "nullable": true },
+            "works_on":   { "type": ["string", "null"] },
             "produced":   { "type": "array",
                             "items": { "type": "string" } }
         },

--- a/crates/onsager-registry/src/catalog.rs
+++ b/crates/onsager-registry/src/catalog.rs
@@ -1,4 +1,4 @@
-//! First registered catalog — the engineering pipeline (Spec → PullRequest).
+//! First registered catalog — the engineering pipeline (Issue → PR).
 //!
 //! Per issue #14: the engineering catalog is **not** part of the seed. It
 //! goes through the registry just like any other artifact, via
@@ -9,21 +9,102 @@
 //! Calling [`register_engineering_catalog`] is idempotent: rerunning it is a
 //! no-op (the propose step conflicts, the approve step finds the row already
 //! approved).
+//!
+//! ## Naming
+//!
+//! MVP is GitHub-only (issue #100), so the kind ids here are
+//! GitHub-projection names:
+//!
+//! - `Issue` — previously `Spec`; kept as "Spec" alias in the legacy
+//!   `github-issue` workflow-builtin for one release cycle.
+//! - `PR` — previously `PullRequest`; shipped alongside a `PullRequest`
+//!   alias so old catalog consumers keep resolving.
 
-use crate::registry::{RegistryId, TypeDefinition};
+use crate::registry::{MergeRule, RegistryId, TypeDefinition};
 use crate::registry_store::RegistryStore;
 
 /// Actor recorded on events produced by this bootstrap function.
 pub const CATALOG_ACTOR: &str = "catalog-bootstrap";
+
+/// JSON Schema for the `Issue` intrinsic fields. Issues are thin — title /
+/// body / labels / state live on GitHub (source of truth); we keep a
+/// reference and let the adapter fetch fresh.
+pub fn issue_intrinsic_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "number": { "type": "integer" },
+            "title":  { "type": "string"  },
+            "state":  { "type": "string",
+                        "enum": ["open", "closed"] },
+            "labels": { "type": "array",
+                        "items": { "type": "string" } }
+        },
+        "required": ["number"]
+    })
+}
+
+/// JSON Schema for the `PR` intrinsic fields (issue #103). Gates write
+/// partial updates; the `DeepMerge` rule folds them in.
+pub fn pr_intrinsic_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "number":  { "type": "integer" },
+            "target":  { "type": "object",
+                         "properties": {
+                             "repo":   { "type": "string" },
+                             "branch": { "type": "string" }
+                         } },
+            "commits": { "type": "array",
+                         "items": {
+                             "type": "object",
+                             "properties": {
+                                 "sha":     { "type": "string" },
+                                 "message": { "type": "string" },
+                                 "author":  { "type": "string" }
+                             },
+                             "required": ["sha"]
+                         } },
+            "checks":  { "type": "object",
+                         "additionalProperties": {
+                             "type": "object",
+                             "properties": {
+                                 "status":     { "type": "string" },
+                                 "conclusion": { "type": "string" }
+                             }
+                         } },
+            "reviews": { "type": "object",
+                         "additionalProperties": {
+                             "type": "object",
+                             "properties": {
+                                 "state":       { "type": "string" },
+                                 "submitted_at":{ "type": "string",
+                                                  "format": "date-time" }
+                             },
+                             "required": ["state"]
+                         } },
+            "merged":  { "type": "object",
+                         "nullable": true,
+                         "properties": {
+                             "sha":       { "type": "string" },
+                             "merged_at": { "type": "string",
+                                            "format": "date-time" }
+                         } },
+            "closes_issue": { "type": "string" }
+        },
+        "required": ["number"]
+    })
+}
 
 /// Produce the engineering catalog's [`TypeDefinition`]s. Callers can use
 /// these directly, or pass them to [`register_engineering_catalog`].
 pub fn engineering_types() -> Vec<TypeDefinition> {
     vec![
         TypeDefinition {
-            type_id: RegistryId::new("Spec"),
-            description: "Engineering specification; external ref is a GitHub issue \
-                          labelled 'spec'."
+            type_id: RegistryId::new("Issue"),
+            description: "Engineering issue; external ref is a GitHub issue \
+                          labelled 'spec' or similar."
                 .into(),
             adapter_id: RegistryId::new("github.issue"),
             gate_ids: vec![RegistryId::new("ReviewApproved")],
@@ -32,10 +113,15 @@ pub fn engineering_types() -> Vec<TypeDefinition> {
                 "external_kind": "github.issue",
                 "label": "spec",
             }),
+            intrinsic_schema: issue_intrinsic_schema(),
+            merge_rule: MergeRule::Overwrite,
         },
         TypeDefinition {
-            type_id: RegistryId::new("PullRequest"),
-            description: "Pull request implementing a Spec; external ref is a GitHub PR.".into(),
+            type_id: RegistryId::new("PR"),
+            description: "Pull request implementing an Issue; external ref is a GitHub PR. \
+                          Rich kind — carries commits, checks, reviews, merged status \
+                          as intrinsic fields (issue #103)."
+                .into(),
             adapter_id: RegistryId::new("github.pr"),
             gate_ids: vec![
                 RegistryId::new("CiGreen"),
@@ -45,30 +131,31 @@ pub fn engineering_types() -> Vec<TypeDefinition> {
             config: serde_json::json!({
                 "external_kind": "github.pr",
             }),
+            intrinsic_schema: pr_intrinsic_schema(),
+            merge_rule: MergeRule::DeepMerge,
         },
     ]
 }
 
-/// Built-in artifact kinds exposed to mobile/chat workflow selectors
-/// (issue #81). These are the only kinds the dashboard surfaces when a user
-/// configures a workflow; custom kinds registered via the seed-catalog path
-/// stay hidden from mobile selectors.
-pub const BUILTIN_WORKFLOW_KINDS: &[&str] = &["github-issue", "github-pr"];
+/// Built-in artifact kinds exposed as workflow kinds. The dashboard's
+/// `/api/workflow/kinds` endpoint serves this set as its v1 surface; custom
+/// kinds registered via the seed-catalog path stay hidden from the
+/// workflow-builder picker until listed here.
+pub const BUILTIN_WORKFLOW_KINDS: &[&str] = &["Issue", "PR", "Deployment", "Session"];
 
-/// Whether a given artifact-kind id is one of the selectors-API built-ins.
-/// Callers behind a "selectors" endpoint filter by this to hide custom
-/// types the user hasn't explicitly surfaced.
+/// Whether a given artifact-kind id is one of the built-in workflow kinds.
 pub fn is_builtin_workflow_kind(kind: &str) -> bool {
     BUILTIN_WORKFLOW_KINDS.contains(&kind)
 }
 
-/// Produce the workflow-built-in [`TypeDefinition`]s — the `github-issue` and
-/// `github-pr` kinds referenced from v1 presets. Distinct from the
-/// engineering catalog so old catalog consumers stay unchanged.
+/// Produce the workflow-built-in [`TypeDefinition`]s. Aligned with #100 kind
+/// naming: `Issue`, `PR`, plus v1 seeds `Deployment` and `Session` (see
+/// issue #105). Distinct from the engineering catalog so old catalog
+/// consumers stay unchanged.
 pub fn workflow_builtin_types() -> Vec<TypeDefinition> {
     vec![
         TypeDefinition {
-            type_id: RegistryId::new("github-issue"),
+            type_id: RegistryId::new("Issue"),
             description: "A GitHub issue surfaced as a factory artifact by a \
                           workflow trigger (v1 built-in)."
                 .into(),
@@ -78,12 +165,16 @@ pub fn workflow_builtin_types() -> Vec<TypeDefinition> {
             config: serde_json::json!({
                 "external_kind": "github.issue",
                 "builtin": true,
+                "aliases": ["Spec", "github-issue"],
             }),
+            intrinsic_schema: issue_intrinsic_schema(),
+            merge_rule: MergeRule::Overwrite,
         },
         TypeDefinition {
-            type_id: RegistryId::new("github-pr"),
-            description: "A GitHub pull request produced by a workflow \
-                          stage (v1 built-in)."
+            type_id: RegistryId::new("PR"),
+            description: "A GitHub pull request produced by a workflow stage \
+                          (v1 built-in). Gates fold partial updates via \
+                          DeepMerge — see issue #103."
                 .into(),
             adapter_id: RegistryId::new("github.pr"),
             gate_ids: vec![],
@@ -91,9 +182,79 @@ pub fn workflow_builtin_types() -> Vec<TypeDefinition> {
             config: serde_json::json!({
                 "external_kind": "github.pr",
                 "builtin": true,
+                "aliases": ["PullRequest", "github-pr"],
             }),
+            intrinsic_schema: pr_intrinsic_schema(),
+            merge_rule: MergeRule::DeepMerge,
+        },
+        TypeDefinition {
+            type_id: RegistryId::new("Deployment"),
+            description:
+                "A rollout of a merged commit to an environment (v1 built-in, issue #105).".into(),
+            adapter_id: RegistryId::new("deployment.local"),
+            gate_ids: vec![],
+            producer_profile_id: None,
+            config: serde_json::json!({
+                "external_kind": "deployment",
+                "builtin": true,
+            }),
+            intrinsic_schema: deployment_intrinsic_schema(),
+            merge_rule: MergeRule::DeepMerge,
+        },
+        TypeDefinition {
+            type_id: RegistryId::new("Session"),
+            description: "Stiglab agent session promoted to a first-class \
+                          registered artifact (v1 built-in, issue #105)."
+                .into(),
+            adapter_id: RegistryId::new("stiglab.session"),
+            gate_ids: vec![],
+            producer_profile_id: None,
+            config: serde_json::json!({
+                "external_kind": "stiglab.session",
+                "builtin": true,
+            }),
+            intrinsic_schema: session_intrinsic_schema(),
+            merge_rule: MergeRule::DeepMerge,
         },
     ]
+}
+
+/// JSON Schema for `Deployment` intrinsic fields (issue #105).
+pub fn deployment_intrinsic_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "env":          { "type": "string" },
+            "sha":          { "type": "string" },
+            "status":       { "type": "string",
+                              "enum": ["queued", "running", "success",
+                                       "failed", "rolled_back"] },
+            "url":          { "type": "string", "nullable": true },
+            "started_at":   { "type": "string", "format": "date-time" },
+            "completed_at": { "type": "string", "format": "date-time",
+                              "nullable": true },
+            "logs_ref":     { "type": "string", "nullable": true },
+            "from_pr":      { "type": "string", "nullable": true }
+        },
+        "required": ["env", "sha", "status"]
+    })
+}
+
+/// JSON Schema for `Session` intrinsic fields (issue #105). Stiglab's
+/// `Session` struct is the source of truth; the schema mirrors its
+/// public-surface fields so the registry can project it uniformly.
+pub fn session_intrinsic_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" },
+            "state":      { "type": "string" },
+            "works_on":   { "type": "string", "nullable": true },
+            "produced":   { "type": "array",
+                            "items": { "type": "string" } }
+        },
+        "required": ["session_id", "state"]
+    })
 }
 
 /// Register the workflow built-in kinds through the registry (propose +
@@ -149,8 +310,8 @@ mod tests {
     fn engineering_types_are_well_formed() {
         let types = engineering_types();
         let ids: Vec<_> = types.iter().map(|t| t.type_id.as_str()).collect();
-        assert!(ids.contains(&"Spec"));
-        assert!(ids.contains(&"PullRequest"));
+        assert!(ids.contains(&"Issue"));
+        assert!(ids.contains(&"PR"));
         for t in &types {
             assert!(!t.adapter_id.as_str().is_empty());
             assert!(t.producer_profile_id.is_some());
@@ -158,18 +319,56 @@ mod tests {
     }
 
     #[test]
-    fn workflow_builtin_types_include_github_issue_and_pr() {
+    fn pr_kind_uses_deep_merge() {
+        let pr = engineering_types()
+            .into_iter()
+            .find(|t| t.type_id.as_str() == "PR")
+            .expect("PR must be registered");
+        assert_eq!(pr.merge_rule, MergeRule::DeepMerge);
+        assert!(pr.intrinsic_schema.get("properties").is_some());
+    }
+
+    #[test]
+    fn issue_kind_uses_overwrite() {
+        let issue = engineering_types()
+            .into_iter()
+            .find(|t| t.type_id.as_str() == "Issue")
+            .expect("Issue must be registered");
+        assert_eq!(issue.merge_rule, MergeRule::Overwrite);
+    }
+
+    #[test]
+    fn workflow_builtin_types_cover_v1_kinds() {
         let types = workflow_builtin_types();
         let ids: Vec<_> = types.iter().map(|t| t.type_id.as_str()).collect();
-        assert!(ids.contains(&"github-issue"));
-        assert!(ids.contains(&"github-pr"));
+        assert!(ids.contains(&"Issue"));
+        assert!(ids.contains(&"PR"));
+        assert!(ids.contains(&"Deployment"));
+        assert!(ids.contains(&"Session"));
     }
 
     #[test]
     fn builtin_predicate_matches_known_kinds() {
-        assert!(is_builtin_workflow_kind("github-issue"));
-        assert!(is_builtin_workflow_kind("github-pr"));
+        assert!(is_builtin_workflow_kind("Issue"));
+        assert!(is_builtin_workflow_kind("PR"));
+        assert!(is_builtin_workflow_kind("Deployment"));
+        assert!(is_builtin_workflow_kind("Session"));
         assert!(!is_builtin_workflow_kind("custom-kind"));
-        assert!(!is_builtin_workflow_kind("Spec"));
+    }
+
+    #[test]
+    fn legacy_alias_preserved_in_config() {
+        let issue = workflow_builtin_types()
+            .into_iter()
+            .find(|t| t.type_id.as_str() == "Issue")
+            .unwrap();
+        let aliases = issue
+            .config
+            .get("aliases")
+            .and_then(|v| v.as_array())
+            .expect("Issue should carry legacy aliases in config");
+        let alias_strs: Vec<_> = aliases.iter().filter_map(|v| v.as_str()).collect();
+        assert!(alias_strs.contains(&"Spec"));
+        assert!(alias_strs.contains(&"github-issue"));
     }
 }

--- a/crates/onsager-registry/src/registry.rs
+++ b/crates/onsager-registry/src/registry.rs
@@ -99,16 +99,36 @@ impl RegistryStatus {
 // Type definitions
 // ---------------------------------------------------------------------------
 
-/// Definition of an artifact type — the shape of every `Spec`, `PullRequest`,
+/// Per-kind merge rule. Declares how partial updates to an artifact of this
+/// kind combine — the canonical example is a `PullRequest`, which accumulates
+/// commits, checks, and reviews as gates complete (see issue #103). Merge
+/// rules are a first-class registry concept: every registered
+/// [`TypeDefinition`] declares one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeRule {
+    /// Latest write wins. The default for simple value kinds.
+    #[default]
+    Overwrite,
+    /// Treat the artifact as a map keyed by an identity field; merge by key.
+    MergeByKey,
+    /// List concatenation — callers guarantee idempotency on exact element.
+    Append,
+    /// Recursive per-field merge. Used by `PullRequest` to fold in partial
+    /// updates (commits: append, checks/reviews: merge-by-key, merged: overwrite).
+    DeepMerge,
+}
+
+/// Definition of an artifact type — the shape of every `Issue`, `PR`,
 /// `TestableEnvironment`, etc.
 ///
 /// Types are data: no variants in the engine. Adding a new type is a registry
 /// insert (a `type.proposed` event followed by `type.approved`). The engine
-/// reads `adapter_id`, `gate_ids`, and `producer_profile_id` and looks up the
-/// corresponding registered implementations.
+/// reads `adapter_id`, `gate_ids`, `producer_profile_id`, `intrinsic_schema`,
+/// and `merge_rule` and looks up the corresponding registered implementations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TypeDefinition {
-    /// Stable id, e.g. `"Spec"`, `"PullRequest"`.
+    /// Stable id, e.g. `"Issue"`, `"PR"`.
     pub type_id: RegistryId,
     /// Human-readable description (one sentence).
     #[serde(default)]
@@ -124,6 +144,14 @@ pub struct TypeDefinition {
     /// Arbitrary type-specific configuration (labels, templates, …).
     #[serde(default)]
     pub config: serde_json::Value,
+    /// JSON-Schema fragment describing the intrinsic fields on artifacts of
+    /// this kind (issue #102). Optional — kinds that only carry a reference
+    /// (e.g. `Issue`) can leave it `Null`.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub intrinsic_schema: serde_json::Value,
+    /// How partial updates to an artifact of this kind combine.
+    #[serde(default)]
+    pub merge_rule: MergeRule,
 }
 
 /// A registered artifact type as stored in the registry.
@@ -434,16 +462,37 @@ mod tests {
     #[test]
     fn type_definition_serde_roundtrip() {
         let def = TypeDefinition {
-            type_id: "Spec".into(),
-            description: "Engineering specification artifact.".into(),
+            type_id: "Issue".into(),
+            description: "Engineering issue artifact.".into(),
             adapter_id: "github.issue".into(),
             gate_ids: vec!["ReviewApproved".into()],
             producer_profile_id: Some("spec-writer".into()),
             config: serde_json::json!({"label": "spec"}),
+            intrinsic_schema: serde_json::json!({"type": "object"}),
+            merge_rule: MergeRule::Overwrite,
         };
         let yaml = serde_yaml::to_string(&def).unwrap();
         let back: TypeDefinition = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(def, back);
+    }
+
+    #[test]
+    fn type_definition_defaults_merge_rule_to_overwrite() {
+        let yaml = r#"
+type_id: Simple
+adapter_id: github.issue
+"#;
+        let def: TypeDefinition = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(def.merge_rule, MergeRule::Overwrite);
+        assert!(def.intrinsic_schema.is_null());
+    }
+
+    #[test]
+    fn merge_rule_deep_merge_serializes_snake_case() {
+        let json = serde_json::to_string(&MergeRule::DeepMerge).unwrap();
+        assert_eq!(json, r#""deep_merge""#);
+        let back: MergeRule = serde_json::from_str(r#""merge_by_key""#).unwrap();
+        assert_eq!(back, MergeRule::MergeByKey);
     }
 
     #[test]

--- a/crates/onsager-registry/tests/registry_flow.rs
+++ b/crates/onsager-registry/tests/registry_flow.rs
@@ -49,6 +49,8 @@ async fn propose_then_approve_type_lifecycle() {
         gate_ids: vec!["HumanApproval".into()],
         producer_profile_id: Some("Human".into()),
         config: serde_json::json!({}),
+        intrinsic_schema: serde_json::Value::Null,
+        merge_rule: Default::default(),
     };
 
     // propose inserts once

--- a/crates/onsager-spine/migrations/007_artifact_version_rename.sql
+++ b/crates/onsager-spine/migrations/007_artifact_version_rename.sql
@@ -1,0 +1,58 @@
+-- Issue #100 / #101: rename the artifact-level warehouse pointer fields
+-- from `bundle`-prefixed names to `version`-prefixed names. The name
+-- `BundleId` implied "workflow output container" but the column actually
+-- stores a per-artifact version snapshot id; the ADR 0003 / #100 redesign
+-- introduces a separate `Deliverable` for the aggregate concept.
+--
+-- The `bundles` / `deliveries` tables in migration 005 stay under their
+-- current names — they're the warehouse's storage model and rename is out
+-- of scope for this migration.
+
+-- Rename the two columns on `artifacts` added in migration 005.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'artifacts' AND column_name = 'current_bundle_id'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'artifacts' AND column_name = 'current_version_id'
+    ) THEN
+        ALTER TABLE artifacts RENAME COLUMN current_bundle_id TO current_version_id;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'artifacts' AND column_name = 'bundle_history'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'artifacts' AND column_name = 'version_history'
+    ) THEN
+        ALTER TABLE artifacts RENAME COLUMN bundle_history TO version_history;
+    END IF;
+END;
+$$;
+
+-- The FK constraint on `current_bundle_id` (added in 005) keeps its
+-- original name via PostgreSQL's column-rename semantics — the constraint
+-- references the column by attnum, not by textual name. Rename it to match
+-- the new column so `pg_constraint` is legible.
+ALTER TABLE artifacts
+    DROP CONSTRAINT IF EXISTS artifacts_current_bundle_fkey;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'artifacts_current_version_fkey'
+    ) THEN
+        ALTER TABLE artifacts
+            ADD CONSTRAINT artifacts_current_version_fkey
+            FOREIGN KEY (current_version_id) REFERENCES bundles(bundle_id);
+    END IF;
+END;
+$$;

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -6,7 +6,9 @@
 //! library provides a single typed vocabulary.
 
 use chrono::{DateTime, Utc};
-use onsager_artifact::{ArtifactId, ArtifactState, BundleId, Kind, QualitySignal};
+use onsager_artifact::{
+    ArtifactId, ArtifactState, BundleId, DeliverableId, Kind, KindId, QualitySignal, WorkflowRunId,
+};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -124,6 +126,23 @@ pub enum FactoryEventKind {
         reason: String,
         /// Whether the delivery has been abandoned (terminal) or will retry.
         abandoned: bool,
+    },
+
+    // -- Deliverable (workflow-run output, issue #100/#101) -----------------
+    /// A workflow run produced its first artifact reference. Emitted once per
+    /// run; subsequent additions flow through `DeliverableUpdated`.
+    DeliverableCreated {
+        deliverable_id: DeliverableId,
+        workflow_run_id: WorkflowRunId,
+    },
+
+    /// A workflow run added an artifact reference to its deliverable under a
+    /// given kind. Replay is idempotent on exact `(kind, artifact_id)`.
+    DeliverableUpdated {
+        deliverable_id: DeliverableId,
+        workflow_run_id: WorkflowRunId,
+        kind: KindId,
+        artifact_id: ArtifactId,
     },
 
     // -- Git lifecycle events -------------------------------------------------
@@ -613,6 +632,8 @@ impl FactoryEventKind {
             Self::BundleSealed { .. } => "warehouse.bundle_sealed",
             Self::DeliverySucceeded { .. } => "delivery.succeeded",
             Self::DeliveryFailed { .. } => "delivery.failed",
+            Self::DeliverableCreated { .. } => "deliverable.created",
+            Self::DeliverableUpdated { .. } => "deliverable.updated",
             Self::GitBranchCreated { .. } => "git.branch_created",
             Self::GitCommitPushed { .. } => "git.commit_pushed",
             Self::GitPrOpened { .. } => "git.pr_opened",
@@ -689,6 +710,7 @@ impl FactoryEventKind {
             | Self::ArtifactArchived { .. } => "artifact",
             Self::BundleSealed { .. } => "warehouse",
             Self::DeliverySucceeded { .. } | Self::DeliveryFailed { .. } => "delivery",
+            Self::DeliverableCreated { .. } | Self::DeliverableUpdated { .. } => "deliverable",
             Self::GitBranchCreated { .. }
             | Self::GitCommitPushed { .. }
             | Self::GitPrOpened { .. }
@@ -766,6 +788,8 @@ impl FactoryEventKind {
             Self::DeliverySucceeded { bundle_id, .. } | Self::DeliveryFailed { bundle_id, .. } => {
                 bundle_id.to_string()
             }
+            Self::DeliverableCreated { deliverable_id, .. }
+            | Self::DeliverableUpdated { deliverable_id, .. } => deliverable_id.to_string(),
             Self::GitBranchCreated { artifact_id, .. }
             | Self::GitCommitPushed { artifact_id, .. }
             | Self::GitPrOpened { artifact_id, .. }

--- a/crates/onsager-warehouse/tests/warehouse_flow.rs
+++ b/crates/onsager-warehouse/tests/warehouse_flow.rs
@@ -24,7 +24,7 @@ async fn reset_artifact(store: &EventStore, artifact_id: &str) {
         .execute(store.pool())
         .await
         .ok();
-    sqlx::query("UPDATE artifacts SET current_bundle_id = NULL WHERE artifact_id = $1")
+    sqlx::query("UPDATE artifacts SET current_version_id = NULL WHERE artifact_id = $1")
         .bind(artifact_id)
         .execute(store.pool())
         .await

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 onsager-artifact = { path = "../onsager-artifact" }
 onsager-protocol = { path = "../onsager-protocol" }
+onsager-registry = { path = "../onsager-registry" }
 onsager-spine = { path = "../onsager-spine" }
 
 # From stiglab-core

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -136,6 +136,13 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/workflows/{id}",
             get(routes::workflows::get_workflow).patch(routes::workflows::patch_workflow),
         )
+        // Workflow artifact-kind catalog (issue #102). Runtime surface of
+        // the registry's `workflow_builtin_types()` — lets the dashboard
+        // render the kind picker without hardcoding the union.
+        .route(
+            "/api/workflow/kinds",
+            get(routes::workflow_kinds::list_workflow_kinds),
+        )
         // Spine API — exposes shared event spine data to the dashboard
         .route("/api/spine/events", get(routes::spine::list_events))
         .route(

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -10,4 +10,5 @@ pub mod spine;
 pub mod tasks;
 pub mod tenants;
 pub mod webhooks;
+pub mod workflow_kinds;
 pub mod workflows;

--- a/crates/stiglab/src/server/routes/workflow_kinds.rs
+++ b/crates/stiglab/src/server/routes/workflow_kinds.rs
@@ -1,0 +1,113 @@
+//! Workflow artifact-kind listing (issue #102).
+//!
+//! Serves the registry's built-in workflow kinds to the dashboard so the
+//! workflow builder can render the kind picker from runtime data instead of
+//! a hardcoded TypeScript union. V1 returns only the registry's builtin
+//! catalog; custom kinds registered later via the registry seed path stay
+//! hidden from mobile/chat workflow selectors until explicitly surfaced
+//! here (matches the `BUILTIN_WORKFLOW_KINDS` filter in
+//! `onsager-registry::catalog`).
+
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use onsager_registry::catalog::{workflow_builtin_types, BUILTIN_WORKFLOW_KINDS};
+use onsager_registry::registry::MergeRule;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct WorkflowKind {
+    pub id: String,
+    pub description: String,
+    pub merge_rule: MergeRule,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_kind: Option<String>,
+    pub aliases: Vec<String>,
+    pub intrinsic_schema: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListResponse {
+    pub kinds: Vec<WorkflowKind>,
+}
+
+/// GET /api/workflow/kinds — return the registry's built-in workflow kinds.
+///
+/// Public by design: the dashboard fetches this without a session to render
+/// the workflow-builder's kind picker before the user has picked a tenant.
+pub async fn list_workflow_kinds() -> Response {
+    let kinds = workflow_builtin_types()
+        .into_iter()
+        .filter(|def| BUILTIN_WORKFLOW_KINDS.contains(&def.type_id.as_str()))
+        .map(|def| {
+            let external_kind = def
+                .config
+                .get("external_kind")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let aliases = def
+                .config
+                .get("aliases")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default();
+            WorkflowKind {
+                id: def.type_id.as_str().to_owned(),
+                description: def.description,
+                merge_rule: def.merge_rule,
+                external_kind,
+                aliases,
+                intrinsic_schema: def.intrinsic_schema,
+            }
+        })
+        .collect();
+
+    Json(ListResponse { kinds }).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn list_returns_builtin_kinds_as_json() {
+        let resp = list_workflow_kinds().await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let ids: Vec<_> = parsed["kinds"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|k| k["id"].as_str().unwrap().to_owned())
+            .collect();
+        assert!(ids.contains(&"Issue".to_owned()));
+        assert!(ids.contains(&"PR".to_owned()));
+        assert!(ids.contains(&"Deployment".to_owned()));
+        assert!(ids.contains(&"Session".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn issue_kind_carries_spec_alias() {
+        let resp = list_workflow_kinds().await;
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue = parsed["kinds"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|k| k["id"].as_str() == Some("Issue"))
+            .expect("Issue kind in response");
+        let aliases: Vec<_> = issue["aliases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|a| a.as_str())
+            .collect();
+        assert!(aliases.contains(&"Spec"));
+    }
+}


### PR DESCRIPTION
Closes #100
Part of #101
Part of #102
Part of #103
Part of #104
Part of #105

Ships the v1 slice of #100 across spine, registry, forge, and dashboard.
Parent spec is #100; the five sub-issues (#101–#105) land together on this
branch — scope and follow-ups noted below.

## Summary

- **#101** — `BundleId` → `ArtifactVersionId` rename (type alias kept for
  compat); new `Deliverable`, `DeliverableId`, `WorkflowRunId`, `KindId`
  value objects; `DeliverableCreated` / `DeliverableUpdated` spine events;
  migration 007 renames the two columns on `artifacts`.
- **#102** — `TypeDefinition` gains `intrinsic_schema` + `merge_rule`; new
  `MergeRule` enum; `Spec` → `Issue`, `PullRequest` → `PR` across catalogs
  with legacy ids preserved as `aliases`; new `GET /api/workflow/kinds`
  endpoint; dashboard fetches kinds at runtime with a static fallback.
- **#103** — PR kind registered with `DeepMerge` + full JSON Schema
  (commits / checks / reviews / merged / closes_issue); added
  `Artifact::record_closes_issue` helper; deep forge-side reducer is
  a follow-up.
- **#104** — Flow strip rewritten to render one pill per gate (fixes the
  `Issue → PR → PR → PR → PR` duplicate-PR regression on Governed
  pipeline); new `DeliverablePanel` with a typed PR card;
  `CardStackEditor` accepts `currentStageIndex` + `deliverable` so the
  run-detail view can plug both views in.
- **#105** — `Deployment` + `Session` seeded in `workflow_builtin_types()`
  with intrinsic schemas; dashboard ships a `Merge → Deploy staging`
  preset chaining `PR → Deployment`; stiglab's `Session` struct stays
  canonical.

## Out of scope (follow-ups)

- Full forge rewrite to create separate PR artifacts from Issue
  triggers and adopt `record_closes_issue` on the hot path (#103).
- Partial-update reducer in forge gate handlers that writes checks /
  reviews through the PR artifact's DeepMerge rule (#103).
- SSE invalidation of the dashboard kinds list; v1 polls on load (#102).

## Test plan

- [x] `cargo +stable build --workspace`
- [x] `cargo +stable test --workspace --lib` — 480+ tests green
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +stable fmt --all -- --check`
- [x] `npx tsc -b` (apps/dashboard)
- [x] `npx vitest run` — 77/77 tests green
- [x] `npx eslint . --max-warnings 0`
- [ ] Exercise the Governed pipeline preset in the dashboard and confirm
      the flow strip no longer duplicates the PR pill.
- [ ] Hit `GET /api/workflow/kinds` against a live stiglab and verify the
      four built-in kinds come back with their intrinsic schemas.
- [ ] Apply migration 007 against a non-empty database and verify the
      artifacts columns rename without dropping the FK.

https://claude.ai/code/session_01LyQaCRb82Un8wYUvbuwE9W