### PR TITLE
fix(stiglab): fall back to shared app webhook secret env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # GITHUB_CLIENT_SECRET=
 # STIGLAB_CREDENTIAL_KEY=          # 32-byte hex key for AES-256-GCM credential encryption
 # STIGLAB_PUBLIC_URL=               # Public URL for OAuth callback
+# Shared webhook secret for the Onsager GitHub App. Used to verify HMAC
+# signatures on installations registered via the OAuth callback (which
+# don't store a per-install cipher). Per-install secrets, if configured
+# via the manual tenant endpoint, take precedence.
+# GITHUB_APP_WEBHOOK_SECRET=
 
 # Webhook base URL — where stiglab tells GitHub to deliver repo webhooks.
 # Resolved in this order; first non-empty layer wins:

--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -13,6 +13,10 @@ pub struct ServerConfig {
     pub github_client_secret: Option<String>,
     pub credential_key: Option<String>,
     pub public_url: Option<String>,
+    /// Shared webhook secret for the (single) Onsager GitHub App. Used to
+    /// verify HMAC signatures when an installation has no per-install
+    /// override cipher. Set via `GITHUB_APP_WEBHOOK_SECRET`.
+    pub github_app_webhook_secret: Option<String>,
     /// Cross-environment SSO — owner side. `Some` on the prod deployment
     /// that owns the GitHub OAuth app and is willing to serve preview envs.
     pub sso_state_secret: Option<String>,
@@ -48,6 +52,9 @@ impl ServerConfig {
             .filter(|s| !s.is_empty());
         let credential_key = env::var("STIGLAB_CREDENTIAL_KEY").ok();
         let public_url = env::var("STIGLAB_PUBLIC_URL").ok();
+        let github_app_webhook_secret = env::var("GITHUB_APP_WEBHOOK_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty());
         let sso_state_secret = env::var("SSO_STATE_SECRET").ok().filter(|s| !s.is_empty());
         let sso_exchange_secret = env::var("SSO_EXCHANGE_SECRET")
             .ok()
@@ -70,6 +77,7 @@ impl ServerConfig {
             github_client_secret,
             credential_key,
             public_url,
+            github_app_webhook_secret,
             sso_state_secret,
             sso_exchange_secret,
             sso_return_host_allowlist,
@@ -153,6 +161,7 @@ mod tests {
             github_client_secret: None,
             credential_key: None,
             public_url: None,
+            github_app_webhook_secret: None,
             sso_state_secret: None,
             sso_exchange_secret: None,
             sso_return_host_allowlist: Vec::new(),

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -90,31 +90,49 @@ pub async fn handle(State(state): State<AppState>, headers: HeaderMap, body: Byt
         }
     };
 
-    let cipher = match workflow_db::get_install_webhook_secret_cipher(&state.db, install_id).await {
-        Ok(Some(c)) => c,
-        Ok(None) => {
-            tracing::warn!(install_id, "installation has no webhook secret");
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({ "error": "unknown installation" })),
-            )
-                .into_response();
+    let per_install_cipher =
+        match workflow_db::get_install_webhook_secret_cipher(&state.db, install_id).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("install secret lookup failed: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+    // Precedence: per-install cipher (manual tenant endpoint) → shared App
+    // secret from `GITHUB_APP_WEBHOOK_SECRET` (Railway env var). The shared
+    // secret covers installs registered via the normal OAuth callback, which
+    // persists the row without a cipher.
+    let secret = match per_install_cipher {
+        Some(cipher) => {
+            let Some(key_hex) = state.config.credential_key.as_ref() else {
+                tracing::error!(
+                    "STIGLAB_CREDENTIAL_KEY not set — cannot decrypt per-install webhook secret"
+                );
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            };
+            match decrypt_credential(key_hex, &cipher) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!("webhook secret decrypt failed: {e}");
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
+            }
         }
-        Err(e) => {
-            tracing::error!("install secret lookup failed: {e}");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
-    let Some(key_hex) = state.config.credential_key.as_ref() else {
-        tracing::error!("STIGLAB_CREDENTIAL_KEY not set — cannot verify webhook signature");
-        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    };
-    let secret = match decrypt_credential(key_hex, &cipher) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("webhook secret decrypt failed: {e}");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
+        None => match state.config.github_app_webhook_secret.as_deref() {
+            Some(s) => s.to_string(),
+            None => {
+                tracing::warn!(
+                    install_id,
+                    "no webhook secret available (no per-install cipher and \
+                     GITHUB_APP_WEBHOOK_SECRET unset)"
+                );
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({ "error": "unknown installation" })),
+                )
+                    .into_response();
+            }
+        },
     };
     let Some(sig) = signature.as_deref() else {
         return (

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -11,6 +11,8 @@
 //! deliveries, malformed signatures, and unknown installations all return
 //! `401`. Malformed payloads return `400`. Successful routing returns `202`.
 
+use std::borrow::Cow;
+
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -90,20 +92,27 @@ pub async fn handle(State(state): State<AppState>, headers: HeaderMap, body: Byt
         }
     };
 
-    let per_install_cipher =
-        match workflow_db::get_install_webhook_secret_cipher(&state.db, install_id).await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!("install secret lookup failed: {e}");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-        };
+    let lookup = match workflow_db::get_install_webhook_secret_cipher(&state.db, install_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("install secret lookup failed: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
     // Precedence: per-install cipher (manual tenant endpoint) → shared App
-    // secret from `GITHUB_APP_WEBHOOK_SECRET` (Railway env var). The shared
-    // secret covers installs registered via the normal OAuth callback, which
-    // persists the row without a cipher.
-    let secret = match per_install_cipher {
-        Some(cipher) => {
+    // secret from `GITHUB_APP_WEBHOOK_SECRET` (Railway env var) when the
+    // install row exists without a cipher. Unknown installations still fail
+    // closed — the global fallback is only reachable for rows we registered.
+    let secret: Cow<'_, str> = match lookup {
+        None => {
+            tracing::warn!(install_id, "unknown installation");
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": "unknown installation" })),
+            )
+                .into_response();
+        }
+        Some(Some(cipher)) => {
             let Some(key_hex) = state.config.credential_key.as_ref() else {
                 tracing::error!(
                     "STIGLAB_CREDENTIAL_KEY not set — cannot decrypt per-install webhook secret"
@@ -111,20 +120,19 @@ pub async fn handle(State(state): State<AppState>, headers: HeaderMap, body: Byt
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             };
             match decrypt_credential(key_hex, &cipher) {
-                Ok(s) => s,
+                Ok(s) => Cow::Owned(s),
                 Err(e) => {
                     tracing::error!("webhook secret decrypt failed: {e}");
                     return StatusCode::INTERNAL_SERVER_ERROR.into_response();
                 }
             }
         }
-        None => match state.config.github_app_webhook_secret.as_deref() {
-            Some(s) => s.to_string(),
+        Some(None) => match state.config.github_app_webhook_secret.as_deref() {
+            Some(s) => Cow::Borrowed(s),
             None => {
                 tracing::warn!(
                     install_id,
-                    "no webhook secret available (no per-install cipher and \
-                     GITHUB_APP_WEBHOOK_SECRET unset)"
+                    "install has no per-install cipher and GITHUB_APP_WEBHOOK_SECRET unset"
                 );
                 return (
                     StatusCode::UNAUTHORIZED,

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -621,6 +621,7 @@ async fn resolve_install_webhook_secret(state: &AppState, install_id: i64) -> Op
     let cipher = workflow_db::get_install_webhook_secret_cipher(&state.db, install_id)
         .await
         .ok()
+        .flatten()
         .flatten()?;
     let key = state.config.credential_key.as_ref()?;
     decrypt_credential(key, &cipher).ok()

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -247,20 +247,26 @@ pub async fn any_other_active_workflow_on_repo(
     Ok(count > 0)
 }
 
-/// Look up the webhook-secret cipher for a given numeric install id. Returns
-/// `None` when the install row has no secret yet (the webhook receiver
-/// fails closed on that — see issue #81 notes).
+/// Look up the webhook-secret cipher for a given numeric install id.
+///
+/// Outer `Option` distinguishes installation presence so the webhook
+/// handler can fail closed on genuinely unknown installations while still
+/// falling back to the global App secret for installs registered via the
+/// OAuth callback (which persist without a cipher):
+/// - `None` — no row for this `install_id` (unknown installation).
+/// - `Some(None)` — row exists, no per-install cipher stored.
+/// - `Some(Some(cipher))` — row exists with a per-install cipher.
 pub async fn get_install_webhook_secret_cipher(
     pool: &AnyPool,
     install_id: i64,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<Option<String>>> {
     let row: Option<(Option<String>,)> = sqlx::query_as(
         "SELECT webhook_secret_cipher FROM github_app_installations WHERE install_id = $1",
     )
     .bind(install_id)
     .fetch_optional(pool)
     .await?;
-    Ok(row.and_then(|(c,)| c))
+    Ok(row.map(|(c,)| c))
 }
 
 /// Resolve `(install_id, repo_owner, repo_name)` for a workflow — used by the

--- a/crates/stiglab/tests/sso.rs
+++ b/crates/stiglab/tests/sso.rs
@@ -45,6 +45,7 @@ fn base_config() -> ServerConfig {
         github_client_secret: None,
         credential_key: None,
         public_url: None,
+        github_app_webhook_secret: None,
         sso_state_secret: None,
         sso_exchange_secret: None,
         sso_return_host_allowlist: Vec::new(),

--- a/crates/stiglab/tests/workflow_webhook.rs
+++ b/crates/stiglab/tests/workflow_webhook.rs
@@ -92,6 +92,60 @@ async fn seed_tenant_and_installation(pool: &AnyPool, install_numeric_id: i64) -
     tenant_id
 }
 
+/// Seed an installation as the OAuth-callback flow does — row exists, but
+/// no per-install webhook-secret cipher is stored. The global App secret
+/// from `GITHUB_APP_WEBHOOK_SECRET` is expected to cover it.
+async fn seed_tenant_and_installation_without_cipher(
+    pool: &AnyPool,
+    install_numeric_id: i64,
+) -> String {
+    let tenant_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO users (id, github_id, github_login, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $4)",
+    )
+    .bind("u1")
+    .bind(1i64)
+    .bind("u1")
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let t = Tenant {
+        id: tenant_id.clone(),
+        slug: format!("t-{}", &tenant_id[..8]),
+        name: "workspace".into(),
+        created_by: "u1".into(),
+        created_at: Utc::now(),
+    };
+    db::insert_tenant(pool, &t).await.unwrap();
+    db::insert_tenant_member(
+        pool,
+        &TenantMember {
+            tenant_id: tenant_id.clone(),
+            user_id: "u1".into(),
+            joined_at: Utc::now(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let install = GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        tenant_id: tenant_id.clone(),
+        install_id: install_numeric_id,
+        account_login: "acme".into(),
+        account_type: GitHubAccountType::Organization,
+        created_at: Utc::now(),
+    };
+    db::insert_github_app_installation(pool, &install, None)
+        .await
+        .unwrap();
+
+    tenant_id
+}
+
 async fn seed_active_workflow(pool: &AnyPool, tenant_id: &str, install_id: i64, label: &str) {
     let now = Utc::now();
     let wf = Workflow {
@@ -362,11 +416,11 @@ async fn webhook_with_malformed_body_returns_400() {
 
 #[tokio::test]
 async fn webhook_with_global_app_secret_is_verified_and_accepted() {
-    // Installation registered via the OAuth callback has no per-install
-    // cipher. The `GITHUB_APP_WEBHOOK_SECRET` env var is the fallback the
-    // HMAC is checked against.
+    // Install row exists (via OAuth callback) but has no per-install
+    // cipher — the `GITHUB_APP_WEBHOOK_SECRET` env var is the fallback.
     let pool = test_pool().await;
     let install_id = 126368686;
+    seed_tenant_and_installation_without_cipher(&pool, install_id).await;
     let mut state = app_state(pool);
     let mut cfg = state.config.clone();
     cfg.github_app_webhook_secret = Some("railway-app-secret".into());
@@ -398,6 +452,7 @@ async fn webhook_with_global_app_secret_is_verified_and_accepted() {
 async fn webhook_with_global_app_secret_rejects_bad_signature() {
     let pool = test_pool().await;
     let install_id = 126368686;
+    seed_tenant_and_installation_without_cipher(&pool, install_id).await;
     let mut state = app_state(pool);
     let mut cfg = state.config.clone();
     cfg.github_app_webhook_secret = Some("railway-app-secret".into());
@@ -408,6 +463,38 @@ async fn webhook_with_global_app_secret_rejects_bad_signature() {
 
     let body = issues_labeled_payload(install_id, "spec");
     let sig = hmac_header(&body, b"wrong-secret");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/webhooks/github")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", sig)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_with_global_app_secret_but_unknown_install_returns_401() {
+    // Regression guard: the global-secret fallback must NOT accept
+    // webhooks for installations stiglab has never seen.
+    let pool = test_pool().await;
+    let mut state = app_state(pool);
+    let mut cfg = state.config.clone();
+    cfg.github_app_webhook_secret = Some("railway-app-secret".into());
+    state.config = cfg;
+
+    let config = state.config.clone();
+    let app = stiglab::server::build_router(state, &config);
+
+    let body = issues_labeled_payload(9999, "spec");
+    let sig = hmac_header(&body, b"railway-app-secret");
 
     let resp = app
         .oneshot(

--- a/crates/stiglab/tests/workflow_webhook.rs
+++ b/crates/stiglab/tests/workflow_webhook.rs
@@ -132,6 +132,7 @@ fn app_state(pool: AnyPool) -> AppState {
         github_client_secret: None,
         credential_key: Some(TEST_KEY_HEX.to_string()),
         public_url: None,
+        github_app_webhook_secret: None,
         sso_state_secret: None,
         sso_exchange_secret: None,
         sso_return_host_allowlist: Vec::new(),
@@ -357,4 +358,69 @@ async fn webhook_with_malformed_body_returns_400() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn webhook_with_global_app_secret_is_verified_and_accepted() {
+    // Installation registered via the OAuth callback has no per-install
+    // cipher. The `GITHUB_APP_WEBHOOK_SECRET` env var is the fallback the
+    // HMAC is checked against.
+    let pool = test_pool().await;
+    let install_id = 126368686;
+    let mut state = app_state(pool);
+    let mut cfg = state.config.clone();
+    cfg.github_app_webhook_secret = Some("railway-app-secret".into());
+    state.config = cfg;
+
+    let config = state.config.clone();
+    let app = stiglab::server::build_router(state, &config);
+
+    let body = issues_labeled_payload(install_id, "spec");
+    let sig = hmac_header(&body, b"railway-app-secret");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/webhooks/github")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", sig)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn webhook_with_global_app_secret_rejects_bad_signature() {
+    let pool = test_pool().await;
+    let install_id = 126368686;
+    let mut state = app_state(pool);
+    let mut cfg = state.config.clone();
+    cfg.github_app_webhook_secret = Some("railway-app-secret".into());
+    state.config = cfg;
+
+    let config = state.config.clone();
+    let app = stiglab::server::build_router(state, &config);
+
+    let body = issues_labeled_payload(install_id, "spec");
+    let sig = hmac_header(&body, b"wrong-secret");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/webhooks/github")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", sig)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }


### PR DESCRIPTION
## Summary

- Installations registered via the GitHub App OAuth callback (`tenants.rs:918`) persist without a per-install webhook-secret cipher, so every delivery for them was 401'd at `webhooks.rs:95` as `"unknown installation"`. Observed in prod for install `126368686`.
- Add `GITHUB_APP_WEBHOOK_SECRET` to `ServerConfig` (managed via Railway env vars) and honor it as the fallback secret when no per-install cipher is stored. Per-install overrides from the manual tenant endpoint still take precedence.
- Decryption via `STIGLAB_CREDENTIAL_KEY` now only runs on the per-install path — the fallback uses the plaintext env var directly.

## Why env var (not a new `github_apps` table)

Onsager runs a single GitHub App, and Railway env vars *are* managed secret storage (encrypted, per-environment, rotatable from the dashboard). Rejected alternatives: App Manifest flow + `github_apps` singleton row (more surface area than justified for one secret); per-install cipher only (blocks every OAuth-flow install forever).

## Test plan

- [x] `cargo test -p stiglab --test workflow_webhook` — 9/9 pass, including two new tests covering the fallback path (`webhook_with_global_app_secret_is_verified_and_accepted`, `..._rejects_bad_signature`).
- [x] Existing `webhook_with_unknown_installation_returns_401` stands in as the regression check: still 401s when neither per-install cipher nor global secret is set.
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`, `cargo test --workspace --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean.
- [ ] After merge: set `GITHUB_APP_WEBHOOK_SECRET` in the Railway `stiglab` service to the value shown on the App's GitHub settings page, then redeliver a past webhook from GitHub's Recent Deliveries to confirm 202.

https://claude.ai/code/session_017u3wMDmT6DLNsA5bUno5p7

---
_Generated by [Claude Code](https://claude.ai/code/session_017u3wMDmT6DLNsA5bUno5p7)_