### PR TITLE
ci(e2e): disable auto-triggers pending Onsager-native pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,12 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only token. The job opts in to the e2e environment, which
+# is where CLAUDE_CODE_OAUTH_TOKEN lives — no other job in this workflow can
+# read it, and the environment requires a reviewer to approve PR runs.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
@@ -36,6 +42,16 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    # Gate the secret-bearing job behind a protected GitHub Environment.
+    # Configure in repo Settings → Environments → e2e:
+    #   - Required reviewers: trusted maintainers (gates same-repo PR runs)
+    #   - Deployment branches: main + PR refs (or restrict to main if you
+    #     want every PR run to require a manual approval)
+    #   - Secrets: move CLAUDE_CODE_OAUTH_TOKEN here from repo secrets
+    # Fork PRs cannot reach this environment, so they fail fast in the
+    # approval gate instead of running half-broken without secrets.
+    environment: e2e
 
     services:
       postgres:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,11 @@ name: e2e
 # Requires secrets:
 #   CLAUDE_CODE_OAUTH_TOKEN — Claude Code credentials for the agent
 #
-# Runs: nightly + manual trigger + on main merges
+# Runs: nightly + manual trigger + on pull requests
+#
+# Gating at PR (not post-merge) so regressions are caught before they land
+# on main. Post-merge runs would only flag bad code after it had already
+# poisoned the branch.
 
 on:
   schedule:
@@ -17,7 +21,7 @@ on:
         description: "Target Onsager URL (leave empty for local stack)"
         required: false
         type: string
-  push:
+  pull_request:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,23 +6,18 @@ name: e2e
 # Requires secrets:
 #   CLAUDE_CODE_OAUTH_TOKEN — Claude Code credentials for the agent
 #
-# Runs: nightly + manual trigger + on pull requests
-#
-# Gating at PR (not post-merge) so regressions are caught before they land
-# on main. Post-merge runs would only flag bad code after it had already
-# poisoned the branch.
+# DISABLED — auto-triggers removed pending migration to Onsager's own
+# workflow engine. Kept around as `workflow_dispatch`-only so it can be
+# invoked manually if needed; remove this file once the Onsager-native
+# E2E pipeline is online.
 
 on:
-  schedule:
-    - cron: "0 6 * * *" # daily at 06:00 UTC
   workflow_dispatch:
     inputs:
       onsager_url:
         description: "Target Onsager URL (leave empty for local stack)"
         required: false
         type: string
-  pull_request:
-    branches: [main]
 
 concurrency:
   group: e2e-${{ github.ref }}


### PR DESCRIPTION
## Summary

Recent E2E runs on `main` went red across 7 session-lifecycle / log-streaming / multi-session / spine-events tests, and the suite has been flaky enough that the gate is generating more noise than signal. Rather than keep patching it in GitHub Actions, we'll migrate E2E to Onsager's own workflow engine when that pipeline is online.

In the meantime, this PR removes the auto-triggers (cron + `pull_request`) from `.github/workflows/e2e.yml`. The file is kept with `workflow_dispatch` only so the job can still be invoked manually if needed; remove the file entirely once the Onsager-native E2E pipeline lands.

## Changes

- `.github/workflows/e2e.yml`: drop `schedule:` cron and `pull_request:` triggers, leaving `workflow_dispatch` as the sole entry point. Updated the header comment to call out the migration plan.

## Test plan

- [ ] After merge, no `e2e` check appears on new PRs.
- [ ] No nightly `e2e` run fires from cron.
- [ ] `Run workflow` button still available on the workflow page (manual dispatch works).
