### PR TITLE
fix(stiglab): accept webhook at /api/github-app/webhook alias

### DIFF
--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -140,12 +140,12 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/webhooks/github",
             post(routes::webhooks::handle).layer(axum::extract::DefaultBodyLimit::max(1024 * 1024)),
         )
-        // Forgiving alias for the webhook receiver. The `/api/github-app/*`
-        // prefix hosts the GET-only OAuth/install flow, so a GitHub App
-        // configured to POST its webhook to `/api/github-app/webhook` (a
-        // plausible-looking but wrong URL) would otherwise 405. Accept it
-        // here so a misconfigured App heals itself instead of silently
-        // dropping every delivery.
+        // Forgiving alias for the webhook receiver. `/api/github-app/*`
+        // hosts the GET-only OAuth/install flow and had no POST handler
+        // here, so a GitHub App configured to POST its webhook to
+        // `/api/github-app/webhook` (a plausible-looking but wrong URL)
+        // had every delivery silently dropped. Accept it so a
+        // misconfigured App heals itself.
         .route(
             "/api/github-app/webhook",
             post(routes::webhooks::handle).layer(axum::extract::DefaultBodyLimit::max(1024 * 1024)),

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -140,6 +140,16 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/webhooks/github",
             post(routes::webhooks::handle).layer(axum::extract::DefaultBodyLimit::max(1024 * 1024)),
         )
+        // Forgiving alias for the webhook receiver. The `/api/github-app/*`
+        // prefix hosts the GET-only OAuth/install flow, so a GitHub App
+        // configured to POST its webhook to `/api/github-app/webhook` (a
+        // plausible-looking but wrong URL) would otherwise 405. Accept it
+        // here so a misconfigured App heals itself instead of silently
+        // dropping every delivery.
+        .route(
+            "/api/github-app/webhook",
+            post(routes::webhooks::handle).layer(axum::extract::DefaultBodyLimit::max(1024 * 1024)),
+        )
         // Workflow CRUD (issue #81).
         .route(
             "/api/workflows",

--- a/crates/stiglab/tests/workflow_webhook.rs
+++ b/crates/stiglab/tests/workflow_webhook.rs
@@ -192,6 +192,40 @@ async fn webhook_with_valid_signature_returns_202() {
 }
 
 #[tokio::test]
+async fn webhook_alias_under_github_app_prefix_returns_202() {
+    // `/api/github-app/*` hosts the GET-only OAuth/install flow. A GitHub
+    // App configured to POST its webhook to `/api/github-app/webhook` (a
+    // plausible-looking but wrong URL) would 405 without this alias; we
+    // accept it so a misconfigured App heals itself.
+    let pool = test_pool().await;
+    let install_id = 987;
+    let tenant_id = seed_tenant_and_installation(&pool, install_id).await;
+    seed_active_workflow(&pool, &tenant_id, install_id, "spec").await;
+
+    let state = app_state(pool);
+    let config = state.config.clone();
+    let app = stiglab::server::build_router(state, &config);
+
+    let body = issues_labeled_payload(install_id, "spec");
+    let sig = hmac_header(&body, b"webhook-shared-secret");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/github-app/webhook")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", sig)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
 async fn webhook_with_bad_signature_returns_401() {
     let pool = test_pool().await;
     let install_id = 987;

--- a/crates/stiglab/tests/workflow_webhook.rs
+++ b/crates/stiglab/tests/workflow_webhook.rs
@@ -193,10 +193,10 @@ async fn webhook_with_valid_signature_returns_202() {
 
 #[tokio::test]
 async fn webhook_alias_under_github_app_prefix_returns_202() {
-    // `/api/github-app/*` hosts the GET-only OAuth/install flow. A GitHub
-    // App configured to POST its webhook to `/api/github-app/webhook` (a
-    // plausible-looking but wrong URL) would 405 without this alias; we
-    // accept it so a misconfigured App heals itself.
+    // `/api/github-app/*` hosts the GET-only OAuth/install flow and had
+    // no handler at `/api/github-app/webhook`, so an App configured to
+    // POST its webhook there never reached the handler. Verify the alias
+    // catches it.
     let pool = test_pool().await;
     let install_id = 987;
     let tenant_id = seed_tenant_and_installation(&pool, install_id).await;


### PR DESCRIPTION
Part of #120.

## Summary

- A tenant configured their GitHub App to POST webhooks to `https://app.onsager.ai/api/github-app/webhook`. That prefix hosts only GET-only OAuth/install endpoints, so the POST fell through to the SPA shell (`ServeFile` refuses non-GET with 405) and every `issues.labeled` delivery was silently dropped — activated workflows never fired.
- Add a POST alias at `/api/github-app/webhook` that dispatches to the same `routes::webhooks::handle` (same 1 MiB body limit). A misconfigured App now heals itself instead of dropping every delivery.
- The canonical URL is still `/api/webhooks/github`; the alias is purely a forgiving path.

This PR lands only Plan item 1 of spec #120. Items 2 (alias-path logging), 3 (install-time URL enforcement), and 4 (dashboard webhook-health surfacing) are follow-ups.

## Test plan
- [x] `cargo test -p stiglab --test workflow_webhook` — 7 passed, including a new `webhook_alias_under_github_app_prefix_returns_202` that posts a signed `issues.labeled` to `/api/github-app/webhook` and asserts 202.
- [x] `cargo fmt -p stiglab -- --check`
- [x] `cargo clippy -p stiglab --all-targets -- -D warnings`
- [ ] Post-deploy: re-send a past `issues.labeled` delivery from the GitHub App's Recent Deliveries to `/api/github-app/webhook`; confirm 202 and a `TriggerFired` event on the spine.

https://claude.ai/code/session_01CBVAZTGcr83dWMbMPrdBwu