### PR TITLE
fix(dashboard): align frontend with #100 — registry fetch + workflow CRUD

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/ArtifactBadge.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ArtifactBadge.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils"
 import type { WorkflowArtifactKind } from "@/lib/api"
-import { artifactKindMeta } from "./workflow-meta"
+import { useWorkflowKinds } from "./useWorkflowKinds"
 
 export interface ArtifactBadgeProps {
   kind: WorkflowArtifactKind
@@ -18,7 +18,8 @@ export function ArtifactBadge({
   size = "sm",
   className,
 }: ArtifactBadgeProps) {
-  const meta = artifactKindMeta(kind)
+  const { metaFor } = useWorkflowKinds()
+  const meta = metaFor(kind)
   const Icon = meta.icon
   return (
     <span

--- a/apps/dashboard/src/components/factory/workflows/ArtifactKindSelect.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ArtifactKindSelect.tsx
@@ -6,11 +6,12 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import type { WorkflowArtifactKind } from "@/lib/api"
-import { WORKFLOW_ARTIFACT_KINDS } from "./workflow-meta"
+import { useWorkflowKinds } from "./useWorkflowKinds"
 
-// Mobile-facing artifact-kind selector. Custom (user-defined) artifact
-// kinds are deliberately hidden — power users edit those on desktop or via
-// backend config.
+// Mobile-facing artifact-kind selector. The option list comes from the
+// registry via `GET /api/workflow/kinds` (issue #102); `useWorkflowKinds`
+// silently falls back to the static set baked into `workflow-meta.ts` if
+// the fetch is loading or fails, so the builder stays usable offline.
 export interface ArtifactKindSelectProps {
   value: WorkflowArtifactKind
   onChange: (value: WorkflowArtifactKind) => void
@@ -18,6 +19,7 @@ export interface ArtifactKindSelectProps {
 }
 
 export function ArtifactKindSelect({ value, onChange, id }: ArtifactKindSelectProps) {
+  const { kinds } = useWorkflowKinds()
   return (
     <Select
       value={value}
@@ -25,13 +27,13 @@ export function ArtifactKindSelect({ value, onChange, id }: ArtifactKindSelectPr
         // Registry-backed kinds (#102) — accept any id the registry emits.
         if (typeof v === "string" && v.length > 0) onChange(v)
       }}
-      items={WORKFLOW_ARTIFACT_KINDS}
+      items={kinds}
     >
       <SelectTrigger id={id} className="w-full">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {WORKFLOW_ARTIFACT_KINDS.map((k) => (
+        {kinds.map((k) => (
           <SelectItem key={k.value} value={k.value}>
             {k.label}
           </SelectItem>

--- a/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
+++ b/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
@@ -49,20 +49,17 @@ export function DeliverablePanel({ entries, empty }: DeliverablePanelProps) {
   )
 }
 
-// Canonical PR kind detection (issue #102). Mirrors the alias map in
-// `workflow-meta.ts` so legacy persisted `github-pr` / `PullRequest`
-// values still get the rich PR card instead of falling through to the
-// generic one.
-function isPrDeliverableKind(kind: WorkflowArtifactKind): boolean {
-  return kind === "PR" || kind === "github-pr" || kind === "PullRequest"
-}
-
 function DeliverableCard({ entry }: { entry: DeliverableEntry }) {
   const { metaFor } = useWorkflowKinds()
   const meta = metaFor(entry.kind)
   const Icon = meta.icon
 
-  if (isPrDeliverableKind(entry.kind)) {
+  // Canonical PR detection (issue #102). `metaFor` resolves via the
+  // registry alias map first, then the static fallback — so any PR
+  // alias the server reports (legacy `github-pr` / `PullRequest` or a
+  // future one) canonicalizes to `meta.value === "PR"` without needing
+  // a hardcoded table here.
+  if (meta.value === "PR") {
     return <PrCard entry={entry} />
   }
 

--- a/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
+++ b/apps/dashboard/src/components/factory/workflows/DeliverablePanel.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react"
 import { CircleDot, GitPullRequest } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import type { WorkflowArtifactKind } from "@/lib/api"
-import { artifactKindMeta } from "./workflow-meta"
+import { useWorkflowKinds } from "./useWorkflowKinds"
 
 // The "product" view of a workflow run — a live snapshot of the
 // Deliverable (issue #100/#101). Sits beside the flow strip so the UI
@@ -58,7 +58,8 @@ function isPrDeliverableKind(kind: WorkflowArtifactKind): boolean {
 }
 
 function DeliverableCard({ entry }: { entry: DeliverableEntry }) {
-  const meta = artifactKindMeta(entry.kind)
+  const { metaFor } = useWorkflowKinds()
+  const meta = metaFor(entry.kind)
   const Icon = meta.icon
 
   if (isPrDeliverableKind(entry.kind)) {

--- a/apps/dashboard/src/components/factory/workflows/WorkflowActions.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowActions.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "react-router-dom"
+import { Pause, Play, Trash2 } from "lucide-react"
+import { api, type Workflow } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// Lifecycle controls for a single workflow. Lives on the detail page so
+// pause/resume and destructive delete are one tap away from "what does
+// this workflow do?" — the same place the user just evaluated it.
+//
+// `status` maps to the backend's `active` flag (draft/paused both
+// render as "Publish", active renders as "Pause"). Delete always asks
+// for confirmation in a modal — a workflow is durable state with a
+// webhook and a label side effect, not a typo.
+export interface WorkflowActionsProps {
+  workflow: Workflow
+}
+
+export function WorkflowActions({ workflow }: WorkflowActionsProps) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [confirming, setConfirming] = useState(false)
+
+  const isActive = workflow.status === "active"
+
+  const toggle = useMutation({
+    mutationFn: (active: boolean) => api.setWorkflowActive(workflow.id, active),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workflow", workflow.id] })
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+    },
+  })
+
+  const remove = useMutation({
+    mutationFn: () => api.deleteWorkflow(workflow.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      setConfirming(false)
+      navigate("/workflows")
+    },
+  })
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      data-testid="workflow-actions"
+    >
+      <Button
+        type="button"
+        variant={isActive ? "outline" : "default"}
+        size="sm"
+        disabled={toggle.isPending}
+        onClick={() => toggle.mutate(!isActive)}
+      >
+        {isActive ? (
+          <>
+            <Pause className="h-4 w-4" />
+            Pause
+          </>
+        ) : (
+          <>
+            <Play className="h-4 w-4" />
+            {workflow.status === "draft" ? "Publish" : "Resume"}
+          </>
+        )}
+      </Button>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setConfirming(true)}
+      >
+        <Trash2 className="h-4 w-4" />
+        Delete
+      </Button>
+
+      {toggle.isError && (
+        <p className="w-full text-xs text-destructive">
+          {toggle.error instanceof Error
+            ? toggle.error.message
+            : "Failed to update workflow"}
+        </p>
+      )}
+
+      <Dialog open={confirming} onOpenChange={setConfirming}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete workflow?</DialogTitle>
+            <DialogDescription>
+              Removes <span className="font-medium">{workflow.name}</span> and
+              its stage chain. The GitHub webhook is dropped if no other
+              workflow on {workflow.trigger.repo_owner}/
+              {workflow.trigger.repo_name} still needs it. In-flight runs
+              aren&apos;t affected retroactively.
+            </DialogDescription>
+          </DialogHeader>
+          {remove.isError && (
+            <p className="text-sm text-destructive">
+              {remove.error instanceof Error
+                ? remove.error.message
+                : "Delete failed"}
+            </p>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirming(false)}
+              disabled={remove.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => remove.mutate()}
+              disabled={remove.isPending}
+            >
+              {remove.isPending ? "Deleting…" : "Delete workflow"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowBuilder.tsx
@@ -44,9 +44,9 @@ export function WorkflowBuilder({
     },
   })
 
-  const save = () => {
+  const save = (active: boolean) => {
     if (!canSave) return
-    create.mutate(draftToCreateRequest(draft, installations, tenantId, true))
+    create.mutate(draftToCreateRequest(draft, installations, tenantId, active))
   }
 
   return (
@@ -78,15 +78,27 @@ export function WorkflowBuilder({
         </p>
       )}
 
-      <Button
-        type="button"
-        size="lg"
-        className="w-full"
-        disabled={!canSave || create.isPending}
-        onClick={save}
-      >
-        {create.isPending ? "Saving…" : "Activate workflow"}
-      </Button>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          className="w-full sm:flex-1"
+          disabled={!canSave || create.isPending}
+          onClick={() => save(false)}
+        >
+          Save as draft
+        </Button>
+        <Button
+          type="button"
+          size="lg"
+          className="w-full sm:flex-1"
+          disabled={!canSave || create.isPending}
+          onClick={() => save(true)}
+        >
+          {create.isPending ? "Saving…" : "Activate workflow"}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/components/factory/workflows/useWorkflowKinds.ts
+++ b/apps/dashboard/src/components/factory/workflows/useWorkflowKinds.ts
@@ -81,8 +81,12 @@ export function useWorkflowKinds(): UseWorkflowKindsResult {
   })
 
   return useMemo<UseWorkflowKindsResult>(() => {
-    const registry = data?.kinds ?? []
-    if (registry.length === 0) {
+    // Fall back to the static list only while the fetch hasn't produced
+    // a usable response — i.e. the initial load hasn't resolved yet or
+    // the request errored. A successful response with an empty `kinds`
+    // array is legitimate server state (registry genuinely has nothing
+    // exposed) and should render as empty, not as the static set.
+    if (!data || isError) {
       return {
         kinds: WORKFLOW_ARTIFACT_KINDS,
         metaFor: staticArtifactKindMeta,
@@ -90,6 +94,7 @@ export function useWorkflowKinds(): UseWorkflowKindsResult {
         isError,
       }
     }
+    const registry = data.kinds
     const kinds = registry.map(metaFromRegistry)
     const byValue = Object.fromEntries(
       kinds.map((k) => [k.value, k]),

--- a/apps/dashboard/src/components/factory/workflows/useWorkflowKinds.ts
+++ b/apps/dashboard/src/components/factory/workflows/useWorkflowKinds.ts
@@ -1,0 +1,104 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import {
+  Bot,
+  CircleDot,
+  GitPullRequest,
+  Rocket,
+  Terminal,
+} from "lucide-react"
+import { api, type WorkflowKindInfo } from "@/lib/api"
+import {
+  WORKFLOW_ARTIFACT_KINDS,
+  artifactKindMeta as staticArtifactKindMeta,
+  type ArtifactKindMeta,
+} from "./workflow-meta"
+
+// Icon fallback for registry kinds the static meta list doesn't know about.
+// Keeps the card-stack editor visually coherent when a registry-only kind
+// (e.g. a tenant-specific Deliverable) shows up in the picker.
+const KIND_ICON_FALLBACKS: Record<string, ArtifactKindMeta["icon"]> = {
+  Issue: CircleDot,
+  PR: GitPullRequest,
+  Deployment: Rocket,
+  Session: Terminal,
+}
+
+function metaFromRegistry(info: WorkflowKindInfo): ArtifactKindMeta {
+  const staticMeta = WORKFLOW_ARTIFACT_KINDS.find((k) => k.value === info.id)
+  if (staticMeta) {
+    return staticMeta
+  }
+  return {
+    value: info.id,
+    label: info.description || info.id,
+    shortLabel: info.id,
+    icon: KIND_ICON_FALLBACKS[info.id] ?? Bot,
+  }
+}
+
+// Build an alias → canonical-id map from a registry response. Lets us
+// resolve a persisted legacy value (e.g. `Spec`, `PullRequest`) to the
+// current canonical id without a hardcoded table.
+function aliasLookup(kinds: WorkflowKindInfo[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of kinds) {
+    for (const alias of k.aliases) {
+      out[alias] = k.id
+    }
+  }
+  return out
+}
+
+export interface UseWorkflowKindsResult {
+  /// Ordered list of kinds to render in pickers. Falls back to the static
+  /// set when the registry fetch is still loading or has failed.
+  kinds: ArtifactKindMeta[]
+  /// Resolve a kind id (possibly a registry alias) to its display meta.
+  /// Prefers the runtime-fetched alias map, then falls back to the static
+  /// LEGACY_KIND_ALIASES table baked into `artifactKindMeta`.
+  metaFor: (value: string) => ArtifactKindMeta
+  /// True while the initial fetch is in flight. Callers can use this to
+  /// suppress flicker when the static fallback resolves differently from
+  /// the registry response.
+  isLoading: boolean
+  /// True when the fetch failed. UI should silently fall back to the
+  /// static list — the workflow builder stays usable offline.
+  isError: boolean
+}
+
+// Registry-backed workflow artifact kinds (issue #102). Poll-on-load +
+// cache for the session; falls back to the static list in `workflow-meta.ts`
+// if the fetch fails (offline / dev without stiglab).
+export function useWorkflowKinds(): UseWorkflowKindsResult {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["workflow-kinds"],
+    queryFn: () => api.listWorkflowKinds(),
+    // Registry contents rarely change inside a session. Re-fetch on window
+    // focus is enough to pick up a new custom kind without hammering the API.
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+
+  return useMemo<UseWorkflowKindsResult>(() => {
+    const registry = data?.kinds ?? []
+    if (registry.length === 0) {
+      return {
+        kinds: WORKFLOW_ARTIFACT_KINDS,
+        metaFor: staticArtifactKindMeta,
+        isLoading,
+        isError,
+      }
+    }
+    const kinds = registry.map(metaFromRegistry)
+    const byValue = Object.fromEntries(
+      kinds.map((k) => [k.value, k]),
+    ) as Record<string, ArtifactKindMeta>
+    const aliases = aliasLookup(registry)
+    const metaFor = (value: string): ArtifactKindMeta => {
+      const canonical = aliases[value] ?? value
+      return byValue[canonical] ?? staticArtifactKindMeta(value)
+    }
+    return { kinds, metaFor, isLoading, isError }
+  }, [data, isLoading, isError])
+}

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
 import { ArtifactFlowOverview } from "@/components/factory/workflows/ArtifactFlowOverview"
+import { WorkflowActions } from "@/components/factory/workflows/WorkflowActions"
 import { outputArtifactKind } from "@/components/factory/workflows/workflow-meta"
 
 const STATUS_VARIANT: Record<StageRunStatus, "default" | "secondary" | "destructive" | "outline"> = {
@@ -79,6 +80,7 @@ export function WorkflowDetailPage() {
             {workflow.status}
           </Badge>
         </div>
+        <WorkflowActions workflow={workflow} />
       </div>
 
       <Card>

--- a/apps/dashboard/tests/smoke/workflow-actions.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-actions.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import type { ReactNode } from "react"
+import { WorkflowActions } from "@/components/factory/workflows/WorkflowActions"
+import { api, type Workflow } from "@/lib/api"
+
+function mount(node: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "wf_1",
+    tenant_id: "t_1",
+    name: "Issue → PR",
+    preset: null,
+    status: "active",
+    trigger: {
+      kind: "github-label",
+      install_id: "42",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      label: "factory",
+    },
+    stages: [],
+    created_at: "2026-04-22T00:00:00Z",
+    updated_at: "2026-04-22T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("WorkflowActions lifecycle controls", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "setWorkflowActive").mockResolvedValue({
+      workflow: makeWorkflow(),
+    })
+    vi.spyOn(api, "deleteWorkflow").mockResolvedValue({ ok: true })
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("pauses an active workflow via PATCH active:false", async () => {
+    mount(<WorkflowActions workflow={makeWorkflow({ status: "active" })} />)
+    fireEvent.click(screen.getByRole("button", { name: /Pause/i }))
+    await waitFor(() =>
+      expect(api.setWorkflowActive).toHaveBeenCalledWith("wf_1", false),
+    )
+  })
+
+  it("labels the toggle as 'Publish' on a draft workflow", () => {
+    mount(<WorkflowActions workflow={makeWorkflow({ status: "draft" })} />)
+    expect(screen.getByRole("button", { name: /Publish/i })).toBeTruthy()
+  })
+
+  it("labels the toggle as 'Resume' on a paused workflow", () => {
+    mount(<WorkflowActions workflow={makeWorkflow({ status: "paused" })} />)
+    expect(screen.getByRole("button", { name: /Resume/i })).toBeTruthy()
+  })
+
+  it("requires confirmation before DELETE fires", async () => {
+    mount(<WorkflowActions workflow={makeWorkflow()} />)
+    fireEvent.click(screen.getByRole("button", { name: /^Delete$/i }))
+    // The modal's destructive button is the one that actually calls the API.
+    const confirm = await screen.findByRole("button", {
+      name: /Delete workflow/i,
+    })
+    fireEvent.click(confirm)
+    await waitFor(() => expect(api.deleteWorkflow).toHaveBeenCalledWith("wf_1"))
+  })
+})

--- a/apps/dashboard/tests/smoke/workflow-kinds-hook.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-kinds-hook.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
+import { api, type WorkflowKindInfo } from "@/lib/api"
+
+function mount(node: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>)
+}
+
+describe("useWorkflowKinds (issue #102 runtime fetch)", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "listWorkflowKinds")
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("resolves a registry alias to the canonical kind label", async () => {
+    const kinds: WorkflowKindInfo[] = [
+      {
+        id: "Issue",
+        description: "GitHub Issue",
+        merge_rule: "overwrite",
+        aliases: ["Spec", "github-issue"],
+        intrinsic_schema: null,
+      },
+    ]
+    vi.mocked(api.listWorkflowKinds).mockResolvedValue({ kinds })
+
+    // `Spec` is a legacy id that the registry reports as an alias for
+    // `Issue` — the badge should render the canonical short label once
+    // the fetch resolves.
+    mount(<ArtifactBadge kind="Spec" />)
+    await waitFor(() => expect(screen.getByText("Issue")).toBeTruthy())
+  })
+
+  it("falls back to the static meta when the registry fetch fails", async () => {
+    vi.mocked(api.listWorkflowKinds).mockRejectedValue(new Error("offline"))
+
+    mount(<ArtifactBadge kind="PR" />)
+    // Static fallback is synchronous, so the short label is visible on
+    // the first render without waiting for the fetch to settle.
+    expect(screen.getByText("PR")).toBeTruthy()
+  })
+})

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -134,7 +134,9 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         )
         .route(
             "/api/workflows/{id}",
-            get(routes::workflows::get_workflow).patch(routes::workflows::patch_workflow),
+            get(routes::workflows::get_workflow)
+                .patch(routes::workflows::patch_workflow)
+                .delete(routes::workflows::delete_workflow),
         )
         // Workflow artifact-kind catalog (issue #102). Runtime surface of
         // the registry's `workflow_builtin_types()` — lets the dashboard

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -356,6 +356,45 @@ pub async fn patch_workflow(
     Json(serde_json::json!({ "workflow": updated })).into_response()
 }
 
+/// DELETE /api/workflows/:id — remove the workflow row + stages. If the
+/// workflow is currently active the deactivation hook runs first, which
+/// flips `active=false` and drops the repo webhook when no sibling
+/// workflow still needs it. After that the row and stage chain go away
+/// in a single transaction so a partial delete can't leak.
+pub async fn delete_workflow(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workflow_id): Path<String>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    let workflow = match workflow_db::get_workflow(&state.db, &workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return not_found("workflow not found"),
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_tenant_member(&state.db, &user_id, &workflow.tenant_id).await {
+        return r;
+    }
+
+    if workflow.active {
+        if let Err(r) = deactivate_workflow(&state, &workflow_id).await {
+            return r;
+        }
+    }
+
+    if let Err(e) = workflow_db::delete_workflow(&state.db, &workflow_id).await {
+        tracing::error!("failed to delete workflow: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
 /// Run the activation pipeline against the live GitHub App install. Emits
 /// typed failure modes through `Response` so the caller can bubble the HTTP
 /// status directly.

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -179,6 +179,24 @@ pub async fn set_workflow_active(
     Ok(())
 }
 
+/// Delete the workflow row and its ordered stage chain in a single
+/// transaction. Callers are expected to have deactivated the workflow
+/// first (the label-watcher side effect is undone before the row goes
+/// away); this helper only touches the database state.
+pub async fn delete_workflow(pool: &AnyPool, workflow_id: &str) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("DELETE FROM tenant_workflow_stages WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM tenant_workflows WHERE id = $1")
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 /// Find every **active** workflow whose `github-issue-webhook` trigger
 /// targets this repo and matches the supplied label set. The webhook router
 /// calls this to decide which workflows should fire `trigger.fired` for a
@@ -376,6 +394,21 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn delete_workflow_drops_row_and_stages() {
+        let pool = pool().await;
+        let wf = sample_workflow("t1", "widgets", "spec", false);
+        insert_workflow_with_stages(&pool, &wf, std::slice::from_ref(&agent_stage(&wf.id)))
+            .await
+            .unwrap();
+
+        delete_workflow(&pool, &wf.id).await.unwrap();
+
+        assert!(get_workflow(&pool, &wf.id).await.unwrap().is_none());
+        let stages = list_stages_for_workflow(&pool, &wf.id).await.unwrap();
+        assert!(stages.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #107 (closes #100). Two gaps showed up once the backend landed:

## 1. Registry fetch wasn't actually wired

`api.listWorkflowKinds()` was defined in the client but no component
ever called it — the builder still only rendered the static fallback
in `workflow-meta.ts`, so any kind registered via the registry stayed
invisible. This branch adds a `useWorkflowKinds()` query and drives
`ArtifactKindSelect`, `ArtifactBadge`, and `DeliverablePanel` off the
runtime list. Alias resolution now uses the registry response, so
legacy `Spec` / `PullRequest` values resolve to the canonical card
without a hardcoded table.

## 2. Standard CRUD was half-wired

`setWorkflowActive` and `deleteWorkflow` existed in the API client
but no UI called them, and `DELETE /api/workflows/:id` wasn't
implemented backend-side at all. Fill in both sides:

- **Backend:** add `DELETE /api/workflows/:id` that deactivates first
  (so the webhook + label side effects unwind), then drops the row +
  stage chain in a single transaction.
- **Detail page:** new `WorkflowActions` bar with a pause/resume
  toggle (PATCH `active`) and a destructive delete with modal
  confirmation that navigates back to the list.
- **Builder:** split the single "Activate workflow" button into
  "Save as draft" / "Activate workflow" so a workflow can land
  unpublished and be flipped on later from the detail page.

## Test plan

- [x] `cargo test -p stiglab --lib` — 92/92 (adds `delete_workflow_drops_row_and_stages`)
- [x] `cargo clippy -p stiglab --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npx tsc -b` (apps/dashboard)
- [x] `npx vitest run` — 83/83 (adds `workflow-kinds-hook.test.tsx` + `workflow-actions.test.tsx`)
- [x] `npx eslint . --max-warnings 0`
- [ ] Exercise on a live dashboard: create a draft, publish from detail, pause, delete.

https://claude.ai/code/session_01Qjo3ksLcenLuP9HjjMu4Vw