### PR TITLE
docs: name the "internal aesthetic" value in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,37 @@ still defines `HttpStiglabDispatcher` (≈52–304) and `HttpSynodicGate`
 (≈344–397), and instantiates them against sibling-subsystem ports in
 `run` (≈469–490). New code must not add to that pattern.
 
+## Internal aesthetic
+
+Care about the inside the same way you'd care about the outside. The wires
+inside an Apple product are routed and dressed even though no user will ever
+open the case. We hold the codebase to the same standard: the seams between
+subsystems, the shape of internal modules, the consistency of names and
+errors, the absence of dead wires — these are first-class quality, not
+cleanup chores deferred until "after the feature lands."
+
+This is a value, not a checklist. Three operating principles fall out of it:
+
+- **Internal symmetry is a feature.** When two things are *the same concept*,
+  they should have the same shape — same name, same type, same error model,
+  same write path. Asymmetry between equivalent things (`TriggerKind` here,
+  `TriggerSpec` there; one creation path setting `current_version=0`, another
+  setting `=1`) is a defect, even when nothing user-visible is broken.
+- **No dangling wires.** Code marked `#[allow(dead_code)]` "for later," event
+  types with no consumer, endpoints with no UI caller, and compat aliases with
+  no removal date are all the same defect: a wire connected at one end. Either
+  finish the connection in the same PR, or remove the loose end.
+- **The inside is reviewable.** Files that grow past ~500 LOC, modules that
+  mix unrelated concerns, error types that change shape across a subsystem
+  boundary — these aren't style preferences, they're tax on every future
+  reader. Splitting and unifying them is real work, worth scheduling.
+
+The seam rule above and the "Architectural drift patterns to watch" list
+below are both operational projections of this value onto the seams between
+subsystems. Internal-quality work that doesn't fit those projections —
+interior-to-a-subsystem hygiene — is equally in scope and should be specced
+and shipped on the same footing as feature work.
+
 ## Architectural drift patterns to watch
 
 Loose runtime coupling is correct and stays — but the seams it creates are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ This is a value, not a checklist. Three operating principles fall out of it:
   finish the connection in the same PR, or remove the loose end.
 - **The inside is reviewable.** Files that grow past ~500 LOC, modules that
   mix unrelated concerns, error types that change shape across a subsystem
-  boundary — these aren't style preferences, they're tax on every future
+  boundary — these aren't style preferences, they're a tax on every future
   reader. Splitting and unifying them is real work, worth scheduling.
 
 The seam rule above and the "Architectural drift patterns to watch" list


### PR DESCRIPTION
## Summary

- Adds an **Internal aesthetic** section to root `CLAUDE.md`, placed
  directly above the existing "Architectural drift patterns to watch"
  list. Names the value (Apple-style "the inside is dressed too")
  that the drift-patterns list already operationalizes for the seam
  layer.
- Three operating principles called out by name so reviewers can
  reach for them: *internal symmetry is a feature*, *no dangling
  wires*, *the inside is reviewable*.
- Doc-only. Zero behavior change, zero crate touched. Companion to
  spec issue #153 which operationalizes the value on six specific
  interior-cleanup findings.

## Why now

Recent dev-process work (#131 / Lever A / PR #144) already persisted
the **seam rule** into CLAUDE.md and the dev-loop skills. That
captures *one* projection of internal-quality discipline — the one
between subsystems. An audit on this branch surfaced a second class
of drift, *interior to a subsystem*, that the seam rule doesn't
reach: divergent write paths for the same row, dead-code clusters
under `#[allow(dead_code)]`, ~2k-LOC monolith files,
error-handling asymmetry across crate boundaries, naming duplication
(e.g. `TriggerKind` vs `TriggerSpec`).

Naming the parent value lets future PRs cite "violates the internal
aesthetic" as a first-class review reason, the same way they
already cite "violates the seam rule." It also gives spec #153 a
foundation to point at instead of re-justifying interior cleanup
from scratch each time.

## Relationship to existing work

- **#131 (tighten the seams).** Owns the inter-subsystem projection
  of internal quality. Untouched by this PR.
- **#153 (tidy interior — internal-aesthetic cleanup).** Filed
  alongside this PR. Operationalizes the value on six concrete
  audit findings that #131's six levers don't cover.

Part of #153

## Test plan

- [x] `CLAUDE.md` renders correctly on GitHub (preview)
- [x] No code changes — `cargo build` / `cargo test` not affected
- [ ] Section reads cleanly when picked up cold by a reviewer who
      hasn't followed the audit thread

https://claude.ai/code/session_016UC639yLTQEG9coxsvNApd

---
_Generated by [Claude Code](https://claude.ai/code/session_016UC639yLTQEG9coxsvNApd)_