### PR TITLE
feat(stiglab): personal access tokens for programmable API access

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -51,6 +51,11 @@ const WorkflowDetailPage = lazy(() =>
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 )
+const PersonalAccessTokensPage = lazy(() =>
+  import("@/pages/PersonalAccessTokensPage").then((m) => ({
+    default: m.PersonalAccessTokensPage,
+  })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -274,6 +279,10 @@ function AppRoutes() {
                     <Route
                       path="/settings"
                       element={<LazyRoute><SettingsPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/settings/tokens"
+                      element={<LazyRoute><PersonalAccessTokensPage /></LazyRoute>}
                     />
                   </Routes>
                 </WorkflowsFirstRunGate>

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -70,6 +70,30 @@ export interface Credential {
   updated_at: string;
 }
 
+// Personal Access Tokens (issue #143). The full token value is only ever
+// returned by `createPat`; subsequent `listPats` calls expose prefix +
+// metadata only. `tenant_id` pins the PAT to a workspace; `null` means
+// "all workspaces the user belongs to".
+export interface Pat {
+  id: string;
+  name: string;
+  tenant_id: string | null;
+  token_prefix: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  last_used_ip: string | null;
+  last_used_user_agent: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface CreatePatResponse {
+  pat: Pat;
+  /// Returned exactly once on creation. After this response, the only way
+  /// to recover access is to mint a new token.
+  token: string;
+}
+
 // Workspace (tenant) / membership / GitHub App installation / project
 // types, issue #59 (Phase 0).
 export interface Workspace {
@@ -524,9 +548,27 @@ export const api = {
     }),
   getHealth: () => request<{ status: string; version: string }>('/health'),
   // Auth
-  getMe: () => request<{ user: User; auth_enabled: boolean }>('/auth/me'),
+  getMe: () =>
+    request<{ user: User; auth_enabled: boolean; via?: 'session' | 'pat' }>(
+      '/auth/me',
+    ),
   logout: () =>
     request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
+  // Personal Access Tokens (issue #143)
+  listPats: () => request<{ pats: Pat[] }>('/pats'),
+  createPat: (body: {
+    name: string;
+    tenant_id?: string | null;
+    expires_at: string | null;
+  }) =>
+    request<CreatePatResponse>('/pats', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  revokePat: (id: string) =>
+    request<{ ok: boolean }>(`/pats/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }),
   // Credentials
   getCredentials: () =>
     request<{ credentials: Credential[] }>('/credentials'),

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -559,7 +559,9 @@ export const api = {
   createPat: (body: {
     name: string;
     tenant_id?: string | null;
-    expires_at: string | null;
+    // v1: an explicit ISO-8601 future timestamp is required. The "never
+    // expires" affordance is intentionally not exposed in this release.
+    expires_at: string;
   }) =>
     request<CreatePatResponse>('/pats', {
       method: 'POST',

--- a/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
+++ b/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
@@ -384,7 +384,10 @@ export function PersonalAccessTokensPage() {
   const patsQuery = useQuery({
     queryKey: ["pats"],
     queryFn: api.listPats,
-    enabled: !authEnabled || !!user,
+    // PATs only make sense for an authenticated user — anonymous mode
+    // renders the "unavailable" stub below, so don't fire a doomed
+    // request that would just 401 and clutter logs.
+    enabled: authEnabled && !!user,
   })
   const workspacesQuery = useQuery({
     queryKey: ["workspaces"],

--- a/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
+++ b/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
@@ -1,0 +1,524 @@
+import { useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  KeyRound,
+  Plus,
+  ShieldAlert,
+  Trash2,
+} from "lucide-react"
+
+import { useAuth } from "@/lib/auth"
+import { api, type Pat } from "@/lib/api"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+// GitHub-style expiry choices. v1 spec (#143) freezes the option set so
+// users can't accidentally mint a never-expiring token from the UI.
+const EXPIRY_CHOICES = [
+  { id: "7", label: "7 days", days: 7 },
+  { id: "30", label: "30 days", days: 30 },
+  { id: "60", label: "60 days", days: 60 },
+  { id: "90", label: "90 days", days: 90 },
+  { id: "custom", label: "Custom date" },
+] as const
+
+type ExpiryChoiceId = (typeof EXPIRY_CHOICES)[number]["id"]
+
+function expiryFromChoice(
+  choice: ExpiryChoiceId,
+  customDate: string,
+): { iso: string; error?: string } {
+  if (choice === "custom") {
+    if (!customDate) {
+      return { iso: "", error: "Pick a custom date" }
+    }
+    const d = new Date(customDate)
+    if (Number.isNaN(d.getTime()) || d.getTime() <= Date.now()) {
+      return { iso: "", error: "Custom date must be in the future" }
+    }
+    return { iso: d.toISOString() }
+  }
+  const days = EXPIRY_CHOICES.find((c) => c.id === choice)
+  if (!days || days.id === "custom") {
+    return { iso: "", error: "Select an expiry" }
+  }
+  const d = new Date(Date.now() + days.days * 24 * 60 * 60 * 1000)
+  return { iso: d.toISOString() }
+}
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return "—"
+  return new Date(ts).toLocaleString()
+}
+
+// Truncate a UA string for table cells. Full string is available on the
+// `title` attribute for hover.
+function truncate(s: string | null, max = 40): string {
+  if (!s) return "—"
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`
+}
+
+interface CreatePatDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaces: { id: string; name: string }[]
+}
+
+function CreatePatDialog({ open, onOpenChange, workspaces }: CreatePatDialogProps) {
+  const queryClient = useQueryClient()
+  const [name, setName] = useState("")
+  const [tenantId, setTenantId] = useState<string>("__all__")
+  const [expiryChoice, setExpiryChoice] = useState<ExpiryChoiceId>("30")
+  const [customDate, setCustomDate] = useState("")
+  const [revealedToken, setRevealedToken] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const create = useMutation({
+    mutationFn: (body: {
+      name: string
+      tenant_id: string | null
+      expires_at: string
+    }) =>
+      api.createPat({
+        name: body.name,
+        tenant_id: body.tenant_id,
+        expires_at: body.expires_at,
+      }),
+    onSuccess: (data) => {
+      setRevealedToken(data.token)
+      queryClient.invalidateQueries({ queryKey: ["pats"] })
+    },
+    onError: (e) => {
+      setError(e instanceof Error ? e.message : "Failed to create token")
+    },
+  })
+
+  function reset() {
+    setName("")
+    setTenantId("__all__")
+    setExpiryChoice("30")
+    setCustomDate("")
+    setRevealedToken(null)
+    setCopied(false)
+    setError(null)
+  }
+
+  function handleClose(next: boolean) {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (create.isPending) return
+    setError(null)
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError("Name is required")
+      return
+    }
+    const exp = expiryFromChoice(expiryChoice, customDate)
+    if (exp.error) {
+      setError(exp.error)
+      return
+    }
+    create.mutate({
+      name: trimmed,
+      tenant_id: tenantId === "__all__" ? null : tenantId,
+      expires_at: exp.iso,
+    })
+  }
+
+  async function copyToken() {
+    if (!revealedToken) return
+    try {
+      await navigator.clipboard.writeText(revealedToken)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Some browsers (older Safari, denied permissions) reject the
+      // clipboard write — fall back to letting the user select manually.
+      setError("Copy failed; select the token text and copy manually")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        {!revealedToken ? (
+          <form onSubmit={handleSubmit}>
+            <DialogHeader>
+              <DialogTitle>New personal access token</DialogTitle>
+              <DialogDescription>
+                You won't be able to see the token again after closing this
+                dialog. Copy it before navigating away.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <label htmlFor="pat-name" className="text-sm font-medium">
+                  Name
+                </label>
+                <Input
+                  id="pat-name"
+                  placeholder="e.g. ci, my-laptop"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="pat-workspace" className="text-sm font-medium">
+                  Workspace
+                </label>
+                <Select
+                  value={tenantId}
+                  onValueChange={(v) => setTenantId(v ?? "__all__")}
+                >
+                  <SelectTrigger id="pat-workspace">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__all__">All workspaces</SelectItem>
+                    {workspaces.map((w) => (
+                      <SelectItem key={w.id} value={w.id}>
+                        {w.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Restricting to a workspace blocks the token from touching
+                  other workspaces.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="pat-expiry" className="text-sm font-medium">
+                  Expiration
+                </label>
+                <Select
+                  value={expiryChoice}
+                  onValueChange={(v) =>
+                    v && setExpiryChoice(v as ExpiryChoiceId)
+                  }
+                >
+                  <SelectTrigger id="pat-expiry">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {EXPIRY_CHOICES.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {expiryChoice === "custom" && (
+                  <Input
+                    type="date"
+                    value={customDate}
+                    onChange={(e) => setCustomDate(e.target.value)}
+                  />
+                )}
+              </div>
+
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={create.isPending}>
+                {create.isPending ? "Creating…" : "Create token"}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Token created</DialogTitle>
+              <DialogDescription>
+                Copy this token now. It won't be shown again.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 py-4">
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={revealedToken}
+                  className="font-mono text-xs"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <Button type="button" onClick={copyToken} variant="outline">
+                  {copied ? (
+                    <>
+                      <Check className="mr-1 h-4 w-4" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="mr-1 h-4 w-4" /> Copy
+                    </>
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Use it as <code>Authorization: Bearer {"<token>"}</code> on
+                requests to the Onsager API.
+              </p>
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </div>
+            <DialogFooter>
+              <Button type="button" onClick={() => handleClose(false)}>
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface PatRowProps {
+  pat: Pat
+  workspaceName: (id: string | null) => string
+  onRevoke: (id: string) => void
+  isRevoking: boolean
+}
+
+function PatRow({ pat, workspaceName, onRevoke, isRevoking }: PatRowProps) {
+  const expired =
+    pat.expires_at != null && new Date(pat.expires_at) <= new Date()
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate font-medium">{pat.name}</p>
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+              {pat.token_prefix}…
+            </code>
+            {pat.revoked_at && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                Revoked
+              </span>
+            )}
+            {!pat.revoked_at && expired && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                Expired
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Workspace: {workspaceName(pat.tenant_id)} · Expires{" "}
+            {formatTimestamp(pat.expires_at)}
+          </p>
+          <p
+            className="text-xs text-muted-foreground"
+            title={pat.last_used_user_agent ?? undefined}
+          >
+            Last used: {formatTimestamp(pat.last_used_at)}
+            {pat.last_used_ip ? ` from ${pat.last_used_ip}` : ""}
+            {pat.last_used_user_agent
+              ? ` (${truncate(pat.last_used_user_agent)})`
+              : ""}
+          </p>
+        </div>
+        {!pat.revoked_at && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onRevoke(pat.id)}
+            disabled={isRevoking}
+            aria-label={`Revoke ${pat.name}`}
+            title={`Revoke ${pat.name}`}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function PersonalAccessTokensPage() {
+  usePageHeader({ title: "Tokens", backTo: "/settings" })
+  const { user, authEnabled } = useAuth()
+  const queryClient = useQueryClient()
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const patsQuery = useQuery({
+    queryKey: ["pats"],
+    queryFn: api.listPats,
+    enabled: !authEnabled || !!user,
+  })
+  const workspacesQuery = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: api.listWorkspaces,
+    enabled: authEnabled && !!user,
+  })
+
+  const revoke = useMutation({
+    mutationFn: (id: string) => api.revokePat(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pats"] }),
+  })
+
+  const workspaces = useMemo(
+    () => workspacesQuery.data?.tenants ?? [],
+    [workspacesQuery.data],
+  )
+  const workspaceName = useMemo(() => {
+    const byId = new Map(workspaces.map((w) => [w.id, w.name]))
+    return (id: string | null) =>
+      id == null ? "All workspaces" : byId.get(id) ?? id
+  }, [workspaces])
+
+  // Anonymous mode (auth disabled or no session) has no concept of a user
+  // to mint a PAT against — render a stub instead of a 401.
+  if (authEnabled && !user) {
+    return null
+  }
+  if (!authEnabled) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4" />
+              Tokens unavailable
+            </CardTitle>
+            <CardDescription>
+              Personal access tokens require authentication. Configure GitHub
+              OAuth on this server to enable them.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  const pats = patsQuery.data?.pats ?? []
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <Button
+            render={<Link to="/settings" />}
+            variant="ghost"
+            size="sm"
+            className="-ml-2 mb-1 hidden md:inline-flex"
+          >
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Settings
+          </Button>
+          <h1 className="hidden text-2xl font-bold tracking-tight md:block">
+            Personal access tokens
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Bearer tokens for calling the Onsager API from CLIs, agents, and
+            scheduled jobs.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} className="hidden md:inline-flex">
+          <Plus className="mr-1 h-4 w-4" />
+          Create token
+        </Button>
+      </div>
+
+      {pats.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+              <KeyRound className="h-4 w-4" />
+              No tokens yet
+            </CardTitle>
+            <CardDescription>
+              Create a token to call <code>/api</code> from outside the
+              dashboard. Pass it as <code>Authorization: Bearer &lt;token&gt;</code>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-1 h-4 w-4" />
+              Create token
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+              <KeyRound className="h-4 w-4" />
+              Active tokens
+            </CardTitle>
+            <CardDescription>
+              Revoking a token immediately invalidates any future request that
+              presents it.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {pats.map((pat) => (
+              <PatRow
+                key={pat.id}
+                pat={pat}
+                workspaceName={workspaceName}
+                onRevoke={(id) => revoke.mutate(id)}
+                isRevoking={revoke.isPending}
+              />
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              className="md:hidden"
+              onClick={() => setCreateOpen(true)}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Create token
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      <CreatePatDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        workspaces={workspaces.map((w) => ({ id: w.id, name: w.name }))}
+      />
+    </div>
+  )
+}

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -118,6 +118,31 @@ export function SettingsPage() {
         </CardContent>
       </Card>
 
+      {/* Personal Access Tokens — link-out to the dedicated page. Sits
+          directly above Credentials because users hunting for "API access"
+          look in the same place they store provider keys. Hidden in
+          anonymous mode (no user to mint a token against). */}
+      {authEnabled && user && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+              <KeyRound className="h-4 w-4" />
+              Personal access tokens
+            </CardTitle>
+            <CardDescription>
+              Bearer tokens for calling the Onsager API from CLIs, agents, and
+              scheduled jobs.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button render={<Link to="/settings/tokens" />} variant="outline">
+              Manage tokens
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Credentials */}
       <Card>
         <CardHeader>

--- a/crates/stiglab/src/server/auth.rs
+++ b/crates/stiglab/src/server/auth.rs
@@ -2,11 +2,15 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use ring::aead;
+use ring::digest;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::Deserialize;
 
 use crate::server::db;
+use crate::server::sso::secrets_equal;
 use crate::server::state::AppState;
 
 // ── Credential Encryption (AES-256-GCM) ──
@@ -152,9 +156,161 @@ pub fn generate_state() -> String {
     hex::encode(bytes)
 }
 
+// ── Personal Access Tokens (issue #143) ──
+
+/// Token namespace prefix. Matches GitHub's `ghp_` style so secret scanners
+/// can recognize Onsager PATs in source-control / log scrapes.
+pub const PAT_TOKEN_NAMESPACE: &str = "ons_pat_";
+
+/// Length of the prefix stored in the DB for display + indexed lookup.
+/// `ons_pat_` (8 chars) + 4 chars of token entropy = 12 chars total.
+pub const PAT_PREFIX_LEN: usize = 12;
+
+/// Number of random bytes mixed into a PAT after the namespace prefix.
+const PAT_RANDOM_BYTES: usize = 32;
+
+/// A freshly generated PAT, ready to be persisted (`hash`) and shown to the
+/// user exactly once (`token`).
+pub struct GeneratedPat {
+    /// The full token to hand to the user. Begins with `ons_pat_`.
+    pub token: String,
+    /// First [`PAT_PREFIX_LEN`] characters of `token`. Stored in the clear
+    /// for display + lookup.
+    pub prefix: String,
+    /// Hex-encoded SHA-256 of `token`. The only thing persisted to the DB
+    /// from the secret material.
+    pub hash: String,
+}
+
+/// Generate a fresh personal access token. The full token is `ons_pat_` plus
+/// 32 random url-safe bytes — about 256 bits of entropy after the namespace
+/// prefix. Only the hash is stored; the caller is responsible for showing
+/// `token` to the user exactly once.
+pub fn generate_pat_token() -> GeneratedPat {
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; PAT_RANDOM_BYTES];
+    rng.fill(&mut bytes).expect("rng failed to generate bytes");
+    let token = format!("{PAT_TOKEN_NAMESPACE}{}", URL_SAFE_NO_PAD.encode(bytes));
+    let prefix = pat_prefix(&token);
+    let hash = hash_pat_token(&token);
+    GeneratedPat {
+        token,
+        prefix,
+        hash,
+    }
+}
+
+/// Hex-encoded SHA-256 of the raw token. Used both at insert time and on
+/// every verification.
+pub fn hash_pat_token(token: &str) -> String {
+    let digest = digest::digest(&digest::SHA256, token.as_bytes());
+    hex::encode(digest.as_ref())
+}
+
+/// Return the lookup prefix for a token. Always [`PAT_PREFIX_LEN`] chars
+/// when the token is well-formed; for malformed (too-short) tokens returns
+/// the entire string so callers can compare without panicking.
+pub fn pat_prefix(token: &str) -> String {
+    if token.len() >= PAT_PREFIX_LEN {
+        token[..PAT_PREFIX_LEN].to_string()
+    } else {
+        token.to_string()
+    }
+}
+
+/// Outcome of verifying a PAT against the DB. The `Invalid` arms are split
+/// from `Ok` so the extractor can return the right `WWW-Authenticate` body
+/// without leaking which step failed. `UserPat` is boxed to keep the enum
+/// itself pointer-sized — most call sites match the small arms.
+#[derive(Debug)]
+pub enum PatVerifyOutcome {
+    Ok(Box<db::UserPat>),
+    /// Prefix matched no row, or the hash didn't match any candidate row.
+    Unknown,
+    /// Row matched but is revoked or past its `expires_at`.
+    Revoked,
+    Expired,
+}
+
+/// Verify a presented PAT. Looks up candidate rows by `token_prefix`, then
+/// constant-time compares the SHA-256 hash against each candidate. The
+/// prefix is non-secret; the hash compare is the actual identity check.
+pub async fn verify_pat(
+    pool: &sqlx::AnyPool,
+    presented_token: &str,
+) -> anyhow::Result<PatVerifyOutcome> {
+    if !presented_token.starts_with(PAT_TOKEN_NAMESPACE) {
+        return Ok(PatVerifyOutcome::Unknown);
+    }
+    let prefix = pat_prefix(presented_token);
+    let presented_hash = hash_pat_token(presented_token);
+    let candidates = db::find_pats_by_prefix(pool, &prefix).await?;
+    if candidates.is_empty() {
+        return Ok(PatVerifyOutcome::Unknown);
+    }
+
+    let mut matched: Option<db::UserPat> = None;
+    for (pat, stored_hash) in candidates {
+        if secrets_equal(&presented_hash, &stored_hash) {
+            matched = Some(pat);
+            // Don't break — keep iterating to keep the work uniform across
+            // collision and non-collision paths. The hash space makes >1
+            // match astronomically unlikely; the loop is still O(n) on the
+            // (non-secret) prefix bucket.
+        }
+    }
+
+    let Some(pat) = matched else {
+        return Ok(PatVerifyOutcome::Unknown);
+    };
+
+    if pat.revoked_at.is_some() {
+        return Ok(PatVerifyOutcome::Revoked);
+    }
+    if let Some(exp) = pat.expires_at {
+        if exp < chrono::Utc::now() {
+            return Ok(PatVerifyOutcome::Expired);
+        }
+    }
+    Ok(PatVerifyOutcome::Ok(Box::new(pat)))
+}
+
 // ── Auth Extractor ──
 
-/// Authenticated user extracted from request cookies.
+/// Whether the request was authenticated via a browser session cookie or a
+/// PAT bearer token. Surfaced on [`AuthUser`] so destructive endpoints can
+/// gate behavior on the principal kind.
+#[derive(Debug, Clone)]
+pub enum RequestPrincipal {
+    /// Cookie-based session (the existing `stiglab_session` flow), or the
+    /// synthetic anonymous principal when auth is disabled.
+    Session,
+    /// PAT-authenticated request. `pat_id` identifies the issuing token row;
+    /// `tenant_id` pins the request to a single workspace when set on the PAT.
+    Pat {
+        pat_id: String,
+        tenant_id: Option<String>,
+    },
+}
+
+impl RequestPrincipal {
+    pub fn is_pat(&self) -> bool {
+        matches!(self, RequestPrincipal::Pat { .. })
+    }
+
+    /// The tenant a PAT is pinned to, if any. `None` for sessions and for
+    /// PATs that aren't workspace-scoped.
+    pub fn pinned_tenant_id(&self) -> Option<&str> {
+        match self {
+            RequestPrincipal::Pat {
+                tenant_id: Some(t), ..
+            } => Some(t.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Authenticated user extracted from request cookies or a PAT Bearer token.
 /// When auth is disabled (no GitHub config), returns a synthetic anonymous user.
 #[derive(Debug, Clone)]
 pub struct AuthUser {
@@ -162,6 +318,7 @@ pub struct AuthUser {
     pub github_login: String,
     pub github_name: Option<String>,
     pub github_avatar_url: Option<String>,
+    pub principal: RequestPrincipal,
 }
 
 impl AuthUser {
@@ -171,8 +328,35 @@ impl AuthUser {
             github_login: "anonymous".to_string(),
             github_name: None,
             github_avatar_url: None,
+            principal: RequestPrincipal::Session,
         }
     }
+}
+
+/// Pull the bearer token (if any) out of the `Authorization` header.
+pub fn parse_bearer_token(parts: &Parts) -> Option<String> {
+    let v = parts
+        .headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = v.strip_prefix("Bearer ")?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+fn unauthorized_invalid_token() -> Response {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(
+            axum::http::header::WWW_AUTHENTICATE,
+            "Bearer error=\"invalid_token\"",
+        )
+        .body(axum::body::Body::from("invalid token"))
+        .unwrap()
 }
 
 impl FromRequestParts<AppState> for AuthUser {
@@ -187,7 +371,81 @@ impl FromRequestParts<AppState> for AuthUser {
             return Ok(AuthUser::anonymous());
         }
 
-        // Extract session cookie
+        // 1) Try PAT Bearer token first. A valid PAT wins over any cookie
+        //    on the same request — cookie + Bearer normally doesn't happen
+        //    in practice, but a CLI smoke test of the dashboard shouldn't
+        //    silently fall through to the browser session.
+        if let Some(token) = parse_bearer_token(parts) {
+            if token.starts_with(PAT_TOKEN_NAMESPACE) {
+                match verify_pat(&state.db, &token).await {
+                    Ok(PatVerifyOutcome::Ok(pat)) => {
+                        let user = match db::get_user(&state.db, &pat.user_id).await {
+                            Ok(Some(u)) => u,
+                            Ok(None) => {
+                                tracing::warn!(
+                                    pat_id = %pat.id,
+                                    "PAT references missing user — rejecting"
+                                );
+                                return Err(unauthorized_invalid_token());
+                            }
+                            Err(e) => {
+                                tracing::error!("PAT auth: failed to load user: {e}");
+                                return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                            }
+                        };
+
+                        // Best-effort touch — failure must not block the
+                        // request. Capture client metadata before the move.
+                        let pool = state.db.clone();
+                        let pat_id = pat.id.clone();
+                        let ip = parts
+                            .headers
+                            .get("x-forwarded-for")
+                            .and_then(|v| v.to_str().ok())
+                            .and_then(|s| s.split(',').next())
+                            .map(|s| s.trim().to_string());
+                        let ua = parts
+                            .headers
+                            .get(axum::http::header::USER_AGENT)
+                            .and_then(|v| v.to_str().ok())
+                            .map(|s| s.to_string());
+                        tokio::spawn(async move {
+                            if let Err(e) =
+                                db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref())
+                                    .await
+                            {
+                                tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
+                            }
+                        });
+
+                        return Ok(AuthUser {
+                            user_id: user.id,
+                            github_login: user.github_login,
+                            github_name: user.github_name,
+                            github_avatar_url: user.github_avatar_url,
+                            principal: RequestPrincipal::Pat {
+                                pat_id: pat.id,
+                                tenant_id: pat.tenant_id,
+                            },
+                        });
+                    }
+                    Ok(PatVerifyOutcome::Unknown)
+                    | Ok(PatVerifyOutcome::Revoked)
+                    | Ok(PatVerifyOutcome::Expired) => {
+                        return Err(unauthorized_invalid_token());
+                    }
+                    Err(e) => {
+                        tracing::error!("PAT verification failed: {e}");
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                    }
+                }
+            }
+            // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
+            // are owned by their dedicated routes — fall through so the
+            // cookie path still works for the dashboard.
+        }
+
+        // 2) Fall back to the session cookie.
         let session_id = parts
             .headers
             .get(axum::http::header::COOKIE)
@@ -206,6 +464,7 @@ impl FromRequestParts<AppState> for AuthUser {
                 github_login: auth_session.user.github_login,
                 github_name: auth_session.user.github_name,
                 github_avatar_url: auth_session.user.github_avatar_url,
+                principal: RequestPrincipal::Session,
             }),
             Ok(None) => Err((StatusCode::UNAUTHORIZED, "session expired").into_response()),
             Err(e) => {
@@ -343,5 +602,59 @@ mod tests {
         assert_eq!(user.user_id, "anonymous");
         assert_eq!(user.github_login, "anonymous");
         assert!(user.github_name.is_none());
+        assert!(matches!(user.principal, RequestPrincipal::Session));
+    }
+
+    #[test]
+    fn test_generate_pat_token_shape() {
+        let pat = generate_pat_token();
+        assert!(
+            pat.token.starts_with(PAT_TOKEN_NAMESPACE),
+            "token should start with the namespace prefix"
+        );
+        assert_eq!(pat.prefix.len(), PAT_PREFIX_LEN);
+        assert_eq!(pat.prefix, &pat.token[..PAT_PREFIX_LEN]);
+        // SHA-256 hex is 64 chars.
+        assert_eq!(pat.hash.len(), 64);
+        assert_eq!(pat.hash, hash_pat_token(&pat.token));
+    }
+
+    #[test]
+    fn test_generate_pat_token_uniqueness() {
+        let a = generate_pat_token();
+        let b = generate_pat_token();
+        assert_ne!(a.token, b.token);
+        assert_ne!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn test_hash_pat_token_deterministic() {
+        let token = "ons_pat_abc123";
+        assert_eq!(hash_pat_token(token), hash_pat_token(token));
+        assert_ne!(hash_pat_token(token), hash_pat_token("ons_pat_abc124"));
+    }
+
+    #[test]
+    fn test_pat_prefix_short_token_doesnt_panic() {
+        let s = pat_prefix("abc");
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn test_request_principal_helpers() {
+        assert!(!RequestPrincipal::Session.is_pat());
+        assert_eq!(RequestPrincipal::Session.pinned_tenant_id(), None);
+        let p = RequestPrincipal::Pat {
+            pat_id: "p1".into(),
+            tenant_id: Some("t1".into()),
+        };
+        assert!(p.is_pat());
+        assert_eq!(p.pinned_tenant_id(), Some("t1"));
+        let p2 = RequestPrincipal::Pat {
+            pat_id: "p2".into(),
+            tenant_id: None,
+        };
+        assert!(p2.is_pat());
+        assert_eq!(p2.pinned_tenant_id(), None);
     }
 }

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -162,6 +162,43 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // Personal Access Tokens (issue #143). Server-issued bearer tokens that
+    // authenticate non-browser callers as a specific user. The full token is
+    // never stored — `token_hash` is the SHA-256 hex of the raw token, and
+    // `token_prefix` is the first 12 characters for display + indexed lookup.
+    // `tenant_id` is an optional scope-down to a single workspace; when set,
+    // the request's tenant context is pinned and cross-tenant calls 403.
+    // `revoked_at` is a soft-delete: revoked rows stay for audit but fail
+    // verification.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS user_pats (
+            id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            tenant_id TEXT,
+            name TEXT NOT NULL,
+            token_prefix TEXT NOT NULL,
+            token_hash TEXT NOT NULL,
+            scopes TEXT NOT NULL DEFAULT '[\"*\"]',
+            expires_at TEXT,
+            last_used_at TEXT,
+            last_used_ip TEXT,
+            last_used_user_agent TEXT,
+            created_at TEXT NOT NULL,
+            revoked_at TEXT,
+            UNIQUE(user_id, name)
+        )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_user_pats_user_id ON user_pats (user_id)")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_user_pats_token_prefix ON user_pats (token_prefix)",
+    )
+    .execute(pool)
+    .await?;
+
     // Add user_id column to sessions if it doesn't exist.
     // Swallow duplicate-column errors on both SQLite and PostgreSQL.
     let _ = sqlx::query("ALTER TABLE sessions ADD COLUMN user_id TEXT")
@@ -1016,6 +1053,208 @@ pub async fn delete_user_credential(
         .bind(name)
         .execute(pool)
         .await?;
+    Ok(())
+}
+
+pub async fn user_credential_exists(
+    pool: &AnyPool,
+    user_id: &str,
+    name: &str,
+) -> anyhow::Result<bool> {
+    let row = sqlx::query_scalar::<_, String>(
+        "SELECT name FROM user_credentials WHERE user_id = $1 AND name = $2",
+    )
+    .bind(user_id)
+    .bind(name)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.is_some())
+}
+
+// ── Personal Access Tokens (issue #143) ──
+
+#[derive(Debug, Clone)]
+pub struct UserPat {
+    pub id: String,
+    pub user_id: String,
+    pub tenant_id: Option<String>,
+    pub name: String,
+    pub token_prefix: String,
+    pub expires_at: Option<chrono::DateTime<Utc>>,
+    pub last_used_at: Option<chrono::DateTime<Utc>>,
+    pub last_used_ip: Option<String>,
+    pub last_used_user_agent: Option<String>,
+    pub created_at: chrono::DateTime<Utc>,
+    pub revoked_at: Option<chrono::DateTime<Utc>>,
+}
+
+#[derive(sqlx::FromRow)]
+struct UserPatRow {
+    id: String,
+    user_id: String,
+    tenant_id: Option<String>,
+    name: String,
+    token_prefix: String,
+    expires_at: Option<String>,
+    last_used_at: Option<String>,
+    last_used_ip: Option<String>,
+    last_used_user_agent: Option<String>,
+    created_at: String,
+    revoked_at: Option<String>,
+}
+
+fn parse_optional_ts(v: Option<String>) -> anyhow::Result<Option<chrono::DateTime<Utc>>> {
+    match v {
+        Some(s) => Ok(Some(
+            chrono::DateTime::parse_from_rfc3339(&s)?.with_timezone(&Utc),
+        )),
+        None => Ok(None),
+    }
+}
+
+impl TryFrom<UserPatRow> for UserPat {
+    type Error = anyhow::Error;
+
+    fn try_from(row: UserPatRow) -> anyhow::Result<Self> {
+        Ok(UserPat {
+            id: row.id,
+            user_id: row.user_id,
+            tenant_id: row.tenant_id,
+            name: row.name,
+            token_prefix: row.token_prefix,
+            expires_at: parse_optional_ts(row.expires_at)?,
+            last_used_at: parse_optional_ts(row.last_used_at)?,
+            last_used_ip: row.last_used_ip,
+            last_used_user_agent: row.last_used_user_agent,
+            created_at: chrono::DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+            revoked_at: parse_optional_ts(row.revoked_at)?,
+        })
+    }
+}
+
+const PAT_FIELDS: &str = "id, user_id, tenant_id, name, token_prefix, expires_at, \
+                          last_used_at, last_used_ip, last_used_user_agent, created_at, revoked_at";
+
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_user_pat(
+    pool: &AnyPool,
+    id: &str,
+    user_id: &str,
+    tenant_id: Option<&str>,
+    name: &str,
+    token_prefix: &str,
+    token_hash: &str,
+    expires_at: Option<chrono::DateTime<Utc>>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO user_pats (id, user_id, tenant_id, name, token_prefix, token_hash, \
+                                scopes, expires_at, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+    )
+    .bind(id)
+    .bind(user_id)
+    .bind(tenant_id)
+    .bind(name)
+    .bind(token_prefix)
+    .bind(token_hash)
+    .bind("[\"*\"]")
+    .bind(expires_at.map(|d| d.to_rfc3339()))
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn list_user_pats(pool: &AnyPool, user_id: &str) -> anyhow::Result<Vec<UserPat>> {
+    let q =
+        format!("SELECT {PAT_FIELDS} FROM user_pats WHERE user_id = $1 ORDER BY created_at DESC");
+    let rows = sqlx::query_as::<_, UserPatRow>(&q)
+        .bind(user_id)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+/// Look up candidate PATs by token prefix. The caller must verify the
+/// `token_hash` against the presented token in constant time before
+/// accepting any row.
+pub async fn find_pats_by_prefix(
+    pool: &AnyPool,
+    token_prefix: &str,
+) -> anyhow::Result<Vec<(UserPat, String)>> {
+    let q = format!("SELECT {PAT_FIELDS}, token_hash FROM user_pats WHERE token_prefix = $1");
+    let rows = sqlx::query_as::<_, UserPatWithHashRow>(&q)
+        .bind(token_prefix)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter()
+        .map(|r| {
+            let hash = r.token_hash.clone();
+            let pat: UserPat = UserPatRow {
+                id: r.id,
+                user_id: r.user_id,
+                tenant_id: r.tenant_id,
+                name: r.name,
+                token_prefix: r.token_prefix,
+                expires_at: r.expires_at,
+                last_used_at: r.last_used_at,
+                last_used_ip: r.last_used_ip,
+                last_used_user_agent: r.last_used_user_agent,
+                created_at: r.created_at,
+                revoked_at: r.revoked_at,
+            }
+            .try_into()?;
+            Ok((pat, hash))
+        })
+        .collect()
+}
+
+#[derive(sqlx::FromRow)]
+struct UserPatWithHashRow {
+    id: String,
+    user_id: String,
+    tenant_id: Option<String>,
+    name: String,
+    token_prefix: String,
+    expires_at: Option<String>,
+    last_used_at: Option<String>,
+    last_used_ip: Option<String>,
+    last_used_user_agent: Option<String>,
+    created_at: String,
+    revoked_at: Option<String>,
+    token_hash: String,
+}
+
+pub async fn revoke_user_pat(pool: &AnyPool, user_id: &str, pat_id: &str) -> anyhow::Result<bool> {
+    let now = Utc::now().to_rfc3339();
+    let res = sqlx::query(
+        "UPDATE user_pats SET revoked_at = $1 \
+         WHERE id = $2 AND user_id = $3 AND revoked_at IS NULL",
+    )
+    .bind(&now)
+    .bind(pat_id)
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+pub async fn touch_user_pat(
+    pool: &AnyPool,
+    pat_id: &str,
+    ip: Option<&str>,
+    user_agent: Option<&str>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "UPDATE user_pats SET last_used_at = $1, last_used_ip = $2, last_used_user_agent = $3 \
+         WHERE id = $4",
+    )
+    .bind(Utc::now().to_rfc3339())
+    .bind(ip)
+    .bind(user_agent)
+    .bind(pat_id)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -16,7 +16,7 @@ pub mod ws;
 pub use sqlx::AnyPool;
 
 use axum::http::{header, HeaderValue};
-use axum::routing::{any, get, post, put};
+use axum::routing::{any, delete, get, post, put};
 use axum::Router;
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
@@ -75,6 +75,12 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/credentials/{name}",
             put(routes::credentials::set_credential).delete(routes::credentials::delete_credential),
         )
+        // Personal Access Tokens (issue #143)
+        .route(
+            "/api/pats",
+            get(routes::pats::list_pats).post(routes::pats::create_pat),
+        )
+        .route("/api/pats/{id}", delete(routes::pats::delete_pat))
         // Tenant / workspace routes (issue #59 — Phase 0)
         .route(
             "/api/tenants",

--- a/crates/stiglab/src/server/routes/auth.rs
+++ b/crates/stiglab/src/server/routes/auth.rs
@@ -9,7 +9,7 @@ use crate::core::User;
 
 use crate::server::auth::{
     self, exchange_code, generate_session_token, generate_state, get_github_user,
-    github_authorize_url, AuthUser,
+    github_authorize_url, AuthUser, RequestPrincipal,
 };
 use crate::server::db;
 use crate::server::sso::{
@@ -539,6 +539,10 @@ pub async fn sso_finish(
 
 /// GET /api/auth/me — Return current authenticated user
 pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl IntoResponse {
+    let via = match auth_user.principal {
+        RequestPrincipal::Pat { .. } => "pat",
+        RequestPrincipal::Session => "session",
+    };
     Json(serde_json::json!({
         "user": {
             "id": auth_user.user_id,
@@ -547,6 +551,7 @@ pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl Into
             "github_avatar_url": auth_user.github_avatar_url,
         },
         "auth_enabled": state.config.auth_enabled(),
+        "via": via,
     }))
 }
 

--- a/crates/stiglab/src/server/routes/credentials.rs
+++ b/crates/stiglab/src/server/routes/credentials.rs
@@ -4,9 +4,25 @@ use axum::response::IntoResponse;
 use axum::Json;
 use serde::Deserialize;
 
-use crate::server::auth::{encrypt_credential, AuthUser};
+use crate::server::auth::{encrypt_credential, AuthUser, RequestPrincipal};
 use crate::server::db;
 use crate::server::state::AppState;
+
+/// Standard 403 body for the PAT destructive-credential guardrail (issue
+/// #143). PATs may read and create credentials, but deleting an existing
+/// credential or overwriting one requires a real browser session — those
+/// actions take a refresh of the secret out of the user's hands and into
+/// any system that holds the token, which is the explicit non-goal here.
+fn pat_destructive_blocked() -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "pat_destructive_blocked",
+            "detail": "Use the dashboard to delete or overwrite credentials",
+        })),
+    )
+        .into_response()
+}
 
 #[derive(Deserialize)]
 pub struct SetCredentialBody {
@@ -46,6 +62,20 @@ pub async fn set_credential(
     Path(name): Path<String>,
     Json(body): Json<SetCredentialBody>,
 ) -> impl IntoResponse {
+    // PAT principals can create new credentials but not overwrite existing
+    // ones — silently rotating a secret over the API while the dashboard
+    // still shows the old one would be confusing and a footgun.
+    if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
+        match db::user_credential_exists(&state.db, &auth_user.user_id, &name).await {
+            Ok(true) => return pat_destructive_blocked(),
+            Ok(false) => {}
+            Err(e) => {
+                tracing::error!("failed to check credential existence: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+            }
+        }
+    }
+
     let Some(ref key) = state.config.credential_key else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -77,6 +107,11 @@ pub async fn delete_credential(
     auth_user: AuthUser,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
+    // The destructive guard is unconditional for PATs — deletion is always
+    // a session-only operation regardless of whether the credential exists.
+    if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
+        return pat_destructive_blocked();
+    }
     match db::delete_user_credential(&state.db, &auth_user.user_id, &name).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => {

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -3,6 +3,7 @@ pub mod credentials;
 pub mod governance;
 pub mod health;
 pub mod nodes;
+pub mod pats;
 pub mod portal;
 pub mod sessions;
 pub mod shaping;

--- a/crates/stiglab/src/server/routes/pats.rs
+++ b/crates/stiglab/src/server/routes/pats.rs
@@ -1,0 +1,216 @@
+//! Personal Access Token CRUD (issue #143).
+//!
+//! Tokens are user-owned bearer credentials minted server-side, stored only
+//! as a SHA-256 hash, and revealed to the user exactly once on creation.
+//! Listing returns prefix-only metadata; the full token is unrecoverable
+//! after the create call returns.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::server::auth::{generate_pat_token, AuthUser};
+use crate::server::db;
+use crate::server::state::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePatBody {
+    pub name: String,
+    /// Workspace scope-down. When set, requests authenticated by the new
+    /// PAT are pinned to this tenant — calls touching another tenant 403.
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    /// Required by the API surface; the dashboard always sends one of the
+    /// 7/30/60/90/custom-date choices. `null` is reserved for a future
+    /// "never expires" affordance.
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[allow(clippy::result_large_err)]
+fn require_authenticated(auth_user: &AuthUser) -> Result<&str, Response> {
+    if auth_user.user_id == "anonymous" {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "authentication required" })),
+        )
+            .into_response())
+    } else {
+        Ok(auth_user.user_id.as_str())
+    }
+}
+
+fn pat_summary(pat: &db::UserPat) -> serde_json::Value {
+    serde_json::json!({
+        "id": pat.id,
+        "name": pat.name,
+        "tenant_id": pat.tenant_id,
+        "token_prefix": pat.token_prefix,
+        "expires_at": pat.expires_at,
+        "last_used_at": pat.last_used_at,
+        "last_used_ip": pat.last_used_ip,
+        "last_used_user_agent": pat.last_used_user_agent,
+        "created_at": pat.created_at,
+        "revoked_at": pat.revoked_at,
+    })
+}
+
+/// GET /api/pats — List the caller's PATs (no token material).
+pub async fn list_pats(State(state): State<AppState>, auth_user: AuthUser) -> Response {
+    let user_id = match require_authenticated(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    match db::list_user_pats(&state.db, &user_id).await {
+        Ok(pats) => {
+            let items: Vec<_> = pats.iter().map(pat_summary).collect();
+            Json(serde_json::json!({ "pats": items })).into_response()
+        }
+        Err(e) => {
+            tracing::error!("failed to list pats: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "failed to list pats").into_response()
+        }
+    }
+}
+
+/// POST /api/pats — Mint a new PAT. The full token is returned exactly
+/// once; subsequent reads show only the prefix.
+pub async fn create_pat(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(body): Json<CreatePatBody>,
+) -> Response {
+    let user_id = match require_authenticated(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+
+    let name = body.name.trim();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "name is required" })),
+        )
+            .into_response();
+    }
+    if name.len() > 100 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "name must be at most 100 characters" })),
+        )
+            .into_response();
+    }
+
+    if let Some(exp) = body.expires_at {
+        if exp <= Utc::now() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "expires_at must be in the future" })),
+            )
+                .into_response();
+        }
+    }
+
+    // If the caller pinned the PAT to a workspace, they must be a member of
+    // it — otherwise the token would be created for a tenant they can't
+    // address.
+    if let Some(ref tenant_id) = body.tenant_id {
+        match db::is_tenant_member(&state.db, tenant_id, &user_id).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "not a member of the requested workspace",
+                    })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("create_pat: failed to check tenant membership: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+            }
+        }
+    }
+
+    let generated = generate_pat_token();
+    let id = Uuid::new_v4().to_string();
+    let tenant_id = body.tenant_id.as_deref();
+
+    if let Err(e) = db::insert_user_pat(
+        &state.db,
+        &id,
+        &user_id,
+        tenant_id,
+        name,
+        &generated.prefix,
+        &generated.hash,
+        body.expires_at,
+    )
+    .await
+    {
+        // Translate the unique-name violation into a 409 — every other
+        // error is opaque-500 for now.
+        let msg = e.to_string();
+        if msg.contains("UNIQUE") || msg.contains("unique") || msg.contains("duplicate") {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "a token with this name already exists",
+                })),
+            )
+                .into_response();
+        }
+        tracing::error!("failed to insert pat: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+    }
+
+    let pat = db::UserPat {
+        id: id.clone(),
+        user_id: user_id.clone(),
+        tenant_id: body.tenant_id.clone(),
+        name: name.to_string(),
+        token_prefix: generated.prefix.clone(),
+        expires_at: body.expires_at,
+        last_used_at: None,
+        last_used_ip: None,
+        last_used_user_agent: None,
+        created_at: Utc::now(),
+        revoked_at: None,
+    };
+
+    Json(serde_json::json!({
+        "pat": pat_summary(&pat),
+        // Returned exactly once. After this response, the only way to
+        // recover access is to mint a new token.
+        "token": generated.token,
+    }))
+    .into_response()
+}
+
+/// DELETE /api/pats/{id} — Soft-delete (revoke) a PAT.
+pub async fn delete_pat(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(pat_id): Path<String>,
+) -> Response {
+    let user_id = match require_authenticated(&auth_user) {
+        Ok(id) => id.to_string(),
+        Err(r) => return r,
+    };
+    match db::revoke_user_pat(&state.db, &user_id, &pat_id).await {
+        Ok(true) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "token not found" })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("failed to revoke pat: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}

--- a/crates/stiglab/src/server/routes/pats.rs
+++ b/crates/stiglab/src/server/routes/pats.rs
@@ -104,14 +104,23 @@ pub async fn create_pat(
             .into_response();
     }
 
-    if let Some(exp) = body.expires_at {
-        if exp <= Utc::now() {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "expires_at must be in the future" })),
-            )
-                .into_response();
-        }
+    // v1: explicit expiry required. The dashboard always sends one of the
+    // 7/30/60/90/custom-date choices; `null` is reserved for a future
+    // "never expires" affordance and must not silently mint long-lived
+    // tokens today.
+    let Some(expires_at) = body.expires_at else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "expires_at is required" })),
+        )
+            .into_response();
+    };
+    if expires_at <= Utc::now() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "expires_at must be in the future" })),
+        )
+            .into_response();
     }
 
     // If the caller pinned the PAT to a workspace, they must be a member of
@@ -148,7 +157,7 @@ pub async fn create_pat(
         name,
         &generated.prefix,
         &generated.hash,
-        body.expires_at,
+        Some(expires_at),
     )
     .await
     {
@@ -174,7 +183,7 @@ pub async fn create_pat(
         tenant_id: body.tenant_id.clone(),
         name: name.to_string(),
         token_prefix: generated.prefix.clone(),
-        expires_at: body.expires_at,
+        expires_at: Some(expires_at),
         last_used_at: None,
         last_used_ip: None,
         last_used_user_agent: None,
@@ -182,13 +191,24 @@ pub async fn create_pat(
         revoked_at: None,
     };
 
-    Json(serde_json::json!({
+    // The body carries the only copy of the secret token. Tell every
+    // intermediary not to cache it — the response is single-use by design.
+    let mut response = Json(serde_json::json!({
         "pat": pat_summary(&pat),
         // Returned exactly once. After this response, the only way to
         // recover access is to mint a new token.
         "token": generated.token,
     }))
-    .into_response()
+    .into_response();
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    response.headers_mut().insert(
+        axum::http::header::PRAGMA,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    response
 }
 
 /// DELETE /api/pats/{id} — Soft-delete (revoke) a PAT.

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -106,7 +106,7 @@ pub async fn create_task(
     // tenant-owned project (issue #59). Non-members get 404 via
     // `assert_tenant_member` so project IDs can't be enumerated.
     if let Some(ref project_id) = request.project_id {
-        let Some(caller_id) = user_id else {
+        if user_id.is_none() {
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(serde_json::json!({
@@ -131,7 +131,7 @@ pub async fn create_task(
         };
         if let Err(r) = crate::server::routes::tenants::assert_tenant_member(
             &state.db,
-            caller_id,
+            &auth_user,
             &project.tenant_id,
         )
         .await

--- a/crates/stiglab/src/server/routes/tenants.rs
+++ b/crates/stiglab/src/server/routes/tenants.rs
@@ -30,13 +30,31 @@ use crate::server::state::AppState;
 /// **404** (not 403) for non-members — callers get the same response for
 /// "tenant doesn't exist" and "you're not a member", so tenant IDs can't be
 /// enumerated.
+///
+/// PAT principals carry an optional `tenant_id` scope (issue #143); when
+/// set, the request must target that exact tenant. A mismatch returns
+/// **403** (not 404) — the caller already proved membership at PAT-mint
+/// time, so hiding the tenant's existence is moot, and a distinct error
+/// makes the scope-violation observable in client tooling.
 #[allow(clippy::result_large_err)]
 async fn require_tenant_member(
     pool: &AnyPool,
-    user_id: &str,
+    auth_user: &AuthUser,
     tenant_id: &str,
 ) -> Result<(), Response> {
-    match db::is_tenant_member(pool, tenant_id, user_id).await {
+    if let Some(pinned) = auth_user.principal.pinned_tenant_id() {
+        if pinned != tenant_id {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": "pat_tenant_scope_mismatch",
+                    "detail": "PAT is pinned to a different workspace",
+                })),
+            )
+                .into_response());
+        }
+    }
+    match db::is_tenant_member(pool, tenant_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),
         Ok(false) => Err(not_found("tenant not found")),
         Err(e) => {
@@ -164,11 +182,11 @@ pub async fn get_tenant(
     auth_user: AuthUser,
     Path(tenant_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     match db::get_tenant(&state.db, &tenant_id).await {
@@ -187,11 +205,11 @@ pub async fn list_members(
     auth_user: AuthUser,
     Path(tenant_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     match db::list_tenant_members_with_users(&state.db, &tenant_id).await {
@@ -229,11 +247,11 @@ pub async fn register_installation(
     Path(tenant_id): Path<String>,
     Json(body): Json<RegisterInstallationBody>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id.to_string(),
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
 
@@ -305,11 +323,11 @@ pub async fn list_installations(
     auth_user: AuthUser,
     Path(tenant_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     match db::list_github_app_installations_for_tenant(&state.db, &tenant_id).await {
@@ -333,11 +351,11 @@ pub async fn delete_installation(
     auth_user: AuthUser,
     Path((tenant_id, install_id)): Path<(String, String)>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
 
@@ -398,11 +416,11 @@ pub async fn add_project(
     Path(tenant_id): Path<String>,
     Json(body): Json<AddProjectBody>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
 
@@ -493,11 +511,11 @@ pub async fn list_projects(
     auth_user: AuthUser,
     Path(tenant_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     match db::list_projects_for_tenant(&state.db, &tenant_id).await {
@@ -536,7 +554,7 @@ pub async fn get_project(
     auth_user: AuthUser,
     Path(project_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
@@ -548,7 +566,7 @@ pub async fn get_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &project.tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &project.tenant_id).await {
         return r;
     }
     Json(serde_json::json!({ "project": project })).into_response()
@@ -562,7 +580,7 @@ pub async fn delete_project(
     auth_user: AuthUser,
     Path(project_id): Path<String>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
@@ -574,7 +592,7 @@ pub async fn delete_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &project.tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &project.tenant_id).await {
         return r;
     }
 
@@ -606,14 +624,15 @@ pub async fn delete_project(
 }
 
 /// Public helper re-exported so `routes::tasks` can reuse the same 404
-/// semantics when creating a session scoped to a project.
+/// semantics (and PAT scope check) when creating a session scoped to a
+/// project.
 #[allow(clippy::result_large_err)]
 pub async fn assert_tenant_member(
     pool: &AnyPool,
-    user_id: &str,
+    auth_user: &AuthUser,
     tenant_id: &str,
 ) -> Result<(), Response> {
-    require_tenant_member(pool, user_id, tenant_id).await
+    require_tenant_member(pool, auth_user, tenant_id).await
 }
 
 // ── Accessible-repos picker + GitHub App install flow ──
@@ -648,11 +667,11 @@ pub async fn list_accessible_repos(
     auth_user: AuthUser,
     Path((tenant_id, install_id)): Path<(String, String)>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id.to_string(),
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     // Confirm the install row belongs to this tenant before burning a token.
@@ -703,11 +722,11 @@ pub async fn list_repo_labels(
     auth_user: AuthUser,
     Path((tenant_id, install_id, owner, repo)): Path<(String, String, String, String)>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id,
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
     match db::get_github_app_installation(&state.db, &install_id).await {
@@ -768,11 +787,11 @@ pub async fn github_app_install_start(
     use axum::http::header;
     use axum::response::Redirect;
 
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id.to_string(),
         Err(r) => return r,
     };
-    if let Err(r) = require_tenant_member(&state.db, &user_id, &query.tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &query.tenant_id).await {
         return r;
     }
 
@@ -833,7 +852,7 @@ pub async fn github_app_install_callback(
 ) -> Response {
     use axum::http::header;
 
-    let user_id = match require_auth_user(&auth_user) {
+    let _user_id = match require_auth_user(&auth_user) {
         Ok(id) => id.to_string(),
         Err(r) => return r,
     };
@@ -851,7 +870,7 @@ pub async fn github_app_install_callback(
         Some((t, _)) if !t.is_empty() => t.to_string(),
         _ => return (StatusCode::BAD_REQUEST, "malformed state").into_response(),
     };
-    if let Err(r) = require_tenant_member(&state.db, &user_id, &tenant_id).await {
+    if let Err(r) = require_tenant_member(&state.db, &auth_user, &tenant_id).await {
         return r;
     }
 

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -442,6 +442,7 @@ async fn create_pat_409s_on_duplicate_name() {
     let state = AppState::new(pool, auth_enabled_config(), None);
     let app_ = app(state);
 
+    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
     let make = || {
         Request::builder()
             .method("POST")
@@ -449,7 +450,7 @@ async fn create_pat_409s_on_duplicate_name() {
             .header(header::COOKIE, format!("stiglab_session={session_token}"))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                serde_json::json!({ "name": "ci", "expires_at": null }).to_string(),
+                serde_json::json!({ "name": "ci", "expires_at": exp }).to_string(),
             ))
             .unwrap()
     };
@@ -478,6 +479,7 @@ async fn create_pat_rejects_empty_name() {
     .unwrap();
     let state = AppState::new(pool, auth_enabled_config(), None);
 
+    let exp = (Utc::now() + chrono::Duration::days(7)).to_rfc3339();
     let resp = app(state)
         .oneshot(
             Request::builder()
@@ -486,13 +488,96 @@ async fn create_pat_rejects_empty_name() {
                 .header(header::COOKIE, format!("stiglab_session={session_token}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({ "name": "  ", "expires_at": null }).to_string(),
+                    serde_json::json!({ "name": "  ", "expires_at": exp }).to_string(),
                 ))
                 .unwrap(),
         )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_pat_rejects_missing_expires_at() {
+    // v1 contract: an explicit expiry is required. `null` is reserved for
+    // a future "never expires" affordance and must not silently mint a
+    // long-lived token today.
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    for body in [
+        serde_json::json!({ "name": "ci", "expires_at": null }),
+        serde_json::json!({ "name": "ci" }),
+    ] {
+        let resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/pats")
+                    .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn create_pat_response_carries_no_store_cache_headers() {
+    // The body holds the only copy of the secret token — every
+    // intermediary must be told not to cache it.
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/pats")
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "name": "ci", "expires_at": exp }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+        Some("no-store")
+    );
+    assert_eq!(
+        resp.headers().get("pragma").and_then(|v| v.to_str().ok()),
+        Some("no-cache")
+    );
 }
 
 #[tokio::test]

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -1,0 +1,760 @@
+//! Integration tests for Personal Access Tokens (issue #143).
+//!
+//! Covers the contract surface most likely to break:
+//!   * the PAT extractor accepts the Bearer header end-to-end and prefers
+//!     it over the session cookie,
+//!   * revoked / expired PATs return 401 with the documented
+//!     `WWW-Authenticate` body and don't leak which arm failed,
+//!   * the destructive-credential guardrail (PUT-overwrite + DELETE) maps
+//!     to 403 `pat_destructive_blocked`,
+//!   * `GET /api/auth/me` reports `via: "pat" | "session"`,
+//!   * tenant-scoped PATs reject calls to a different workspace, and
+//!   * `last_used_at` advances on a successful PAT auth.
+//!
+//! Reuses the in-memory SQLite + `build_router` harness established by
+//! `tests/sso.rs`.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::Utc;
+use sqlx::pool::PoolOptions;
+use sqlx::AnyPool;
+use stiglab::core::{Tenant, TenantMember, User};
+use stiglab::server::auth::{generate_pat_token, hash_pat_token, PAT_PREFIX_LEN};
+use stiglab::server::config::ServerConfig;
+use stiglab::server::db;
+use stiglab::server::state::AppState;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+async fn test_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = PoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite connect");
+    db::run_migrations(&pool).await.expect("migrations");
+    pool
+}
+
+fn auth_enabled_config() -> ServerConfig {
+    ServerConfig {
+        host: "0.0.0.0".into(),
+        port: 3000,
+        database_url: "sqlite::memory:".into(),
+        static_dir: None,
+        cors_origin: None,
+        // Set both client_id + client_secret so config.auth_enabled() == true
+        // — the PAT extractor only kicks in when auth is enabled.
+        github_client_id: Some("client-id".into()),
+        github_client_secret: Some("client-secret".into()),
+        // Required for the credential set/get path used by the guardrail tests.
+        credential_key: Some(stiglab::server::auth::generate_credential_key()),
+        public_url: None,
+        github_app_webhook_secret: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
+    }
+}
+
+async fn seed_user(pool: &AnyPool) -> User {
+    let user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id: 7,
+        github_login: "patuser".into(),
+        github_name: Some("PAT User".into()),
+        github_avatar_url: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(pool, &user).await.unwrap();
+    user
+}
+
+async fn seed_tenant_with_member(pool: &AnyPool, user_id: &str, slug: &str) -> Tenant {
+    let now = Utc::now();
+    let tenant = Tenant {
+        id: Uuid::new_v4().to_string(),
+        slug: slug.into(),
+        name: slug.into(),
+        created_by: user_id.into(),
+        created_at: now,
+    };
+    let member = TenantMember {
+        tenant_id: tenant.id.clone(),
+        user_id: user_id.into(),
+        joined_at: now,
+    };
+    db::insert_tenant_with_creator(pool, &tenant, &member)
+        .await
+        .unwrap();
+    tenant
+}
+
+/// Mint a PAT directly via the DB layer, bypassing `POST /api/pats`. Used
+/// to set up auth state before exercising other endpoints.
+async fn mint_pat(
+    pool: &AnyPool,
+    user_id: &str,
+    tenant_id: Option<&str>,
+    name: &str,
+    expires_at: Option<chrono::DateTime<Utc>>,
+) -> (String, String) {
+    let generated = generate_pat_token();
+    let id = Uuid::new_v4().to_string();
+    db::insert_user_pat(
+        pool,
+        &id,
+        user_id,
+        tenant_id,
+        name,
+        &generated.prefix,
+        &generated.hash,
+        expires_at,
+    )
+    .await
+    .unwrap();
+    (id, generated.token)
+}
+
+fn app(state: AppState) -> axum::Router {
+    stiglab::server::build_router(state.clone(), &state.config)
+}
+
+fn bearer(req: axum::http::request::Builder, token: &str) -> axum::http::request::Builder {
+    req.header(header::AUTHORIZATION, format!("Bearer {token}"))
+}
+
+async fn read_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+// ── Token format + hash invariants ──
+
+#[test]
+fn token_has_correct_prefix_and_length() {
+    let pat = generate_pat_token();
+    assert!(pat.token.starts_with("ons_pat_"));
+    assert_eq!(pat.prefix.len(), PAT_PREFIX_LEN);
+    assert_eq!(&pat.prefix, &pat.token[..PAT_PREFIX_LEN]);
+    assert_eq!(pat.hash, hash_pat_token(&pat.token));
+}
+
+// ── DB-level verify_pat ──
+
+#[tokio::test]
+async fn verify_pat_rejects_unknown_prefix() {
+    let pool = test_pool().await;
+    let outcome = stiglab::server::auth::verify_pat(&pool, "ons_pat_doesnotexistxyz123abc")
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        stiglab::server::auth::PatVerifyOutcome::Unknown
+    ));
+}
+
+#[tokio::test]
+async fn verify_pat_rejects_wrong_namespace() {
+    let pool = test_pool().await;
+    let outcome = stiglab::server::auth::verify_pat(&pool, "ghp_aaaaaaaaaaaaaaaa")
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        stiglab::server::auth::PatVerifyOutcome::Unknown
+    ));
+}
+
+#[tokio::test]
+async fn verify_pat_accepts_valid_token() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let outcome = stiglab::server::auth::verify_pat(&pool, &token)
+        .await
+        .unwrap();
+    match outcome {
+        stiglab::server::auth::PatVerifyOutcome::Ok(pat) => {
+            assert_eq!(pat.id, pat_id);
+            assert_eq!(pat.user_id, user.id);
+        }
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn verify_pat_reports_revoked_separately_from_unknown() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    db::revoke_user_pat(&pool, &user.id, &pat_id).await.unwrap();
+    let outcome = stiglab::server::auth::verify_pat(&pool, &token)
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        stiglab::server::auth::PatVerifyOutcome::Revoked
+    ));
+}
+
+#[tokio::test]
+async fn verify_pat_reports_expired_separately_from_unknown() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let past = Utc::now() - chrono::Duration::seconds(60);
+    let (_, token) = mint_pat(&pool, &user.id, None, "ci", Some(past)).await;
+    let outcome = stiglab::server::auth::verify_pat(&pool, &token)
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        stiglab::server::auth::PatVerifyOutcome::Expired
+    ));
+}
+
+// ── End-to-end PAT-authenticated requests ──
+
+#[tokio::test]
+async fn me_under_pat_reports_via_pat() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(Request::builder().uri("/api/auth/me"), &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = read_json(resp).await;
+    assert_eq!(v["via"], "pat");
+    assert_eq!(v["user"]["github_login"], "patuser");
+}
+
+#[tokio::test]
+async fn me_under_session_reports_via_session_when_no_pat() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    // Mint a real session row.
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/me")
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = read_json(resp).await;
+    assert_eq!(v["via"], "session");
+}
+
+#[tokio::test]
+async fn revoked_pat_returns_401_with_invalid_token_challenge() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    db::revoke_user_pat(&pool, &user.id, &pat_id).await.unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(Request::builder().uri("/api/auth/me"), &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let www = resp
+        .headers()
+        .get(header::WWW_AUTHENTICATE)
+        .map(|v| v.to_str().unwrap().to_string());
+    assert_eq!(
+        www.as_deref(),
+        Some("Bearer error=\"invalid_token\""),
+        "WWW-Authenticate must report invalid_token"
+    );
+}
+
+#[tokio::test]
+async fn expired_pat_returns_401_with_invalid_token_challenge() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let past = Utc::now() - chrono::Duration::seconds(60);
+    let (_, token) = mint_pat(&pool, &user.id, None, "ci", Some(past)).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(Request::builder().uri("/api/auth/me"), &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        resp.headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer error=\"invalid_token\"")
+    );
+}
+
+#[tokio::test]
+async fn pat_bearer_takes_precedence_over_cookie() {
+    // A request that carries BOTH a valid PAT and a valid session cookie
+    // should be authenticated as the PAT user (so that smoke-testing from
+    // a CLI doesn't silently fall through to the browser session that
+    // happens to be in scope).
+    let pool = test_pool().await;
+    let pat_user = seed_user(&pool).await;
+    let cookie_user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id: 999,
+        github_login: "cookieuser".into(),
+        github_name: None,
+        github_avatar_url: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(&pool, &cookie_user).await.unwrap();
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &cookie_user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let (_, pat_token) = mint_pat(&pool, &pat_user.id, None, "ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/me")
+                .header(header::AUTHORIZATION, format!("Bearer {pat_token}"))
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = read_json(resp).await;
+    assert_eq!(v["via"], "pat");
+    assert_eq!(v["user"]["github_login"], "patuser");
+}
+
+// ── PAT CRUD via /api/pats ──
+
+#[tokio::test]
+async fn create_pat_returns_token_once_then_listing_hides_it() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    // Bootstrap auth via a session cookie so we can create a PAT.
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let app_ = app(state);
+
+    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
+    let create = Request::builder()
+        .method("POST")
+        .uri("/api/pats")
+        .header(header::COOKIE, format!("stiglab_session={session_token}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({ "name": "ci", "expires_at": exp }).to_string(),
+        ))
+        .unwrap();
+    let resp = app_.clone().oneshot(create).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    let token = body["token"].as_str().unwrap().to_string();
+    assert!(token.starts_with("ons_pat_"));
+    let prefix = body["pat"]["token_prefix"].as_str().unwrap();
+    assert_eq!(prefix.len(), PAT_PREFIX_LEN);
+
+    // List — must NOT echo the secret token, only metadata + prefix.
+    let list = Request::builder()
+        .uri("/api/pats")
+        .header(header::COOKIE, format!("stiglab_session={session_token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app_.oneshot(list).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    let pats = body["pats"].as_array().unwrap();
+    assert_eq!(pats.len(), 1);
+    assert_eq!(pats[0]["token_prefix"].as_str().unwrap(), prefix);
+    assert!(pats[0].get("token").is_none());
+    assert!(pats[0].get("token_hash").is_none());
+}
+
+#[tokio::test]
+async fn create_pat_409s_on_duplicate_name() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let app_ = app(state);
+
+    let make = || {
+        Request::builder()
+            .method("POST")
+            .uri("/api/pats")
+            .header(header::COOKIE, format!("stiglab_session={session_token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({ "name": "ci", "expires_at": null }).to_string(),
+            ))
+            .unwrap()
+    };
+    assert_eq!(
+        app_.clone().oneshot(make()).await.unwrap().status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        app_.oneshot(make()).await.unwrap().status(),
+        StatusCode::CONFLICT
+    );
+}
+
+#[tokio::test]
+async fn create_pat_rejects_empty_name() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/pats")
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "name": "  ", "expires_at": null }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_pat_revokes_so_subsequent_use_401s() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let app_ = app(state);
+
+    // Sanity: PAT works before revoke.
+    let pre = app_
+        .clone()
+        .oneshot(
+            bearer(Request::builder().uri("/api/auth/me"), &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(pre.status(), StatusCode::OK);
+
+    // Revoke via the API.
+    let revoke = app_
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/pats/{pat_id}"))
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(revoke.status(), StatusCode::OK);
+
+    // After revoke: same Bearer token now 401s with invalid_token.
+    let post = app_
+        .oneshot(
+            bearer(Request::builder().uri("/api/auth/me"), &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(post.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── Destructive-credential guardrail ──
+
+#[tokio::test]
+async fn pat_can_create_credential_but_not_overwrite() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let app_ = app(state);
+
+    // PUT to a brand-new credential name succeeds.
+    let create = bearer(
+        Request::builder()
+            .method("PUT")
+            .uri("/api/credentials/CI_TOKEN")
+            .header(header::CONTENT_TYPE, "application/json"),
+        &token,
+    )
+    .body(Body::from(
+        serde_json::json!({ "value": "abc" }).to_string(),
+    ))
+    .unwrap();
+    let resp = app_.clone().oneshot(create).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // PUT to the same name now must 403 with the documented body.
+    let overwrite = bearer(
+        Request::builder()
+            .method("PUT")
+            .uri("/api/credentials/CI_TOKEN")
+            .header(header::CONTENT_TYPE, "application/json"),
+        &token,
+    )
+    .body(Body::from(
+        serde_json::json!({ "value": "xyz" }).to_string(),
+    ))
+    .unwrap();
+    let resp = app_.oneshot(overwrite).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = read_json(resp).await;
+    assert_eq!(v["error"], "pat_destructive_blocked");
+}
+
+#[tokio::test]
+async fn pat_cannot_delete_credential() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    // Pre-create a credential via the DB so the DELETE actually has
+    // something to refer to.
+    let key = stiglab::server::auth::generate_credential_key();
+    let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
+    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+        .await
+        .unwrap();
+    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/credentials/CI_TOKEN"),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = read_json(resp).await;
+    assert_eq!(v["error"], "pat_destructive_blocked");
+}
+
+#[tokio::test]
+async fn session_can_still_delete_credential_after_guardrail_added() {
+    // Regression guard: the destructive guardrail must only fire for PATs.
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let key = stiglab::server::auth::generate_credential_key();
+    let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
+    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+        .await
+        .unwrap();
+    let session_token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        &pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/credentials/CI_TOKEN")
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ── last_used_at ──
+
+#[tokio::test]
+async fn last_used_at_advances_after_pat_auth() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    // Sanity: brand-new PAT has no last_used_at.
+    {
+        let pats = db::list_user_pats(&pool, &user.id).await.unwrap();
+        assert!(pats
+            .iter()
+            .any(|p| p.id == pat_id && p.last_used_at.is_none()));
+    }
+
+    let state = AppState::new(pool.clone(), auth_enabled_config(), None);
+    let resp = app(state)
+        .oneshot(
+            bearer(
+                Request::builder()
+                    .uri("/api/auth/me")
+                    .header(header::USER_AGENT, "test-agent/1.0"),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The touch is best-effort + spawned, so poll briefly for the update.
+    let mut populated = false;
+    for _ in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        let pats = db::list_user_pats(&pool, &user.id).await.unwrap();
+        if let Some(p) = pats.iter().find(|p| p.id == pat_id) {
+            if p.last_used_at.is_some() {
+                populated = true;
+                assert_eq!(p.last_used_user_agent.as_deref(), Some("test-agent/1.0"));
+                break;
+            }
+        }
+    }
+    assert!(populated, "last_used_at should be set after a PAT auth");
+}
+
+// ── Tenant scope ──
+
+#[tokio::test]
+async fn tenant_scoped_pat_can_read_its_own_workspace() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let tenant = seed_tenant_with_member(&pool, &user.id, "wsa").await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&tenant.id), "wsa-ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(
+                Request::builder().uri(format!("/api/tenants/{}", tenant.id)),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = read_json(resp).await;
+    assert_eq!(v["tenant"]["id"], tenant.id);
+}
+
+#[tokio::test]
+async fn tenant_scoped_pat_rejects_other_workspace() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool).await;
+    let tenant_a = seed_tenant_with_member(&pool, &user.id, "wsa").await;
+    let tenant_b = seed_tenant_with_member(&pool, &user.id, "wsb").await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&tenant_a.id), "wsa-ci", None).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            bearer(
+                Request::builder().uri(format!("/api/tenants/{}", tenant_b.id)),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = read_json(resp).await;
+    assert_eq!(v["error"], "pat_tenant_scope_mismatch");
+}

--- a/docs/api/personal-access-tokens.md
+++ b/docs/api/personal-access-tokens.md
@@ -1,0 +1,111 @@
+# Personal Access Tokens
+
+Personal Access Tokens (PATs) are user-owned bearer credentials that
+authenticate non-browser callers — CLIs, CI jobs, agents, notebooks —
+against the same `/api/*` surface the dashboard uses. Issued in
+[#143](https://github.com/onsager-ai/onsager/issues/143).
+
+## Token format
+
+```
+ons_pat_<32 url-safe random bytes>
+```
+
+The `ons_pat_` namespace prefix matches GitHub's `ghp_` style so secret
+scanners can match on it. The full token is shown to the user **exactly
+once**, on creation. The server stores only the SHA-256 hash plus the first
+12 characters (the `token_prefix`) for display + indexed lookup; there is
+no decrypt path, even for the owner.
+
+## Header shape
+
+```
+Authorization: Bearer ons_pat_<...>
+```
+
+A request that carries both a valid PAT and a valid `stiglab_session`
+cookie is authenticated as the PAT user — the bearer wins, so a CLI smoke
+test from a developer's terminal can't silently fall through to the
+browser session that happens to be in scope.
+
+`/api/auth/me` includes a `via` field so callers can confirm which path
+authenticated the request:
+
+```json
+{ "user": { ... }, "auth_enabled": true, "via": "pat" }
+```
+
+## Lifecycle
+
+| Operation | Endpoint | Notes |
+| --- | --- | --- |
+| List | `GET /api/pats` | Prefix-only metadata. The full token is **not** returned. |
+| Create | `POST /api/pats` | Returns the full token in the response body, **once**. |
+| Revoke | `DELETE /api/pats/{id}` | Soft-delete (sets `revoked_at`). Audit row is kept. |
+
+Create body:
+
+```json
+{
+  "name": "ci",
+  "tenant_id": null,
+  "expires_at": "2026-07-25T00:00:00Z"
+}
+```
+
+* `name` is required, must be unique per user.
+* `tenant_id` is optional. When set, the PAT is **pinned** to that
+  workspace — calls touching another tenant return 403
+  `pat_tenant_scope_mismatch`. The dashboard form defaults to "All
+  workspaces".
+* `expires_at` is required from the API. The dashboard offers GitHub-style
+  choices (7 / 30 / 60 / 90 days / custom date). `null` is reserved for a
+  future "never expires" affordance and not exposed in v1.
+
+A revoked or expired PAT returns:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer error="invalid_token"
+```
+
+## Destructive-operation guardrail
+
+PATs authenticate the same user as a session, but the API treats them as a
+**lower-privilege principal** for destructive credential operations:
+
+* `DELETE /api/credentials/{name}` returns 403 `pat_destructive_blocked`.
+* `PUT /api/credentials/{name}` is allowed only when the credential does
+  **not** already exist (create-only); overwriting an existing credential
+  returns the same 403.
+* All other endpoints (sessions, tasks, governance, tenants, projects,
+  list/read credentials) behave as for a session.
+
+The intent is that rotating a stored secret stays a deliberate
+human-in-the-browser action, even when an automated PAT-bearing pipeline
+has full access otherwise.
+
+## Curl example
+
+```sh
+TOKEN="ons_pat_..."   # paste from the create response
+API="https://app.onsager.ai"
+
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  $API/api/sessions | jq
+
+# Tenant-scoped PAT can post sessions in its own workspace:
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"hello","project_id":"<scoped-project-id>"}' \
+  $API/api/tasks
+```
+
+## Notes for v1
+
+* No fine-grained scopes — every PAT carries `["*"]`. The schema reserves
+  the column for a future scope language.
+* Tokens are user-owned; tenant-owned / service-account principals are a
+  separate spec.
+* No IP allowlists, per-token rate limits, or rotation reminders.
+* No CLI tooling that auto-stores the token; that's tracked as a follow-up.


### PR DESCRIPTION
## Summary

Adds user-owned bearer credentials (`ons_pat_…`) so external CLIs, CI jobs, agents, and notebooks can authenticate against `/api/*` without screen-scraping a session cookie.

## Delivers

Implements the full Plan in #143:

**Backend (stiglab)**
- `user_pats` migration: `tenant_id` workspace scope-down, `last_used_at` / `last_used_ip` / `last_used_user_agent`, soft-delete via `revoked_at`, indexed `token_prefix`.
- `RequestPrincipal::{Session, Pat}` on `AuthUser`. The extractor now tries `Authorization: Bearer ons_pat_…` first and only falls back to the cookie. Revoked / expired / unknown PATs return 401 with `WWW-Authenticate: Bearer error="invalid_token"` — outcomes split internally so the response can't leak which step failed.
- `GET/POST /api/pats` + `DELETE /api/pats/{id}`. The full token is returned exactly once; subsequent listings show prefix + metadata only.
- Destructive-credential guardrail in `routes/credentials.rs`: PAT-authed `DELETE /api/credentials/{name}` and overwrite-`PUT` return 403 `{"error":"pat_destructive_blocked"}`. Create-`PUT` of a new name still works.
- Tenant-scope guard threaded through `require_tenant_member` — a PAT pinned to one workspace hitting another returns 403 `pat_tenant_scope_mismatch`. Public `assert_tenant_member` updated; tasks-side caller in `routes/tasks.rs` adjusted accordingly.
- `GET /api/auth/me` reports `via: "session" | "pat"`.
- Token format: `ons_pat_` + 32 url-safe random bytes (~256 bits). Stored as SHA-256 hex via `ring::digest`; constant-time compare via existing `secrets_equal`. No new crate deps.

**Dashboard**
- `/settings/tokens` page: empty-state CTA, list view (name, prefix, expiry, last-used IP + truncated UA on hover), revoke, and a one-shot reveal modal with copy-to-clipboard.
- Token-create form follows GitHub's 7 / 30 / 60 / 90 / custom-date convention; "Restrict to workspace" select defaults to "All workspaces".
- "Personal access tokens" card on `SettingsPage` (directly above Credentials), hidden in anonymous mode.
- `apps/dashboard/src/lib/api.ts`: `Pat` type, `listPats`, `createPat`, `revokePat`. `getMe` typed with `via?: "session" | "pat"`.

**Tests + docs**
- 21 integration tests in `crates/stiglab/tests/pats.rs` (verify_pat outcomes, end-to-end auth precedence Bearer-over-cookie, revoked/expired 401 + `WWW-Authenticate`, destructive-credential guardrail, session-side regression, `last_used_at` advancement, tenant scope enforcement).
- 5 unit tests covering token shape, hash determinism, prefix safety, `RequestPrincipal` helpers.
- `docs/api/personal-access-tokens.md` covering token format, header shape, the destructive-credential guardrail, and a curl example.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` (clean)
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` (113 + 149 + … passing)
- [x] `cargo test -p stiglab --test pats` (21/21 passing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `pnpm build` + `pnpm lint` in `apps/dashboard` (clean)
- [ ] Manual: create a PAT in the dashboard, hit `curl -H "Authorization: Bearer ons_pat_…" $API/api/sessions`, see the same response as the cookie session.
- [ ] Manual: revoke the PAT, repeat the curl, confirm 401 with `WWW-Authenticate: Bearer error="invalid_token"`.
- [ ] Manual: tenant-scoped PAT can `POST /api/sessions` in its workspace and gets 403 in another.
- [ ] Manual (Reach): brand-new user with zero PATs lands on `/settings/tokens` and sees the empty-state CTA.
- [ ] Manual (Reach): with `authEnabled=false`, the Settings card and `/settings/tokens` route are hidden.

Closes #143


---
_Generated by [Claude Code](https://claude.ai/code/session_018wTinwMBS4QJpXFiRY4CZN)_