### PR TITLE
fix(forge): lazy-load workflows + surface events/sessions in workflow detail

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/WorkflowEventsCard.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowEventsCard.tsx
@@ -1,0 +1,105 @@
+import { Fragment, useMemo, useState } from "react"
+import { useQueries } from "@tanstack/react-query"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import { api, type SpineEvent, type WorkflowRun } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+// Events scoped to a single workflow: one `trigger.fired` stream keyed by
+// workflow_id plus a per-artifact stream (`workflow:{artifact_id}`) for
+// stage.entered / stage.gate_* / stage.advanced. Fans out into N+1 small
+// queries rather than one over-wide query so we only pull the events that
+// actually belong to this workflow.
+export function WorkflowEventsCard({
+  workflowId,
+  runs,
+}: {
+  workflowId: string
+  runs: WorkflowRun[]
+}) {
+  const artifactIds = useMemo(
+    () =>
+      Array.from(
+        new Set(runs.map((r) => r.artifact_id).filter((id): id is string => !!id)),
+      ),
+    [runs],
+  )
+
+  const streamIds = useMemo(
+    () => [`workflow:${workflowId}`, ...artifactIds.map((id) => `workflow:${id}`)],
+    [workflowId, artifactIds],
+  )
+
+  const queries = useQueries({
+    queries: streamIds.map((sid) => ({
+      queryKey: ["workflow-events", sid],
+      queryFn: () => api.getSpineEvents({ stream_id: sid, limit: 50 }),
+      refetchInterval: 5000,
+    })),
+  })
+
+  const events = useMemo(() => {
+    const all: SpineEvent[] = []
+    for (const q of queries) {
+      if (q.data?.events) all.push(...q.data.events)
+    }
+    all.sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    return all.slice(0, 50)
+  }, [queries])
+
+  const loading = queries.some((q) => q.isLoading)
+
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Events</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 md:px-6">
+        {loading ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+        ) : events.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No events yet. They appear as triggers fire and stages advance.
+          </p>
+        ) : (
+          events.map((e) => <EventRow key={`${e.id}-${e.stream_id}`} event={e} />)
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EventRow({ event }: { event: SpineEvent }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <Badge variant="outline" className="shrink-0 font-mono text-[10px]">
+          {event.event_type}
+        </Badge>
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          {event.stream_id}
+        </span>
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+          {new Date(event.created_at).toLocaleString()}
+        </span>
+      </button>
+      {open && (
+        <Fragment>
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words border-t bg-muted/30 p-3 text-xs text-muted-foreground">
+            {JSON.stringify(event.data ?? {}, null, 2)}
+          </pre>
+        </Fragment>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/WorkflowSessionsCard.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowSessionsCard.tsx
@@ -1,33 +1,58 @@
 import { useMemo } from "react"
 import { Link } from "react-router-dom"
-import { useQuery } from "@tanstack/react-query"
+import { useQueries } from "@tanstack/react-query"
 import { api, type WorkflowRun } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-// Sessions linked to this workflow's artifacts. Derived from
-// `stiglab.session_completed` spine events (the only place the
-// session<->artifact edge is recorded on the wire). Running sessions
-// aren't yet surfaced here — they'd need a separate query that joins the
-// live sessions table to the artifact graph.
+// Sessions that shaped this workflow's artifacts. The durable edge lives
+// in the `vertical_lineage` table (artifact_id, version, session_id),
+// which forge writes on every session completion linked to an artifact.
+// The `stiglab.session_completed` event does not carry artifact_id in
+// its current emission path, so we read lineage directly via the
+// artifact-detail endpoint rather than filtering events client-side.
 export function WorkflowSessionsCard({ runs }: { runs: WorkflowRun[] }) {
   const artifactIds = useMemo(
     () =>
-      new Set(runs.map((r) => r.artifact_id).filter((id): id is string => !!id)),
+      Array.from(
+        new Set(runs.map((r) => r.artifact_id).filter((id): id is string => !!id)),
+      ),
     [runs],
   )
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["workflow-sessions", [...artifactIds].sort()],
-    queryFn: () => api.getSessionSpend(100),
-    refetchInterval: 5000,
-    enabled: artifactIds.size > 0,
+  const queries = useQueries({
+    queries: artifactIds.map((id) => ({
+      queryKey: ["artifact", id],
+      queryFn: () => api.getArtifact(id),
+      refetchInterval: 5000,
+    })),
   })
 
   const rows = useMemo(() => {
-    if (!data) return []
-    return data.filter((r) => r.artifact_id && artifactIds.has(r.artifact_id))
-  }, [data, artifactIds])
+    const out: {
+      session_id: string
+      artifact_id: string
+      version: number
+      recorded_at: string
+    }[] = []
+    for (let i = 0; i < queries.length; i++) {
+      const artifact_id = artifactIds[i]
+      const detail = queries[i].data?.artifact
+      if (!detail) continue
+      for (const lineage of detail.vertical_lineage ?? []) {
+        out.push({
+          session_id: lineage.session_id,
+          artifact_id,
+          version: lineage.version,
+          recorded_at: lineage.recorded_at,
+        })
+      }
+    }
+    out.sort((a, b) => (a.recorded_at < b.recorded_at ? 1 : -1))
+    return out
+  }, [queries, artifactIds])
+
+  const loading = queries.some((q) => q.isLoading)
 
   return (
     <Card>
@@ -35,38 +60,35 @@ export function WorkflowSessionsCard({ runs }: { runs: WorkflowRun[] }) {
         <CardTitle className="text-base">Sessions</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2 px-4 pb-4 md:px-6">
-        {artifactIds.size === 0 ? (
+        {artifactIds.length === 0 ? (
           <p className="py-4 text-center text-sm text-muted-foreground">
             No artifacts yet — sessions appear once a trigger fires and the
             first stage dispatches one.
           </p>
-        ) : isLoading ? (
+        ) : loading ? (
           <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
         ) : rows.length === 0 ? (
           <p className="py-4 text-center text-sm text-muted-foreground">
-            No completed sessions for this workflow's artifacts yet.
+            No sessions recorded against this workflow's artifacts yet.
           </p>
         ) : (
           rows.map((r) => (
             <Link
-              key={r.id}
+              key={`${r.artifact_id}:${r.session_id}:${r.version}`}
               to={`/sessions/${r.session_id}`}
               className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
             >
               <Badge variant="outline" className="shrink-0 font-mono text-[10px]">
-                session
+                v{r.version}
               </Badge>
               <span className="truncate font-mono text-xs">
                 {r.session_id.slice(0, 12)}
               </span>
-              {r.artifact_id && (
-                <span className="truncate font-mono text-[10px] text-muted-foreground">
-                  → {r.artifact_id}
-                </span>
-              )}
+              <span className="truncate font-mono text-[10px] text-muted-foreground">
+                → {r.artifact_id}
+              </span>
               <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                {formatDuration(r.duration_ms)} ·{" "}
-                {new Date(r.created_at).toLocaleString()}
+                {new Date(r.recorded_at).toLocaleString()}
               </span>
             </Link>
           ))
@@ -74,13 +96,4 @@ export function WorkflowSessionsCard({ runs }: { runs: WorkflowRun[] }) {
       </CardContent>
     </Card>
   )
-}
-
-function formatDuration(ms: number): string {
-  if (ms <= 0) return "—"
-  const s = Math.round(ms / 1000)
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  const rem = s % 60
-  return rem === 0 ? `${m}m` : `${m}m${rem}s`
 }

--- a/apps/dashboard/src/components/factory/workflows/WorkflowSessionsCard.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowSessionsCard.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react"
+import { Link } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import { api, type WorkflowRun } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+// Sessions linked to this workflow's artifacts. Derived from
+// `stiglab.session_completed` spine events (the only place the
+// session<->artifact edge is recorded on the wire). Running sessions
+// aren't yet surfaced here — they'd need a separate query that joins the
+// live sessions table to the artifact graph.
+export function WorkflowSessionsCard({ runs }: { runs: WorkflowRun[] }) {
+  const artifactIds = useMemo(
+    () =>
+      new Set(runs.map((r) => r.artifact_id).filter((id): id is string => !!id)),
+    [runs],
+  )
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["workflow-sessions", [...artifactIds].sort()],
+    queryFn: () => api.getSessionSpend(100),
+    refetchInterval: 5000,
+    enabled: artifactIds.size > 0,
+  })
+
+  const rows = useMemo(() => {
+    if (!data) return []
+    return data.filter((r) => r.artifact_id && artifactIds.has(r.artifact_id))
+  }, [data, artifactIds])
+
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Sessions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 md:px-6">
+        {artifactIds.size === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No artifacts yet — sessions appear once a trigger fires and the
+            first stage dispatches one.
+          </p>
+        ) : isLoading ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+        ) : rows.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No completed sessions for this workflow's artifacts yet.
+          </p>
+        ) : (
+          rows.map((r) => (
+            <Link
+              key={r.id}
+              to={`/sessions/${r.session_id}`}
+              className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
+            >
+              <Badge variant="outline" className="shrink-0 font-mono text-[10px]">
+                session
+              </Badge>
+              <span className="truncate font-mono text-xs">
+                {r.session_id.slice(0, 12)}
+              </span>
+              {r.artifact_id && (
+                <span className="truncate font-mono text-[10px] text-muted-foreground">
+                  → {r.artifact_id}
+                </span>
+              )}
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                {formatDuration(r.duration_ms)} ·{" "}
+                {new Date(r.created_at).toLocaleString()}
+              </span>
+            </Link>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) return "—"
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem === 0 ? `${m}m` : `${m}m${rem}s`
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -665,7 +665,12 @@ export const api = {
     });
   },
   // Spine
-  getSpineEvents: (params?: { stream_type?: string; event_type?: string; limit?: number }) => {
+  getSpineEvents: (params?: {
+    stream_type?: string;
+    event_type?: string;
+    stream_id?: string;
+    limit?: number;
+  }) => {
     const qs = params ? '?' + new URLSearchParams(
       Object.entries(params).filter(([, v]) => v != null).map(([k, v]) => [k, String(v)])
     ).toString() : '';

--- a/apps/dashboard/src/pages/SpinePage.tsx
+++ b/apps/dashboard/src/pages/SpinePage.tsx
@@ -111,7 +111,16 @@ export function SpinePage() {
                         <Fragment key={e.id}>
                           <TableRow
                             className="cursor-pointer hover:bg-muted/50"
+                            role="button"
+                            tabIndex={0}
+                            aria-expanded={isOpen}
                             onClick={() => toggle(e.id)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault()
+                                toggle(e.id)
+                              }
+                            }}
                           >
                             <TableCell className="text-muted-foreground">
                               {isOpen ? (

--- a/apps/dashboard/src/pages/SpinePage.tsx
+++ b/apps/dashboard/src/pages/SpinePage.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { ChevronDown, ChevronRight } from "lucide-react"
 import { api, type SpineEvent } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -24,6 +25,7 @@ const STREAM_TYPES = ["", "stiglab", "synodic", "forge", "ising"]
 
 export function SpinePage() {
   const [streamType, setStreamType] = useState("")
+  const [expandedId, setExpandedId] = useState<number | null>(null)
 
   const { data, isLoading } = useQuery({
     queryKey: ["spine-events", streamType],
@@ -35,6 +37,7 @@ export function SpinePage() {
   })
 
   const events = data?.events ?? []
+  const toggle = (id: number) => setExpandedId((cur) => (cur === id ? null : id))
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -78,7 +81,12 @@ export function SpinePage() {
               {/* Mobile: card list */}
               <div className="flex flex-col gap-2 md:hidden">
                 {events.map((e) => (
-                  <SpineEventCard key={e.id} event={e} />
+                  <SpineEventCard
+                    key={e.id}
+                    event={e}
+                    expanded={expandedId === e.id}
+                    onToggle={() => toggle(e.id)}
+                  />
                 ))}
               </div>
 
@@ -87,6 +95,7 @@ export function SpinePage() {
                 <Table>
                   <TableHeader>
                     <TableRow>
+                      <TableHead className="w-[32px]"></TableHead>
                       <TableHead className="w-[60px]">ID</TableHead>
                       <TableHead>Subsystem</TableHead>
                       <TableHead>Event Type</TableHead>
@@ -96,29 +105,51 @@ export function SpinePage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {events.map((e) => (
-                      <TableRow key={e.id}>
-                        <TableCell className="font-mono text-xs text-muted-foreground">
-                          {e.id}
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant="outline"
-                            className={STREAM_TYPE_COLORS[e.stream_type] || ""}
+                    {events.map((e) => {
+                      const isOpen = expandedId === e.id
+                      return (
+                        <Fragment key={e.id}>
+                          <TableRow
+                            className="cursor-pointer hover:bg-muted/50"
+                            onClick={() => toggle(e.id)}
                           >
-                            {e.stream_type}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="font-mono text-sm">{e.event_type}</TableCell>
-                        <TableCell className="max-w-[200px] truncate font-mono text-xs text-muted-foreground">
-                          {e.stream_id}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">{e.actor}</TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {new Date(e.created_at).toLocaleString()}
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                            <TableCell className="text-muted-foreground">
+                              {isOpen ? (
+                                <ChevronDown className="h-4 w-4" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4" />
+                              )}
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-muted-foreground">
+                              {e.id}
+                            </TableCell>
+                            <TableCell>
+                              <Badge
+                                variant="outline"
+                                className={STREAM_TYPE_COLORS[e.stream_type] || ""}
+                              >
+                                {e.stream_type}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="font-mono text-sm">{e.event_type}</TableCell>
+                            <TableCell className="max-w-[200px] truncate font-mono text-xs text-muted-foreground">
+                              {e.stream_id}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground">{e.actor}</TableCell>
+                            <TableCell className="text-xs text-muted-foreground">
+                              {new Date(e.created_at).toLocaleString()}
+                            </TableCell>
+                          </TableRow>
+                          {isOpen && (
+                            <TableRow>
+                              <TableCell colSpan={7} className="bg-muted/30 p-0">
+                                <EventDataPanel event={e} />
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </Fragment>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </div>
@@ -130,23 +161,55 @@ export function SpinePage() {
   )
 }
 
-function SpineEventCard({ event }: { event: SpineEvent }) {
+function SpineEventCard({
+  event,
+  expanded,
+  onToggle,
+}: {
+  event: SpineEvent
+  expanded: boolean
+  onToggle: () => void
+}) {
   return (
     <div className="flex flex-col gap-1.5 rounded-lg border p-3">
-      <div className="flex items-center gap-2">
-        <Badge variant="outline" className={STREAM_TYPE_COLORS[event.stream_type] || ""}>
-          {event.stream_type}
-        </Badge>
-        <span className="truncate font-mono text-sm">{event.event_type}</span>
-        <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
-          #{event.id}
-        </span>
-      </div>
-      <p className="truncate font-mono text-xs text-muted-foreground">{event.stream_id}</p>
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span className="truncate">{event.actor}</span>
-        <span className="shrink-0">{new Date(event.created_at).toLocaleString()}</span>
-      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex flex-col gap-1.5 text-left"
+      >
+        <div className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )}
+          <Badge variant="outline" className={STREAM_TYPE_COLORS[event.stream_type] || ""}>
+            {event.stream_type}
+          </Badge>
+          <span className="truncate font-mono text-sm">{event.event_type}</span>
+          <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
+            #{event.id}
+          </span>
+        </div>
+        <p className="truncate font-mono text-xs text-muted-foreground">{event.stream_id}</p>
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span className="truncate">{event.actor}</span>
+          <span className="shrink-0">{new Date(event.created_at).toLocaleString()}</span>
+        </div>
+      </button>
+      {expanded && <EventDataPanel event={event} />}
     </div>
+  )
+}
+
+// Render the `data` JSON blob carried by the event. Unknown shape varies by
+// `event_type`; a pretty-printed pre is the universal fallback and keeps the
+// page useful for every subsystem without a per-type component.
+export function EventDataPanel({ event }: { event: SpineEvent }) {
+  const pretty = JSON.stringify(event.data ?? {}, null, 2)
+  return (
+    <pre className="overflow-x-auto whitespace-pre-wrap break-words p-3 text-xs text-muted-foreground md:p-4">
+      {pretty}
+    </pre>
   )
 }

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -15,6 +15,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
 import { ArtifactFlowOverview } from "@/components/factory/workflows/ArtifactFlowOverview"
 import { WorkflowActions } from "@/components/factory/workflows/WorkflowActions"
+import { WorkflowEventsCard } from "@/components/factory/workflows/WorkflowEventsCard"
+import { WorkflowSessionsCard } from "@/components/factory/workflows/WorkflowSessionsCard"
 import { outputArtifactKind } from "@/components/factory/workflows/workflow-meta"
 
 const STATUS_VARIANT: Record<StageRunStatus, "default" | "secondary" | "destructive" | "outline"> = {
@@ -150,6 +152,9 @@ export function WorkflowDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      <WorkflowEventsCard workflowId={workflow.id} runs={runs} />
+      <WorkflowSessionsCard runs={runs} />
     </div>
   )
 }

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -756,28 +756,24 @@ impl TriggerHandler for WorkflowTriggerHandler {
             );
             return Ok(());
         };
-        let workflow = match workflow_persistence::load_workflow(
-            spine_ref.pool(),
-            &event.workflow_id,
-        )
-        .await
-        {
-            Ok(Some(w)) => w,
-            Ok(None) => {
-                tracing::warn!(
-                    workflow_id = %event.workflow_id,
-                    "trigger.fired for unknown workflow (no row in spine)"
-                );
-                return Ok(());
-            }
-            Err(e) => {
-                tracing::error!(
-                    workflow_id = %event.workflow_id,
-                    "forge: failed to load workflow for trigger.fired: {e}"
-                );
-                return Ok(());
-            }
-        };
+        let workflow =
+            match workflow_persistence::load_workflow(spine_ref.pool(), &event.workflow_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    tracing::warn!(
+                        workflow_id = %event.workflow_id,
+                        "trigger.fired for unknown workflow (no row in spine)"
+                    );
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::error!(
+                        workflow_id = %event.workflow_id,
+                        "forge: failed to load workflow for trigger.fired: {e}"
+                    );
+                    return Ok(());
+                }
+            };
 
         // Perform the registration under the write lock and capture the
         // resulting StageEntered event.

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -27,7 +27,6 @@ use crate::core::stage_runner::{self, StageEvent};
 use crate::core::trigger_subscriber::{
     self, register_artifact_from_trigger, TriggerFired, TriggerHandler,
 };
-use crate::core::workflow::Workflow;
 use crate::core::workflow_gates::LiveGateEvaluator;
 use crate::core::workflow_persistence;
 use crate::core::workflow_signal_listener;
@@ -335,8 +334,6 @@ struct ForgeSharedState {
     pipeline: ForgePipeline<HttpStiglabDispatcher, HttpSynodicGate>,
     kernel: BaselineKernel,
     spine: Option<EventStore>,
-    /// Active + in-flight workflows (issue #80). Keyed by workflow_id.
-    workflows: std::collections::HashMap<String, Workflow>,
     /// Shared signal cache populated by the workflow signal listener and
     /// consumed by the gate evaluator on each stage-runner tick. Held
     /// here so the HTTP API can introspect pending gates if a future
@@ -432,28 +429,19 @@ pub fn run(database_url: &str, tick_ms: u64) {
             ForgePipeline::new(stiglab, synodic).with_insight_cache(insight_cache.clone());
         pipeline.store = artifact_store;
 
-        // Load workflows (issue #80). Absent spine → empty registry.
-        let workflows = match spine.as_ref() {
-            Some(s) => match workflow_persistence::load_workflows(s.pool()).await {
-                Ok(w) => {
-                    tracing::info!("forge: loaded {} workflows from spine", w.len());
-                    w
-                }
-                Err(e) => {
-                    tracing::error!("forge: failed to load workflows: {e}");
-                    std::collections::HashMap::new()
-                }
-            },
-            None => std::collections::HashMap::new(),
-        };
-
+        // Workflows are read from the spine DB on demand — both at the top
+        // of every tick (for the stage runner) and inside the trigger
+        // handler (for `trigger.fired` lookups). No in-memory registry:
+        // stiglab's `workflows` table is the single source of truth, which
+        // means workflow edits, deactivations, and fresh creations are
+        // picked up without a restart and without risking a stale-cache
+        // branch that silently disagrees with the DB.
         let signals = SignalCache::new();
 
         let shared = Arc::new(RwLock::new(ForgeSharedState {
             pipeline,
             kernel: BaselineKernel::new(),
             spine,
-            workflows,
             signals: signals.clone(),
         }));
 
@@ -478,6 +466,27 @@ pub fn run(database_url: &str, tick_ms: u64) {
             loop {
                 interval.tick().await;
 
+                // Load workflows fresh from the spine DB before taking the
+                // tick write lock. DB query outside the lock so HTTP reads
+                // aren't blocked, and a per-tick snapshot means no stale
+                // in-memory entries can mask an edit or deactivation.
+                let workflows_snapshot = {
+                    let spine_handle = {
+                        let state = tick_shared.read().await;
+                        state.spine.clone()
+                    };
+                    match spine_handle.as_ref() {
+                        Some(s) => match workflow_persistence::load_workflows(s.pool()).await {
+                            Ok(m) => m,
+                            Err(e) => {
+                                tracing::error!("forge: failed to reload workflows: {e}");
+                                continue;
+                            }
+                        },
+                        None => std::collections::HashMap::new(),
+                    }
+                };
+
                 // Run the pipeline tick under the write lock, then release it
                 // before emitting spine events so HTTP reads aren't starved.
                 let (output, spine, stage_events, stage_touched_ids) = {
@@ -493,7 +502,6 @@ pub fn run(database_url: &str, tick_ms: u64) {
                     // before the pass so a burst of new artifacts can't
                     // synchronously hammer Stiglab under the lock.
                     gate_evaluator.reset_dispatch_budget();
-                    let workflows_snapshot = state.workflows.clone();
                     let stage_events = stage_runner::advance_workflow_artifacts(
                         &workflows_snapshot,
                         &mut state.pipeline.store,
@@ -733,55 +741,41 @@ struct WorkflowTriggerHandler {
 #[async_trait]
 impl TriggerHandler for WorkflowTriggerHandler {
     async fn on_trigger_fired(&self, event: TriggerFired) -> anyhow::Result<()> {
-        let (spine, workflow_opt) = {
+        let spine = {
             let state = self.shared.read().await;
-            (
-                state.spine.clone(),
-                state.workflows.get(&event.workflow_id).cloned(),
-            )
+            state.spine.clone()
         };
-        // Workflows are loaded into memory at startup, but new workflows
-        // can be created in stiglab while forge is running. Rather than
-        // drop a valid trigger for a workflow forge simply hasn't heard
-        // about yet, fetch it on demand and cache it in the registry.
-        let workflow = match workflow_opt {
-            Some(w) => w,
-            None => {
-                let Some(ref s) = spine else {
-                    tracing::warn!(
-                        workflow_id = %event.workflow_id,
-                        "trigger.fired for unknown workflow (no spine to lazy-load)"
-                    );
-                    return Ok(());
-                };
-                match workflow_persistence::load_workflow(s.pool(), &event.workflow_id).await {
-                    Ok(Some(w)) => {
-                        tracing::info!(
-                            workflow_id = %event.workflow_id,
-                            "forge: lazy-loaded workflow from spine for trigger.fired"
-                        );
-                        let mut state = self.shared.write().await;
-                        state
-                            .workflows
-                            .entry(event.workflow_id.clone())
-                            .or_insert_with(|| w.clone());
-                        w
-                    }
-                    Ok(None) => {
-                        tracing::warn!(
-                            workflow_id = %event.workflow_id,
-                            "trigger.fired for unknown workflow (no row in spine)"
-                        );
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            workflow_id = %event.workflow_id,
-                            "forge: failed to lazy-load workflow: {e}"
-                        );
-                        return Ok(());
-                    }
-                }
+        // Resolve the workflow by reading the spine DB directly — no
+        // in-memory cache means no stale view of active/inactive or
+        // edited stages. Absent spine means forge can't advance
+        // workflows at all; surface and bail.
+        let Some(ref spine_ref) = spine else {
+            tracing::warn!(
+                workflow_id = %event.workflow_id,
+                "trigger.fired dropped (no spine to resolve workflow)"
+            );
+            return Ok(());
+        };
+        let workflow = match workflow_persistence::load_workflow(
+            spine_ref.pool(),
+            &event.workflow_id,
+        )
+        .await
+        {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                tracing::warn!(
+                    workflow_id = %event.workflow_id,
+                    "trigger.fired for unknown workflow (no row in spine)"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::error!(
+                    workflow_id = %event.workflow_id,
+                    "forge: failed to load workflow for trigger.fired: {e}"
+                );
+                return Ok(());
             }
         };
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -740,12 +740,49 @@ impl TriggerHandler for WorkflowTriggerHandler {
                 state.workflows.get(&event.workflow_id).cloned(),
             )
         };
-        let Some(workflow) = workflow_opt else {
-            tracing::warn!(
-                workflow_id = %event.workflow_id,
-                "trigger.fired for unknown workflow"
-            );
-            return Ok(());
+        // Workflows are loaded into memory at startup, but new workflows
+        // can be created in stiglab while forge is running. Rather than
+        // drop a valid trigger for a workflow forge simply hasn't heard
+        // about yet, fetch it on demand and cache it in the registry.
+        let workflow = match workflow_opt {
+            Some(w) => w,
+            None => {
+                let Some(ref s) = spine else {
+                    tracing::warn!(
+                        workflow_id = %event.workflow_id,
+                        "trigger.fired for unknown workflow (no spine to lazy-load)"
+                    );
+                    return Ok(());
+                };
+                match workflow_persistence::load_workflow(s.pool(), &event.workflow_id).await {
+                    Ok(Some(w)) => {
+                        tracing::info!(
+                            workflow_id = %event.workflow_id,
+                            "forge: lazy-loaded workflow from spine for trigger.fired"
+                        );
+                        let mut state = self.shared.write().await;
+                        state
+                            .workflows
+                            .entry(event.workflow_id.clone())
+                            .or_insert_with(|| w.clone());
+                        w
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            workflow_id = %event.workflow_id,
+                            "trigger.fired for unknown workflow (no row in spine)"
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            workflow_id = %event.workflow_id,
+                            "forge: failed to lazy-load workflow: {e}"
+                        );
+                        return Ok(());
+                    }
+                }
+            }
         };
 
         // Perform the registration under the write lock and capture the

--- a/crates/forge/src/core/workflow_persistence.rs
+++ b/crates/forge/src/core/workflow_persistence.rs
@@ -17,13 +17,45 @@ use super::workflow::{GateSpec, StageSpec, TriggerSpec, Workflow};
 /// in-flight artifacts are also needed so the stage runner can continue
 /// walking them to completion.
 pub async fn load_workflows(pool: &PgPool) -> Result<HashMap<String, Workflow>, sqlx::Error> {
-    let wf_rows = sqlx::query(
-        "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_install_ref \
-           FROM workflows",
-    )
-    .fetch_all(pool)
-    .await?;
+    load_workflows_filtered(pool, None).await
+}
+
+/// Load a single workflow by id. Returns `Ok(None)` when no row matches.
+/// Used by the trigger handler to resolve workflows created after startup,
+/// rather than silently dropping `trigger.fired` for unknown ids.
+pub async fn load_workflow(
+    pool: &PgPool,
+    workflow_id: &str,
+) -> Result<Option<Workflow>, sqlx::Error> {
+    let map = load_workflows_filtered(pool, Some(workflow_id)).await?;
+    Ok(map.into_iter().next().map(|(_, w)| w))
+}
+
+async fn load_workflows_filtered(
+    pool: &PgPool,
+    only_id: Option<&str>,
+) -> Result<HashMap<String, Workflow>, sqlx::Error> {
+    let wf_rows = match only_id {
+        Some(id) => {
+            sqlx::query(
+                "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
+                        workspace_install_ref \
+                   FROM workflows WHERE workflow_id = $1",
+            )
+            .bind(id)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query(
+                "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
+                        workspace_install_ref \
+                   FROM workflows",
+            )
+            .fetch_all(pool)
+            .await?
+        }
+    };
 
     let mut workflows = HashMap::new();
     for row in wf_rows {

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -17,6 +17,10 @@ use crate::server::state::AppState;
 pub struct EventsQuery {
     pub stream_type: Option<String>,
     pub event_type: Option<String>,
+    /// Exact-match filter on `stream_id`. Used by per-artifact and
+    /// per-workflow views in the dashboard to pull just the events for
+    /// one entity without scanning the whole table client-side.
+    pub stream_id: Option<String>,
     pub limit: Option<i64>,
 }
 
@@ -134,55 +138,25 @@ pub async fn list_events(
     // `events_ext` stores the partition key in `namespace` and the actor inside
     // `metadata`. The API surfaces them as `stream_type` / `actor` for clients,
     // so we alias on the way out.
-    let result = match (params.stream_type.as_deref(), params.event_type.as_deref()) {
-        (Some(st), Some(et)) => {
-            sqlx::query_as::<_, SpineEvent>(
-                "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
-                        COALESCE(metadata->>'actor', '') AS actor, created_at \
-                 FROM events_ext WHERE namespace = $1 AND event_type = $2 \
-                 ORDER BY id DESC LIMIT $3",
-            )
-            .bind(st)
-            .bind(et)
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-        (Some(st), None) => {
-            sqlx::query_as::<_, SpineEvent>(
-                "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
-                        COALESCE(metadata->>'actor', '') AS actor, created_at \
-                 FROM events_ext WHERE namespace = $1 \
-                 ORDER BY id DESC LIMIT $2",
-            )
-            .bind(st)
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-        (None, Some(et)) => {
-            sqlx::query_as::<_, SpineEvent>(
-                "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
-                        COALESCE(metadata->>'actor', '') AS actor, created_at \
-                 FROM events_ext WHERE event_type = $1 \
-                 ORDER BY id DESC LIMIT $2",
-            )
-            .bind(et)
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-        (None, None) => {
-            sqlx::query_as::<_, SpineEvent>(
-                "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
-                        COALESCE(metadata->>'actor', '') AS actor, created_at \
-                 FROM events_ext ORDER BY id DESC LIMIT $1",
-            )
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-    };
+    let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
+                COALESCE(metadata->>'actor', '') AS actor, created_at \
+         FROM events_ext",
+    );
+    let mut sep = " WHERE ";
+    if let Some(st) = params.stream_type.as_deref() {
+        qb.push(sep).push("namespace = ").push_bind(st.to_string());
+        sep = " AND ";
+    }
+    if let Some(et) = params.event_type.as_deref() {
+        qb.push(sep).push("event_type = ").push_bind(et.to_string());
+        sep = " AND ";
+    }
+    if let Some(sid) = params.stream_id.as_deref() {
+        qb.push(sep).push("stream_id = ").push_bind(sid.to_string());
+    }
+    qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
+    let result = qb.build_query_as::<SpineEvent>().fetch_all(pool).await;
 
     match result {
         Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),


### PR DESCRIPTION
Closes #125

## Summary

Two coupled issues on workflow presets:

1. **Bug: new workflows silently swallow their first trigger.** Forge loaded its workflow registry only at startup (`crates/forge/src/cmd/serve.rs`). Workflows created in stiglab while forge was running emitted `trigger.fired` (visible on the Event Spine page) but forge's handler missed the lookup, logged `"unknown workflow"`, and dropped the event — so no artifact or session was ever registered.

   **Fix:** the in-memory workflow `HashMap` is removed entirely. The spine DB is the only source of truth — the tick loop reloads workflows fresh on every pass, and the trigger handler queries the DB per event. No cache, no dual write, no staleness when workflows are edited or deactivated.

2. **Missing UX on the workflow detail page.** Only "Live artifacts" was shown, so trigger failures and post-dispatch session activity were invisible from the workflow's own view. Event details (the `data` JSON blob) were also missing from the Event Spine page.

   **Added:**
   - **Events** card: merges trigger events from the workflow stream with stage events from each run's artifact stream; rows expand to the raw `data` payload.
   - **Sessions** card: reads `vertical_lineage` per artifact via `/api/spine/artifacts/{id}` (the durable session↔artifact edge that forge actually records). Rows link to session detail.
   - **Event Spine** rows are now expandable and keyboard-accessible (`Enter`/`Space`, `aria-expanded`).
   - New `stream_id` exact-match filter on `GET /api/spine/events`.

## Test plan

- [ ] Create a workflow preset while forge is running; tag an issue with the trigger label; verify an artifact is registered and a session dispatched (previously silently dropped).
- [ ] Deactivate a workflow in stiglab; verify forge stops advancing its in-flight artifacts on the next tick (no stale cache).
- [ ] Open the workflow detail page — verify Events card shows trigger + stage events, and clicking a row reveals the `data` JSON.
- [ ] After a session completes against an artifact, verify it appears in the Sessions card and links through to the session detail page.
- [ ] Confirm `cargo test -p forge` and `cargo test -p stiglab` pass (98 + 132 tests green locally).

https://claude.ai/code/session_017aU9aT1BXdPEBsVYWp5LCf