### PR TITLE
deploy: ship forge in the unified container

### DIFF
--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir -p \
       crates/onsager-portal/src/main.rs \
       crates/refract/src/main.rs \
     && cargo build --release \
-         -p stiglab -p synodic -p onsager-portal \
+         -p stiglab -p synodic -p onsager-portal -p forge \
          --features synodic/postgres 2>/dev/null || true
 # Copy actual source and rebuild.
 # Touch all .rs files so their mtime is newer than the dummy-build artifacts —
@@ -76,7 +76,7 @@ RUN mkdir -p \
 COPY crates/ crates/
 RUN find crates -name "*.rs" | xargs touch \
     && cargo build --release \
-         -p stiglab -p synodic -p onsager-portal \
+         -p stiglab -p synodic -p onsager-portal -p forge \
          --features synodic/postgres
 
 # ---- Stage 3: Node.js for runtime (glibc-compatible) ----
@@ -113,6 +113,7 @@ WORKDIR /app
 COPY --from=rust-builder /app/target/release/stiglab        /app/stiglab
 COPY --from=rust-builder /app/target/release/synodic        /app/synodic
 COPY --from=rust-builder /app/target/release/onsager-portal /app/onsager-portal
+COPY --from=rust-builder /app/target/release/forge          /app/forge
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static
 # Spine migrations — applied on startup when ONSAGER_DATABASE_URL is set
 COPY crates/onsager-spine/migrations/ /app/spine-migrations/

--- a/crates/stiglab/deploy/entrypoint.sh
+++ b/crates/stiglab/deploy/entrypoint.sh
@@ -48,10 +48,26 @@ if [ -n "$ONSAGER_DATABASE_URL" ]; then
     gosu onsager sh -c "while true; do PORTAL_BIND=\"$PORTAL_BIND\" DATABASE_URL=\"$ONSAGER_DATABASE_URL\" ONSAGER_CREDENTIAL_KEY=\"$PORTAL_CREDENTIAL_KEY\" SYNODIC_URL=\"$PORTAL_SYNODIC_URL\" /app/onsager-portal serve 2>&1; echo 'onsager-portal exited, restarting in 1s...'; sleep 1; done" &
 fi
 
+# Start forge (workflow orchestrator) on an internal port.
+# Forge subscribes to `trigger.fired` events on the spine, registers the
+# workflow's first artifact, and dispatches stage-0 work back to stiglab
+# via HTTP. Without forge running, trigger events accumulate with no
+# downstream effect — see CLAUDE.md "factory event bus".
+# Skipped when the spine DB isn't configured (no events to consume).
+if [ -n "$ONSAGER_DATABASE_URL" ]; then
+    # Default 3002 collides with portal — use 3003.
+    FORGE_PORT="${FORGE_PORT:-3003}"
+    # stiglab binds to $PORT first (Railway-injected) then STIGLAB_PORT.
+    FORGE_STIGLAB_URL="${STIGLAB_URL:-http://127.0.0.1:${PORT:-${STIGLAB_PORT:-3000}}}"
+    FORGE_SYNODIC_URL="${SYNODIC_URL:-http://127.0.0.1:${SYNODIC_PORT}}"
+    echo "Starting forge on :${FORGE_PORT}..."
+    gosu onsager sh -c "while true; do DATABASE_URL=\"$ONSAGER_DATABASE_URL\" FORGE_PORT=\"$FORGE_PORT\" STIGLAB_URL=\"$FORGE_STIGLAB_URL\" SYNODIC_URL=\"$FORGE_SYNODIC_URL\" /app/forge serve 2>&1; echo 'forge exited, restarting in 1s...'; sleep 1; done" &
+fi
+
 # Drop from root to unprivileged user and start stiglab.
 # Claude Code CLI refuses --permission-mode bypassPermissions under root.
 echo "==> pre-exec: binaries present"
-ls -la /app/stiglab /app/synodic /app/onsager-portal
+ls -la /app/stiglab /app/synodic /app/onsager-portal /app/forge
 echo "==> pre-exec: gosu version"
 gosu --version || true
 echo "==> pre-exec: PORT=${PORT:-unset} STIGLAB_PORT=${STIGLAB_PORT:-unset}"

--- a/justfile
+++ b/justfile
@@ -55,6 +55,11 @@ dev: dev-infra
     echo "==> Starting synodic on :3001..."
     PORT=3001 cargo run -p synodic -- serve &
 
+    echo "==> Starting forge on :3003..."
+    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+    FORGE_PORT=3003 \
+        cargo run -p forge -- serve &
+
     echo "==> Starting dashboard on :5173..."
     pnpm --filter dashboard dev &
 
@@ -63,6 +68,7 @@ dev: dev-infra
     echo "  Dashboard:  http://localhost:5173"
     echo "  Stiglab:    http://localhost:3000"
     echo "  Synodic:    http://localhost:3001"
+    echo "  Forge:      http://localhost:3003"
     echo "  Postgres:   postgres://onsager:onsager@localhost:5432/onsager"
     echo ""
     echo "Press Ctrl+C to stop all services."

--- a/railway.toml
+++ b/railway.toml
@@ -7,6 +7,7 @@
 #   stiglab         | Sessions, agents, dashboard, API          | 3000 (exposed)
 #   synodic         | Governance API (internal)                 | 3001 (proxied)
 #   onsager-portal  | GitHub webhook ingress (internal)         | 3002 (proxied)
+#   forge           | Workflow orchestrator (spine consumer)    | 3003 (internal)
 #   PostgreSQL      | Shared event spine (Railway plugin)       | 5432
 #
 # Stiglab is the front door — it serves the dashboard, its own API, and


### PR DESCRIPTION
Closes #128

## Summary

Fixes the symptom where `trigger.fired` events appear in the workflow event log but never produce an artifact or session. Root cause: forge — the spine consumer that turns `trigger.fired` into an artifact and dispatches stage-0 work — was coded but never deployed. The unified container only ran stiglab + synodic + onsager-portal, so the bus had a producer with no consumer.

- Build `-p forge` in the stiglab Dockerfile and copy the binary into the runtime image.
- Supervise `forge serve` from `entrypoint.sh` on internal port 3003 (3002 is taken by portal). Wires `DATABASE_URL=$ONSAGER_DATABASE_URL` and points `STIGLAB_URL` / `SYNODIC_URL` at localhost.
- Add forge to `just dev` so the local stack matches production.
- Document forge in `railway.toml`'s process table.

A second symptom — the dashboard's "Live artifacts" / "Sessions" cards rely on `GET /api/workflows/{id}/runs`, which is not implemented in stiglab — is left for a follow-up. With this PR, artifacts and sessions are actually created; the runs endpoint is what makes them visible on the workflow detail page.

## Test plan

- [x] `cargo check -p forge --release` passes (verified locally)
- [x] `cargo clippy -p forge --release --all-targets -- -D warnings` passes (verified locally)
- [ ] CI green on this branch
- [ ] Railway preview deploy reaches healthy state with all four processes in logs
- [ ] Post-merge: trigger a label-matched issue on a workflow and verify a session is dispatched (sessions visible via `/api/sessions` even if the dashboard's runs card stays empty until the follow-up).

https://claude.ai/code/session_014bfHSpGC14LjbqCvYJ6ADQ