### PR TITLE
docs(arch): persist the seam rule (Lever A of #131)

### DIFF
--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -176,6 +176,49 @@ Examples: `spec(stiglab): add session timeout`, `spec(dashboard): fix node statu
 - Any open questions that need human decisions
 - Sub-issue links if the spec was split
 
+## The seam rule (restated for spec authors)
+
+Every spec on Onsager inherits this constraint — drafting one means
+checking that the proposed design respects it before publishing:
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+If your spec needs a new cross-subsystem interaction, the Design
+section must:
+
+- Describe the interaction as event(s) on the spine, not as an HTTP
+  request between two subsystems.
+- Name the producing subsystem, the consuming subsystem, and at least
+  one event type (preferably an existing `FactoryEventKind` variant or
+  a clearly proposed new one).
+- Land the producer + consumer + (when introduced) registry entry as
+  one PR — see the "producer with no consumer" drift pattern in the
+  root `CLAUDE.md`.
+
+If your spec needs a new shared piece of state, the spine wins — the
+Design section must propose a spine table (with a discriminator
+column if it's tenant-scoped) rather than a per-subsystem table that
+mirrors a spine concept.
+
+If your spec is a rename or migration, do not propose a `serde(alias)`
+shim, a `*_mirror.rs` translator module, or a "legacy compat" type
+alias as the destination — those are bridge debt by construction
+(spec #131 Lever B will hard-fail them in CI). Database schema
+migrations are the only multi-step exception and stay governed by
+the existing `migrations/NNN_*.sql` convention.
+
+When the spec is large enough that the seam rule pushes the work into
+two PRs (a back-end emit + a front-end consume, for instance), keep
+them in one spec and split into sub-issues — one per PR — rather than
+splitting the spec.
+
 ## Area label taxonomy (Onsager monorepo)
 
 Pick one or more, aligned with `crates/` and `apps/`:

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -214,10 +214,18 @@ alias as the destination — those are bridge debt by construction
 migrations are the only multi-step exception and stay governed by
 the existing `migrations/NNN_*.sql` convention.
 
-When the spec is large enough that the seam rule pushes the work into
-two PRs (a back-end emit + a front-end consume, for instance), keep
-them in one spec and split into sub-issues — one per PR — rather than
-splitting the spec.
+When a contract under the seam rule splits the work across two
+subsystems (a back-end producer + a front-end consumer of an event,
+for instance), follow the existing parent-plus-children rule below
+under "Area label taxonomy": one parent spec captures the end-to-end
+slice, one child spec per subsystem captures its half. The contract
+lives in the parent's Plan (e.g. "stiglab emits `X`; forge consumes
+`X` and emits `Y`"); each child spec scopes to a single subsystem so
+each PR stays inside one `area:*`. Producer and consumer halves can
+land in separate PRs as long as both children close before the parent
+does — but the parent's Plan should require a contract test that
+fails until both halves exist, so the half-wired API/UI pattern from
+PR #108 can't recur.
 
 ## Area label taxonomy (Onsager monorepo)
 

--- a/.claude/skills/onsager-dev-process/SKILL.md
+++ b/.claude/skills/onsager-dev-process/SKILL.md
@@ -98,9 +98,31 @@ Implement the spec's Plan items in order. Keep commits small and focused.
 Commit messages should be imperative and under 72 chars.
 
 Respect the architectural invariant: subsystems (`forge`, `stiglab`,
-`synodic`, `ising`) do not import each other. If your spec forces a
-cross-subsystem dependency, split it into parent + sub-issues before
-continuing.
+`synodic`, `ising`) do not import each other. The seam rule (canonical
+form, also persisted in root `CLAUDE.md` and each subsystem's
+`CLAUDE.md`) makes this concrete:
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+If implementation surfaces a need to break this rule — a sibling-port
+HTTP call, a `*_mirror.rs` translator, a `serde(alias)` shim, a "for
+compat" type alias — stop. The right move is one of: emit an event +
+listener pair (cross-subsystem coordination), collapse the schema into
+the spine with a discriminator (shared state), or land the rename in
+one PR (no aliases). If the spec doesn't yet describe that path,
+update the spec first; do not add a bridge "for now". Spec #131 Lever
+B will hard-fail these in CI, so a bridge that ships today is a
+revert tomorrow.
+
+The `onsager-pre-push` skill includes a seam-rule self-check that
+scans the diff for these violations before push.
 
 ### 4. Pre-push
 

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -227,8 +227,11 @@ is explicitly trivial). This is the local counterpart to the
    title, two issues silently left open after merge.
 
 5. **If this is genuinely trivial** (typo, doc-only, one-line obvious
-   fix), skip steps 6.1–6.4 and plan to apply the `trivial` label to the
-   PR immediately after `mcp__github__create_pull_request`. Use sparingly.
+   fix), skip the spec-link substeps above (1–4) and plan to apply the
+   `trivial` label to the PR immediately after
+   `mcp__github__create_pull_request`. The seam-rule self-check in
+   step 6.5 still runs — it's a no-op for genuinely doc-only diffs and
+   takes seconds otherwise. Use the trivial label sparingly.
 
 ### 6.5. Seam-rule self-check
 

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -230,6 +230,55 @@ is explicitly trivial). This is the local counterpart to the
    fix), skip steps 6.1–6.4 and plan to apply the `trivial` label to the
    PR immediately after `mcp__github__create_pull_request`. Use sparingly.
 
+### 6.5. Seam-rule self-check
+
+Before pushing, look at the diff once more against the canonical rule:
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+Run a focused diff scan — Lever B of spec #131 will eventually hard-fail
+each of these in CI; until that lands, catch them locally:
+
+```bash
+git diff origin/main...HEAD -- 'crates/forge/**' 'crates/stiglab/**' \
+  'crates/synodic/**' 'crates/ising/**'
+```
+
+Flag any of:
+
+- **New sibling-subsystem HTTP client.** A new `reqwest::Client` /
+  `hyper::Client` constructed in `forge|stiglab|synodic|ising` whose
+  URL targets a sibling-subsystem port (3000, 3001, …) or service
+  name. The right shape is event emit + listener pair.
+- **New cross-subsystem Cargo dep.** Subsystem A's `Cargo.toml`
+  declaring B as a dep, e.g. `forge` adding `stiglab = { path = ... }`.
+  Subsystems may depend only on `onsager-{artifact, warehouse,
+  protocol, spine, registry, delivery}` per their existing manifests.
+- **New `serde(alias = …)`.** Renames must land atomically; aliases
+  ossify (PR #107 is the canonical case).
+- **New `*_mirror.rs` file or "translator" module.** The spine is
+  already the source of truth; mirror modules drift (PR #129 / Lever
+  D is removing the live one).
+- **New `pub type X = Y` "for compatibility".** Same problem as a
+  serde alias.
+- **New `FactoryEventKind` variant without a consumer.** Producer +
+  consumer should land together (PR #127 drift pattern). Lever E will
+  make this CI-enforceable.
+- **New API endpoint with no dashboard caller, or new dashboard
+  client method with no backend handler.** PR #108 drift pattern;
+  ship both halves in one PR (or two PRs gated by a contract test).
+
+If any of these appear, fix the seam before pushing — do not file a
+follow-up issue and ship the bridge. (Database schema migrations are
+the only exception; they remain governed by `migrations/NNN_*.sql`.)
+
 ### 7. Push
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,10 @@ API/UI contract enforcement). Until the levers all land, the rule is
 review-time discipline; treat the drift patterns below as the working
 heuristics.
 
-Live violation (Lever C target): `crates/forge/src/cmd/serve.rs:65–180`
-still constructs `HttpStiglabDispatcher` and `HttpSynodicGate` against
-sibling subsystem ports. New code must not add to that pattern.
+Live violation (Lever C target): `crates/forge/src/cmd/serve.rs`
+still defines `HttpStiglabDispatcher` (≈52–304) and `HttpSynodicGate`
+(≈344–397), and instantiates them against sibling-subsystem ports in
+`run` (≈469–490). New code must not add to that pattern.
 
 ## Architectural drift patterns to watch
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,29 @@ must NOT import each other, and must NOT be statically linked into the same
 binary. The `onsager` dispatcher has zero business dependencies -- it discovers
 subsystem binaries on PATH.
 
+## The seam rule (canonical)
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+This is the rule. ADR 0001 set it; spec #131 is collapsing the
+remaining places it is informally stated or informally enforced into
+six levers (A–F: persisted rule → mechanical guardrails → finish ADR
+0001 migration → spine as SoT → registry-backed event types →
+API/UI contract enforcement). Until the levers all land, the rule is
+review-time discipline; treat the drift patterns below as the working
+heuristics.
+
+Live violation (Lever C target): `crates/forge/src/cmd/serve.rs:65–180`
+still constructs `HttpStiglabDispatcher` and `HttpSynodicGate` against
+sibling subsystem ports. New code must not add to that pattern.
+
 ## Architectural drift patterns to watch
 
 Loose runtime coupling is correct and stays — but the seams it creates are
@@ -64,7 +87,7 @@ follow-up issue with a `bridge-debt` label and a target removal date.
   to outlive their intended window. File a `bridge-debt` issue at rename
   time; remove the alias on the target date, not "eventually".
 
-The strategy spec #131 captures the full reasoning and the five-lever plan
+The strategy spec #131 captures the full reasoning and the six-lever plan
 to make these contracts enforced rather than informal. Until that lands,
 treat the patterns above as review-time heuristics.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,13 @@ subsystem binaries on PATH.
 > shared spine tables. No subsystem makes HTTP calls to another
 > subsystem. No subsystem imports another subsystem's crate.
 
-This is the rule. ADR 0001 set it; spec #131 is collapsing the
-remaining places it is informally stated or informally enforced into
-six levers (A–F: persisted rule → mechanical guardrails → finish ADR
-0001 migration → spine as SoT → registry-backed event types →
-API/UI contract enforcement). Until the levers all land, the rule is
-review-time discipline; treat the drift patterns below as the working
-heuristics.
+This is the rule. ADR 0001 set it; [ADR 0004](docs/adr/0004-tighten-the-seams.md)
+captures the decision to make it machine-checkable and the six-lever
+execution plan that spec #131 tracks (A–F: persisted rule →
+mechanical guardrails → finish ADR 0001 migration → spine as SoT →
+registry-backed event types → API/UI contract enforcement). Until the
+levers all land, the rule is review-time discipline; treat the drift
+patterns below as the working heuristics.
 
 Live violation (Lever C target): `crates/forge/src/cmd/serve.rs`
 still defines `HttpStiglabDispatcher` (≈52–304) and `HttpSynodicGate`

--- a/crates/onsager-spine/CLAUDE.md
+++ b/crates/onsager-spine/CLAUDE.md
@@ -30,6 +30,41 @@ All subsystems live under `crates/` in the workspace root:
 Each depends on `onsager-spine` via `path = "../onsager-spine"`.
 Subsystems must NOT import each other.
 
+## The seam rule (canonical)
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+What this means for the spine specifically:
+
+- **Spine = mechanism, not a subsystem.** It does not have a sibling
+  HTTP surface and is not addressable on a port. Subsystems link the
+  library; they coordinate by writing/reading `events` / `events_ext`
+  rows and listening on `pg_notify`.
+- **New event types are the cross-subsystem contract.** When a new
+  `FactoryEventKind` variant is added here, the producer and at least
+  one consumer must land in the same PR (or two PRs gated by a contract
+  test). A producer with no consumer is the drift pattern from PR #127;
+  Lever E will make this CI-enforceable via a registry manifest.
+- **Don't grow a sync RPC API on the spine.** If a question feels like
+  "stiglab needs to ask synodic *now*", the answer is an event +
+  listener pair, not a request/response surface. ADR 0001 documents
+  why; spec #131 is closing the last place this is still violated.
+- **Spine tables are the single source of truth.** Subsystem-private
+  tables that mirror a spine concept (e.g. `tenant_workflows` ↔
+  `workflows`, PR #129) are the Lever D drift pattern: collapse into
+  the spine table with a discriminator column rather than building a
+  mirror.
+
+See [ADR 0001](../../docs/adr/0001-event-bus-coordination-model.md) for
+the original decision and spec #131 for the six-lever enforcement plan.
+
 ## Build & Test
 
 ```bash

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -23,20 +23,22 @@ What this means for stiglab specifically:
   webhook router at `src/server/webhook_router.rs`) called by external
   services. Both are "external boundary" by definition.
 - **Forbidden HTTP surfaces.** Anything called from `forge`, `synodic`,
-  or `ising`. The legacy `HttpStiglabDispatcher` path in
-  `crates/forge/src/cmd/serve.rs:65–180` is the one remaining
-  violation, and Lever C of spec #131 deletes it. Do not add new
-  internal routes to satisfy a sibling subsystem — emit/consume an
-  event instead.
+  or `ising`. The legacy `HttpStiglabDispatcher` path
+  (`crates/forge/src/cmd/serve.rs` ≈52–304, instantiated in `run`
+  ≈469–490) is the one remaining violation, and Lever C of spec #131
+  deletes it. Do not add new internal routes to satisfy a sibling
+  subsystem — emit/consume an event instead.
 - **Coordinating with forge or synodic.** Listen on the spine for the
   event you care about, write your response as a new event. Concrete
   pattern: forge will emit `forge.shaping_dispatched` once Lever C
   lands; stiglab consumes it and emits `stiglab.session_completed` (or
   the equivalent error event) when the session resolves.
-- **Cargo deps.** `stiglab` may depend on `onsager-{artifact, protocol,
-  spine}` (and on `onsager-protocol` only until Lever C deletes that
-  crate). It must NOT depend on `forge`, `synodic`, or `ising`. CI
-  will hard-fail this once Lever B's architecture lint lands.
+- **Cargo deps.** `stiglab` may depend on `onsager-{artifact,
+  protocol, registry, spine}` (and on `onsager-protocol` only until
+  Lever C deletes that crate; matches the current
+  `crates/stiglab/Cargo.toml`). It must NOT depend on `forge`,
+  `synodic`, or `ising`. CI will hard-fail this once Lever B's
+  architecture lint lands.
 - **Spine as single source of truth.** `src/server/workflow_db.rs` +
   `src/server/workflow_spine_mirror.rs` are the live drift example —
   stiglab owns `tenant_workflows` while the spine owns `workflows`.

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -1,0 +1,81 @@
+# Stiglab
+
+Distributed AI agent session orchestration. Lives behind a public-ish
+HTTP surface on port 3000 (sessions, nodes, WebSocket, OAuth/SSO,
+GitHub webhooks) and listens on the spine for cross-subsystem
+coordination.
+
+## The seam rule (canonical)
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+What this means for stiglab specifically:
+
+- **Allowed HTTP surfaces.** Routes under `src/server/routes/` that are
+  called by the dashboard, and webhook receivers (e.g. the GitHub
+  webhook router at `src/server/webhook_router.rs`) called by external
+  services. Both are "external boundary" by definition.
+- **Forbidden HTTP surfaces.** Anything called from `forge`, `synodic`,
+  or `ising`. The legacy `HttpStiglabDispatcher` path in
+  `crates/forge/src/cmd/serve.rs:65–180` is the one remaining
+  violation, and Lever C of spec #131 deletes it. Do not add new
+  internal routes to satisfy a sibling subsystem — emit/consume an
+  event instead.
+- **Coordinating with forge or synodic.** Listen on the spine for the
+  event you care about, write your response as a new event. Concrete
+  pattern: forge will emit `forge.shaping_dispatched` once Lever C
+  lands; stiglab consumes it and emits `stiglab.session_completed` (or
+  the equivalent error event) when the session resolves.
+- **Cargo deps.** `stiglab` may depend on `onsager-{artifact, protocol,
+  spine}` (and on `onsager-protocol` only until Lever C deletes that
+  crate). It must NOT depend on `forge`, `synodic`, or `ising`. CI
+  will hard-fail this once Lever B's architecture lint lands.
+- **Spine as single source of truth.** `src/server/workflow_db.rs` +
+  `src/server/workflow_spine_mirror.rs` are the live drift example —
+  stiglab owns `tenant_workflows` while the spine owns `workflows`.
+  Lever D collapses these into the spine schema with a `tenant_id`
+  discriminator, in one PR, alongside removal of the mirror module.
+  New code: write to spine tables directly; do not extend the mirror.
+- **In-memory caches.** State the spine owns is read from the spine.
+  Cache only with an explicit invalidation path tied to a spine event
+  (the PR #123 drift pattern is what happens otherwise).
+
+See [ADR 0001](../../docs/adr/0001-event-bus-coordination-model.md) for
+the original decision and spec #131 for the six-lever enforcement plan.
+
+## Architecture quick map
+
+```
+src/
+  agent/                <- agent connection + session execution
+  core/                 <- session lifecycle, queue, drain logic
+  server/
+    routes/             <- dashboard-facing HTTP (allowed seam)
+    webhook_router.rs   <- GitHub webhook (allowed seam)
+    spine.rs            <- spine read/write helpers (preferred path
+                            for cross-subsystem coordination)
+    workflow_db.rs      <- Lever D target: collapse into spine
+    workflow_spine_mirror.rs  <- Lever D target: delete with the migration
+    ws/                 <- agent WebSocket (allowed seam)
+```
+
+## Build & Test
+
+Run from repo root:
+
+```bash
+cargo build -p stiglab
+cargo test  -p stiglab --lib
+cargo clippy -p stiglab --all-targets -- -D warnings
+```
+
+CI runs the workspace pass with `RUSTFLAGS="-D warnings"` against a
+merge preview of `origin/main`; reproduce that locally via the
+`onsager-pre-push` skill before pushing.

--- a/crates/synodic/CLAUDE.md
+++ b/crates/synodic/CLAUDE.md
@@ -1,0 +1,59 @@
+# Synodic
+
+AI agent governance — gate evaluation, policy, verdicts. Exposes a
+small HTTP surface on port 3001 for the dashboard's governance views;
+otherwise coordinates over the spine.
+
+## The seam rule (canonical)
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+What this means for synodic specifically:
+
+- **Allowed HTTP surfaces.** Dashboard-facing endpoints for
+  governance UI (rule lists, verdict views, etc.). Webhooks from
+  external policy sources, if any.
+- **Forbidden HTTP surfaces.** Anything called from `forge`, `stiglab`,
+  or `ising`. The legacy `HttpSynodicGate` path in
+  `crates/forge/src/cmd/serve.rs:65–180` is the one remaining
+  violation, and Lever C of spec #131 deletes it. Gate verdicts must
+  flow as events: forge emits `forge.gate_requested`; synodic consumes
+  it and emits `synodic.gate_verdict` with the decision.
+- **`SYNODIC_FAIL_POLICY` (forge-side).** When forge cannot reach the
+  HTTP gate today, it falls back per `SYNODIC_FAIL_POLICY` (default
+  `escalate`). Once Lever C lands, the equivalent failure mode is "no
+  `synodic.gate_verdict` arrived in window" — the same `escalate /
+  deny / allow` choice applies to event-time math, not HTTP timeouts.
+  The default stays `escalate` (forge invariant #5).
+- **Cargo deps.** `synodic` may depend on `onsager-{artifact, protocol,
+  spine}` (and on `onsager-protocol` only until Lever C deletes that
+  crate). It must NOT depend on `forge`, `stiglab`, or `ising`. CI
+  will hard-fail this once Lever B's architecture lint lands.
+- **Verdict shape stays in the registry.** Per ADR 0003, `MergeRule`
+  for verdict channels lives in `onsager-registry`. Synodic produces
+  partial updates that get folded by the registry-declared rule — do
+  not invent a private merge in this crate.
+
+See [ADR 0001](../../docs/adr/0001-event-bus-coordination-model.md) for
+the original decision and spec #131 for the six-lever enforcement plan.
+
+## Build & Test
+
+Run from repo root:
+
+```bash
+cargo build -p synodic
+cargo test  -p synodic --lib
+cargo clippy -p synodic --all-targets -- -D warnings
+```
+
+CI runs the workspace pass with `RUSTFLAGS="-D warnings"` against a
+merge preview of `origin/main`; reproduce that locally via the
+`onsager-pre-push` skill before pushing.

--- a/crates/synodic/CLAUDE.md
+++ b/crates/synodic/CLAUDE.md
@@ -21,11 +21,12 @@ What this means for synodic specifically:
   governance UI (rule lists, verdict views, etc.). Webhooks from
   external policy sources, if any.
 - **Forbidden HTTP surfaces.** Anything called from `forge`, `stiglab`,
-  or `ising`. The legacy `HttpSynodicGate` path in
-  `crates/forge/src/cmd/serve.rs:65–180` is the one remaining
-  violation, and Lever C of spec #131 deletes it. Gate verdicts must
-  flow as events: forge emits `forge.gate_requested`; synodic consumes
-  it and emits `synodic.gate_verdict` with the decision.
+  or `ising`. The legacy `HttpSynodicGate` path
+  (`crates/forge/src/cmd/serve.rs` ≈344–397, instantiated in `run`
+  ≈469–490) is the one remaining violation, and Lever C of spec #131
+  deletes it. Gate verdicts must flow as events: forge emits
+  `forge.gate_requested`; synodic consumes it and emits
+  `synodic.gate_verdict` with the decision.
 - **`SYNODIC_FAIL_POLICY` (forge-side).** When forge cannot reach the
   HTTP gate today, it falls back per `SYNODIC_FAIL_POLICY` (default
   `escalate`). Once Lever C lands, the equivalent failure mode is "no

--- a/docs/adr/0004-tighten-the-seams.md
+++ b/docs/adr/0004-tighten-the-seams.md
@@ -1,0 +1,248 @@
+# ADR 0004 — Tighten the seams: HTTP at external boundaries, spine for everything internal
+
+- **Status**: Accepted
+- **Date**: 2026-04-26
+- **Tracking issues**: #131 (parent spec) with children for each
+  lever (A: PR #144 / completed; B–F: opened concurrently with this
+  ADR)
+- **Supersedes**: none
+- **Superseded by**: none
+
+## Context
+
+ADR 0001 committed Onsager to stigmergic coordination over the spine —
+no sync HTTP between subsystems, no static linking across them. The
+rule is sound. It is also informally stated and informally enforced,
+so it drifts. By April 2026 the drift had accumulated in predictable
+shapes:
+
+- Two `forge → stiglab/synodic` HTTP RPCs still live in
+  `crates/forge/src/cmd/serve.rs` (`HttpStiglabDispatcher` ≈52–304 and
+  `HttpSynodicGate` ≈344–397, instantiated in `run` ≈469–490). These
+  are the only place in the codebase where the rule is *currently*
+  violated; they were left as a known migration debt by ADR 0001 #41.
+- A parallel-schema mirror: stiglab's `tenant_workflows` ↔ spine's
+  `workflows` (PR #129), with `crates/stiglab/src/server/workflow_spine_mirror.rs`
+  as a translator module. The mirror was filed as a bridge with no
+  removal date.
+- Producer-without-consumer events (PR #127): a `FactoryEventKind`
+  variant emitted by one subsystem with no deployed consumer.
+- In-memory state caches drifting from the spine (PR #123).
+- Half-wired API/UI contracts: backend endpoint shipped without a
+  dashboard caller, or vice versa (PR #108).
+- Divergent shapes from multiple write paths into the same row (PR #122).
+- Compat aliases that ossified (PR #107: `BundleId` → `ArtifactVersionId`
+  alias, kept "for one release", still in tree).
+
+The pattern is consistent: the rule is a review-time heuristic, and
+review is the wrong place to catch it — by the time a reviewer sees
+the bridge, the cost of removing it is higher than the cost of
+landing it.
+
+ADR 0002's outer loop argues that durable dev-process patterns
+deserve a primitive. This ADR is that primitive for the seam rule.
+
+## Decision
+
+We commit to making the seam rule **explicit, machine-checkable, and
+durable across AI sessions**, and to completing the unfinished
+structural migrations the rule implies, via six levers landed in
+order (A→F). The rule itself, restated:
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+The six levers, each landing as a sub-issue under #131:
+
+1. **A — Persist the rule.** Verbatim in root `CLAUDE.md`, in each
+   subsystem's `CLAUDE.md`, and restated in the `issue-spec`,
+   `onsager-pre-push`, and `onsager-dev-process` skills. Doc-only.
+   Landed in PR #144.
+2. **B — Mechanical guardrails (no-escape-hatch).** Architecture lint
+   (subsystem-A→B Cargo dep, sibling-subsystem HTTP client) and
+   bridge-pattern lint (`serde(alias)`, `*_mirror.rs`, legacy type
+   alias) hard-fail at CI and pre-push. Producer-without-consumer
+   warns from day 1 against the static event registry; hard-fails
+   once Lever E lands. **Bridges are not allowed**; cross-subsystem
+   migrations land in a single PR. The only exception is database
+   schema migrations under `migrations/NNN_*.sql`, which keep their
+   existing sequential convention.
+3. **C — Complete the ADR 0001 migration.** Delete
+   `HttpStiglabDispatcher` and `HttpSynodicGate` from
+   `crates/forge/src/cmd/serve.rs`. Replace each with an event
+   emit + listener pair: `forge.shaping_dispatched` →
+   stiglab listener → `stiglab.session_completed`;
+   `forge.gate_requested` → synodic listener → `synodic.gate_verdict`.
+   Delete the `onsager-protocol` crate. Removes the only place the
+   rule is currently violated.
+4. **D — Spine as single source of truth.** Collapse
+   `tenant_workflows` / `tenant_workflow_stages` into spine
+   `workflows` / `workflow_stages` with a `tenant_id` discriminator.
+   Remove `crates/stiglab/src/server/workflow_spine_mirror.rs` in the
+   same PR. Removes the `BundleId` → `ArtifactVersionId` alias as part
+   of cleanup. Sets the precedent for shared schemas going forward.
+5. **E — Registry-backed event types and capability advertisement.**
+   Extend `onsager-registry` (per ADR 0003 already the SoT for
+   artifact kinds) to event types and subsystem capabilities. Static
+   manifest in the registry crate, **checked at CI** — not runtime
+   self-report. Each subsystem declares produced/consumed events;
+   the registry surfaces "producer with no consumer" so Lever B's
+   check can hard-fail.
+6. **F — API/UI contract enforcement.** Either OpenAPI emit from
+   stiglab/synodic + generated dashboard client, or a CI contract
+   test that hits every endpoint the dashboard declares. Either
+   approach satisfies the rule. The choice is deferred to the
+   Lever F sub-issue.
+
+The execution order — process and enforcement first (A, B), then
+structural surgery (C, D), then the registry contract that future
+work will hang from (E), then the API/UI contract (F) — is chosen so
+that the cheapest-and-soonest items immediately stop new accumulation,
+and so that the structural work happens with the guardrails already
+in place.
+
+## Rejected alternatives
+
+- **Leave the rule as a review-time heuristic.** Documented as the
+  status quo for the last six months; the drift evidence under
+  Context demonstrates that this does not scale. Rejected.
+- **Allow bridges with `bridge-debt` labels and target removal dates.**
+  Considered. Rejected because PR #107's "one release" alias is
+  still in tree, and PR #129's mirror module had no removal date at
+  all. The label-and-promise pattern relies on the same review-time
+  discipline that already failed; the no-escape-hatch posture under
+  Lever B replaces it. Database migrations are the only multi-step
+  exception, governed separately.
+- **Replace the spine with synchronous RPC across subsystems
+  (Option B in ADR 0001).** Re-rejected. The naming, ADR 0001, ADR
+  0002, and the current dashboard architecture all assume stigmergic
+  coordination; reversing that decision is a much larger change than
+  finishing the migration to it.
+- **Split the registry per-subsystem** (each subsystem owns its event
+  catalog). Rejected: defeats the "producer with no consumer" check
+  by construction, and creates a new sync point — every subsystem
+  has to read every other subsystem's catalog to validate
+  cross-subsystem contracts. The static manifest in the central
+  registry is one point of authority, and CI is the validator.
+- **Defer Lever B until Lever C lands** (no point lint-checking
+  something that's about to be deleted). Rejected: B catches *new*
+  violations, not the existing one. Landing B before C means the
+  Lever C PR is also the last PR that will ever need to add an
+  exception, and even that exception is internal to forge's serve.rs
+  during the transition (which is one PR by design).
+
+## Consequences
+
+### Positive
+
+- The rule is in two places (CLAUDE.md + skills) where every AI
+  session and every human reviewer encounters it before writing
+  code. Drift surfaces at draft-and-pre-push time, not at review.
+- The two HTTP RPCs from ADR 0001's known-debt list finally go
+  away. Forge's tick becomes a pure state machine end-to-end —
+  the original ADR 0001 commitment is fulfilled.
+- The mirror module pattern (`workflow_spine_mirror.rs`) is removed
+  and forbidden going forward. Future shared-schema work uses the
+  spine table with a discriminator, set as precedent by Lever D.
+- The compat-alias pattern (`BundleId`, `serde(alias)`, "for one
+  release" types) is forbidden by CI, not by promise. The renames
+  that already failed to land cleanly will land cleanly the next
+  time around.
+- Half-wired API/UI surfaces (PR #108) become un-mergeable under
+  Lever F.
+
+### Negative / trade-offs
+
+- Cross-subsystem migrations get harder. The Lever D PR is, by
+  construction, the schema migration *and* the call-site swap *and*
+  the mirror-module deletion in one diff. If that exceeds a
+  reviewable size, the sub-issue must negotiate the multi-PR plan
+  up front — Lever B will not be retroactively waived for a half-
+  landed bridge. The trade-off is intentional: the alternative is
+  the drift the spec is closing.
+- Adding a new cross-subsystem contract now requires a registry
+  update (Lever E's manifest) plus producer + consumer in the same
+  PR. That's discipline, not burden, but it's real paperwork per
+  contract.
+- The spine schema accumulates discriminator columns
+  (`tenant_id`, etc.) instead of per-subsystem tables. The
+  Postgres-side cost is bounded — these are partitioning columns
+  with indexes, not new joins — but it does shift schema evolution
+  pressure onto the spine crate, which now has to think about
+  multi-tenant from the start of every shared concept.
+- Lever B's lints have false-positive risk (a legitimate use of
+  `serde(alias)` for a wire-format-stable rename outside the
+  subsystem-coupling case). The sub-issue handles this by scoping
+  the lint to `crates/{forge,stiglab,synodic,ising}/**` — spine and
+  registry rename mechanics keep their flexibility.
+
+### Neutral
+
+- No new tables. Lever D collapses two existing tables into the
+  spine schema; Lever E extends `onsager-registry`'s existing
+  manifest format.
+- ADR 0001's runtime invariant (loose coupling, no static linking)
+  is preserved end-to-end. This ADR adds *contracts* on the seams,
+  not direct calls across them.
+- ADR 0003's registry pattern extends naturally — events become a
+  registered kind with the same shape as artifacts. Lever E reuses
+  the type-definition machinery already in the registry crate.
+
+## Dev-process counterpart
+
+Per ADR 0002, every ADR declares the dev-process analog of the
+decision it records.
+
+The decision here *is* a dev-process change as much as it is a code
+change. Lever A makes the rule visible at every entry point an AI
+session has into the codebase (root `CLAUDE.md`, subsystem
+`CLAUDE.md`, the three skills that bracket the inner loop). Lever B
+is a process counterpart by construction: a CI-checked rule is a
+process artifact, and the `onsager-pre-push` skill restates the same
+rule so the local check and the remote check converge.
+
+The product-side analog is the registry (Lever E): the same kind
+catalog that ADR 0003 made authoritative for artifacts now becomes
+authoritative for events, with the same producer/consumer
+contract surface. Process ↔ product isomorphism is preserved: the
+review-time pattern ("does this PR have a consumer?") becomes a
+registry entry that CI validates.
+
+## Adoption checklist
+
+Execution lives in the child specs of #131. Each lever's checklist
+is in its sub-issue:
+
+- [x] **Lever A** — persist the rule in `CLAUDE.md` + skills.
+      _Landed: PR #144._
+- [ ] **Lever B** — mechanical guardrails (no-escape-hatch CI lint).
+- [ ] **Lever C** — complete the ADR 0001 migration; delete
+      `onsager-protocol`.
+- [ ] **Lever D** — spine as SoT for workflows; remove
+      `workflow_spine_mirror.rs` and the `BundleId` alias.
+- [ ] **Lever E** — registry-backed event types + capability
+      advertisement.
+- [ ] **Lever F** — API/UI contract enforcement.
+
+## Out of scope
+
+- **Per-lever implementation detail.** Each lever's sub-issue
+  carries its own Design / Plan / Test. This ADR is the umbrella
+  decision and execution order.
+- **Lever F's enforcement choice** (OpenAPI codegen vs. CI contract
+  test). Either satisfies the rule; the sub-issue picks one.
+- **Cross-tenant data movement.** Lever D's `tenant_id` discriminator
+  is for partitioning shared schemas, not for cross-tenant queries
+  or admin tooling. That's a separate concern.
+- **Out-of-tree consumers of `onsager-protocol`.** Lever C deletes
+  the crate; if any consumer outside this repo emerges, that's a
+  bridge-debt issue handled at that point — not pre-allocated here.
+- **A retroactive audit of every existing `serde(alias)` and type
+  alias in the workspace.** Lever B's lint applies to *new* code;
+  pre-existing aliases get triaged as their owning sub-issues land.


### PR DESCRIPTION
Part of #131

Lands **Lever A** of spec #131 — persist the canonical seam rule
across `CLAUDE.md` files and the dev-loop skills. Doc-only; no
behavior change.

The rule (verbatim, copied from #131):

> HTTP APIs exist only at external boundaries:
> - **User-facing endpoints** called by the dashboard.
> - **Webhooks** called by external services (GitHub, etc.).
>
> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
> **exclusively** via the spine: events on the bus + reads against
> shared spine tables. No subsystem makes HTTP calls to another
> subsystem. No subsystem imports another subsystem's crate.

## Delivers

From #131's Plan:

- [x] Create sub-issue: Lever A — persist the rule in CLAUDE.md + skills _(landing the work directly here per the spec's "AI implements" note: "Land Lever A doc-only PR in this branch first (unblocks everything else)")_

## Summary of changes

- `CLAUDE.md` — adds a top-level "The seam rule (canonical)" section
  with the rule verbatim, plus a pointer to the live violation
  (`crates/forge/src/cmd/serve.rs:65–180`, the Lever C target). Also
  fixes a stale "five-lever" → "six-lever" reference now that the
  spec carries six levers.
- `crates/onsager-spine/CLAUDE.md` — adds the rule + spine-specific
  notes: spine is mechanism (not a subsystem), new event types are
  the cross-subsystem contract, no sync RPC API on the spine, spine
  tables are the single source of truth.
- `crates/stiglab/CLAUDE.md` (new) — adds the rule + stiglab-specific
  notes: which HTTP surfaces are allowed (dashboard, webhooks) vs.
  forbidden (sibling-subsystem callers), how to coordinate with forge
  and synodic via events, the Lever D drift in `workflow_db.rs` /
  `workflow_spine_mirror.rs`, cache discipline.
- `crates/synodic/CLAUDE.md` (new) — adds the rule + synodic-specific
  notes: allowed/forbidden HTTP surfaces, the event-time math
  equivalent of `SYNODIC_FAIL_POLICY` once Lever C lands, verdict
  shape stays in `onsager-registry`.
- `.claude/skills/issue-spec/SKILL.md` — adds a "seam rule (restated
  for spec authors)" section so every new spec inherits the
  constraint at draft time.
- `.claude/skills/onsager-pre-push/SKILL.md` — adds a 6.5
  "seam-rule self-check" step with the exact diff scan to run before
  push (sibling-subsystem HTTP clients, cross-subsystem cargo deps,
  `serde(alias)`, `*_mirror.rs`, "for compat" type aliases,
  producer-without-consumer event variants, half-wired API/UI
  contracts).
- `.claude/skills/onsager-dev-process/SKILL.md` — restates the rule
  in stage 3 (branch and implement) with concrete "stop and update
  the spec" guidance instead of bridging.

## Scope discipline

This PR is intentionally **doc-only**. The other items in #131's
"AI implements" section — drafting ADR 0004 and opening Lever B–F
sub-issues — depend on human-decides items that are still unchecked
on #131 (framing approval, canonical wording confirmation, no-escape-hatch
confirmation, Lever B hard-fail set, Lever E advertisement model). I'm
stopping here so a human can confirm those before we proceed; #131's
Plan also explicitly orders Lever A first as the unblocker for the
rest.

## Test plan

- [x] Rule statement appears verbatim in root `CLAUDE.md` and in
  `crates/onsager-spine/CLAUDE.md`, `crates/stiglab/CLAUDE.md`,
  `crates/synodic/CLAUDE.md` (≥3 subsystem CLAUDE files — the spec's
  Test item).
- [x] Each of the three skills (`issue-spec`, `onsager-pre-push`,
  `onsager-dev-process`) has a section that restates or operationalizes
  the rule.
- [x] No code changes — `crates/` source untouched. Verified via
  `git diff --stat` (only `CLAUDE.md`/`SKILL.md` files changed).
- [x] `git fetch origin main && git merge` — fast-forwarded cleanly.



---
_Generated by [Claude Code](https://claude.ai/code/session_01TYFmw3yaMA4r6C9MVikimB)_