### PR TITLE
fix(stiglab): mirror tenant_workflows to spine workflows for forge

### DIFF
--- a/crates/stiglab/src/main.rs
+++ b/crates/stiglab/src/main.rs
@@ -120,6 +120,16 @@ async fn run_server(
 
     let state = AppState::new(pool.clone(), config.clone(), spine);
 
+    // Backfill the spine `workflows` schema from `tenant_workflows` so
+    // forge can resolve workflows created before the mirror landed (and
+    // self-heal any drift caused by best-effort CRUD-time mirroring).
+    if let Some(spine) = state.spine.as_ref() {
+        match stiglab::server::workflow_spine_mirror::backfill(&state.db, spine.pool()).await {
+            Ok(n) => tracing::info!("workflow spine backfill: synced {n} workflow(s)"),
+            Err(e) => tracing::warn!("workflow spine backfill failed: {e}"),
+        }
+    }
+
     // Start built-in runner if enabled
     if !no_runner {
         let runner_node_name = node_name.unwrap_or_else(|| "built-in-runner".to_string());

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -10,6 +10,7 @@ pub mod state;
 pub mod webhook_router;
 pub mod workflow_activation;
 pub mod workflow_db;
+pub mod workflow_spine_mirror;
 pub mod ws;
 
 pub use sqlx::AnyPool;

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -25,6 +25,36 @@ use crate::server::workflow_activation::{
     ActivationError,
 };
 use crate::server::workflow_db;
+use crate::server::workflow_spine_mirror;
+
+/// Push the current `tenant_workflows` row + its stages into the spine
+/// `workflows` schema forge reads. Best-effort: a failure here means the
+/// workflow won't fire until the next successful sync (via another CRUD or
+/// startup backfill), but we don't abort the request — the stiglab-side
+/// write already committed.
+async fn mirror_to_spine(state: &AppState, workflow_id: &str) {
+    let Some(spine) = state.spine.as_ref() else {
+        return;
+    };
+    let workflow = match workflow_db::get_workflow(&state.db, workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(workflow_id, "spine mirror: load workflow failed: {e}");
+            return;
+        }
+    };
+    let stages = match workflow_db::list_stages_for_workflow(&state.db, workflow_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(workflow_id, "spine mirror: load stages failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = workflow_spine_mirror::upsert(spine.pool(), &workflow, &stages).await {
+        tracing::warn!(workflow_id, "spine mirror: upsert failed: {e}");
+    }
+}
 
 #[allow(clippy::result_large_err)]
 async fn require_tenant_member(
@@ -228,6 +258,7 @@ pub async fn create_workflow(
         )
             .into_response();
     }
+    mirror_to_spine(&state, &workflow.id).await;
 
     // Activation runs after the row is durable. If it fails the workflow
     // stays `active=false` and the caller sees the activation error.
@@ -402,6 +433,11 @@ pub async fn delete_workflow(
         tracing::error!("failed to delete workflow: {e}");
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
+    if let Some(spine) = state.spine.as_ref() {
+        if let Err(e) = workflow_spine_mirror::delete(spine.pool(), &workflow_id).await {
+            tracing::warn!(workflow_id = %workflow_id, "spine mirror: delete failed: {e}");
+        }
+    }
     Json(serde_json::json!({ "ok": true })).into_response()
 }
 
@@ -485,6 +521,7 @@ async fn activate_workflow(
         tracing::error!("mark workflow active: {e}");
         return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
+    mirror_to_spine(state, workflow_id).await;
     Ok(())
 }
 
@@ -503,6 +540,7 @@ async fn deactivate_workflow(state: &AppState, workflow_id: &str) -> Result<(), 
         tracing::error!("mark workflow inactive: {e}");
         return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
+    mirror_to_spine(state, workflow_id).await;
 
     // Dedup: keep the webhook if any other active workflow on the same repo
     // still needs it.

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -150,6 +150,19 @@ pub async fn list_workflows_for_tenant(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// List every workflow across tenants. Used by the spine-mirror startup
+/// backfill so workflows pre-dating the bridge sync into the spine schema.
+pub async fn list_all_workflows(pool: &AnyPool) -> anyhow::Result<Vec<Workflow>> {
+    let rows = sqlx::query_as::<_, WorkflowRow>(
+        "SELECT id, tenant_id, name, trigger_kind, repo_owner, repo_name, trigger_label, \
+                install_id, preset_id, active, created_by, created_at, updated_at \
+         FROM tenant_workflows ORDER BY created_at ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 pub async fn list_stages_for_workflow(
     pool: &AnyPool,
     workflow_id: &str,

--- a/crates/stiglab/src/server/workflow_spine_mirror.rs
+++ b/crates/stiglab/src/server/workflow_spine_mirror.rs
@@ -98,25 +98,18 @@ pub async fn delete(spine_pool: &PgPool, workflow_id: &str) -> anyhow::Result<()
 /// stages and upserts the spine schema. Idempotent; safe to run on every
 /// boot. Logs a warning per failed row but does not abort startup —
 /// individual translation failures shouldn't take stiglab down.
-pub async fn backfill(
-    stiglab_pool: &sqlx::AnyPool,
-    spine_pool: &PgPool,
-) -> anyhow::Result<usize> {
+pub async fn backfill(stiglab_pool: &sqlx::AnyPool, spine_pool: &PgPool) -> anyhow::Result<usize> {
     let workflows = crate::server::workflow_db::list_all_workflows(stiglab_pool).await?;
     let mut synced = 0usize;
     for w in workflows {
-        let stages = match crate::server::workflow_db::list_stages_for_workflow(
-            stiglab_pool,
-            &w.id,
-        )
-        .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(workflow_id = %w.id, "backfill: stage load failed: {e}");
-                continue;
-            }
-        };
+        let stages =
+            match crate::server::workflow_db::list_stages_for_workflow(stiglab_pool, &w.id).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(workflow_id = %w.id, "backfill: stage load failed: {e}");
+                    continue;
+                }
+            };
         if let Err(e) = upsert(spine_pool, &w, &stages).await {
             tracing::warn!(workflow_id = %w.id, "backfill: spine upsert failed: {e}");
             continue;

--- a/crates/stiglab/src/server/workflow_spine_mirror.rs
+++ b/crates/stiglab/src/server/workflow_spine_mirror.rs
@@ -1,0 +1,242 @@
+//! Mirror stiglab's `tenant_workflows` rows into the spine `workflows` /
+//! `workflow_stages` tables that forge reads.
+//!
+//! Stiglab owns the multi-tenant CRUD schema (`tenant_workflows`); forge
+//! consumes the spine schema defined in `crates/onsager-spine/migrations/
+//! 006_workflows.sql`. Without this bridge, every `trigger.fired` event
+//! emitted by stiglab references a `workflow_id` forge can't resolve, and
+//! the trigger is dropped with a "trigger.fired for unknown workflow"
+//! warning (no artifact, no session).
+//!
+//! Called from every CRUD handler that mutates a workflow, plus a one-shot
+//! backfill on startup so workflows that pre-date this bridge sync over.
+
+use anyhow::Context;
+use serde_json::json;
+use sqlx::PgPool;
+
+use crate::core::workflow::{GateKind, TriggerKind, Workflow, WorkflowStage};
+
+/// Insert or update the spine workflow row + its full stage chain. Stages
+/// are replaced wholesale on every call (delete-then-insert) so removing a
+/// stage in stiglab actually removes it from the spine.
+pub async fn upsert(
+    spine_pool: &PgPool,
+    workflow: &Workflow,
+    stages: &[WorkflowStage],
+) -> anyhow::Result<()> {
+    let mut tx = spine_pool.begin().await?;
+
+    let trigger_kind = trigger_kind_to_spine(workflow.trigger_kind);
+    let trigger_config = trigger_config_for(workflow);
+    let install_ref = workflow.install_id.to_string();
+
+    sqlx::query(
+        "INSERT INTO workflows (workflow_id, name, trigger_kind, trigger_config, \
+                                active, preset_id, workspace_install_ref) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) \
+         ON CONFLICT (workflow_id) DO UPDATE SET \
+             name = EXCLUDED.name, \
+             trigger_kind = EXCLUDED.trigger_kind, \
+             trigger_config = EXCLUDED.trigger_config, \
+             active = EXCLUDED.active, \
+             preset_id = EXCLUDED.preset_id, \
+             workspace_install_ref = EXCLUDED.workspace_install_ref",
+    )
+    .bind(&workflow.id)
+    .bind(&workflow.name)
+    .bind(trigger_kind)
+    .bind(&trigger_config)
+    .bind(workflow.active)
+    .bind(workflow.preset_id.as_deref())
+    .bind(&install_ref)
+    .execute(&mut *tx)
+    .await
+    .context("upsert spine workflows row")?;
+
+    sqlx::query("DELETE FROM workflow_stages WHERE workflow_id = $1")
+        .bind(&workflow.id)
+        .execute(&mut *tx)
+        .await
+        .context("clear spine workflow_stages")?;
+
+    for stage in stages {
+        let (target_state, gates) = translate_stage(stage.gate_kind, &stage.params);
+        sqlx::query(
+            "INSERT INTO workflow_stages (workflow_id, stage_order, name, target_state, \
+                                          gates, params) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(&workflow.id)
+        .bind(stage.seq)
+        .bind(stage.gate_kind.to_string())
+        .bind(target_state)
+        .bind(&gates)
+        .bind(&stage.params)
+        .execute(&mut *tx)
+        .await
+        .context("insert spine workflow_stages row")?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Remove the spine workflow row + cascading stages. Called from
+/// stiglab's delete handler so forge stops resolving a workflow that no
+/// longer exists in stiglab.
+pub async fn delete(spine_pool: &PgPool, workflow_id: &str) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM workflows WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .execute(spine_pool)
+        .await
+        .context("delete spine workflows row")?;
+    Ok(())
+}
+
+/// One-shot startup sync. Reads every `tenant_workflows` row plus its
+/// stages and upserts the spine schema. Idempotent; safe to run on every
+/// boot. Logs a warning per failed row but does not abort startup —
+/// individual translation failures shouldn't take stiglab down.
+pub async fn backfill(
+    stiglab_pool: &sqlx::AnyPool,
+    spine_pool: &PgPool,
+) -> anyhow::Result<usize> {
+    let workflows = crate::server::workflow_db::list_all_workflows(stiglab_pool).await?;
+    let mut synced = 0usize;
+    for w in workflows {
+        let stages = match crate::server::workflow_db::list_stages_for_workflow(
+            stiglab_pool,
+            &w.id,
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(workflow_id = %w.id, "backfill: stage load failed: {e}");
+                continue;
+            }
+        };
+        if let Err(e) = upsert(spine_pool, &w, &stages).await {
+            tracing::warn!(workflow_id = %w.id, "backfill: spine upsert failed: {e}");
+            continue;
+        }
+        synced += 1;
+    }
+    Ok(synced)
+}
+
+fn trigger_kind_to_spine(kind: TriggerKind) -> &'static str {
+    match kind {
+        TriggerKind::GithubIssueWebhook => "github_issue_webhook",
+    }
+}
+
+fn trigger_config_for(workflow: &Workflow) -> serde_json::Value {
+    match workflow.trigger_kind {
+        TriggerKind::GithubIssueWebhook => json!({
+            "repo": format!("{}/{}", workflow.repo_owner, workflow.repo_name),
+            "label": workflow.trigger_label,
+        }),
+    }
+}
+
+/// Translate stiglab's `gate_kind` + opaque `params` into the spine's
+/// `(target_state, gates)` pair. The artifact-state transitions match the
+/// "issue → PR" flow forge expects: agent-session moves Draft → InProgress,
+/// review-style gates move to UnderReview.
+fn translate_stage(
+    gate_kind: GateKind,
+    params: &serde_json::Value,
+) -> (Option<&'static str>, serde_json::Value) {
+    match gate_kind {
+        GateKind::AgentSession => {
+            let gate = json!({
+                "kind": "agent_session",
+                "shaping_intent": params.clone(),
+            });
+            (Some("in_progress"), json!([gate]))
+        }
+        GateKind::ExternalCheck => {
+            let check_name = params
+                .get("check_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ci");
+            let gate = json!({
+                "kind": "external_check",
+                "check_name": check_name,
+            });
+            (Some("under_review"), json!([gate]))
+        }
+        GateKind::Governance => {
+            let gate_point = params.get("gate_point").and_then(|v| v.as_str());
+            let gate = match gate_point {
+                Some(p) => json!({"kind": "governance", "gate_point": p}),
+                None => json!({"kind": "governance"}),
+            };
+            (Some("under_review"), json!([gate]))
+        }
+        GateKind::ManualApproval => {
+            let signal_kind = params
+                .get("signal_kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("dashboard_approve");
+            let gate = json!({
+                "kind": "manual_approval",
+                "signal_kind": signal_kind,
+            });
+            (Some("under_review"), json!([gate]))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_session_maps_to_in_progress() {
+        let (state, gates) =
+            translate_stage(GateKind::AgentSession, &json!({"action": "implement"}));
+        assert_eq!(state, Some("in_progress"));
+        assert_eq!(gates[0]["kind"], "agent_session");
+        assert_eq!(gates[0]["shaping_intent"]["action"], "implement");
+    }
+
+    #[test]
+    fn external_check_pulls_check_name() {
+        let (state, gates) =
+            translate_stage(GateKind::ExternalCheck, &json!({"check_name": "ci/test"}));
+        assert_eq!(state, Some("under_review"));
+        assert_eq!(gates[0]["kind"], "external_check");
+        assert_eq!(gates[0]["check_name"], "ci/test");
+    }
+
+    #[test]
+    fn manual_approval_defaults_signal_kind() {
+        let (_, gates) = translate_stage(GateKind::ManualApproval, &json!({}));
+        assert_eq!(gates[0]["signal_kind"], "dashboard_approve");
+    }
+
+    #[test]
+    fn trigger_config_pairs_repo_and_label() {
+        let w = Workflow {
+            id: "wf_x".into(),
+            tenant_id: "t".into(),
+            name: "x".into(),
+            trigger_kind: TriggerKind::GithubIssueWebhook,
+            repo_owner: "owner".into(),
+            repo_name: "repo".into(),
+            trigger_label: "planned".into(),
+            install_id: 42,
+            preset_id: None,
+            active: true,
+            created_by: "u".into(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let cfg = trigger_config_for(&w);
+        assert_eq!(cfg["repo"], "owner/repo");
+        assert_eq!(cfg["label"], "planned");
+    }
+}


### PR DESCRIPTION
Closes #130

After #127 deployed forge, the next symptom surfaced: forge logs

```
trigger.fired for unknown workflow (no row in spine)
  workflow_id=wf_bb7ec751-2093-4fc7-8e31-e2f1d1b9953f
```

for every webhook-fired trigger. Root cause: stiglab and forge keep parallel workflow schemas. Stiglab's CRUD writes `tenant_workflows` / `tenant_workflow_stages`; forge reads the spine `workflows` / `workflow_stages` schema (`crates/onsager-spine/migrations/006_workflows.sql`). Nothing bridged them — every workflow was invisible to forge.

## Summary

Add a translator from stiglab's schema to the spine schema:

- New `crates/stiglab/src/server/workflow_spine_mirror.rs`: idempotent `upsert` + `delete` against the spine pool using `ON CONFLICT DO UPDATE`, plus a one-shot `backfill` for startup. Translates `GateKind` to forge's `GateSpec` (`agent-session` / `external-check` / `governance` / `manual-approval`) and derives `target_state` per gate (`in_progress` for agent-session, `under_review` for review-style gates).
- Plumb `mirror_to_spine` into `create_workflow`, `activate_workflow`, `deactivate_workflow`, `delete_workflow`. Best-effort: a failed mirror logs a warning rather than failing the request — the next CRUD or startup backfill repairs drift.
- Startup backfill in `main.rs` upserts every existing `tenant_workflow` into the spine on boot, so workflows pre-dating this fix (including the user's `wf_bb7ec751…` example) sync over without needing a manual re-save.

This is a bridge, not a unification — `tenant_workflows` stays as stiglab's CRUD-facing multi-tenant schema; `workflows` is the spine contract forge consumes. Long-term the schemas should converge, but doing that now would dramatically widen the change.

## Test plan

- [x] 4 new unit tests cover the translation (target_state mapping, gate JSON shape, trigger config pairing)
- [x] `cargo test -p stiglab --lib --release` — 136 passing
- [x] `cargo clippy --workspace --release --all-targets -- -D warnings` clean
- [ ] Post-merge: re-trigger the same workflow that was firing the warning; confirm forge logs `trigger.fired for unknown workflow` no longer appear and an artifact + session is created.

https://claude.ai/code/session_014bfHSpGC14LjbqCvYJ6ADQ