### PR TITLE
fix: surface workflow artifacts/lineage and unblock session dispatch

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -224,6 +224,7 @@ export interface ArtifactDetail extends SpineArtifact {
   created_by: string;
   versions: ArtifactVersion[];
   vertical_lineage: ArtifactLineageEntry[];
+  horizontal_lineage?: ArtifactHorizontalLineageEntry[];
   related_events?: SpineEvent[];
 }
 
@@ -240,6 +241,15 @@ export interface ArtifactVersion {
 export interface ArtifactLineageEntry {
   version: number;
   session_id: string;
+  recorded_at: string;
+}
+
+// Horizontal lineage — cross-artifact dependency edges, e.g. a PR's
+// `closes_issue` link back to the spec issue it implements.
+export interface ArtifactHorizontalLineageEntry {
+  source_artifact_id: string;
+  source_version: number;
+  role: string;
   recorded_at: string;
 }
 

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -357,8 +357,10 @@ export function ArtifactDetailPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {artifact.horizontal_lineage.map((entry, i) => (
-                  <TableRow key={i}>
+                {artifact.horizontal_lineage.map((entry) => (
+                  <TableRow
+                    key={`${entry.role}-${entry.source_artifact_id}-${entry.source_version}-${entry.recorded_at}`}
+                  >
                     <TableCell className="text-xs">{entry.role}</TableCell>
                     <TableCell>
                       <Link

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -340,6 +340,45 @@ export function ArtifactDetailPage() {
           </CardContent>
         </Card>
       )}
+
+      {artifact.horizontal_lineage && artifact.horizontal_lineage.length > 0 && (
+        <Card>
+          <CardHeader className="px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Horizontal Lineage</CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 md:px-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Source Artifact</TableHead>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Recorded</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {artifact.horizontal_lineage.map((entry, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="text-xs">{entry.role}</TableCell>
+                    <TableCell>
+                      <Link
+                        to={`/artifacts/${entry.source_artifact_id}`}
+                        className="font-mono text-xs hover:underline"
+                      >
+                        {entry.source_artifact_id}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="font-mono">v{entry.source_version}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {new Date(entry.recorded_at).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -205,7 +205,7 @@ impl StiglabDispatcher for HttpStiglabDispatcher {
         }
     }
 
-    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) {
+    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) -> bool {
         // Workflow gates only need Stiglab to accept the dispatch — the
         // session_completed event listener resolves the signal cache for
         // a later tick. Polling here would hold the Forge write lock for
@@ -222,6 +222,7 @@ impl StiglabDispatcher for HttpStiglabDispatcher {
                     session_id,
                     "workflow agent-session dispatched"
                 );
+                true
             }
             Err(e) => {
                 tracing::error!(
@@ -229,6 +230,7 @@ impl StiglabDispatcher for HttpStiglabDispatcher {
                     artifact_id = %request.artifact_id,
                     "workflow agent-session dispatch failed: {e}"
                 );
+                false
             }
         }
     }

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -140,6 +140,41 @@ impl HttpStiglabDispatcher {
     }
 }
 
+impl HttpStiglabDispatcher {
+    /// POST `/api/shaping` and return as soon as Stiglab accepts the
+    /// request. No status polling, no waiting for terminal state — used
+    /// by `dispatch_fire_and_forget` on the workflow gate path.
+    async fn post_only(&self, request: &ShapingRequest) -> Result<String, anyhow::Error> {
+        let create_url = format!("{}/api/shaping", self.stiglab_url);
+        let body = serde_json::to_value(request)?;
+        let resp = self
+            .client
+            .post(&create_url)
+            .header("Idempotency-Key", &request.request_id)
+            .json(&body)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!(
+                "stiglab POST /api/shaping returned {status}: {text}"
+            ));
+        }
+        let body_text = resp.text().await?;
+        // Stiglab can return either 202 with `{ session_id, ... }` or a
+        // legacy 200 with a full `ShapingResult`; both carry a session id
+        // we can surface.
+        if status == reqwest::StatusCode::OK {
+            let result: ShapingResult = serde_json::from_str(&body_text)?;
+            Ok(result.session_id)
+        } else {
+            let accepted: ShapingAccepted = serde_json::from_str(&body_text)?;
+            Ok(accepted.session_id)
+        }
+    }
+}
+
 impl StiglabDispatcher for HttpStiglabDispatcher {
     fn dispatch(&self, request: &ShapingRequest) -> ShapingResult {
         // The pipeline tick is synchronous, so block_in_place lets us await
@@ -166,6 +201,34 @@ impl StiglabDispatcher for HttpStiglabDispatcher {
                         retriable: Some(true),
                     }),
                 }
+            }
+        }
+    }
+
+    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) {
+        // Workflow gates only need Stiglab to accept the dispatch — the
+        // session_completed event listener resolves the signal cache for
+        // a later tick. Polling here would hold the Forge write lock for
+        // the full shaping deadline whenever no agent is connected to
+        // pick the session up.
+        let outcome = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.post_only(request))
+        });
+        match outcome {
+            Ok(session_id) => {
+                tracing::info!(
+                    request_id = %request.request_id,
+                    artifact_id = %request.artifact_id,
+                    session_id,
+                    "workflow agent-session dispatched"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    request_id = %request.request_id,
+                    artifact_id = %request.artifact_id,
+                    "workflow agent-session dispatch failed: {e}"
+                );
             }
         }
     }

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -89,12 +89,22 @@ pub trait StiglabDispatcher: Send + Sync {
     /// `stiglab.session_completed` event listener writing into the
     /// signal cache, which the next tick observes.
     ///
+    /// Returns `true` when Stiglab accepted the request, `false`
+    /// otherwise (network error, 5xx, …). The caller uses the return
+    /// value to decide whether to mark this dispatch as done — a
+    /// failed POST must not be marked dispatched, or the gate will
+    /// stall waiting for a completion signal that can never arrive.
+    ///
     /// Default implementation falls back to the blocking `dispatch` for
     /// backwards compatibility with mocks; production paths override
     /// with a true non-blocking call so the Forge write lock isn't held
     /// for the full shaping deadline when no agent is available.
-    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) {
-        let _ = self.dispatch(request);
+    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) -> bool {
+        let result = self.dispatch(request);
+        !matches!(
+            result.outcome,
+            ShapingOutcome::Failed | ShapingOutcome::Aborted
+        )
     }
 }
 

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -76,7 +76,26 @@ pub enum PipelineEvent {
 /// Production implementations call Stiglab's HTTP API.
 /// Tests use mock implementations.
 pub trait StiglabDispatcher: Send + Sync {
+    /// Synchronous dispatch — used by the legacy `ForgePipeline` tick,
+    /// which folds the terminal `ShapingResult` back into the artifact
+    /// state inline. Blocks until Stiglab returns a terminal state or the
+    /// request deadline elapses.
     fn dispatch(&self, request: &ShapingRequest) -> ShapingResult;
+
+    /// Fire-and-forget dispatch — used by the workflow stage runner's
+    /// `agent-session` gate. POSTs the shaping request and returns as
+    /// soon as Stiglab acknowledges; the runner does NOT wait for the
+    /// session to complete. Resolution comes via the
+    /// `stiglab.session_completed` event listener writing into the
+    /// signal cache, which the next tick observes.
+    ///
+    /// Default implementation falls back to the blocking `dispatch` for
+    /// backwards compatibility with mocks; production paths override
+    /// with a true non-blocking call so the Forge write lock isn't held
+    /// for the full shaping deadline when no agent is available.
+    fn dispatch_fire_and_forget(&self, request: &ShapingRequest) {
+        let _ = self.dispatch(request);
+    }
 }
 
 /// Trait for consulting Synodic at gate points.

--- a/crates/forge/src/core/workflow_gates.rs
+++ b/crates/forge/src/core/workflow_gates.rs
@@ -173,11 +173,13 @@ where
                 constraints: vec![],
                 deadline: None,
             };
-            // The dispatcher call may complete synchronously (legacy
-            // stiglab path) and return immediately; the session listener
-            // is still responsible for writing the signal so the gate
-            // resolves on a subsequent tick.
-            let _ = self.stiglab.dispatch(&request);
+            // Fire-and-forget: the workflow path resolves via the
+            // `stiglab.session_completed` listener writing into the
+            // signal cache, not by waiting for the HTTP roundtrip to
+            // finish. Using the blocking `dispatch` here would hold the
+            // Forge write lock for the full shaping deadline if no agent
+            // is connected to pick the session up.
+            self.stiglab.dispatch_fire_and_forget(&request);
             self.mark_dispatched(artifact.artifact_id.as_str(), stage_index);
         }
         GateOutcome::Pending

--- a/crates/forge/src/core/workflow_gates.rs
+++ b/crates/forge/src/core/workflow_gates.rs
@@ -179,8 +179,16 @@ where
             // finish. Using the blocking `dispatch` here would hold the
             // Forge write lock for the full shaping deadline if no agent
             // is connected to pick the session up.
-            self.stiglab.dispatch_fire_and_forget(&request);
-            self.mark_dispatched(artifact.artifact_id.as_str(), stage_index);
+            //
+            // Only mark the gate as dispatched when Stiglab actually
+            // accepted the POST. Marking unconditionally would strand
+            // the artifact at this stage on transient network/5xx
+            // errors — already_dispatched would suppress retries
+            // forever, and the completion signal can't arrive for a
+            // session that was never created.
+            if self.stiglab.dispatch_fire_and_forget(&request) {
+                self.mark_dispatched(artifact.artifact_id.as_str(), stage_index);
+            }
         }
         GateOutcome::Pending
     }

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -617,6 +617,31 @@ pub async fn update_session_state(
     Ok(())
 }
 
+/// Atomically claim a `pending` session by transitioning it to the given
+/// state. Returns `true` only when this caller won the race (the row was
+/// `pending` at update time and exactly one row was affected).
+///
+/// Used by the agent reconnect drain so a session that's already been
+/// claimed by another path (e.g. the create-time WebSocket dispatch, or
+/// a parallel reconnect that beat us) doesn't get sent twice.
+pub async fn claim_pending_session(
+    pool: &AnyPool,
+    session_id: &str,
+    new_state: SessionState,
+) -> anyhow::Result<bool> {
+    let affected = sqlx::query(
+        "UPDATE sessions SET state = $1, updated_at = $2 \
+         WHERE id = $3 AND state = 'pending'",
+    )
+    .bind(new_state.to_string())
+    .bind(Utc::now().to_rfc3339())
+    .bind(session_id)
+    .execute(pool)
+    .await?
+    .rows_affected();
+    Ok(affected == 1)
+}
+
 // ── Session Logs (append-only) ──
 
 pub async fn append_session_log(

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -510,6 +510,26 @@ pub async fn list_sessions(pool: &AnyPool) -> anyhow::Result<Vec<Session>> {
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// Sessions assigned to `node_id` that were created while the agent was
+/// not connected (state still `Pending`). The agent registration handler
+/// drains these on (re)connect so a session created during a brief
+/// disconnect doesn't sit in `Pending` forever.
+pub async fn list_pending_sessions_for_node(
+    pool: &AnyPool,
+    node_id: &str,
+) -> anyhow::Result<Vec<Session>> {
+    let rows = sqlx::query_as::<_, SessionRow>(
+        "SELECT id, task_id, node_id, state, prompt, output, working_dir, \
+                artifact_id, artifact_version, created_at, updated_at \
+         FROM sessions WHERE node_id = $1 AND state = 'pending' \
+         ORDER BY created_at ASC",
+    )
+    .bind(node_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 pub async fn get_session(pool: &AnyPool, session_id: &str) -> anyhow::Result<Option<Session>> {
     let row = sqlx::query_as::<_, SessionRow>(
         "SELECT id, task_id, node_id, state, prompt, output, working_dir, \

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -162,6 +162,11 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
                 .patch(routes::workflows::patch_workflow)
                 .delete(routes::workflows::delete_workflow),
         )
+        // Live runs (artifacts flowing through this workflow).
+        .route(
+            "/api/workflows/{id}/runs",
+            get(routes::workflows::list_workflow_runs),
+        )
         // Workflow artifact-kind catalog (issue #102). Runtime surface of
         // the registry's `workflow_builtin_types()` — lets the dashboard
         // render the kind picker without hardcoding the union.

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -66,6 +66,14 @@ pub struct VerticalLineageRow {
     pub recorded_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Serialize, FromRow)]
+pub struct HorizontalLineageRow {
+    pub source_artifact_id: String,
+    pub source_version: i32,
+    pub role: String,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RegisterArtifactRequest {
     pub kind: String,
@@ -385,6 +393,31 @@ pub async fn get_artifact(
         }
     };
 
+    // Fetch horizontal lineage — which other artifacts were used as
+    // inputs when shaping this one (artifact-model §4, e.g. PR
+    // `closes_issue` link). Empty for artifacts with no cross-kind
+    // references; we still surface the (possibly empty) field so the UI
+    // doesn't have to special-case undefined.
+    let horizontal = match sqlx::query_as::<_, HorizontalLineageRow>(
+        "SELECT source_artifact_id, source_version, role, recorded_at \
+         FROM horizontal_lineage WHERE artifact_id = $1 \
+         ORDER BY recorded_at ASC",
+    )
+    .bind(&id)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("failed to load horizontal lineage for artifact {id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load horizontal lineage" })),
+            )
+                .into_response();
+        }
+    };
+
     // Fetch created_by from artifacts table
     let created_by: String =
         sqlx::query_scalar("SELECT created_by FROM artifacts WHERE artifact_id = $1")
@@ -414,6 +447,7 @@ pub async fn get_artifact(
             "updated_at": artifact.updated_at,
             "versions": versions,
             "vertical_lineage": lineage,
+            "horizontal_lineage": horizontal,
             "related_events": related_events,
         }
     }))

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -342,6 +342,164 @@ pub async fn get_workflow(
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RunsQuery {
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+/// GET /api/workflows/:id/runs — list every artifact flowing through a
+/// workflow, projected as a "run" (1 artifact == 1 run) with per-stage
+/// status derived from `artifacts.current_stage_index` and
+/// `workflow_parked_reason`.
+///
+/// Stage IDs come from `tenant_workflow_stages` (stiglab DB) in `seq`
+/// order; the per-run stage list aligns 1:1 with that ordering so the
+/// dashboard can zip stages by index.
+pub async fn list_workflow_runs(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workflow_id): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<RunsQuery>,
+) -> Response {
+    let user_id = match require_auth_user(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    let workflow = match workflow_db::get_workflow(&state.db, &workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return not_found("workflow not found"),
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_tenant_member(&state.db, &user_id, &workflow.tenant_id).await {
+        return r;
+    }
+    let stages = match workflow_db::list_stages_for_workflow(&state.db, &workflow_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to load stages: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+
+    let Some(spine) = state.spine.as_ref() else {
+        // Without a spine connection there are no artifacts to surface —
+        // return an empty list rather than 503 so the dashboard's
+        // empty-state copy still renders sensibly in dev.
+        return Json(serde_json::json!({ "runs": Vec::<serde_json::Value>::new() }))
+            .into_response();
+    };
+
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    let rows = match sqlx::query_as::<_, ArtifactRunRow>(
+        "SELECT artifact_id, workflow_id, state, current_stage_index, \
+                workflow_parked_reason, created_at, updated_at \
+         FROM artifacts \
+         WHERE workflow_id = $1 \
+         ORDER BY updated_at DESC \
+         LIMIT $2",
+    )
+    .bind(&workflow_id)
+    .bind(limit)
+    .fetch_all(spine.pool())
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("failed to load workflow runs: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load runs" })),
+            )
+                .into_response();
+        }
+    };
+
+    let runs: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|row| project_run(&row, &stages))
+        .collect();
+    Json(serde_json::json!({ "runs": runs })).into_response()
+}
+
+#[derive(sqlx::FromRow)]
+struct ArtifactRunRow {
+    artifact_id: String,
+    workflow_id: String,
+    state: String,
+    current_stage_index: Option<i32>,
+    workflow_parked_reason: Option<String>,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Project a single artifact row + its workflow's stage chain into the
+/// dashboard `WorkflowRun` shape.
+///
+/// Status mapping:
+/// - `archived` → run failed; stages before parked index passed,
+///   stage at parked index failed, rest pending.
+/// - `released` → all stages passed, run passed.
+/// - `workflow_parked_reason` set → run blocked; current stage blocked.
+/// - otherwise → stages [0..idx] passed, stage[idx] pending, rest pending.
+fn project_run(
+    row: &ArtifactRunRow,
+    stages: &[crate::core::workflow::WorkflowStage],
+) -> serde_json::Value {
+    let current_idx = row
+        .current_stage_index
+        .and_then(|i| usize::try_from(i).ok());
+
+    let archived = row.state == "archived";
+    let released = row.state == "released";
+    let parked = row.workflow_parked_reason.is_some();
+
+    let stage_entries: Vec<serde_json::Value> = stages
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let status = match (released, archived, parked, current_idx) {
+                (true, _, _, _) => "passed",
+                (_, true, _, Some(idx)) if i < idx => "passed",
+                (_, true, _, Some(idx)) if i == idx => "failed",
+                (_, true, _, _) => "pending",
+                (_, _, true, Some(idx)) if i < idx => "passed",
+                (_, _, true, Some(idx)) if i == idx => "blocked",
+                (_, _, _, Some(idx)) if i < idx => "passed",
+                _ => "pending",
+            };
+            serde_json::json!({
+                "stage_id": s.id,
+                "status": status,
+                "updated_at": row.updated_at,
+            })
+        })
+        .collect();
+
+    let run_status = if released {
+        "passed"
+    } else if archived {
+        "failed"
+    } else if parked {
+        "blocked"
+    } else {
+        "pending"
+    };
+
+    serde_json::json!({
+        "id": row.artifact_id,
+        "workflow_id": row.workflow_id,
+        "artifact_id": row.artifact_id,
+        "status": run_status,
+        "stages": stage_entries,
+        "started_at": row.created_at,
+        "updated_at": row.updated_at,
+    })
+}
+
+#[derive(Debug, Deserialize)]
 pub struct PatchWorkflowBody {
     pub active: Option<bool>,
 }

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -936,4 +936,138 @@ mod tests {
         let err = validate_create_body(&body).unwrap_err();
         assert!(err.contains("preset_id or stages"));
     }
+
+    // ---------------------------------------------------------------
+    // project_run — status table for /api/workflows/:id/runs
+    // ---------------------------------------------------------------
+
+    fn run_row(
+        state: &str,
+        current_stage_index: Option<i32>,
+        parked: Option<&str>,
+    ) -> ArtifactRunRow {
+        let now = chrono::Utc::now();
+        ArtifactRunRow {
+            artifact_id: "art_test".into(),
+            workflow_id: "wf_test".into(),
+            state: state.into(),
+            current_stage_index,
+            workflow_parked_reason: parked.map(str::to_string),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn three_stages() -> Vec<WorkflowStage> {
+        let now = Utc::now();
+        let _ = now; // silence unused — only seq/id matter for projection
+        (0..3)
+            .map(|i| WorkflowStage {
+                id: format!("stage_{i}"),
+                workflow_id: "wf_test".into(),
+                seq: i,
+                gate_kind: GateKind::AgentSession,
+                params: serde_json::json!({}),
+            })
+            .collect()
+    }
+
+    fn stage_status(value: &serde_json::Value, idx: usize) -> &str {
+        value["stages"][idx]["status"].as_str().expect("status str")
+    }
+
+    #[test]
+    fn project_run_in_progress_partway_through() {
+        let row = run_row("in_progress", Some(1), None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["status"], "pending");
+        assert_eq!(stage_status(&v, 0), "passed");
+        assert_eq!(stage_status(&v, 1), "pending");
+        assert_eq!(stage_status(&v, 2), "pending");
+    }
+
+    #[test]
+    fn project_run_released_marks_all_stages_passed() {
+        let row = run_row("released", Some(2), None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["status"], "passed");
+        for i in 0..3 {
+            assert_eq!(stage_status(&v, i), "passed", "stage {i}");
+        }
+    }
+
+    #[test]
+    fn project_run_archived_marks_current_stage_failed() {
+        let row = run_row("archived", Some(1), None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["status"], "failed");
+        assert_eq!(stage_status(&v, 0), "passed");
+        assert_eq!(stage_status(&v, 1), "failed");
+        assert_eq!(stage_status(&v, 2), "pending");
+    }
+
+    #[test]
+    fn project_run_parked_marks_current_stage_blocked() {
+        let row = run_row("under_review", Some(1), Some("ci red"));
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["status"], "blocked");
+        assert_eq!(stage_status(&v, 0), "passed");
+        assert_eq!(stage_status(&v, 1), "blocked");
+        assert_eq!(stage_status(&v, 2), "pending");
+    }
+
+    #[test]
+    fn project_run_no_current_stage_index_keeps_all_pending() {
+        // current_stage_index None happens for trigger-just-fired
+        // artifacts before the first tick has set the column.
+        let row = run_row("draft", None, None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["status"], "pending");
+        for i in 0..3 {
+            assert_eq!(stage_status(&v, i), "pending", "stage {i}");
+        }
+    }
+
+    #[test]
+    fn project_run_negative_current_stage_index_clamps_to_pending() {
+        // i32 -> usize fails for negatives; the projection must treat
+        // the index as absent rather than panicking.
+        let row = run_row("draft", Some(-1), None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        for i in 0..3 {
+            assert_eq!(stage_status(&v, i), "pending", "stage {i}");
+        }
+    }
+
+    #[test]
+    fn project_run_current_stage_past_end_keeps_known_passed_intact() {
+        // current_stage_index past the last stage (e.g. workflow was
+        // edited to remove a stage). Stages with seq < idx still
+        // render as passed; nothing renders as the parked/blocked
+        // current stage because there is no current stage in range.
+        let row = run_row("in_progress", Some(5), None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        for i in 0..3 {
+            assert_eq!(stage_status(&v, i), "passed", "stage {i}");
+        }
+    }
+
+    #[test]
+    fn project_run_emits_artifact_id_as_run_id() {
+        // The dashboard treats artifact_id and run id interchangeably;
+        // this test pins that contract.
+        let row = run_row("draft", None, None);
+        let stages = three_stages();
+        let v = project_run(&row, &stages);
+        assert_eq!(v["id"], "art_test");
+        assert_eq!(v["artifact_id"], "art_test");
+        assert_eq!(v["workflow_id"], "wf_test");
+    }
 }

--- a/crates/stiglab/src/server/ws/agent.rs
+++ b/crates/stiglab/src/server/ws/agent.rs
@@ -134,6 +134,16 @@ async fn handle_agent_connection(socket: WebSocket, state: AppState) {
 /// (state stuck in `pending`) and dispatch them now over the freshly
 /// registered WebSocket. Best-effort: a send failure logs but doesn't
 /// abort registration — the next reconnect will retry.
+///
+/// Replay is gated on `artifact_id.is_some()` so we only redispatch
+/// sessions that came from `POST /api/shaping`. The `sessions` row
+/// persists `prompt` / `working_dir` / `artifact_id` / `artifact_version`
+/// but NOT the task-level fields (`allowed_tools`, `max_turns`, `model`,
+/// `system_prompt`, `permission_mode`, `credentials`). For shaping
+/// sessions those are always `None` (see `adapter::shaping_request_to_task`),
+/// so a lossless replay is safe. Direct `POST /api/tasks` sessions can
+/// carry user-set values that aren't on the row, so replaying them with
+/// defaults would silently change the task — skip + log instead.
 async fn dispatch_pending_for_node(state: &AppState, node_id: &str, tx: &WsSender) {
     let pending = match db::list_pending_sessions_for_node(&state.db, node_id).await {
         Ok(s) => s,
@@ -152,10 +162,50 @@ async fn dispatch_pending_for_node(state: &AppState, node_id: &str, tx: &WsSende
     );
 
     for session in pending {
-        // Reconstruct the dispatch payload from the persisted row. The
-        // task id matches the original ShapingRequest.request_id, so a
-        // duplicate dispatch is collapsed by the agent's own idempotency
-        // (it tracks session_id) — there's no double-shape risk.
+        if session.artifact_id.is_none() {
+            // Direct-task session: the persisted row is missing
+            // task-level fields a user may have set on the original
+            // request. Re-dispatching with defaults would silently
+            // change the task; surface the orphan instead.
+            tracing::warn!(
+                session_id = %session.id,
+                task_id = %session.task_id,
+                node_id,
+                "skipping pending direct-task session replay — persisted row \
+                 doesn't carry the full original task payload"
+            );
+            continue;
+        }
+
+        // Atomically claim the session before sending. If another path
+        // (e.g. a parallel reconnect or the create-time dispatch that
+        // raced with our list) already promoted this row past `pending`,
+        // the conditional UPDATE returns 0 affected rows and we skip.
+        // This closes the window where Copilot review #137 worried
+        // about duplicate local processes per session_id.
+        let claimed =
+            match db::claim_pending_session(&state.db, &session.id, SessionState::Dispatched).await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        session_id = %session.id,
+                        "failed to claim pending session for redispatch: {e}"
+                    );
+                    continue;
+                }
+            };
+        if !claimed {
+            tracing::debug!(
+                session_id = %session.id,
+                "pending session already claimed by another path — skipping replay"
+            );
+            continue;
+        }
+
+        // Shaping sessions: all task-level fields are known to be `None`
+        // for the original request (see shaping_request_to_task), so the
+        // reconstruction below is lossless.
         let task = Task {
             id: session.task_id.clone(),
             prompt: session.prompt.clone(),
@@ -179,16 +229,8 @@ async fn dispatch_pending_for_node(state: &AppState, node_id: &str, tx: &WsSende
         if tx.send(Message::Text(json.into())).is_err() {
             tracing::warn!(
                 session_id = %session.id,
-                "failed to dispatch pending session to agent — channel closed"
-            );
-            continue;
-        }
-        if let Err(e) =
-            db::update_session_state(&state.db, &session.id, SessionState::Dispatched).await
-        {
-            tracing::warn!(
-                session_id = %session.id,
-                "dispatched pending session but failed to update state: {e}"
+                "failed to dispatch claimed session to agent — channel closed; \
+                 leaving session in dispatched state for the next reconnect"
             );
         }
     }

--- a/crates/stiglab/src/server/ws/agent.rs
+++ b/crates/stiglab/src/server/ws/agent.rs
@@ -5,11 +5,11 @@ use chrono::Utc;
 use futures_util::{SinkExt, StreamExt};
 use uuid::Uuid;
 
-use crate::core::{AgentMessage, Node, NodeStatus, ServerMessage};
+use crate::core::{AgentMessage, Node, NodeStatus, ServerMessage, SessionState, Task};
 
 use crate::server::db;
 use crate::server::handler;
-use crate::server::state::{AgentConnection, AppState};
+use crate::server::state::{AgentConnection, AppState, WsSender};
 
 pub async fn agent_ws_handler(
     ws: WebSocketUpgrade,
@@ -87,10 +87,21 @@ async fn handle_agent_connection(socket: WebSocket, state: AppState) {
                 tracing::info!("node registered: {} ({})", info.name, id);
 
                 // Send confirmation
-                let response = ServerMessage::Registered { node_id: id };
+                let response = ServerMessage::Registered {
+                    node_id: id.clone(),
+                };
                 if let Ok(json) = serde_json::to_string(&response) {
                     let _ = tx.send(Message::Text(json.into()));
                 }
+
+                // Drain any sessions that were created and assigned to
+                // this node while the agent was disconnected. Without
+                // this, a session created by `POST /api/shaping` during
+                // a brief disconnect (or before the agent has registered
+                // for the first time) sits in `pending` forever even
+                // though the spine's `stiglab.session_created` event
+                // says one was scheduled.
+                dispatch_pending_for_node(&state, &id, &tx).await;
             }
 
             other => {
@@ -117,4 +128,68 @@ async fn handle_agent_connection(socket: WebSocket, state: AppState) {
     }
 
     send_task.abort();
+}
+
+/// Look up sessions that were assigned to this node but never dispatched
+/// (state stuck in `pending`) and dispatch them now over the freshly
+/// registered WebSocket. Best-effort: a send failure logs but doesn't
+/// abort registration — the next reconnect will retry.
+async fn dispatch_pending_for_node(state: &AppState, node_id: &str, tx: &WsSender) {
+    let pending = match db::list_pending_sessions_for_node(&state.db, node_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(node_id, "failed to list pending sessions on register: {e}");
+            return;
+        }
+    };
+    if pending.is_empty() {
+        return;
+    }
+    tracing::info!(
+        node_id,
+        count = pending.len(),
+        "draining pending sessions for newly registered agent"
+    );
+
+    for session in pending {
+        // Reconstruct the dispatch payload from the persisted row. The
+        // task id matches the original ShapingRequest.request_id, so a
+        // duplicate dispatch is collapsed by the agent's own idempotency
+        // (it tracks session_id) — there's no double-shape risk.
+        let task = Task {
+            id: session.task_id.clone(),
+            prompt: session.prompt.clone(),
+            node_id: Some(node_id.to_string()),
+            working_dir: session.working_dir.clone(),
+            allowed_tools: None,
+            max_turns: None,
+            model: None,
+            system_prompt: None,
+            permission_mode: None,
+            created_at: session.created_at,
+        };
+        let msg = ServerMessage::DispatchTask {
+            task: Box::new(task),
+            session_id: session.id.clone(),
+            credentials: None,
+        };
+        let Ok(json) = serde_json::to_string(&msg) else {
+            continue;
+        };
+        if tx.send(Message::Text(json.into())).is_err() {
+            tracing::warn!(
+                session_id = %session.id,
+                "failed to dispatch pending session to agent — channel closed"
+            );
+            continue;
+        }
+        if let Err(e) =
+            db::update_session_state(&state.db, &session.id, SessionState::Dispatched).await
+        {
+            tracing::warn!(
+                session_id = %session.id,
+                "dispatched pending session but failed to update state: {e}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Three related defects in the workflow → agent-session → artifact-lineage flow:

1. **Workflow detail page never showed live artifacts.** `WorkflowDetailPage` polls `GET /api/workflows/{id}/runs`, but the route didn't exist on stiglab — every poll silently 404'd, so the "Live artifacts" card stayed empty regardless of how many artifacts were flowing.
2. **No lineage data on artifact detail.** `horizontal_lineage` is wired in Forge (`record_closes_issue` etc.) and stored in the spine, but the artifact-detail API never queried it. The dashboard had no way to render cross-artifact dependency edges (PR ↔ spec issue).
3. **Sessions created but never triggered.** `stiglab.session_created` events were emitted, but actual claude sessions never ran. Two underlying causes — both fixed.

## Fixes

- **`feat(stiglab)`**: add `GET /api/workflows/{id}/runs` returning artifacts as runs, with per-stage status projected from `current_stage_index` + `workflow_parked_reason`. Tenant-gated like the other workflow routes.
- **`feat(spine)`**: query `horizontal_lineage` in `get_artifact`, surface on the API JSON, type it in the dashboard, and render a "Horizontal Lineage" card linking to source artifacts.
- **`fix(forge)`**: workflow gate's `agent-session` dispatch was `dispatch()` (blocking poll) under the Forge write lock. When no agent was connected, the poll spun until the 5-min deadline holding the lock — every other artifact frozen. Add `dispatch_fire_and_forget` to `StiglabDispatcher`; `HttpStiglabDispatcher` overrides with POST-only; the `session_completed` listener already resolves the signal cache for the next tick.
- **`fix(stiglab)`**: when an agent registers, drain any sessions assigned to its node that are stuck in `pending`. Without this, a session created during a brief disconnect (or before any agent first connects) sat `pending` forever even though the spine event said one was scheduled.

Refs #80

## Test plan

- [x] `cargo build --workspace` (with `RUSTFLAGS="-D warnings"`)
- [x] `cargo test --workspace --lib` — all 11 crates pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: create a workflow, label an issue → confirm `/runs` populates and stage dots progress
- [ ] Manual: open an artifact with a `closes_issue` link → confirm "Horizontal Lineage" card renders
- [ ] Manual: stop the agent, label an issue (so a `pending` session is created), restart agent → confirm session dispatches automatically

https://claude.ai/code/session_01GcKwfzXedKto2G8JygbJAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcKwfzXedKto2G8JygbJAJ)_