### PR TITLE
fix(dashboard): preset name no longer renders as "/ — issue to PR"

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
@@ -73,8 +73,10 @@ export function emptyDraft(): WorkflowDraft {
 export function githubIssueToPrPreset(
   trigger: WorkflowTriggerDraft,
 ): WorkflowDraft {
+  const owner = trigger.repo_owner || "repo"
+  const name = trigger.repo_name || "issue-to-pr"
   return {
-    name: `${trigger.repo_owner}/${trigger.repo_name} — issue to PR`,
+    name: `${owner}/${name} — issue to PR`,
     trigger,
     stages: [
       makeStage("agent-session", "Issue", "Spec → PR"),

--- a/apps/dashboard/tests/smoke/workflow-preset-picker.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-preset-picker.test.tsx
@@ -53,4 +53,17 @@ describe("PresetPicker", () => {
     const next = onApply.mock.calls[0][0] as WorkflowDraft
     expect(next.name.length).toBeGreaterThan(0)
   })
+
+  it("every preset generates a readable name when no repo has been picked yet", () => {
+    // Regression: applying the Issue → PR preset before the trigger repo
+    // was picked used to produce names like "/ — issue to PR" (empty
+    // owner/name around a literal slash). Every preset must fall back to
+    // a placeholder instead.
+    const { trigger } = emptyDraft()
+    for (const p of WORKFLOW_PRESETS) {
+      const next = p.build(trigger)
+      expect(next.name, `${p.id} name`).not.toMatch(/^\s*\//)
+      expect(next.name, `${p.id} name`).not.toMatch(/\/\s+—/)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- `githubIssueToPrPreset` interpolated `trigger.repo_owner` and `trigger.repo_name` straight into its suggested workflow name, so clicking the **Issue → PR** preset before a repo was picked produced a literal `"/ — issue to PR"` in the Name field.
- The four sibling presets already coalesce empty owner/name to placeholders (`repo_owner || "repo"` etc.). This brings the Issue → PR preset in line.
- Adds a regression test that asserts **every** preset in `WORKFLOW_PRESETS`, given an empty trigger, produces a name that neither starts with `/` nor contains `/ —`.

Closes #111

## Test plan

- [x] `pnpm test` (dashboard) — 84/84 pass, including the new assertion over all presets.
- [x] `pnpm build` (dashboard) — typecheck + production build clean.
- [x] `pnpm lint` (dashboard) — clean.
- [ ] Manual: open the workflow builder with a fresh draft, tap **Issue → PR** before picking a repo — suggested name renders as `repo/issue-to-pr — issue to PR` rather than `/ — issue to PR`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E7exaJXHtJL5iA3DQK3sUE)_