### PR TITLE
fix(dashboard): blank screen when opening command palette

### DIFF
--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
+  Command,
   CommandDialog,
   CommandEmpty,
   CommandGroup,
@@ -118,81 +119,87 @@ function CommandPaletteDialog() {
   return (
     <>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search…" />
-        <CommandList>
+        {/* shadcn's CommandDialog wraps in <DialogContent> but NOT in
+            <Command>; the cmdk primitives below need a Command parent
+            for context, otherwise CommandInput throws and the dialog
+            tears down the tree (blank screen). */}
+        <Command>
+          <CommandInput placeholder="Type a command or search…" />
+          <CommandList>
           <CommandEmpty>No results.</CommandEmpty>
 
-          <CommandGroup heading="Create">
-            <CommandItem
-              keywords={["new", "factory", "github"]}
-              onSelect={() => go("/workflows/start")}
-            >
-              <Zap className="mr-2 h-4 w-4" />
-              New workflow
-            </CommandItem>
-            {canAuth && (
+            <CommandGroup heading="Create">
               <CommandItem
-                keywords={["new"]}
-                onSelect={() => run(() => setSessionOpen(true))}
+                keywords={["new", "factory", "github"]}
+                onSelect={() => go("/workflows/start")}
               >
+                <Zap className="mr-2 h-4 w-4" />
+                New workflow
+              </CommandItem>
+              {canAuth && (
+                <CommandItem
+                  keywords={["new"]}
+                  onSelect={() => run(() => setSessionOpen(true))}
+                >
+                  <Terminal className="mr-2 h-4 w-4" />
+                  New session
+                </CommandItem>
+              )}
+              {canAuth && (
+                <CommandItem
+                  keywords={["new", "tenant"]}
+                  onSelect={() => run(() => setWorkspaceOpen(true))}
+                >
+                  <Building2 className="mr-2 h-4 w-4" />
+                  New workspace
+                </CommandItem>
+              )}
+            </CommandGroup>
+
+            <CommandSeparator />
+
+            <CommandGroup heading="Go to">
+              <CommandItem keywords={["overview"]} onSelect={() => go("/")}>
+                <Factory className="mr-2 h-4 w-4" />
+                Factory overview
+              </CommandItem>
+              {canAuth && (
+                <CommandItem onSelect={() => go("/workspaces")}>
+                  <Building2 className="mr-2 h-4 w-4" />
+                  Workspaces
+                </CommandItem>
+              )}
+              <CommandItem onSelect={() => go("/workflows")}>
+                <GitBranch className="mr-2 h-4 w-4" />
+                Workflows
+              </CommandItem>
+              <CommandItem onSelect={() => go("/artifacts")}>
+                <Package className="mr-2 h-4 w-4" />
+                Artifacts
+              </CommandItem>
+              <CommandItem onSelect={() => go("/spine")}>
+                <Activity className="mr-2 h-4 w-4" />
+                Event spine
+              </CommandItem>
+              <CommandItem onSelect={() => go("/governance")}>
+                <Shield className="mr-2 h-4 w-4" />
+                Governance
+              </CommandItem>
+              <CommandItem onSelect={() => go("/sessions")}>
                 <Terminal className="mr-2 h-4 w-4" />
-                New session
+                Sessions
               </CommandItem>
-            )}
-            {canAuth && (
-              <CommandItem
-                keywords={["new", "tenant"]}
-                onSelect={() => run(() => setWorkspaceOpen(true))}
-              >
-                <Building2 className="mr-2 h-4 w-4" />
-                New workspace
+              <CommandItem onSelect={() => go("/nodes")}>
+                <Server className="mr-2 h-4 w-4" />
+                Nodes
               </CommandItem>
-            )}
-          </CommandGroup>
-
-          <CommandSeparator />
-
-          <CommandGroup heading="Go to">
-            <CommandItem keywords={["overview"]} onSelect={() => go("/")}>
-              <Factory className="mr-2 h-4 w-4" />
-              Factory overview
-            </CommandItem>
-            {canAuth && (
-              <CommandItem onSelect={() => go("/workspaces")}>
-                <Building2 className="mr-2 h-4 w-4" />
-                Workspaces
+              <CommandItem onSelect={() => go("/settings")}>
+                <SettingsIcon className="mr-2 h-4 w-4" />
+                Settings
               </CommandItem>
-            )}
-            <CommandItem onSelect={() => go("/workflows")}>
-              <GitBranch className="mr-2 h-4 w-4" />
-              Workflows
-            </CommandItem>
-            <CommandItem onSelect={() => go("/artifacts")}>
-              <Package className="mr-2 h-4 w-4" />
-              Artifacts
-            </CommandItem>
-            <CommandItem onSelect={() => go("/spine")}>
-              <Activity className="mr-2 h-4 w-4" />
-              Event spine
-            </CommandItem>
-            <CommandItem onSelect={() => go("/governance")}>
-              <Shield className="mr-2 h-4 w-4" />
-              Governance
-            </CommandItem>
-            <CommandItem onSelect={() => go("/sessions")}>
-              <Terminal className="mr-2 h-4 w-4" />
-              Sessions
-            </CommandItem>
-            <CommandItem onSelect={() => go("/nodes")}>
-              <Server className="mr-2 h-4 w-4" />
-              Nodes
-            </CommandItem>
-            <CommandItem onSelect={() => go("/settings")}>
-              <SettingsIcon className="mr-2 h-4 w-4" />
-              Settings
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
+            </CommandGroup>
+          </CommandList>
+        </Command>
       </CommandDialog>
 
       {sessionOpen && (

--- a/apps/dashboard/tests/smoke/command-palette.test.tsx
+++ b/apps/dashboard/tests/smoke/command-palette.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import {
+  CommandPaletteProvider,
+  CommandPaletteTrigger,
+} from "@/components/layout/CommandPalette"
+
+// Regression: clicking the search trigger used to render a blank
+// browser because shadcn's CommandDialog does not auto-wrap children
+// in <Command>, so cmdk primitives threw on missing context. This
+// test mounts the trigger, clicks it, and asserts the palette renders
+// real content (groups + items) rather than crashing the tree.
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <CommandPaletteProvider>
+          <CommandPaletteTrigger />
+        </CommandPaletteProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("CommandPalette", () => {
+  it("renders the trigger button without throwing", () => {
+    mount()
+    expect(
+      screen.getByRole("button", { name: /command palette/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("opens a populated palette when the trigger is clicked", () => {
+    mount()
+    fireEvent.click(screen.getByRole("button", { name: /command palette/i }))
+
+    // The palette must render its searchable input + at least one item
+    // from each group. If <Command> context is missing, cmdk primitives
+    // throw and none of these would appear (blank screen).
+    expect(
+      screen.getByPlaceholderText(/type a command or search/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/new workflow/i)).toBeInTheDocument()
+    expect(screen.getByText(/factory overview/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Clicking the command palette search icon (or pressing ⌘K) made the browser go blank.

**Root cause.** shadcn's `CommandDialog` wraps children in `<DialogContent>`, but **does not** wrap them in `<Command>`. cmdk primitives (`CommandInput`, `CommandList`, …) need a `Command` parent for context — without it `CommandInput` throws on render, the unhandled exception tears down the React tree, and the user sees a blank page.

## Fix

- Wrap the palette body in `<Command>` inside `CommandDialog`.
- Add a regression smoke test (`tests/smoke/command-palette.test.tsx`) that mounts `CommandPaletteTrigger`, clicks it, and asserts the input + at least one item from each group are rendered. If the `<Command>` wrapper is removed, this test fails.

The existing tests didn't catch this because they never opened the dialog — the trigger button rendered fine on its own; the crash happened only on click.

## Test plan

- [ ] On the deployed preview, click the search icon in the desktop header — palette opens with Create + Go to groups, no blank screen.
- [ ] Press ⌘K (or Ctrl+K) — same result.
- [ ] On mobile, tap the search icon in the chrome bar — palette opens.
- [ ] Type "work" — fuzzy filters to "New workflow", "Workflows".
- [ ] Lint, build, vitest all pass (verified locally: 86/86).

This is a follow-up bug fix to #141; no spec issue, applying `trivial`.

https://claude.ai/code/session_01HY6ke2iYcHeVxyAAwLxWNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY6ke2iYcHeVxyAAwLxWNE)_