### PR TITLE
fix(forge): dedup trigger-fired artifacts by external_ref

### DIFF
--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -843,7 +843,13 @@ impl TriggerHandler for WorkflowTriggerHandler {
         // Dedup: a single (workflow, issue) must produce a single artifact
         // even if the trigger fires multiple times (e.g. label removed and
         // re-added, retried webhook delivery, rapid double-click). Look up
-        // by external_ref under an advisory lock before creating.
+        // by external_ref before creating; on hit, drop the trigger.
+        //
+        // Best-effort: the lookup is a plain SELECT, not advisory-locked.
+        // True concurrent ties may briefly create two rows; subsequent
+        // deliveries converge via the deterministic ORDER BY in
+        // `find_artifact_id_by_external_ref`. If races appear in practice,
+        // upgrade to the portal's `pg_advisory_xact_lock` pattern.
         let external_ref =
             trigger_external_ref(&event.workflow_id, &event.trigger_kind, &event.payload);
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -25,7 +25,7 @@ use crate::core::session_listener::{self, SessionCompleted, SessionCompletedHand
 use crate::core::signal_cache::SignalCache;
 use crate::core::stage_runner::{self, StageEvent};
 use crate::core::trigger_subscriber::{
-    self, register_artifact_from_trigger, TriggerFired, TriggerHandler,
+    self, register_artifact_from_trigger, trigger_external_ref, TriggerFired, TriggerHandler,
 };
 use crate::core::workflow_gates::LiveGateEvaluator;
 use crate::core::workflow_persistence;
@@ -840,6 +840,34 @@ impl TriggerHandler for WorkflowTriggerHandler {
                 }
             };
 
+        // Dedup: a single (workflow, issue) must produce a single artifact
+        // even if the trigger fires multiple times (e.g. label removed and
+        // re-added, retried webhook delivery, rapid double-click). Look up
+        // by external_ref under an advisory lock before creating.
+        let external_ref =
+            trigger_external_ref(&event.workflow_id, &event.trigger_kind, &event.payload);
+
+        if let (Some(spine_ref), Some(ref ext_ref)) = (spine.as_ref(), external_ref.as_ref()) {
+            match persistence::find_artifact_id_by_external_ref(spine_ref.pool(), ext_ref).await {
+                Ok(Some(existing_id)) => {
+                    tracing::info!(
+                        workflow_id = %event.workflow_id,
+                        external_ref = %ext_ref,
+                        artifact_id = %existing_id,
+                        "trigger.fired dropped (artifact already exists for this issue)"
+                    );
+                    return Ok(());
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        external_ref = %ext_ref,
+                        "forge: dedup lookup failed, falling through to register: {e}"
+                    );
+                }
+            }
+        }
+
         // Perform the registration under the write lock and capture the
         // resulting StageEntered event.
         let emitted = {
@@ -857,12 +885,15 @@ impl TriggerHandler for WorkflowTriggerHandler {
 
         if let Some(spine) = spine {
             // Mirror both the base artifact row and the workflow tagging.
+            // The external_ref column is what makes the next trigger.fired
+            // for this same (workflow, issue) hit the dedup branch above.
             if let Err(e) = persistence::insert_artifact_row(
                 spine.pool(),
                 artifact.artifact_id.as_str(),
                 &artifact.kind.to_string(),
                 &artifact.name,
                 &artifact.owner,
+                external_ref.as_deref(),
             )
             .await
             {
@@ -1030,6 +1061,7 @@ async fn register_artifact(
             &req.kind,
             &req.name,
             &req.owner,
+            None,
         )
         .await
         {

--- a/crates/forge/src/core/kernel.rs
+++ b/crates/forge/src/core/kernel.rs
@@ -76,6 +76,13 @@ impl Ord for SchedulableArtifact {
 ///
 /// - Picks the highest-priority artifact in `Draft` or `InProgress` state
 /// - Skips artifacts that are `UnderReview`, `Released`, or `Archived`
+/// - Skips workflow-tagged artifacts (`workflow_id.is_some()`) — those are
+///   driven by the stage runner, which dispatches sessions fire-and-forget
+///   via the workflow gate path. Letting the kernel ALSO grab them caused
+///   a double-dispatch where the kernel's blocking 5-minute polling call
+///   timed out into `ShapingOutcome::Failed`, surfacing as the
+///   "shaping Failed: not advancing state" log spam (issue: artifact
+///   deduplication, branch claude/fix-artifact-deduplication-NJwA3).
 /// - Respects `max_in_flight` concurrency limit
 #[derive(Debug, Default, Clone)]
 pub struct BaselineKernel {
@@ -121,6 +128,14 @@ impl SchedulingKernel for BaselineKernel {
                 artifact.state,
                 ArtifactState::Draft | ArtifactState::InProgress
             ) {
+                continue;
+            }
+
+            // Workflow-tagged artifacts belong to the stage runner — see
+            // the struct doc comment. Skipping here is what stops the
+            // double-dispatch that produced spurious `shaping Failed`
+            // log lines on every workflow trigger.
+            if artifact.workflow_id.is_some() {
                 continue;
             }
 
@@ -243,6 +258,46 @@ mod tests {
             max_in_flight: 5,
         };
         assert!(kernel.decide(&world).is_none());
+    }
+
+    #[test]
+    fn decide_skips_workflow_tagged_artifacts() {
+        // Workflow-tagged artifacts are driven by the stage runner; the
+        // baseline kernel must not also dispatch shaping for them or we
+        // get the double-dispatch failure mode (the kernel's 5-minute
+        // blocking poll times out into ShapingOutcome::Failed while the
+        // workflow path is meanwhile dispatching its own session).
+        let kernel = BaselineKernel::new();
+        let mut tagged = make_artifact("wf-art", ArtifactState::InProgress, 1);
+        tagged.workflow_id = Some("wf_1".to_string());
+        tagged.current_stage_index = Some(0);
+
+        let world = WorldState {
+            artifacts: vec![tagged],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+        assert!(kernel.decide(&world).is_none());
+    }
+
+    #[test]
+    fn decide_picks_untagged_when_tagged_present() {
+        // The kernel still dispatches for non-workflow artifacts even
+        // when workflow-tagged ones are in the same world.
+        let kernel = BaselineKernel::new();
+        let mut tagged = make_artifact("wf-art", ArtifactState::InProgress, 1);
+        tagged.workflow_id = Some("wf_1".to_string());
+        let untagged = make_artifact("plain-art", ArtifactState::InProgress, 1);
+
+        let world = WorldState {
+            artifacts: vec![tagged, untagged.clone()],
+            insights: vec![],
+            in_flight_count: 0,
+            max_in_flight: 5,
+        };
+        let decision = kernel.decide(&world).expect("should pick untagged");
+        assert_eq!(decision.artifact_id, untagged.artifact_id);
     }
 
     #[test]

--- a/crates/forge/src/core/kernel.rs
+++ b/crates/forge/src/core/kernel.rs
@@ -81,8 +81,7 @@ impl Ord for SchedulableArtifact {
 ///   via the workflow gate path. Letting the kernel ALSO grab them caused
 ///   a double-dispatch where the kernel's blocking 5-minute polling call
 ///   timed out into `ShapingOutcome::Failed`, surfacing as the
-///   "shaping Failed: not advancing state" log spam (issue: artifact
-///   deduplication, branch claude/fix-artifact-deduplication-NJwA3).
+///   "shaping Failed: not advancing state" log spam.
 /// - Respects `max_in_flight` concurrency limit
 #[derive(Debug, Default, Clone)]
 pub struct BaselineKernel {

--- a/crates/forge/src/core/persistence.rs
+++ b/crates/forge/src/core/persistence.rs
@@ -135,29 +135,57 @@ pub async fn load_artifact_store(pool: &PgPool) -> Result<ArtifactStore, sqlx::E
 /// the in-memory write, which is how `register_artifact` in
 /// `cmd/serve.rs` preserves the "no divergent state" property
 /// required by issue #30.
+///
+/// `external_ref` is the stable identity in an upstream system (e.g.
+/// `forge:trigger:{wf}:github-issue:{owner}/{repo}#{n}`). When
+/// non-`None`, callers should first look up by external_ref via
+/// [`find_artifact_id_by_external_ref`] under an advisory lock to avoid
+/// duplicates — `external_ref` is intentionally not `UNIQUE` workspace-
+/// wide (different adapters may legitimately share the column), so the
+/// DB cannot dedup for us via `ON CONFLICT`.
 pub async fn insert_artifact_row(
     pool: &PgPool,
     artifact_id: &str,
     kind: &str,
     name: &str,
     owner: &str,
+    external_ref: Option<&str>,
 ) -> Result<(), sqlx::Error> {
     let mut tx: Transaction<'_, Postgres> = pool.begin().await?;
 
     sqlx::query(
         "INSERT INTO artifacts \
-             (artifact_id, kind, name, owner, created_by, state, current_version) \
-         VALUES ($1, $2, $3, $4, 'forge', 'draft', 0) \
+             (artifact_id, kind, name, owner, created_by, state, current_version, external_ref) \
+         VALUES ($1, $2, $3, $4, 'forge', 'draft', 0, $5) \
          ON CONFLICT (artifact_id) DO NOTHING",
     )
     .bind(artifact_id)
     .bind(kind)
     .bind(name)
     .bind(owner)
+    .bind(external_ref)
     .execute(&mut *tx)
     .await?;
 
     tx.commit().await
+}
+
+/// Look up an artifact_id by its `external_ref`. Returns `None` if no
+/// row matches — the caller then proceeds to insert with that ref.
+///
+/// Used by the trigger subscriber to dedup `trigger.fired` events: the
+/// same GitHub issue label-fired through the same workflow must produce
+/// a single artifact, not one per webhook delivery.
+pub async fn find_artifact_id_by_external_ref(
+    pool: &PgPool,
+    external_ref: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1 LIMIT 1")
+            .bind(external_ref)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(id,)| id))
 }
 
 /// Mirror the post-tick state of `artifact` to the `artifacts` row.

--- a/crates/forge/src/core/persistence.rs
+++ b/crates/forge/src/core/persistence.rs
@@ -139,10 +139,15 @@ pub async fn load_artifact_store(pool: &PgPool) -> Result<ArtifactStore, sqlx::E
 /// `external_ref` is the stable identity in an upstream system (e.g.
 /// `forge:trigger:{wf}:github-issue:{owner}/{repo}#{n}`). When
 /// non-`None`, callers should first look up by external_ref via
-/// [`find_artifact_id_by_external_ref`] under an advisory lock to avoid
-/// duplicates — `external_ref` is intentionally not `UNIQUE` workspace-
-/// wide (different adapters may legitimately share the column), so the
-/// DB cannot dedup for us via `ON CONFLICT`.
+/// [`find_artifact_id_by_external_ref`] and skip the INSERT on hit.
+/// The lookup is intentionally a plain `SELECT` (not advisory-locked):
+/// `external_ref` is not `UNIQUE` workspace-wide (different adapters may
+/// legitimately share the column), and a true concurrent tie would at
+/// worst briefly create two rows — subsequent deliveries converge on
+/// the canonical (oldest) row via the deterministic `ORDER BY` in
+/// `find_artifact_id_by_external_ref`. If concurrency races appear in
+/// practice, the next step is the portal's
+/// `pg_advisory_xact_lock(hashtextextended($1, 0))` pattern.
 pub async fn insert_artifact_row(
     pool: &PgPool,
     artifact_id: &str,
@@ -176,15 +181,26 @@ pub async fn insert_artifact_row(
 /// Used by the trigger subscriber to dedup `trigger.fired` events: the
 /// same GitHub issue label-fired through the same workflow must produce
 /// a single artifact, not one per webhook delivery.
+///
+/// Ordered by `(created_at ASC, artifact_id ASC)` so that if a
+/// concurrent tie briefly creates two rows with the same `external_ref`
+/// (the lookup-then-insert is not advisory-locked — see
+/// [`insert_artifact_row`]), every caller across processes converges
+/// on the same canonical (oldest) row instead of returning whichever
+/// the planner happens to surface.
 pub async fn find_artifact_id_by_external_ref(
     pool: &PgPool,
     external_ref: &str,
 ) -> Result<Option<String>, sqlx::Error> {
-    let row: Option<(String,)> =
-        sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1 LIMIT 1")
-            .bind(external_ref)
-            .fetch_optional(pool)
-            .await?;
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT artifact_id FROM artifacts \
+          WHERE external_ref = $1 \
+          ORDER BY created_at ASC, artifact_id ASC \
+          LIMIT 1",
+    )
+    .bind(external_ref)
+    .fetch_optional(pool)
+    .await?;
     Ok(row.map(|(id,)| id))
 }
 

--- a/crates/forge/src/core/trigger_subscriber.rs
+++ b/crates/forge/src/core/trigger_subscriber.rs
@@ -126,6 +126,33 @@ impl<H: TriggerHandler> EventHandler for Dispatcher<H> {
     }
 }
 
+/// Stable identity for an artifact created from a trigger payload.
+///
+/// Format: `forge:trigger:{workflow_id}:{trigger_kind}:{owner}/{repo}#{n}`.
+/// Returns `None` when the payload is missing the fields needed to form a
+/// stable key (we never fall back to a random ref — that would re-introduce
+/// the duplication this function exists to prevent).
+///
+/// Anchored on `(workflow_id, issue)`: the same issue under two different
+/// workflows produces two distinct artifacts (each workflow drives its own
+/// pipeline), but a re-fired trigger for the same `(workflow, issue)`
+/// converges on the existing row.
+pub fn trigger_external_ref(
+    workflow_id: &str,
+    trigger_kind: &str,
+    payload: &serde_json::Value,
+) -> Option<String> {
+    let owner = payload.get("repo_owner").and_then(|v| v.as_str())?;
+    let repo = payload.get("repo_name").and_then(|v| v.as_str())?;
+    let number = payload.get("issue_number").and_then(|v| v.as_u64())?;
+    if owner.is_empty() || repo.is_empty() || number == 0 {
+        return None;
+    }
+    Some(format!(
+        "forge:trigger:{workflow_id}:{trigger_kind}:{owner}/{repo}#{number}"
+    ))
+}
+
 /// Pure helper: given a fired trigger + the corresponding workflow, build
 /// and register the artifact in the store. Used by the live handler in
 /// `cmd/serve.rs` and by tests that want to exercise the logic without a
@@ -241,6 +268,69 @@ mod tests {
         let trigger = make_trigger();
         assert!(register_artifact_from_trigger(&mut store, &wf, &trigger).is_none());
         assert_eq!(store.active_artifacts().len(), 0);
+    }
+
+    #[test]
+    fn external_ref_is_stable_across_calls() {
+        let payload = serde_json::json!({
+            "repo_owner": "acme",
+            "repo_name": "widgets",
+            "issue_number": 42,
+            "title": "anything",
+        });
+        let a = trigger_external_ref("wf_1", "github_issue_webhook", &payload);
+        let b = trigger_external_ref("wf_1", "github_issue_webhook", &payload);
+        assert_eq!(a, b);
+        assert_eq!(
+            a.as_deref(),
+            Some("forge:trigger:wf_1:github_issue_webhook:acme/widgets#42")
+        );
+    }
+
+    #[test]
+    fn external_ref_distinct_per_workflow() {
+        let payload = serde_json::json!({
+            "repo_owner": "acme",
+            "repo_name": "widgets",
+            "issue_number": 42,
+        });
+        let a = trigger_external_ref("wf_1", "github_issue_webhook", &payload);
+        let b = trigger_external_ref("wf_2", "github_issue_webhook", &payload);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn external_ref_returns_none_when_payload_incomplete() {
+        // Missing repo_owner / repo_name / issue_number → can't form a
+        // stable key, so we don't fabricate one (which would re-introduce
+        // duplicates).
+        assert!(trigger_external_ref("wf", "k", &serde_json::json!({})).is_none());
+        assert!(trigger_external_ref(
+            "wf",
+            "k",
+            &serde_json::json!({ "repo_owner": "a", "repo_name": "b" })
+        )
+        .is_none());
+        assert!(trigger_external_ref(
+            "wf",
+            "k",
+            &serde_json::json!({
+                "repo_owner": "",
+                "repo_name": "b",
+                "issue_number": 1
+            })
+        )
+        .is_none());
+        assert!(trigger_external_ref(
+            "wf",
+            "k",
+            &serde_json::json!({
+                "repo_owner": "a",
+                "repo_name": "b",
+                "issue_number": 0
+            })
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/forge/tests/persistence_restart.rs
+++ b/crates/forge/tests/persistence_restart.rs
@@ -74,7 +74,7 @@ async fn restart_in_mid_tick_preserves_state_and_bundle() {
     reset(&pool, artifact_id).await;
 
     // 1. Register via the DB-first path.
-    persistence::insert_artifact_row(&pool, artifact_id, "code", "restart-test", "marvin")
+    persistence::insert_artifact_row(&pool, artifact_id, "code", "restart-test", "marvin", None)
         .await
         .expect("insert_artifact_row");
 
@@ -127,10 +127,10 @@ async fn load_skips_archived_artifacts() {
     reset(&pool, active_id).await;
     reset(&pool, archived_id).await;
 
-    persistence::insert_artifact_row(&pool, active_id, "code", "active", "marvin")
+    persistence::insert_artifact_row(&pool, active_id, "code", "active", "marvin", None)
         .await
         .unwrap();
-    persistence::insert_artifact_row(&pool, archived_id, "code", "archived", "marvin")
+    persistence::insert_artifact_row(&pool, archived_id, "code", "archived", "marvin", None)
         .await
         .unwrap();
 
@@ -170,9 +170,15 @@ async fn failed_insert_leaves_no_divergent_state() {
 
     let bad_pool = PgPool::connect(&url).await.unwrap();
     bad_pool.close().await;
-    let err =
-        persistence::insert_artifact_row(&bad_pool, artifact_id, "code", "failure-test", "marvin")
-            .await;
+    let err = persistence::insert_artifact_row(
+        &bad_pool,
+        artifact_id,
+        "code",
+        "failure-test",
+        "marvin",
+        None,
+    )
+    .await;
     assert!(err.is_err(), "expected closed-pool insert to fail");
 
     let store = persistence::load_artifact_store(&pool).await.unwrap();

--- a/crates/onsager-spine/migrations/008_artifacts_external_ref_index.sql
+++ b/crates/onsager-spine/migrations/008_artifacts_external_ref_index.sql
@@ -1,0 +1,15 @@
+-- Onsager spine: index on artifacts.external_ref.
+--
+-- The forge trigger subscriber dedups `trigger.fired` events by looking up
+-- an existing artifact via its stable external_ref (e.g.
+-- `forge:trigger:{wf}:github_issue_webhook:{owner}/{repo}#{n}`). Without an
+-- index, that lookup is a sequential scan on `artifacts` for every webhook
+-- delivery — fine while the table is tiny, a problem as soon as it grows.
+--
+-- Partial index: most rows have `external_ref IS NULL` (created via the
+-- manual REST path or older subsystems), so indexing only non-NULL values
+-- keeps the index small while still serving the dedup query.
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_external_ref
+    ON artifacts (external_ref)
+    WHERE external_ref IS NOT NULL;


### PR DESCRIPTION
## Summary

Two bugs surfaced together in production: many artifacts created with the same GitHub issue id, and a flood of `forge tick: Error("shaping Failed for art_…: not advancing state")` log lines.

- **Dedup trigger-fired artifacts.** A re-fired `trigger.fired` (re-label, retried webhook delivery, double-click) created a fresh artifact every time because the trigger subscriber generated a new ULID and never consulted `external_ref`. Now we compute a stable `external_ref` of the form `forge:trigger:{wf}:{trigger_kind}:{owner}/{repo}#{n}` from the payload, look it up before creating, and persist it on the row so the next delivery hits the dedup branch. Pattern mirrors `onsager-portal::upsert_pr_artifact`.
- **Stop the kernel from double-dispatching workflow-tagged artifacts.** The stage runner already drives those via `dispatch_fire_and_forget`. Letting `BaselineKernel` ALSO grab them caused its blocking 5-minute poll to time out into `ShapingOutcome::Failed`, which is the source of the "not advancing state" spam. Kernel now skips artifacts where `workflow_id.is_some()`.

`external_ref` is intentionally not `UNIQUE` workspace-wide (different adapters may legitimately share the column) — same constraint that the portal works around. The lookup-then-insert is best-effort idempotent: a true concurrent tie would briefly create two rows, but the next delivery converges. If real concurrency races appear, the next step is the portal's advisory-lock pattern.

Refs #96 — its Plan/Idempotency section explicitly calls out the per-`(workflow, artifact)` dedup question and the unit test "re-labelling the same `main-red` issue does not dispatch a second agent-session", which this PR satisfies for the trigger side.

## Delivers

- Stable `trigger_external_ref()` helper in `crates/forge/src/core/trigger_subscriber.rs` (with 3 unit tests).
- DB lookup + INSERT-with-external_ref wiring through `crates/forge/src/core/persistence.rs::insert_artifact_row` and the live trigger handler in `crates/forge/src/cmd/serve.rs`.
- Workflow-tagged-artifact skip in `crates/forge/src/core/kernel.rs::BaselineKernel::decide` (with 2 unit tests).

## Test plan

- [x] `cargo test -p forge --lib` — 103 pass (incl. 5 new tests).
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`.
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` — 113 pass.
- [ ] Manual: webhook-relabel a fixture issue twice, verify exactly one `artifacts` row appears with the `forge:trigger:…` `external_ref`.
- [ ] Manual: confirm the `shaping Failed: not advancing state` log lines no longer appear for workflow-tagged artifacts.

https://claude.ai/code/session_01VEHsYbbzYRqxtxoMZ2SHgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEHsYbbzYRqxtxoMZ2SHgt)_