### PR TITLE
fix(dashboard): gate FactoryOverviewPage queries on resolved auth

### DIFF
--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { api } from "@/lib/api"
+import { useAuth } from "@/lib/auth"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -89,25 +90,38 @@ function PipelineStats({ artifacts }: { artifacts: SpineArtifact[] }) {
 }
 
 export function FactoryOverviewPage() {
+  // Gate every poll on resolved auth state so we don't flood the
+  // browser console / network tab with 401s before login. Every query
+  // on this page hits an auth-required endpoint (artifacts, governance
+  // stats, spine events, nodes, session spend, user workflows). The
+  // dedicated `useNodes()` hook applies this gate too — see its
+  // comment for the original motivation.
+  const { user, loading: authLoading, authEnabled } = useAuth()
+  const enabled = !authLoading && (!authEnabled || !!user)
+
   const { data: artifactsData } = useQuery({
     queryKey: ["artifacts"],
     queryFn: api.getArtifacts,
     refetchInterval: 5000,
+    enabled,
   })
   const { data: govStats } = useQuery({
     queryKey: ["governance-stats"],
     queryFn: api.getGovernanceStats,
     refetchInterval: 10000,
+    enabled,
   })
   const { data: spineData } = useQuery({
     queryKey: ["spine-events-overview"],
     queryFn: () => api.getSpineEvents({ limit: 20 }),
     refetchInterval: 5000,
+    enabled,
   })
   const { data: nodesData } = useQuery({
     queryKey: ["nodes"],
     queryFn: api.getNodes,
     refetchInterval: 10000,
+    enabled,
   })
   // Issue #39 — per-session token usage, pulled from the last N
   // session_completed events so the spend card can render without a
@@ -116,12 +130,14 @@ export function FactoryOverviewPage() {
     queryKey: ["session-spend"],
     queryFn: () => api.getSessionSpend(100),
     refetchInterval: 30000,
+    enabled,
   })
   // Issue #82 — empty-state CTA banner when no workflow has been set up yet.
   const { data: workflowsData } = useQuery({
     queryKey: ["workflows", "user"],
     queryFn: () => api.listWorkflowsForUser(),
     staleTime: 30_000,
+    enabled,
   })
   const workflowsCount = workflowsData?.workflows?.length ?? 0
 


### PR DESCRIPTION
Closes #135

The Factory Overview page fired six polling queries on mount (`artifacts`, `governance-stats`, `spine-events-overview`, `nodes`, `session-spend`, `workflows`) without gating on auth state. Every one of them hits an auth-required endpoint, so the browser console / network tab filled up with 401s on every page load and on every poll cycle (5s–30s) until `useAuth()` hydrated.

The dedicated `useNodes()` hook exists for exactly this — see its module comment at `apps/dashboard/src/hooks/useNodes.ts:6-9` — but the overview page bypassed it with a raw `useQuery({ queryFn: api.getNodes })`.

## Summary

- Import `useAuth` in `FactoryOverviewPage.tsx`
- Compute `enabled = !authLoading && (!authEnabled || !!user)` once
- Pass `enabled` to all six `useQuery` calls

## Test plan

- [x] `pnpm exec tsc -b` clean
- [x] `pnpm lint` clean
- [ ] Post-merge: log out, reload `/`, watch the network tab — no `/api/*` 401s before login. Log back in, queries resume.

https://claude.ai/code/session_014bfHSpGC14LjbqCvYJ6ADQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014bfHSpGC14LjbqCvYJ6ADQ)_