### PR TITLE
feat(stiglab): cross-env SSO delegation for Railway previews

### DIFF
--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use crate::server::sso::{parse_host_allowlist, SsoMode};
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub host: String,
@@ -11,6 +13,21 @@ pub struct ServerConfig {
     pub github_client_secret: Option<String>,
     pub credential_key: Option<String>,
     pub public_url: Option<String>,
+    /// Cross-environment SSO — owner side. `Some` on the prod deployment
+    /// that owns the GitHub OAuth app and is willing to serve preview envs.
+    pub sso_state_secret: Option<String>,
+    /// Back-channel secret. Shared between owner and relying parties.
+    /// * Owner: bearer required on `/api/auth/sso/redeem`.
+    /// * Relying: bearer sent on outbound redeem calls.
+    pub sso_exchange_secret: Option<String>,
+    /// Allowlist of hosts the owner will redirect back to. Entries take the
+    /// forms `*.subdomain.example.com` (strict-subdomain match) or
+    /// `host.example.com` (exact match). Non-matching `return_to` is
+    /// rejected at the start of the OAuth flow.
+    pub sso_return_host_allowlist: Vec<String>,
+    /// Cross-environment SSO — relying side. When set, `/api/auth/github`
+    /// redirects here instead of talking to GitHub directly.
+    pub sso_auth_domain: Option<String>,
 }
 
 impl ServerConfig {
@@ -25,12 +42,25 @@ impl ServerConfig {
             env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite://./data/stiglab.db".to_string());
         let static_dir = env::var("STIGLAB_STATIC_DIR").ok();
         let cors_origin = env::var("STIGLAB_CORS_ORIGIN").ok();
-        let github_client_id = env::var("GITHUB_CLIENT_ID").ok();
-        let github_client_secret = env::var("GITHUB_CLIENT_SECRET").ok();
+        let github_client_id = env::var("GITHUB_CLIENT_ID").ok().filter(|s| !s.is_empty());
+        let github_client_secret = env::var("GITHUB_CLIENT_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty());
         let credential_key = env::var("STIGLAB_CREDENTIAL_KEY").ok();
         let public_url = env::var("STIGLAB_PUBLIC_URL").ok();
+        let sso_state_secret = env::var("SSO_STATE_SECRET").ok().filter(|s| !s.is_empty());
+        let sso_exchange_secret = env::var("SSO_EXCHANGE_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let sso_return_host_allowlist = env::var("SSO_RETURN_HOST_ALLOWLIST")
+            .map(|raw| parse_host_allowlist(&raw))
+            .unwrap_or_default();
+        let sso_auth_domain = env::var("SSO_AUTH_DOMAIN")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim_end_matches('/').to_string());
 
-        ServerConfig {
+        let config = ServerConfig {
             host,
             port,
             database_url,
@@ -40,12 +70,71 @@ impl ServerConfig {
             github_client_secret,
             credential_key,
             public_url,
-        }
+            sso_state_secret,
+            sso_exchange_secret,
+            sso_return_host_allowlist,
+            sso_auth_domain,
+        };
+
+        config.assert_sso_consistent();
+        config
     }
 
     /// Returns true if GitHub OAuth is configured (both client ID and secret are set).
     pub fn auth_enabled(&self) -> bool {
-        self.github_client_id.is_some() && self.github_client_secret.is_some()
+        !matches!(self.sso_mode(), SsoMode::Disabled)
+    }
+
+    /// Classify the process's role in the SSO flow.
+    pub fn sso_mode(&self) -> SsoMode {
+        let has_github = self.github_client_id.is_some() && self.github_client_secret.is_some();
+        let has_owner_secrets =
+            self.sso_state_secret.is_some() && self.sso_exchange_secret.is_some();
+        let has_relying =
+            self.sso_auth_domain.is_some() && self.sso_exchange_secret.is_some() && !has_github;
+
+        if has_github {
+            let delegate_enabled = has_owner_secrets && !self.sso_return_host_allowlist.is_empty();
+            SsoMode::Owner { delegate_enabled }
+        } else if has_relying {
+            SsoMode::Relying
+        } else {
+            SsoMode::Disabled
+        }
+    }
+
+    /// Fail fast on ambiguous SSO configuration. Called at startup so
+    /// misconfigured deploys never even begin serving traffic.
+    fn assert_sso_consistent(&self) {
+        let has_github = self.github_client_id.is_some() || self.github_client_secret.is_some();
+        if has_github && self.sso_auth_domain.is_some() {
+            panic!(
+                "invalid SSO config: both GITHUB_CLIENT_ID/SECRET (owner-mode) and \
+                 SSO_AUTH_DOMAIN (relying-mode) are set — these are mutually exclusive"
+            );
+        }
+
+        if self.sso_state_secret.is_some() && !has_github {
+            panic!(
+                "invalid SSO config: SSO_STATE_SECRET is set but GITHUB_CLIENT_ID/SECRET \
+                 are not — the state secret is only meaningful on the owner"
+            );
+        }
+
+        if !self.sso_return_host_allowlist.is_empty() && !has_github {
+            panic!(
+                "invalid SSO config: SSO_RETURN_HOST_ALLOWLIST is set but \
+                 GITHUB_CLIENT_ID/SECRET are not — the allowlist is only meaningful on \
+                 the owner"
+            );
+        }
+
+        if self.sso_auth_domain.is_some() && self.sso_exchange_secret.is_none() {
+            panic!(
+                "invalid SSO config: SSO_AUTH_DOMAIN is set but SSO_EXCHANGE_SECRET is \
+                 not — the relying party cannot authenticate to the owner"
+            );
+        }
     }
 }
 
@@ -53,17 +142,29 @@ impl ServerConfig {
 mod tests {
     use super::*;
 
-    fn make_config(client_id: Option<&str>, client_secret: Option<&str>) -> ServerConfig {
+    fn base_config() -> ServerConfig {
         ServerConfig {
             host: "0.0.0.0".to_string(),
             port: 3000,
             database_url: "sqlite://test.db".to_string(),
             static_dir: None,
             cors_origin: None,
-            github_client_id: client_id.map(|s| s.to_string()),
-            github_client_secret: client_secret.map(|s| s.to_string()),
+            github_client_id: None,
+            github_client_secret: None,
             credential_key: None,
             public_url: None,
+            sso_state_secret: None,
+            sso_exchange_secret: None,
+            sso_return_host_allowlist: Vec::new(),
+            sso_auth_domain: None,
+        }
+    }
+
+    fn make_config(client_id: Option<&str>, client_secret: Option<&str>) -> ServerConfig {
+        ServerConfig {
+            github_client_id: client_id.map(|s| s.to_string()),
+            github_client_secret: client_secret.map(|s| s.to_string()),
+            ..base_config()
         }
     }
 
@@ -89,5 +190,95 @@ mod tests {
     fn auth_disabled_when_both_missing() {
         let config = make_config(None, None);
         assert!(!config.auth_enabled());
+    }
+
+    #[test]
+    fn owner_mode_without_delegation() {
+        let c = make_config(Some("id"), Some("secret"));
+        assert_eq!(
+            c.sso_mode(),
+            SsoMode::Owner {
+                delegate_enabled: false
+            }
+        );
+    }
+
+    #[test]
+    fn owner_mode_with_delegation() {
+        let c = ServerConfig {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            sso_state_secret: Some("state-secret".into()),
+            sso_exchange_secret: Some("exchange-secret".into()),
+            sso_return_host_allowlist: vec!["*.preview.onsager.ai".into()],
+            ..base_config()
+        };
+        assert_eq!(
+            c.sso_mode(),
+            SsoMode::Owner {
+                delegate_enabled: true
+            }
+        );
+    }
+
+    #[test]
+    fn owner_mode_delegation_disabled_when_allowlist_empty() {
+        let c = ServerConfig {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            sso_state_secret: Some("state-secret".into()),
+            sso_exchange_secret: Some("exchange-secret".into()),
+            sso_return_host_allowlist: vec![],
+            ..base_config()
+        };
+        assert_eq!(
+            c.sso_mode(),
+            SsoMode::Owner {
+                delegate_enabled: false
+            }
+        );
+    }
+
+    #[test]
+    fn relying_mode_requires_auth_domain_and_exchange_secret() {
+        let c = ServerConfig {
+            sso_auth_domain: Some("https://app.onsager.ai".into()),
+            sso_exchange_secret: Some("exchange-secret".into()),
+            ..base_config()
+        };
+        assert_eq!(c.sso_mode(), SsoMode::Relying);
+    }
+
+    #[test]
+    #[should_panic(expected = "mutually exclusive")]
+    fn assert_panics_when_both_owner_and_relying() {
+        let c = ServerConfig {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            sso_auth_domain: Some("https://other.example".into()),
+            sso_exchange_secret: Some("exchange-secret".into()),
+            ..base_config()
+        };
+        c.assert_sso_consistent();
+    }
+
+    #[test]
+    #[should_panic(expected = "SSO_STATE_SECRET")]
+    fn assert_panics_when_state_secret_without_github_creds() {
+        let c = ServerConfig {
+            sso_state_secret: Some("state-secret".into()),
+            ..base_config()
+        };
+        c.assert_sso_consistent();
+    }
+
+    #[test]
+    #[should_panic(expected = "SSO_EXCHANGE_SECRET")]
+    fn assert_panics_when_auth_domain_without_exchange_secret() {
+        let c = ServerConfig {
+            sso_auth_domain: Some("https://app.onsager.ai".into()),
+            ..base_config()
+        };
+        c.assert_sso_consistent();
     }
 }

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -124,6 +124,30 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
         .execute(pool)
         .await?;
 
+    // Short-lived opaque codes used by cross-environment SSO delegation.
+    // `redeemed_at` is NULL until a relying party successfully exchanges
+    // the code for the user identity; the UPDATE that flips it is the
+    // single-use gate (see `redeem_sso_exchange_code`).
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS sso_exchange_codes (
+            code TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            return_to_host TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            redeemed_at TEXT,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_sso_exchange_codes_expires_at \
+         ON sso_exchange_codes (expires_at)",
+    )
+    .execute(pool)
+    .await?;
+
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS user_credentials (
             id TEXT PRIMARY KEY,
@@ -793,6 +817,66 @@ pub async fn delete_auth_session(pool: &AnyPool, session_id: &str) -> anyhow::Re
         .execute(pool)
         .await?;
     Ok(())
+}
+
+// ── SSO Exchange Codes (cross-env delegation) ──
+
+pub async fn insert_sso_exchange_code(
+    pool: &AnyPool,
+    code: &str,
+    user_id: &str,
+    return_to_host: &str,
+    expires_at: chrono::DateTime<Utc>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO sso_exchange_codes (code, user_id, return_to_host, expires_at, redeemed_at, created_at)
+         VALUES ($1, $2, $3, $4, NULL, $5)",
+    )
+    .bind(code)
+    .bind(user_id)
+    .bind(return_to_host)
+    .bind(expires_at.to_rfc3339())
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Atomically consume an exchange code. The UPDATE is the single-use gate —
+/// it succeeds for exactly one caller (the one who sees `rows_affected == 1`);
+/// concurrent or repeat calls get `None`. The return-to-host check runs in the
+/// UPDATE predicate so a code issued for host A can't be redeemed by host B
+/// even if both are in the owner's allowlist.
+pub async fn redeem_sso_exchange_code(
+    pool: &AnyPool,
+    code: &str,
+    return_to_host: &str,
+) -> anyhow::Result<Option<User>> {
+    let now = Utc::now().to_rfc3339();
+    let rows = sqlx::query(
+        "UPDATE sso_exchange_codes
+         SET redeemed_at = $1
+         WHERE code = $2
+           AND redeemed_at IS NULL
+           AND expires_at > $1
+           AND return_to_host = $3",
+    )
+    .bind(&now)
+    .bind(code)
+    .bind(return_to_host)
+    .execute(pool)
+    .await?;
+
+    if rows.rows_affected() == 0 {
+        return Ok(None);
+    }
+
+    let user_id: String =
+        sqlx::query_scalar("SELECT user_id FROM sso_exchange_codes WHERE code = $1")
+            .bind(code)
+            .fetch_one(pool)
+            .await?;
+    get_user(pool, &user_id).await
 }
 
 // ── User Credentials CRUD ──

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod github_app;
 pub mod handler;
 pub mod routes;
 pub mod spine;
+pub mod sso;
 pub mod state;
 pub mod webhook_router;
 pub mod workflow_activation;
@@ -52,6 +53,18 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         )
         .route("/api/auth/me", get(routes::auth::me))
         .route("/api/auth/logout", post(routes::auth::logout))
+        // Cross-environment SSO delegation.
+        //
+        // * `/api/auth/sso/redeem` (POST, owner only): server-to-server
+        //   redemption of an opaque exchange code. Requires
+        //   `Authorization: Bearer $SSO_EXCHANGE_SECRET`. 404s when this
+        //   process is not an owner with delegation enabled.
+        // * `/api/auth/sso/finish` (GET, relying only): browser lands here
+        //   after the owner completes the OAuth dance; we redeem the code
+        //   and mint a local session. 404s when this process owns the
+        //   OAuth app directly.
+        .route("/api/auth/sso/redeem", post(routes::auth::sso_redeem))
+        .route("/api/auth/sso/finish", get(routes::auth::sso_finish))
         // Credential routes
         .route(
             "/api/credentials",

--- a/crates/stiglab/src/server/routes/auth.rs
+++ b/crates/stiglab/src/server/routes/auth.rs
@@ -461,7 +461,17 @@ pub async fn sso_finish(
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
         tracing::error!(status = %status, body = %text, "sso_finish: redeem rejected");
-        return (StatusCode::BAD_GATEWAY, "redeem rejected").into_response();
+        // Owner 4xx ("expired/redeemed/unknown code", "bad bearer") is a
+        // client-facing problem with the preview's request — propagate as
+        // 400. Reserve 502 for real upstream failures (5xx, timeouts,
+        // connectivity) so the preview's browser-visible status matches
+        // the underlying condition.
+        let mapped = if status.is_client_error() {
+            StatusCode::BAD_REQUEST
+        } else {
+            StatusCode::BAD_GATEWAY
+        };
+        return (mapped, "redeem rejected").into_response();
     }
 
     let payload: SsoRedeemResponse = match resp.json().await {

--- a/crates/stiglab/src/server/routes/auth.rs
+++ b/crates/stiglab/src/server/routes/auth.rs
@@ -1,5 +1,5 @@
 use axum::extract::{Query, State};
-use axum::http::{header, StatusCode};
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::Json;
 use chrono::Utc;
@@ -12,7 +12,21 @@ use crate::server::auth::{
     github_authorize_url, AuthUser,
 };
 use crate::server::db;
+use crate::server::sso::{
+    self, generate_exchange_code, return_to_allowed, secrets_equal, sign_state, verify_state,
+    SsoMode, StateClaims, EXCHANGE_CODE_LIFETIME_SECS, STATE_LIFETIME_SECS,
+};
 use crate::server::state::AppState;
+
+// ── GitHub OAuth entry + callback (owner) / redirect-to-owner (relying) ──
+
+#[derive(serde::Deserialize)]
+pub struct LoginParams {
+    /// Optional URL the owner should 302 to after a successful sign-in,
+    /// in place of minting a local session. Only honored when
+    /// `return_to`'s host is in the owner's allowlist.
+    return_to: Option<String>,
+}
 
 #[derive(serde::Deserialize)]
 pub struct CallbackParams {
@@ -20,52 +34,174 @@ pub struct CallbackParams {
     state: String,
 }
 
-/// GET /api/auth/github — Redirect to GitHub OAuth
-pub async fn github_login(State(state): State<AppState>) -> impl IntoResponse {
-    let config = &state.config;
-
-    let Some(ref client_id) = config.github_client_id else {
-        return (StatusCode::NOT_FOUND, "auth not configured").into_response();
-    };
-
-    let callback_url = build_callback_url(config);
-    let csrf_state = generate_state();
-
-    let url = github_authorize_url(client_id, &callback_url, &csrf_state);
-
-    // Set CSRF state in cookie
-    let sec = secure_attr(config);
-    let cookie = format!(
-        "stiglab_oauth_state={csrf_state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600{sec}"
-    );
-
-    ([(header::SET_COOKIE, cookie)], Redirect::temporary(&url)).into_response()
-}
-
-/// GET /api/auth/github/callback — Handle OAuth callback
-pub async fn github_callback(
+/// GET /api/auth/github — Start sign-in.
+///
+/// * Owner mode: redirect to GitHub with a signed state envelope.
+/// * Relying mode: redirect to the owner's `/api/auth/github`, passing our
+///   own `/api/auth/sso/finish` as `return_to`.
+/// * Disabled: 404.
+pub async fn github_login(
     State(state): State<AppState>,
-    Query(params): Query<CallbackParams>,
-    headers: axum::http::HeaderMap,
+    Query(params): Query<LoginParams>,
 ) -> impl IntoResponse {
     let config = &state.config;
 
-    let (Some(ref client_id), Some(ref client_secret)) =
-        (&config.github_client_id, &config.github_client_secret)
-    else {
+    match config.sso_mode() {
+        SsoMode::Disabled => (StatusCode::NOT_FOUND, "auth not configured").into_response(),
+        SsoMode::Relying => {
+            // Previews never talk to GitHub directly — bounce through prod.
+            let auth_domain = config
+                .sso_auth_domain
+                .as_deref()
+                .expect("relying mode implies sso_auth_domain set");
+            let Some(public_url) = config.public_url.as_deref() else {
+                tracing::error!(
+                    "cannot initiate relying-mode SSO: STIGLAB_PUBLIC_URL is unset, \
+                     so we have nowhere to tell the owner to send the browser back to"
+                );
+                return (StatusCode::INTERNAL_SERVER_ERROR, "auth misconfigured").into_response();
+            };
+            let return_to = format!("{public_url}/api/auth/sso/finish");
+            let target = match reqwest::Url::parse_with_params(
+                &format!("{auth_domain}/api/auth/github"),
+                &[("return_to", return_to.as_str())],
+            ) {
+                Ok(u) => u.to_string(),
+                Err(e) => {
+                    tracing::error!("failed to build relying-mode redirect URL: {e}");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "auth misconfigured")
+                        .into_response();
+                }
+            };
+            Redirect::temporary(&target).into_response()
+        }
+        SsoMode::Owner { delegate_enabled } => {
+            let Some(client_id) = config.github_client_id.as_deref() else {
+                return (StatusCode::NOT_FOUND, "auth not configured").into_response();
+            };
+
+            // If a `return_to` was provided, it must pass the allowlist
+            // before we even involve GitHub. We reject here rather than at
+            // the callback so misconfigured relying parties fail fast.
+            let return_to = match params.return_to {
+                None => None,
+                Some(ref rt) => {
+                    if !delegate_enabled {
+                        return (
+                            StatusCode::FORBIDDEN,
+                            "cross-environment SSO delegation is not enabled on this owner",
+                        )
+                            .into_response();
+                    }
+                    if !return_to_allowed(&config.sso_return_host_allowlist, rt) {
+                        tracing::warn!(return_to = %rt, "rejected SSO delegation: return_to not on allowlist");
+                        return (StatusCode::FORBIDDEN, "return_to not allowed").into_response();
+                    }
+                    Some(rt.clone())
+                }
+            };
+
+            let csrf_nonce = generate_state();
+            let now = Utc::now().timestamp();
+            let claims = StateClaims {
+                c: csrf_nonce.clone(),
+                r: return_to,
+                e: now + STATE_LIFETIME_SECS,
+            };
+
+            // When delegation is enabled we HMAC-sign the envelope so the
+            // callback can trust the return_to. When only simple OAuth is
+            // needed, fall back to a bare nonce to preserve existing
+            // behavior on owners that haven't opted into delegation.
+            let state_param = if delegate_enabled {
+                let secret = config
+                    .sso_state_secret
+                    .as_deref()
+                    .expect("delegate_enabled implies sso_state_secret set");
+                sign_state(secret, &claims)
+            } else {
+                csrf_nonce.clone()
+            };
+
+            let callback_url = build_callback_url(config);
+            let url = github_authorize_url(client_id, &callback_url, &state_param);
+
+            let sec = secure_attr(config);
+            let cookie = format!(
+                "stiglab_oauth_state={csrf_nonce}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600{sec}"
+            );
+
+            ([(header::SET_COOKIE, cookie)], Redirect::temporary(&url)).into_response()
+        }
+    }
+}
+
+/// GET /api/auth/github/callback — Handle OAuth callback.
+///
+/// In owner mode, exchanges the code for a GitHub token and either mints
+/// a local session (standalone login) or mints an exchange code and 302s
+/// to the return_to URL (delegated login for a preview).
+pub async fn github_callback(
+    State(state): State<AppState>,
+    Query(params): Query<CallbackParams>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let config = &state.config;
+
+    let SsoMode::Owner { delegate_enabled } = config.sso_mode() else {
         return (StatusCode::NOT_FOUND, "auth not configured").into_response();
     };
 
-    // Verify CSRF state
+    let (Some(client_id), Some(client_secret)) = (
+        config.github_client_id.as_deref(),
+        config.github_client_secret.as_deref(),
+    ) else {
+        return (StatusCode::NOT_FOUND, "auth not configured").into_response();
+    };
+
+    // Parse CSRF cookie once — used by both branches below.
     let cookie_header = headers
         .get(header::COOKIE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    let stored_state = auth::parse_cookie(cookie_header, "stiglab_oauth_state");
+    let cookie_csrf = auth::parse_cookie(cookie_header, "stiglab_oauth_state");
 
-    if stored_state != Some(params.state.as_str()) {
-        return (StatusCode::BAD_REQUEST, "invalid OAuth state").into_response();
-    }
+    // Delegated login carries an HMAC-signed state envelope; standalone
+    // login carries a bare nonce that must equal the CSRF cookie.
+    let claims: Option<StateClaims> = if delegate_enabled {
+        let secret = config
+            .sso_state_secret
+            .as_deref()
+            .expect("delegate_enabled implies sso_state_secret set");
+        verify_state(secret, &params.state, Utc::now().timestamp())
+    } else {
+        None
+    };
+
+    let delegated_return_to: Option<String> = match claims {
+        Some(ref c) => {
+            if cookie_csrf != Some(c.c.as_str()) {
+                return (StatusCode::BAD_REQUEST, "invalid OAuth state").into_response();
+            }
+            // If the envelope carries a return_to, double-check the
+            // allowlist at redemption time — the allowlist may have been
+            // tightened between start and callback.
+            if let Some(ref rt) = c.r {
+                if !return_to_allowed(&config.sso_return_host_allowlist, rt) {
+                    tracing::warn!(return_to = %rt, "callback rejected delegated SSO: return_to no longer allowed");
+                    return (StatusCode::FORBIDDEN, "return_to not allowed").into_response();
+                }
+            }
+            c.r.clone()
+        }
+        None => {
+            // Bare-nonce path — matches the pre-delegation behavior.
+            if cookie_csrf != Some(params.state.as_str()) {
+                return (StatusCode::BAD_REQUEST, "invalid OAuth state").into_response();
+            }
+            None
+        }
+    };
 
     // Exchange code for token
     let token = match exchange_code(client_id, client_secret, &params.code).await {
@@ -98,7 +234,7 @@ pub async fn github_callback(
     let user = User {
         id: user_id.clone(),
         github_id: gh_user.id,
-        github_login: gh_user.login,
+        github_login: gh_user.login.clone(),
         github_name: gh_user.name,
         github_avatar_url: gh_user.avatar_url,
         created_at: existing.map(|u| u.created_at).unwrap_or_else(Utc::now),
@@ -110,7 +246,46 @@ pub async fn github_callback(
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
 
-    // Create auth session
+    let sec = secure_attr(config);
+    let clear_state_cookie =
+        format!("stiglab_oauth_state=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0{sec}");
+
+    if let Some(return_to) = delegated_return_to {
+        // Delegated login: mint a single-use exchange code and 302 home.
+        // The relying party redeems it server-to-server in `sso_finish`.
+        let host = match sso::host_of(&return_to) {
+            Some(h) => h,
+            None => {
+                return (StatusCode::BAD_REQUEST, "invalid return_to").into_response();
+            }
+        };
+        let code = generate_exchange_code();
+        let expires_at = Utc::now() + chrono::Duration::seconds(EXCHANGE_CODE_LIFETIME_SECS);
+        if let Err(e) =
+            db::insert_sso_exchange_code(&state.db, &code, &user_id, &host, expires_at).await
+        {
+            tracing::error!("failed to insert sso exchange code: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+
+        tracing::info!(
+            user = %user.github_login,
+            return_to_host = %host,
+            "sso delegation: issued exchange code"
+        );
+
+        let sep = if return_to.contains('?') { '&' } else { '?' };
+        let location = format!("{return_to}{sep}code={code}");
+        return Response::builder()
+            .status(StatusCode::FOUND)
+            .header(header::LOCATION, location)
+            .header(header::SET_COOKIE, clear_state_cookie)
+            .body(axum::body::Body::empty())
+            .unwrap()
+            .into_response();
+    }
+
+    // Standalone login: mint a local session.
     let session_token = generate_session_token();
     let expires_at = Utc::now() + chrono::Duration::days(30);
 
@@ -121,13 +296,9 @@ pub async fn github_callback(
 
     tracing::info!("user logged in: {} ({})", user.github_login, user_id);
 
-    // Set session cookie and clear CSRF cookie
-    let sec = secure_attr(config);
     let session_cookie = format!(
         "stiglab_session={session_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=2592000{sec}"
     );
-    let clear_state_cookie =
-        format!("stiglab_oauth_state=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0{sec}");
 
     Response::builder()
         .status(StatusCode::FOUND)
@@ -139,9 +310,225 @@ pub async fn github_callback(
         .into_response()
 }
 
+// ── Owner-side: /api/auth/sso/redeem (back-channel) ──
+
+#[derive(serde::Deserialize)]
+pub struct SsoRedeemRequest {
+    pub code: String,
+    /// The host the caller is claiming the code was issued for. Must match
+    /// the host baked into the code at issuance.
+    pub host: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SsoRedeemResponse {
+    pub user: SsoUserPayload,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct SsoUserPayload {
+    pub github_id: i64,
+    pub github_login: String,
+    pub github_name: Option<String>,
+    pub github_avatar_url: Option<String>,
+}
+
+/// POST /api/auth/sso/redeem — Exchange an opaque code for user identity.
+///
+/// Called server-to-server by a relying party. Requires
+/// `Authorization: Bearer <SSO_EXCHANGE_SECRET>`. Returns 404 when this
+/// process is not an owner with delegation enabled — the route simply
+/// doesn't exist on a standalone deploy.
+pub async fn sso_redeem(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<SsoRedeemRequest>,
+) -> impl IntoResponse {
+    let config = &state.config;
+
+    let SsoMode::Owner {
+        delegate_enabled: true,
+    } = config.sso_mode()
+    else {
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    };
+
+    let expected_bearer = config
+        .sso_exchange_secret
+        .as_deref()
+        .expect("delegate_enabled implies sso_exchange_secret set");
+    if !bearer_matches(&headers, expected_bearer) {
+        return (StatusCode::UNAUTHORIZED, "invalid bearer").into_response();
+    }
+
+    match db::redeem_sso_exchange_code(&state.db, &body.code, &body.host).await {
+        Ok(Some(user)) => {
+            tracing::info!(
+                user = %user.github_login,
+                host = %body.host,
+                "sso delegation: redeemed exchange code"
+            );
+            Json(SsoRedeemResponse {
+                user: SsoUserPayload {
+                    github_id: user.github_id,
+                    github_login: user.github_login,
+                    github_name: user.github_name,
+                    github_avatar_url: user.github_avatar_url,
+                },
+            })
+            .into_response()
+        }
+        Ok(None) => (StatusCode::BAD_REQUEST, "invalid or expired code").into_response(),
+        Err(e) => {
+            tracing::error!("sso_redeem db error: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}
+
+fn bearer_matches(headers: &HeaderMap, expected: &str) -> bool {
+    let Some(header_val) = headers.get(header::AUTHORIZATION) else {
+        return false;
+    };
+    let Ok(header_str) = header_val.to_str() else {
+        return false;
+    };
+    let Some(token) = header_str.strip_prefix("Bearer ") else {
+        return false;
+    };
+    secrets_equal(token.trim(), expected)
+}
+
+// ── Relying-side: /api/auth/sso/finish ──
+
+#[derive(serde::Deserialize)]
+pub struct SsoFinishParams {
+    code: String,
+}
+
+/// GET /api/auth/sso/finish — Relying-side landing after the owner
+/// completes the OAuth dance.
+///
+/// Server-to-server call to the owner's `/sso/redeem`, then mint a local
+/// session and set the `stiglab_session` cookie on our own origin.
+pub async fn sso_finish(
+    State(state): State<AppState>,
+    Query(params): Query<SsoFinishParams>,
+) -> impl IntoResponse {
+    let config = &state.config;
+
+    if config.sso_mode() != SsoMode::Relying {
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+
+    let auth_domain = config
+        .sso_auth_domain
+        .as_deref()
+        .expect("relying implies sso_auth_domain set");
+    let exchange_secret = config
+        .sso_exchange_secret
+        .as_deref()
+        .expect("relying implies sso_exchange_secret set");
+    let Some(public_url) = config.public_url.as_deref() else {
+        tracing::error!("sso_finish: STIGLAB_PUBLIC_URL is unset");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "auth misconfigured").into_response();
+    };
+
+    let Some(our_host) = sso::host_of(public_url) else {
+        tracing::error!(public_url, "sso_finish: STIGLAB_PUBLIC_URL has no host");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "auth misconfigured").into_response();
+    };
+
+    let redeem_url = format!("{auth_domain}/api/auth/sso/redeem");
+    let body = serde_json::json!({ "code": params.code, "host": our_host });
+
+    let client = reqwest::Client::new();
+    let resp = match client
+        .post(&redeem_url)
+        .bearer_auth(exchange_secret)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("sso_finish: redeem request failed: {e}");
+            return (StatusCode::BAD_GATEWAY, "owner unreachable").into_response();
+        }
+    };
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        tracing::error!(status = %status, body = %text, "sso_finish: redeem rejected");
+        return (StatusCode::BAD_GATEWAY, "redeem rejected").into_response();
+    }
+
+    let payload: SsoRedeemResponse = match resp.json().await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!("sso_finish: failed to parse redeem response: {e}");
+            return (StatusCode::BAD_GATEWAY, "bad redeem response").into_response();
+        }
+    };
+
+    // Upsert the user locally. The preview maintains its own users table;
+    // the github_id is the stable key across environments.
+    let existing = db::get_user_by_github_id(&state.db, payload.user.github_id)
+        .await
+        .ok()
+        .flatten();
+    let user_id = existing
+        .as_ref()
+        .map(|u| u.id.clone())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let user = User {
+        id: user_id.clone(),
+        github_id: payload.user.github_id,
+        github_login: payload.user.github_login.clone(),
+        github_name: payload.user.github_name,
+        github_avatar_url: payload.user.github_avatar_url,
+        created_at: existing.map(|u| u.created_at).unwrap_or_else(Utc::now),
+        updated_at: Utc::now(),
+    };
+
+    if let Err(e) = db::upsert_user(&state.db, &user).await {
+        tracing::error!("sso_finish: failed to upsert user: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+    }
+
+    let session_token = generate_session_token();
+    let expires_at = Utc::now() + chrono::Duration::days(30);
+    if let Err(e) = db::create_auth_session(&state.db, &session_token, &user_id, expires_at).await {
+        tracing::error!("sso_finish: failed to create auth session: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+    }
+
+    tracing::info!(
+        user = %user.github_login,
+        host = %our_host,
+        "sso delegation: minted preview session"
+    );
+
+    let sec = secure_attr(config);
+    let session_cookie = format!(
+        "stiglab_session={session_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=2592000{sec}"
+    );
+
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, "/")
+        .header(header::SET_COOKIE, session_cookie)
+        .body(axum::body::Body::empty())
+        .unwrap()
+        .into_response()
+}
+
+// ── /api/auth/me + logout (unchanged behavior) ──
+
 /// GET /api/auth/me — Return current authenticated user
 pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl IntoResponse {
-    // Return auth_enabled flag so frontend knows whether to show login
     Json(serde_json::json!({
         "user": {
             "id": auth_user.user_id,
@@ -154,10 +541,7 @@ pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl Into
 }
 
 /// POST /api/auth/logout — Delete auth session and clear cookie
-pub async fn logout(
-    State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
-) -> impl IntoResponse {
+pub async fn logout(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let cookie_header = headers
         .get(header::COOKIE)
         .and_then(|v| v.to_str().ok())

--- a/crates/stiglab/src/server/sso.rs
+++ b/crates/stiglab/src/server/sso.rs
@@ -85,9 +85,11 @@ pub fn verify_state(secret: &str, state: &str, now_unix: i64) -> Option<StateCla
 
 /// Parse a comma-separated env-var list like `*.preview.onsager.ai,app.onsager.ai`
 /// into an allowlist vector. Empty and whitespace-only entries are dropped.
+/// Hostnames are case-insensitive in DNS, so entries are lower-cased here so
+/// the match path can compare as raw bytes without per-call normalization.
 pub fn parse_host_allowlist(raw: &str) -> Vec<String> {
     raw.split(',')
-        .map(|s| s.trim().to_string())
+        .map(|s| s.trim().to_ascii_lowercase())
         .filter(|s| !s.is_empty())
         .collect()
 }
@@ -120,6 +122,10 @@ pub fn host_of(url: &str) -> Option<String> {
 }
 
 fn host_matches_allowlist(allowlist: &[String], host: &str) -> bool {
+    // Allowlist entries are already lowercased by `parse_host_allowlist`;
+    // lowercase the incoming host here so both branches compare uniformly
+    // (the wildcard branch uses raw `ends_with`, which is case-sensitive).
+    let host = host.to_ascii_lowercase();
     for entry in allowlist {
         if let Some(suffix) = entry.strip_prefix("*.") {
             // Strict subdomain match: `host` must be `<something>.suffix`.
@@ -129,7 +135,7 @@ fn host_matches_allowlist(allowlist: &[String], host: &str) -> bool {
             {
                 return true;
             }
-        } else if host.eq_ignore_ascii_case(entry) {
+        } else if host == *entry {
             return true;
         }
     }
@@ -256,6 +262,17 @@ mod tests {
     }
 
     #[test]
+    fn allowlist_is_case_insensitive_for_both_branches() {
+        // `parse_host_allowlist` lowercases entries; matching lowercases
+        // the host. Exact-host and wildcard branches must behave the same.
+        let allow = parse_host_allowlist("*.PREVIEW.onsager.ai,APP.onsager.ai");
+        assert!(host_matches_allowlist(&allow, "Pr-1.Preview.Onsager.AI"));
+        assert!(host_matches_allowlist(&allow, "app.ONSAGER.ai"));
+        // Still rejects the usual suffix attack regardless of casing.
+        assert!(!host_matches_allowlist(&allow, "EvilPreview.Onsager.AI"));
+    }
+
+    #[test]
     fn return_to_requires_valid_url() {
         let allow = vec!["*.preview.onsager.ai".into()];
         assert!(return_to_allowed(
@@ -271,8 +288,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_allowlist_trims_and_filters() {
-        let v = parse_host_allowlist(" *.preview.onsager.ai , app.onsager.ai ,  ");
+    fn parse_allowlist_trims_filters_and_lowercases() {
+        let v = parse_host_allowlist(" *.PREVIEW.onsager.ai , App.Onsager.AI ,  ");
         assert_eq!(
             v,
             vec![

--- a/crates/stiglab/src/server/sso.rs
+++ b/crates/stiglab/src/server/sso.rs
@@ -1,0 +1,311 @@
+//! Cross-environment SSO — "auth-domain proxy with back-channel exchange."
+//!
+//! Prod (the OAuth app owner) registers a single GitHub callback. Preview
+//! environments on Railway piggy-back off it: the preview redirects the
+//! browser to prod's `/api/auth/github?return_to=…`, prod completes the
+//! OAuth dance, and hands back a short-lived opaque code that the preview
+//! redeems server-to-server (with a shared bearer secret) for the user
+//! identity. The preview then mints its own local session.
+//!
+//! The state carried through GitHub is an HMAC-signed envelope containing
+//! the CSRF nonce (also echoed in a cookie on the owner) and the optional
+//! `return_to` URL. The owner refuses any `return_to` whose host is not in
+//! `SSO_RETURN_HOST_ALLOWLIST`.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::hmac;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+
+/// How this process relates to the GitHub OAuth app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SsoMode {
+    /// No auth configured — anonymous user.
+    Disabled,
+    /// Owns the GitHub OAuth app; handles callbacks directly.
+    /// `delegate_enabled` is true when the owner-side secrets for serving
+    /// preview environments are also set.
+    Owner { delegate_enabled: bool },
+    /// Delegates to a remote owner; never talks to GitHub itself.
+    Relying,
+}
+
+/// Maximum clock skew tolerated when verifying a state envelope, in seconds.
+const STATE_SKEW_SECS: i64 = 10;
+
+/// Lifetime of an OAuth state envelope — long enough for a human to finish
+/// typing their password on github.com, short enough that replayed states
+/// don't linger.
+pub const STATE_LIFETIME_SECS: i64 = 600;
+
+/// Lifetime of an exchange code — long enough for the preview's server to
+/// follow the redirect and call back to prod.
+pub const EXCHANGE_CODE_LIFETIME_SECS: i64 = 30;
+
+/// Signed-envelope payload. Field names are abbreviated so the encoded
+/// form stays under URL-length limits even with long return_to values.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StateClaims {
+    /// CSRF nonce — also stored in `stiglab_oauth_state` cookie on the owner.
+    pub c: String,
+    /// Optional return URL; when present, the callback mints an exchange
+    /// code and 302s here instead of minting a local session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r: Option<String>,
+    /// Unix expiry timestamp.
+    pub e: i64,
+}
+
+/// Encode and sign the state payload. Output format: `<b64url(json)>.<hex(hmac)>`.
+pub fn sign_state(secret: &str, claims: &StateClaims) -> String {
+    let json = serde_json::to_vec(claims).expect("state claims serialize to JSON");
+    let body = URL_SAFE_NO_PAD.encode(&json);
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes());
+    let tag = hmac::sign(&key, body.as_bytes());
+    format!("{body}.{}", hex::encode(tag.as_ref()))
+}
+
+/// Verify an HMAC-signed state envelope. Returns the claims on success,
+/// or `None` on any signature, format, or expiry failure.
+pub fn verify_state(secret: &str, state: &str, now_unix: i64) -> Option<StateClaims> {
+    let (body_b64, tag_hex) = state.split_once('.')?;
+    let expected_tag = hex::decode(tag_hex).ok()?;
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes());
+    hmac::verify(&key, body_b64.as_bytes(), &expected_tag).ok()?;
+
+    let json = URL_SAFE_NO_PAD.decode(body_b64).ok()?;
+    let claims: StateClaims = serde_json::from_slice(&json).ok()?;
+
+    if claims.e + STATE_SKEW_SECS < now_unix {
+        return None;
+    }
+    Some(claims)
+}
+
+/// Parse a comma-separated env-var list like `*.preview.onsager.ai,app.onsager.ai`
+/// into an allowlist vector. Empty and whitespace-only entries are dropped.
+pub fn parse_host_allowlist(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Check whether a full `return_to` URL is acceptable. Rules:
+/// * URL must parse and be `http`- or `https`-scheme.
+/// * Host must match an allowlist entry.
+///   * `*.example.com` matches any strict subdomain of `example.com`.
+///   * `example.com` matches only `example.com` exactly.
+pub fn return_to_allowed(allowlist: &[String], return_to: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(return_to) else {
+        return false;
+    };
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return false,
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    host_matches_allowlist(allowlist, host)
+}
+
+/// Extract the host component of a URL — useful for comparing the host
+/// claimed by the redeemer to the host baked into the exchange code.
+pub fn host_of(url: &str) -> Option<String> {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+}
+
+fn host_matches_allowlist(allowlist: &[String], host: &str) -> bool {
+    for entry in allowlist {
+        if let Some(suffix) = entry.strip_prefix("*.") {
+            // Strict subdomain match: `host` must be `<something>.suffix`.
+            if host.len() > suffix.len() + 1
+                && host.ends_with(suffix)
+                && host.as_bytes()[host.len() - suffix.len() - 1] == b'.'
+            {
+                return true;
+            }
+        } else if host.eq_ignore_ascii_case(entry) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Generate an opaque single-use exchange code (URL-safe, 32 bytes of entropy).
+pub fn generate_exchange_code() -> String {
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes).expect("rng");
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Constant-time secret comparison. Both inputs are compared as raw bytes.
+/// Short-circuits only on length mismatch — the attacker controls whether
+/// a comparison is made at all, not how long it takes once started.
+pub fn secrets_equal(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let claims = StateClaims {
+            c: "csrf123".into(),
+            r: Some("https://pr-1.preview.example.com/cb".into()),
+            e: 1_000_000_000,
+        };
+        let s = sign_state("secret", &claims);
+        let verified = verify_state("secret", &s, claims.e - 1).unwrap();
+        assert_eq!(verified, claims);
+    }
+
+    #[test]
+    fn verify_rejects_wrong_secret() {
+        let claims = StateClaims {
+            c: "csrf".into(),
+            r: None,
+            e: 2_000_000_000,
+        };
+        let s = sign_state("secret-a", &claims);
+        assert!(verify_state("secret-b", &s, 0).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_expired() {
+        let claims = StateClaims {
+            c: "csrf".into(),
+            r: None,
+            e: 1_000,
+        };
+        let s = sign_state("k", &claims);
+        // `now` far beyond expiry + skew.
+        assert!(verify_state("k", &s, 1_000 + STATE_SKEW_SECS + 1).is_none());
+    }
+
+    #[test]
+    fn verify_tolerates_small_skew() {
+        let claims = StateClaims {
+            c: "csrf".into(),
+            r: None,
+            e: 1_000,
+        };
+        let s = sign_state("k", &claims);
+        assert!(verify_state("k", &s, 1_000 + STATE_SKEW_SECS).is_some());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_body() {
+        let claims = StateClaims {
+            c: "csrf".into(),
+            r: Some("https://good.example/cb".into()),
+            e: 9_999_999_999,
+        };
+        let s = sign_state("k", &claims);
+        // Swap a character in the body portion (before the dot).
+        let dot = s.find('.').unwrap();
+        let mut bytes = s.into_bytes();
+        bytes[0] = if bytes[0] == b'a' { b'b' } else { b'a' };
+        let _ = dot; // (no-op to silence unused)
+        let tampered = String::from_utf8(bytes).unwrap();
+        assert!(verify_state("k", &tampered, 0).is_none());
+    }
+
+    #[test]
+    fn allowlist_subdomain_match() {
+        let allow = vec!["*.preview.onsager.ai".into()];
+        assert!(host_matches_allowlist(&allow, "pr-1.preview.onsager.ai"));
+        assert!(host_matches_allowlist(&allow, "a.b.preview.onsager.ai"));
+        // Apex does not match `*.preview.onsager.ai`.
+        assert!(!host_matches_allowlist(&allow, "preview.onsager.ai"));
+        // Suffix-only attack: `evilpreview.onsager.ai` must not match.
+        assert!(!host_matches_allowlist(&allow, "evilpreview.onsager.ai"));
+        // Totally unrelated.
+        assert!(!host_matches_allowlist(&allow, "attacker.com"));
+    }
+
+    #[test]
+    fn allowlist_exact_match() {
+        let allow = vec!["app.onsager.ai".into()];
+        assert!(host_matches_allowlist(&allow, "app.onsager.ai"));
+        assert!(host_matches_allowlist(&allow, "APP.ONSAGER.AI"));
+        assert!(!host_matches_allowlist(&allow, "foo.app.onsager.ai"));
+        assert!(!host_matches_allowlist(&allow, "app.onsager.com"));
+    }
+
+    #[test]
+    fn allowlist_empty_rejects_all() {
+        let allow: Vec<String> = vec![];
+        assert!(!host_matches_allowlist(&allow, "anything.com"));
+    }
+
+    #[test]
+    fn return_to_requires_valid_url() {
+        let allow = vec!["*.preview.onsager.ai".into()];
+        assert!(return_to_allowed(
+            &allow,
+            "https://pr-1.preview.onsager.ai/api/auth/sso/finish"
+        ));
+        assert!(!return_to_allowed(&allow, "not a url"));
+        assert!(!return_to_allowed(&allow, "javascript:alert(1)"));
+        assert!(!return_to_allowed(
+            &allow,
+            "ftp://pr-1.preview.onsager.ai/x"
+        ));
+    }
+
+    #[test]
+    fn parse_allowlist_trims_and_filters() {
+        let v = parse_host_allowlist(" *.preview.onsager.ai , app.onsager.ai ,  ");
+        assert_eq!(
+            v,
+            vec![
+                "*.preview.onsager.ai".to_string(),
+                "app.onsager.ai".to_string()
+            ]
+        );
+        assert!(parse_host_allowlist("").is_empty());
+        assert!(parse_host_allowlist("  ,  ").is_empty());
+    }
+
+    #[test]
+    fn generate_exchange_code_is_unique() {
+        let a = generate_exchange_code();
+        let b = generate_exchange_code();
+        assert_ne!(a, b);
+        assert!(URL_SAFE_NO_PAD.decode(&a).is_ok());
+    }
+
+    #[test]
+    fn secrets_equal_matches() {
+        assert!(secrets_equal("abc", "abc"));
+        assert!(!secrets_equal("abc", "abd"));
+        assert!(!secrets_equal("abc", "abcd"));
+        assert!(!secrets_equal("", "abc"));
+    }
+
+    #[test]
+    fn host_of_extracts_host() {
+        assert_eq!(
+            host_of("https://pr-1.preview.onsager.ai/cb?x=1"),
+            Some("pr-1.preview.onsager.ai".into())
+        );
+        assert_eq!(host_of("not a url"), None);
+    }
+}

--- a/crates/stiglab/tests/sso.rs
+++ b/crates/stiglab/tests/sso.rs
@@ -1,0 +1,385 @@
+//! Integration tests for cross-environment SSO delegation.
+//!
+//! Covers the two concrete risk areas that aren't exercised by the unit
+//! tests in `server::sso` and `server::config`:
+//!   * the DB-level single-use gate on `sso_exchange_codes`, and
+//!   * the mode-gating on `/api/auth/sso/redeem` and `/api/auth/sso/finish`
+//!     (each route must 404 outside its own mode).
+//!
+//! GitHub is never called; the happy-path tests stop at redeem. The full
+//! owner-callback → exchange-code → relying-finish round-trip is covered
+//! by the DB tests plus the mode-gating tests — wiring a fake GitHub into
+//! these integration tests would add complexity without catching new bugs.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::Utc;
+use sqlx::pool::PoolOptions;
+use sqlx::AnyPool;
+use stiglab::core::User;
+use stiglab::server::config::ServerConfig;
+use stiglab::server::db;
+use stiglab::server::state::AppState;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+async fn test_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = PoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite connect");
+    db::run_migrations(&pool).await.expect("migrations");
+    pool
+}
+
+fn base_config() -> ServerConfig {
+    ServerConfig {
+        host: "0.0.0.0".into(),
+        port: 3000,
+        database_url: "sqlite::memory:".into(),
+        static_dir: None,
+        cors_origin: None,
+        github_client_id: None,
+        github_client_secret: None,
+        credential_key: None,
+        public_url: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
+    }
+}
+
+fn owner_config() -> ServerConfig {
+    ServerConfig {
+        github_client_id: Some("client-id".into()),
+        github_client_secret: Some("client-secret".into()),
+        sso_state_secret: Some("state-secret".into()),
+        sso_exchange_secret: Some("exchange-secret".into()),
+        sso_return_host_allowlist: vec!["*.preview.example.com".into()],
+        public_url: Some("https://app.example.com".into()),
+        ..base_config()
+    }
+}
+
+fn relying_config() -> ServerConfig {
+    ServerConfig {
+        sso_auth_domain: Some("https://app.example.com".into()),
+        sso_exchange_secret: Some("exchange-secret".into()),
+        public_url: Some("https://pr-1.preview.example.com".into()),
+        ..base_config()
+    }
+}
+
+async fn seed_user(pool: &AnyPool) -> User {
+    let user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id: 42,
+        github_login: "octocat".into(),
+        github_name: Some("Octo Cat".into()),
+        github_avatar_url: Some("https://example.com/a.png".into()),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(pool, &user).await.unwrap();
+    user
+}
+
+// ── DB-level exchange-code lifecycle ──
+
+#[tokio::test]
+async fn redeem_happy_path_returns_user_once() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    db::insert_sso_exchange_code(
+        &pool,
+        "code-xyz",
+        &user.id,
+        "pr-1.preview.example.com",
+        Utc::now() + chrono::Duration::seconds(30),
+    )
+    .await
+    .unwrap();
+
+    let got = db::redeem_sso_exchange_code(&pool, "code-xyz", "pr-1.preview.example.com")
+        .await
+        .unwrap();
+    assert!(got.is_some());
+    assert_eq!(got.unwrap().github_id, user.github_id);
+
+    // Second redemption must fail — single-use gate.
+    let again = db::redeem_sso_exchange_code(&pool, "code-xyz", "pr-1.preview.example.com")
+        .await
+        .unwrap();
+    assert!(again.is_none());
+}
+
+#[tokio::test]
+async fn redeem_rejects_host_mismatch() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    db::insert_sso_exchange_code(
+        &pool,
+        "code-a",
+        &user.id,
+        "pr-1.preview.example.com",
+        Utc::now() + chrono::Duration::seconds(30),
+    )
+    .await
+    .unwrap();
+
+    // Even with the right code, a different host must not redeem.
+    let got = db::redeem_sso_exchange_code(&pool, "code-a", "pr-2.preview.example.com")
+        .await
+        .unwrap();
+    assert!(got.is_none());
+
+    // And the code is NOT consumed by a failed host check — the intended
+    // relying party can still redeem it.
+    let got = db::redeem_sso_exchange_code(&pool, "code-a", "pr-1.preview.example.com")
+        .await
+        .unwrap();
+    assert!(got.is_some());
+}
+
+#[tokio::test]
+async fn redeem_rejects_expired_code() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    db::insert_sso_exchange_code(
+        &pool,
+        "code-expired",
+        &user.id,
+        "pr-1.preview.example.com",
+        // Expired one second ago.
+        Utc::now() - chrono::Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+
+    let got = db::redeem_sso_exchange_code(&pool, "code-expired", "pr-1.preview.example.com")
+        .await
+        .unwrap();
+    assert!(got.is_none());
+}
+
+#[tokio::test]
+async fn redeem_rejects_unknown_code() {
+    let pool = test_pool().await;
+    let _ = seed_user(&pool).await;
+
+    let got = db::redeem_sso_exchange_code(&pool, "does-not-exist", "pr-1.preview.example.com")
+        .await
+        .unwrap();
+    assert!(got.is_none());
+}
+
+// ── Route-level mode gating ──
+
+fn app(state: AppState) -> axum::Router {
+    stiglab::server::build_router(state.clone(), &state.config)
+}
+
+fn redeem_request(bearer: &str, code: &str, host: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/api/auth/sso/redeem")
+        .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({ "code": code, "host": host }).to_string(),
+        ))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn redeem_route_404s_outside_owner_mode() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, relying_config(), None);
+    let resp = app(state)
+        .oneshot(redeem_request("exchange-secret", "x", "h"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn redeem_route_401s_on_bad_bearer() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, owner_config(), None);
+    let resp = app(state)
+        .oneshot(redeem_request(
+            "wrong-secret",
+            "x",
+            "pr-1.preview.example.com",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn redeem_route_happy_path() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    db::insert_sso_exchange_code(
+        &pool,
+        "good-code",
+        &user.id,
+        "pr-1.preview.example.com",
+        Utc::now() + chrono::Duration::seconds(30),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, owner_config(), None);
+
+    let resp = app(state)
+        .oneshot(redeem_request(
+            "exchange-secret",
+            "good-code",
+            "pr-1.preview.example.com",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["user"]["github_id"], 42);
+    assert_eq!(v["user"]["github_login"], "octocat");
+}
+
+#[tokio::test]
+async fn redeem_route_rejects_used_code() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    db::insert_sso_exchange_code(
+        &pool,
+        "once",
+        &user.id,
+        "pr-1.preview.example.com",
+        Utc::now() + chrono::Duration::seconds(30),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, owner_config(), None);
+
+    let app_ = app(state);
+    let first = app_
+        .clone()
+        .oneshot(redeem_request(
+            "exchange-secret",
+            "once",
+            "pr-1.preview.example.com",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = app_
+        .oneshot(redeem_request(
+            "exchange-secret",
+            "once",
+            "pr-1.preview.example.com",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn finish_route_404s_outside_relying_mode() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, owner_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/sso/finish?code=whatever")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn relying_github_login_redirects_to_owner() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, relying_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/github")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let location = resp
+        .headers()
+        .get(header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(location.starts_with("https://app.example.com/api/auth/github?"));
+    assert!(location.contains("return_to=https"));
+    assert!(location.contains("preview.example.com"));
+}
+
+#[tokio::test]
+async fn owner_github_login_rejects_return_to_not_on_allowlist() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, owner_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/github?return_to=https://attacker.com/cb")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn owner_github_login_accepts_allowlisted_return_to() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, owner_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/github?return_to=https://pr-1.preview.example.com/api/auth/sso/finish")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Redirects to GitHub, setting the CSRF cookie along the way.
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let location = resp
+        .headers()
+        .get(header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(location.starts_with("https://github.com/login/oauth/authorize"));
+    // The state param must be an HMAC envelope (contains a dot), not a bare nonce.
+    let url = reqwest::Url::parse(location).unwrap();
+    let state_val = url
+        .query_pairs()
+        .find(|(k, _)| k == "state")
+        .map(|(_, v)| v.into_owned())
+        .unwrap();
+    assert!(
+        state_val.contains('.'),
+        "expected HMAC envelope, got bare nonce: {state_val}"
+    );
+}

--- a/crates/stiglab/tests/workflow_webhook.rs
+++ b/crates/stiglab/tests/workflow_webhook.rs
@@ -132,6 +132,10 @@ fn app_state(pool: AnyPool) -> AppState {
         github_client_secret: None,
         credential_key: Some(TEST_KEY_HEX.to_string()),
         public_url: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
     };
     // Auth disabled — the webhook receiver doesn't need AuthUser; the CRUD
     // routes aren't exercised here.

--- a/railway.toml
+++ b/railway.toml
@@ -74,6 +74,22 @@ numReplicas = 1
 #                               split, etc.).
 #   GITHUB_CLIENT_ID          — GitHub OAuth app client ID
 #   GITHUB_CLIENT_SECRET      — GitHub OAuth app client secret
+#
+# Cross-environment SSO (owner side — prod only):
+#   The preview environments piggy-back off prod's GitHub OAuth app via a
+#   back-channel exchange. Prod registers a single OAuth callback with
+#   GitHub; previews delegate to prod over HTTPS. Set these on prod only —
+#   they must NOT be set on preview environments.
+#
+#   SSO_STATE_SECRET            — HMAC secret signing the OAuth `state`
+#                                 envelope (≥ 32 random bytes).
+#   SSO_EXCHANGE_SECRET         — shared bearer token: previews present
+#                                 this to POST /api/auth/sso/redeem.
+#   SSO_RETURN_HOST_ALLOWLIST   — comma-separated. Entries may be a strict
+#                                 subdomain pattern (`*.preview.onsager.ai`)
+#                                 or an exact host (`app.onsager.ai`).
+#                                 Any `return_to` whose host is not listed
+#                                 is rejected at the start of the flow.
 #   SYNODIC_PORT              — internal port for synodic (default: 3001)
 #   PORTAL_PORT               — internal port for onsager-portal (default: 3002)
 #   GITHUB_TOKEN              — optional PAT used by the portal for posting
@@ -146,3 +162,19 @@ ONSAGER_PREVIEW = "true"
 # STIGLAB_WEBHOOK_BASE_URL per-PR. Production deliberately leaves this
 # unset — see the webhook resolution notes above.
 STIGLAB_TRUST_FORWARDED_HEADERS = "1"
+
+# Cross-environment SSO (relying side).
+#
+# Previews never talk to GitHub directly. `/api/auth/github` on a preview
+# 302s to `${SSO_AUTH_DOMAIN}/api/auth/github?return_to=…`; prod runs the
+# OAuth dance against its single registered callback, then hands back an
+# opaque one-shot code via `${return_to}?code=…` which `/api/auth/sso/finish`
+# redeems server-to-server with `SSO_EXCHANGE_SECRET` as Bearer.
+#
+# SSO_EXCHANGE_SECRET must equal the value set on prod and must be kept as
+# a shared secret (configure via the Railway dashboard, NOT in the TOML).
+# GITHUB_CLIENT_ID/SECRET must NOT be set on preview environments — the
+# startup assertion panics if both owner and relying credentials are
+# present, to catch config confusion early.
+SSO_AUTH_DOMAIN = "${{SSO_AUTH_DOMAIN}}"
+SSO_EXCHANGE_SECRET = "${{SSO_EXCHANGE_SECRET}}"


### PR DESCRIPTION
Closes #115.

## Summary

Preview environments on Railway can now sign in via the production GitHub OAuth app without each preview needing its own registered callback URL. Prod owns a single callback; previews delegate to it over HTTPS via a back-channel code exchange.

**Flow.** Preview `/api/auth/github` → 302 to `prod/api/auth/github?return_to=<preview>/api/auth/sso/finish` → GitHub → `prod/api/auth/github/callback` → 302 to `<preview>/api/auth/sso/finish?code=<opaque>` → preview POSTs to `prod/api/auth/sso/redeem` (server-to-server with bearer) → preview mints its own `stiglab_session` cookie.

**Security controls.**
- HMAC-signed `state` envelope carrying `return_to` through GitHub — can't be forged, host is verified both at start and callback.
- Strict-subdomain allowlist (`*.preview.onsager.ai`) — suffix attacks like `evilpreview.onsager.ai` don't match.
- Opaque single-use exchange codes, 30s TTL, bound to the return_to host at issuance.
- Atomic single-use gate in SQL: `UPDATE sso_exchange_codes SET redeemed_at=$now WHERE redeemed_at IS NULL AND expires_at > $now AND return_to_host = $host`.
- Bearer secret on `/sso/redeem` (constant-time compare) — the code in the URL is useless without it.
- Startup assertion panics if both owner and relying credentials are set, catching config confusion.

**Three modes.**
- `Disabled` — no auth (current behavior when GitHub creds unset).
- `Owner { delegate_enabled }` — prod. Delegation activates only when `SSO_STATE_SECRET`, `SSO_EXCHANGE_SECRET`, and a non-empty `SSO_RETURN_HOST_ALLOWLIST` are all set.
- `Relying` — previews. `SSO_AUTH_DOMAIN` + `SSO_EXCHANGE_SECRET` set, GitHub creds absent.

Existing owner-only OAuth flow (no `return_to`) is preserved byte-for-byte when delegation is off — the bare-nonce CSRF check still runs and the local session is minted as before.

## What's in each file

- `crates/stiglab/src/server/sso.rs` — HMAC state sign/verify, host allowlist, exchange-code generation, constant-time compare. 15 unit tests.
- `crates/stiglab/src/server/config.rs` — new fields, `sso_mode()`, startup assertion. 11 unit tests including `#[should_panic]` for each misconfiguration.
- `crates/stiglab/src/server/db.rs` — `sso_exchange_codes` table + `insert_sso_exchange_code` / `redeem_sso_exchange_code`.
- `crates/stiglab/src/server/routes/auth.rs` — `github_login` branches on mode; `github_callback` branches on whether state carries `return_to`; new `sso_redeem` and `sso_finish` handlers.
- `crates/stiglab/src/server/mod.rs` — registers `/api/auth/sso/redeem` and `/api/auth/sso/finish`.
- `crates/stiglab/tests/sso.rs` — 12 integration tests covering the DB single-use gate and route-level mode gating.
- `railway.toml` — preview envs get `SSO_AUTH_DOMAIN` + `SSO_EXCHANGE_SECRET`; inline docs for the owner-side vars.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p stiglab` — 111 unit + 12 new SSO + 6 existing webhook tests pass
- [ ] In Railway: set `SSO_STATE_SECRET`, `SSO_EXCHANGE_SECRET`, `SSO_RETURN_HOST_ALLOWLIST=*.up.railway.app` (or custom preview domain) on prod; set `SSO_AUTH_DOMAIN` + `SSO_EXCHANGE_SECRET` (same value) on preview scope.
- [ ] Open a PR to trigger a preview deploy; visit the preview's `/` → get redirected through prod → land back on preview signed in.
- [ ] Second click on an already-redeemed URL → BAD_REQUEST (single-use gate).
- [ ] Manually hit prod `/api/auth/github?return_to=https://attacker.com/cb` → FORBIDDEN.

## Follow-ups not in this PR

- Background job to `DELETE FROM sso_exchange_codes WHERE expires_at < now() - interval '1 hour'`.
- Rate-limit `/api/auth/sso/redeem` per bearer to bound damage from a leaked `SSO_EXCHANGE_SECRET`.
- If/when a second relying party shows up, consider swapping the hand-rolled exchange for real OIDC (prod becomes an OIDC provider, previews are RPs using a standard crate).