### PR TITLE
feat(xtask): seam-rule lint (Lever B / no escape hatch)

### DIFF
--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -235,7 +235,9 @@ is explicitly trivial). This is the local counterpart to the
 
 ### 6.5. Seam-rule self-check
 
-Before pushing, look at the diff once more against the canonical rule:
+`just lint-rust` runs `cargo run -p xtask --quiet -- lint-seams` as part
+of step 4. That's the canonical check; CI runs the same. The lint
+enforces the rule from ADR 0004 / spec #131 Lever B:
 
 > HTTP APIs exist only at external boundaries:
 > - **User-facing endpoints** called by the dashboard.
@@ -246,41 +248,47 @@ Before pushing, look at the diff once more against the canonical rule:
 > shared spine tables. No subsystem makes HTTP calls to another
 > subsystem. No subsystem imports another subsystem's crate.
 
-Run a focused diff scan — Lever B of spec #131 will eventually hard-fail
-each of these in CI; until that lands, catch them locally:
+What the lint catches (each with a precise file:line and a fix
+hint — see `xtask/src/lint_seams.rs` for the full set):
+
+- **`arch-dep`** — subsystem A's `Cargo.toml` declares another
+  subsystem in `[dependencies]` / `[dev-dependencies]` /
+  `[build-dependencies]`. **No escape hatch** — Cargo.toml violations
+  always hard-fail.
+- **`sibling-env`** — code in subsystem A reads `<B>_URL` / `<B>_PORT`
+  for sibling B. That's the `forge → stiglab/synodic` HTTP-RPC shape.
+- **`sibling-host`** — a literal `http://<sibling>:` or
+  `https://<sibling>:` URL appears in subsystem source.
+- **`sibling-port`** — a literal `localhost:<sibling-port>` appears
+  in subsystem source.
+- **`serde-alias`** — new `#[serde(alias = …)]` in subsystem source.
+- **`mirror-file`** — a file matching `*_mirror.rs` exists under a
+  subsystem's `src/`.
+- **`legacy-type-alias`** — `pub type X = Y;` whose adjacent
+  doc-comment contains "legacy" / "deprecated" / "compat" / "alias
+  for" / "renamed" / "for backwards" / "until …".
+
+(`producer-without-consumer` is gated on Lever E #150 and currently
+warn-only.)
+
+To run the lint by hand without the rest of `lint-rust`:
 
 ```bash
-git diff origin/main...HEAD -- 'crates/forge/**' 'crates/stiglab/**' \
-  'crates/synodic/**' 'crates/ising/**'
+cargo run -p xtask --quiet -- lint-seams
 ```
 
-Flag any of:
+**Escape hatch (use sparingly).** For a single-line non-Cargo.toml
+violation, add `// seam-allow: <reason>` on the line **immediately
+above** the offending line. The reason text is mandatory; the lint
+reports each allow separately so reviewers see them. Every allow is
+debt — file the follow-up ticket in the reason string. Cargo.toml
+violations have no escape hatch.
 
-- **New sibling-subsystem HTTP client.** A new `reqwest::Client` /
-  `hyper::Client` constructed in `forge|stiglab|synodic|ising` whose
-  URL targets a sibling-subsystem port (3000, 3001, …) or service
-  name. The right shape is event emit + listener pair.
-- **New cross-subsystem Cargo dep.** Subsystem A's `Cargo.toml`
-  declaring B as a dep, e.g. `forge` adding `stiglab = { path = ... }`.
-  Subsystems may depend only on `onsager-{artifact, warehouse,
-  protocol, spine, registry, delivery}` per their existing manifests.
-- **New `serde(alias = …)`.** Renames must land atomically; aliases
-  ossify (PR #107 is the canonical case).
-- **New `*_mirror.rs` file or "translator" module.** The spine is
-  already the source of truth; mirror modules drift (PR #129 / Lever
-  D is removing the live one).
-- **New `pub type X = Y` "for compatibility".** Same problem as a
-  serde alias.
-- **New `FactoryEventKind` variant without a consumer.** Producer +
-  consumer should land together (PR #127 drift pattern). Lever E will
-  make this CI-enforceable.
-- **New API endpoint with no dashboard caller, or new dashboard
-  client method with no backend handler.** PR #108 drift pattern;
-  ship both halves in one PR (or two PRs gated by a contract test).
-
-If any of these appear, fix the seam before pushing — do not file a
-follow-up issue and ship the bridge. (Database schema migrations are
-the only exception; they remain governed by `migrations/NNN_*.sql`.)
+If the lint fires on something genuinely new (not a known Lever C/D
+allow-listed exception), fix the seam before pushing — do not add a
+new `seam-allow` without a tracked follow-up issue, and do not file
+a follow-up "to remove this later". Database schema migrations
+remain governed by `migrations/NNN_*.sql` and are not in lint scope.
 
 ### 7. Push
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,8 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Verify docs/events.md is in sync with FactoryEventKind
         run: cargo run -p xtask --quiet -- gen-event-docs --check
+      - name: Seam-rule lint (ADR 0004 / spec #131 Lever B)
+        run: cargo run -p xtask --quiet -- lint-seams
       - name: Apply database migrations
         run: |
           psql "$DATABASE_URL" -f crates/onsager-spine/migrations/001_initial.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,6 +2243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +2954,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3642,6 +3692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3801,7 @@ dependencies = [
  "anyhow",
  "quote",
  "syn",
+ "toml",
 ]
 
 [[package]]

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -451,10 +451,14 @@ pub fn run(database_url: &str, tick_ms: u64) {
             None => ArtifactStore::new(),
         };
 
+        // seam-allow: legacy ADR 0001 sync RPC; replaced by spine events in Lever C (#148)
         let stiglab_port = std::env::var("STIGLAB_PORT").unwrap_or_else(|_| "3000".to_string());
+        // seam-allow: legacy ADR 0001 sync RPC; replaced by spine events in Lever C (#148)
         let stiglab_url = std::env::var("STIGLAB_URL")
             .unwrap_or_else(|_| format!("http://localhost:{stiglab_port}"));
+        // seam-allow: legacy ADR 0001 sync RPC; replaced by spine events in Lever C (#148)
         let synodic_port = std::env::var("SYNODIC_PORT").unwrap_or_else(|_| "3001".to_string());
+        // seam-allow: legacy ADR 0001 sync RPC; replaced by spine events in Lever C (#148)
         let synodic_url = std::env::var("SYNODIC_URL")
             .unwrap_or_else(|_| format!("http://localhost:{synodic_port}"));
 

--- a/crates/stiglab/src/server/routes/governance.rs
+++ b/crates/stiglab/src/server/routes/governance.rs
@@ -11,7 +11,9 @@ use axum::response::{IntoResponse, Response};
 
 /// Base URL for the synodic governance API (internal, not exposed by Railway).
 fn synodic_base_url() -> String {
+    // seam-allow: dashboard governance proxy; Railway only exposes stiglab. Tracked separately from spec #131; revisit once governance UI moves under Lever F.
     let port = std::env::var("SYNODIC_PORT").unwrap_or_else(|_| "3001".to_string());
+    // seam-allow: dashboard governance proxy; Railway only exposes stiglab. Tracked separately from spec #131; revisit once governance UI moves under Lever F.
     std::env::var("SYNODIC_URL").unwrap_or_else(|_| format!("http://localhost:{port}"))
 }
 

--- a/crates/stiglab/src/server/workflow_spine_mirror.rs
+++ b/crates/stiglab/src/server/workflow_spine_mirror.rs
@@ -1,3 +1,4 @@
+// seam-allow: removed in Lever D (#149) — collapses tenant_workflows into spine workflows with a tenant_id discriminator
 //! Mirror stiglab's `tenant_workflows` rows into the spine `workflows` /
 //! `workflow_stages` tables that forge reads.
 //!

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ lint-rust:
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets -- -D warnings
     cargo run -p xtask --quiet -- gen-event-docs --check
+    cargo run -p xtask --quiet -- lint-seams
 
 lint-ui:
     pnpm --filter dashboard lint

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,4 @@ path = "src/main.rs"
 anyhow.workspace = true
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
+toml = "0.8"

--- a/xtask/src/lint_seams.rs
+++ b/xtask/src/lint_seams.rs
@@ -33,10 +33,13 @@ use anyhow::{anyhow, bail, Context, Result};
 
 const SUBSYSTEMS: &[&str] = &["forge", "stiglab", "synodic", "ising"];
 
-/// Well-known ports each subsystem listens on. Hard-coded because they are
-/// part of the subsystem's external contract — see root `CLAUDE.md`.
+/// Well-known **default** ports each subsystem listens on (i.e. what
+/// `cargo run -p <subsys> -- serve` binds without env overrides; verified
+/// against the `*_PORT` defaults in each subsystem's serve command). Hard-
+/// coded because they are part of the subsystem's external contract — see
+/// root `CLAUDE.md`.
 const SUBSYSTEM_PORTS: &[(&str, &str)] =
-    &[("stiglab", "3000"), ("synodic", "3001"), ("forge", "3003")];
+    &[("stiglab", "3000"), ("synodic", "3001"), ("forge", "3002")];
 
 pub fn run() -> Result<()> {
     let root = workspace_root()?;
@@ -176,39 +179,90 @@ fn check_arch_deps(root: &Path, subsys: &str, out: &mut Vec<Violation>) -> Resul
         toml::from_str(&text).with_context(|| format!("parse {}", manifest.display()))?;
 
     let dep_tables = ["dependencies", "dev-dependencies", "build-dependencies"];
+
+    // Top-level [dependencies] / [dev-dependencies] / [build-dependencies].
     for table_key in dep_tables {
-        let Some(table) = parsed.get(table_key).and_then(|v| v.as_table()) else {
-            continue;
-        };
-        for (name, _) in table {
-            if name == subsys {
-                continue;
-            }
-            if SUBSYSTEMS.contains(&name.as_str()) {
-                let line = find_dep_line(&text, table_key, name);
-                out.push(Violation {
-                    path: rel(root, &manifest),
-                    line,
-                    kind: "arch-dep",
-                    message: format!(
-                        "subsystem `{subsys}` declares `{name}` as [{table_key}] — subsystems must not depend on each other (ADR 0001)"
-                    ),
-                });
+        if let Some(table) = parsed.get(table_key).and_then(|v| v.as_table()) {
+            for (name, _) in table {
+                check_arch_dep_entry(root, &manifest, &text, subsys, name, table_key, None, out);
             }
         }
     }
+
+    // Target-specific tables: [target.'<cfg>'.dependencies] / dev / build.
+    // A subsystem-to-subsystem dep dressed up as cfg-gated would otherwise
+    // bypass the lint.
+    if let Some(target) = parsed.get("target").and_then(|v| v.as_table()) {
+        for (cfg, value) in target {
+            for table_key in dep_tables {
+                if let Some(table) = value.get(table_key).and_then(|v| v.as_table()) {
+                    for (name, _) in table {
+                        check_arch_dep_entry(
+                            root,
+                            &manifest,
+                            &text,
+                            subsys,
+                            name,
+                            table_key,
+                            Some(cfg.as_str()),
+                            out,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn check_arch_dep_entry(
+    root: &Path,
+    manifest: &Path,
+    text: &str,
+    subsys: &str,
+    name: &str,
+    table_key: &str,
+    cfg: Option<&str>,
+    out: &mut Vec<Violation>,
+) {
+    if name == subsys {
+        return;
+    }
+    if !SUBSYSTEMS.contains(&name) {
+        return;
+    }
+    let line = find_dep_line(text, table_key, name, cfg);
+    let table_label = match cfg {
+        Some(c) => format!("target.{c}.{table_key}"),
+        None => table_key.to_string(),
+    };
+    out.push(Violation {
+        path: rel(root, manifest),
+        line,
+        kind: "arch-dep",
+        message: format!(
+            "subsystem `{subsys}` declares `{name}` as [{table_label}] — subsystems must not depend on each other (ADR 0001)"
+        ),
+    });
+}
+
 /// Find the 1-indexed line where a dep declaration starts. Best-effort: we
-/// look for a `<name>\s*=` line after the matching `[<table>]` header.
-fn find_dep_line(text: &str, table: &str, name: &str) -> usize {
-    let header = format!("[{table}]");
+/// look for a `<name>\s*=` line after the matching `[<table>]` header. For
+/// target-specific tables (`cfg = Some(...)`), the header is matched on
+/// suffix (`.{table}`) since the cfg literal can be quoted multiple ways.
+fn find_dep_line(text: &str, table: &str, name: &str, cfg: Option<&str>) -> usize {
+    let plain_header = format!("[{table}]");
+    let target_suffix = format!(".{table}]");
     let mut in_section = false;
     for (i, line) in text.lines().enumerate() {
         let t = line.trim_start();
         if t.starts_with('[') && t.ends_with(']') {
-            in_section = t == header;
+            in_section = match cfg {
+                None => t == plain_header,
+                Some(_) => t.starts_with("[target.") && t.ends_with(target_suffix.as_str()),
+            };
             continue;
         }
         if in_section {
@@ -227,11 +281,15 @@ fn find_dep_line(text: &str, table: &str, name: &str) -> usize {
 
 fn check_file(root: &Path, subsys: &str, path: &Path, out: &mut Vec<Violation>) -> Result<()> {
     let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    for (idx, line) in text.lines().enumerate() {
+    // Split once and reuse — `check_legacy_type_alias` needs the full
+    // line context for its doc-comment look-back, and re-collecting per
+    // line would be O(n²) on files with many `pub type` declarations.
+    let lines: Vec<&str> = text.lines().collect();
+    for (idx, line) in lines.iter().enumerate() {
         let n = idx + 1;
         check_sibling_url(root, subsys, path, n, line, out);
         check_serde_alias(root, path, n, line, out);
-        check_legacy_type_alias(root, path, n, line, &text, out);
+        check_legacy_type_alias(root, path, n, line, &lines, out);
     }
     Ok(())
 }
@@ -264,7 +322,7 @@ fn check_sibling_url(
                 line: line_no,
                 kind: "sibling-env",
                 message: format!(
-                    "subsystem `{subsys}` references `{url_var}`/`{port_var}` — that's a `forge → stiglab/synodic`-style HTTP RPC; coordinate via the spine instead (Lever C)"
+                    "subsystem `{subsys}` references sibling `{sibling}` via `{url_var}`/`{port_var}` — that's a direct HTTP RPC to another subsystem; coordinate via the spine instead (Lever C / ADR 0001)"
                 ),
             });
             continue;
@@ -373,7 +431,7 @@ fn check_legacy_type_alias(
     path: &Path,
     line_no: usize,
     line: &str,
-    full: &str,
+    lines: &[&str],
     out: &mut Vec<Violation>,
 ) {
     let trimmed = line.trim_start();
@@ -381,8 +439,8 @@ fn check_legacy_type_alias(
         return;
     }
     // Heuristic: look at up to the previous 5 lines for a doc-comment
-    // containing one of the legacy markers.
-    let lines: Vec<&str> = full.lines().collect();
+    // containing one of the legacy markers. `lines` is split once per file
+    // by `check_file` and reused across all violations in the same file.
     let start = line_no.saturating_sub(5).max(1);
     let mut legacy = false;
     for back in start..line_no {
@@ -421,10 +479,18 @@ fn check_legacy_type_alias(
 // Allow-list
 // ---------------------------------------------------------------------------
 
-/// Apply the `// seam-allow: <reason>` escape. A violation at line N is
-/// suppressed if line N-1 (after trimming) starts with `// seam-allow:` and
-/// has a non-empty reason. Cargo.toml violations are not exempt-able and
-/// always pass through (they're hard-fail per ADR 0004).
+/// Apply the `// seam-allow: <reason>` escape.
+///
+/// - **Line-level violations** (everything except `mirror-file`): a violation
+///   at line N is suppressed if line N-1 (after trimming) starts with
+///   `// seam-allow:` and has a non-empty reason. A violation on line 1
+///   has no "line above" and therefore **cannot** be allow-listed this way.
+/// - **File-level violations** (`mirror-file`): the marker must be the
+///   file's first non-empty line — a single `// seam-allow: <reason>`
+///   header that documents the whole file's exemption.
+///
+/// Cargo.toml violations (`arch-dep`) are not exempt-able and always pass
+/// through (they're hard-fail per ADR 0004).
 fn apply_allow_list(violations: Vec<Violation>) -> (Vec<Violation>, Vec<(Violation, String)>) {
     // Group by file to avoid re-reading.
     let mut by_file: std::collections::BTreeMap<PathBuf, Vec<Violation>> = Default::default();
@@ -456,9 +522,24 @@ fn apply_allow_list(violations: Vec<Violation>) -> (Vec<Violation>, Vec<(Violati
             if !seen_pairs.insert(key) {
                 continue;
             }
-            let prev_idx = v.line.saturating_sub(2);
-            let prev = lines.get(prev_idx).copied().unwrap_or("").trim_start();
-            if let Some(reason) = prev.strip_prefix("// seam-allow:") {
+            let marker = if v.kind == "mirror-file" {
+                // File-level violation: the marker is a single header line
+                // at the top of the file. We accept the first non-empty
+                // line of the file as the marker.
+                lines
+                    .iter()
+                    .find(|l| !l.trim().is_empty())
+                    .copied()
+                    .unwrap_or("")
+                    .trim_start()
+            } else if v.line > 1 {
+                lines.get(v.line - 2).copied().unwrap_or("").trim_start()
+            } else {
+                // Line-level violation on line 1 has no line above; the
+                // "// seam-allow:" rule cannot apply.
+                ""
+            };
+            if let Some(reason) = marker.strip_prefix("// seam-allow:") {
                 let reason = reason.trim();
                 if !reason.is_empty() {
                     allowed.push((v, reason.to_string()));
@@ -598,9 +679,8 @@ mod tests {
     #[test]
     fn flags_legacy_type_alias_with_doc_keyword() {
         let mut v = Vec::new();
-        let full = "/// Legacy alias for the new name.\npub type Old = New;\n";
-        let line = "pub type Old = New;";
-        check_legacy_type_alias(fake_root(), fake_path(), 2, line, full, &mut v);
+        let lines = ["/// Legacy alias for the new name.", "pub type Old = New;"];
+        check_legacy_type_alias(fake_root(), fake_path(), 2, lines[1], &lines, &mut v);
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].kind, "legacy-type-alias");
     }
@@ -608,14 +688,51 @@ mod tests {
     #[test]
     fn ignores_plain_type_alias() {
         let mut v = Vec::new();
-        let full = "/// A reusable shorthand for a complex generic.\npub type Result<T> = std::result::Result<T, Error>;\n";
-        let line = "pub type Result<T> = std::result::Result<T, Error>;";
-        check_legacy_type_alias(fake_root(), fake_path(), 2, line, full, &mut v);
+        let lines = [
+            "/// A reusable shorthand for a complex generic.",
+            "pub type Result<T> = std::result::Result<T, Error>;",
+        ];
+        check_legacy_type_alias(fake_root(), fake_path(), 2, lines[1], &lines, &mut v);
         assert!(
             v.is_empty(),
             "non-legacy aliases must not fire: {:?}",
             v.iter().map(|x| &x.message).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn allow_list_no_marker_above_line_1_for_line_violation() {
+        // For line-level violations on line 1 there is no "line above";
+        // the seam-allow rule must not silently match against line 1 itself.
+        let lines = ["// seam-allow: should NOT apply to a line-1 violation"];
+        let v_line: usize = 1;
+        let marker = if v_line > 1 {
+            lines.get(v_line - 2).copied().unwrap_or("")
+        } else {
+            ""
+        };
+        assert!(
+            marker.is_empty(),
+            "line-1 line-violations must have no marker"
+        );
+    }
+
+    #[test]
+    fn allow_list_uses_first_line_for_mirror_file() {
+        // mirror-file violations are file-level; the marker is the first
+        // non-empty line of the file.
+        let lines = [
+            "// seam-allow: collapsed in Lever D (#149)",
+            "//! file docs",
+            "use anyhow::Result;",
+        ];
+        let marker = lines
+            .iter()
+            .find(|l| !l.trim().is_empty())
+            .copied()
+            .unwrap_or("")
+            .trim_start();
+        assert!(marker.starts_with("// seam-allow:"));
     }
 
     #[test]

--- a/xtask/src/lint_seams.rs
+++ b/xtask/src/lint_seams.rs
@@ -1,0 +1,645 @@
+//! Architecture + bridge-pattern lints for the seam rule (ADR 0004 / spec #131
+//! Lever B).
+//!
+//! What it checks (subsystem source = `crates/{forge,stiglab,synodic,ising}/`):
+//!
+//! 1. **Arch-deps** — subsystem A's `Cargo.toml` must not declare another
+//!    subsystem as a path / git / version dep.
+//! 2. **Sibling-subsystem HTTP** — references to a sibling subsystem's
+//!    `*_URL` / `*_PORT` env var, or a `localhost:<port>` literal whose port
+//!    matches another subsystem's well-known port, are flagged. Self-
+//!    references are fine. The legitimate `reqwest::Client` callers in
+//!    stiglab/synodic talk to GitHub / LLM APIs — those don't trip this lint.
+//! 3. **`#[serde(alias = ...)]`** — bridges that ossify (PR #107 pattern).
+//! 4. **`*_mirror.rs`** — files that mirror a spine concept into a private
+//!    schema (PR #129 pattern, Lever D's removal target).
+//! 5. **Legacy `pub type X = Y;`** — a type alias whose adjacent doc-comment
+//!    contains "legacy" / "compat" / "deprecated" / "alias for" / "renamed".
+//!
+//! Producer-without-consumer is **gated on Lever E #150** — currently a
+//! reminder, not a check.
+//!
+//! ## Escape hatch
+//!
+//! For a single line, prepend `// seam-allow: <non-empty reason>` on the
+//! line immediately above. Reason text is mandatory and grep-able; CI shows
+//! it in the lint output. Use sparingly — every allow is a legacy debt.
+//! Cargo.toml violations have no escape hatch; arch-dep is hard-fail.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+
+const SUBSYSTEMS: &[&str] = &["forge", "stiglab", "synodic", "ising"];
+
+/// Well-known ports each subsystem listens on. Hard-coded because they are
+/// part of the subsystem's external contract — see root `CLAUDE.md`.
+const SUBSYSTEM_PORTS: &[(&str, &str)] =
+    &[("stiglab", "3000"), ("synodic", "3001"), ("forge", "3003")];
+
+pub fn run() -> Result<()> {
+    let root = workspace_root()?;
+    let mut violations: Vec<Violation> = Vec::new();
+
+    for subsys in SUBSYSTEMS {
+        check_arch_deps(&root, subsys, &mut violations)?;
+        let src = root.join("crates").join(subsys).join("src");
+        if !src.is_dir() {
+            continue;
+        }
+        for file in rust_files(&src)? {
+            let name = file.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if name.ends_with("_mirror.rs") {
+                violations.push(Violation {
+                    path: rel(&root, &file),
+                    line: 1,
+                    kind: "mirror-file",
+                    message: format!(
+                        "subsystem `{subsys}` defines `{name}` — mirror modules drift from the spine; collapse the schema with a discriminator and delete the file (Lever D)"
+                    ),
+                });
+                // Per-file violation is enough; we still scan its contents
+                // for any other lints below so they aren't masked.
+            }
+            check_file(&root, subsys, &file, &mut violations)?;
+        }
+    }
+
+    let (kept, allowed) = apply_allow_list(violations);
+
+    if !allowed.is_empty() {
+        eprintln!("seam-allow exemptions used:");
+        for (v, reason) in &allowed {
+            eprintln!(
+                "  {}:{} [{}] — allowed: {reason}",
+                v.path.display(),
+                v.line,
+                v.kind
+            );
+        }
+        eprintln!();
+    }
+
+    if !kept.is_empty() {
+        eprintln!("seam-rule violations:");
+        for v in &kept {
+            eprintln!(
+                "  {}:{} [{}] {}",
+                v.path.display(),
+                v.line,
+                v.kind,
+                v.message
+            );
+        }
+        eprintln!();
+        eprintln!("See ADR 0004 (docs/adr/0004-tighten-the-seams.md) and spec #131.");
+        eprintln!(
+            "To bypass a single line: prepend `// seam-allow: <reason>` immediately above it."
+        );
+        bail!(
+            "seam-rule lint failed: {} violation(s) (excluding {} allowed)",
+            kept.len(),
+            allowed.len()
+        );
+    }
+
+    println!(
+        "seam-rule lint: clean (subsystems: {}; {} allowed exemption(s))",
+        SUBSYSTEMS.join(", "),
+        allowed.len()
+    );
+    eprintln!(
+        "note: producer-without-consumer check is gated on Lever E (#150). \
+         Until that lands, new event types still need a manual reviewer."
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct Violation {
+    path: PathBuf,
+    line: usize,
+    kind: &'static str,
+    message: String,
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+fn rel(root: &Path, p: &Path) -> PathBuf {
+    p.strip_prefix(root).unwrap_or(p).to_path_buf()
+}
+
+fn rust_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    walk(dir, &mut |p| {
+        if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(p.to_path_buf());
+        }
+    })?;
+    out.sort();
+    Ok(out)
+}
+
+fn walk(dir: &Path, visit: &mut dyn FnMut(&Path)) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, visit)?;
+        } else {
+            visit(&path);
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Cargo.toml: arch-deps lint
+// ---------------------------------------------------------------------------
+
+fn check_arch_deps(root: &Path, subsys: &str, out: &mut Vec<Violation>) -> Result<()> {
+    let manifest = root.join("crates").join(subsys).join("Cargo.toml");
+    if !manifest.is_file() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(&manifest)
+        .with_context(|| format!("read {}", manifest.display()))?;
+    let parsed: toml::Value =
+        toml::from_str(&text).with_context(|| format!("parse {}", manifest.display()))?;
+
+    let dep_tables = ["dependencies", "dev-dependencies", "build-dependencies"];
+    for table_key in dep_tables {
+        let Some(table) = parsed.get(table_key).and_then(|v| v.as_table()) else {
+            continue;
+        };
+        for (name, _) in table {
+            if name == subsys {
+                continue;
+            }
+            if SUBSYSTEMS.contains(&name.as_str()) {
+                let line = find_dep_line(&text, table_key, name);
+                out.push(Violation {
+                    path: rel(root, &manifest),
+                    line,
+                    kind: "arch-dep",
+                    message: format!(
+                        "subsystem `{subsys}` declares `{name}` as [{table_key}] — subsystems must not depend on each other (ADR 0001)"
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Find the 1-indexed line where a dep declaration starts. Best-effort: we
+/// look for a `<name>\s*=` line after the matching `[<table>]` header.
+fn find_dep_line(text: &str, table: &str, name: &str) -> usize {
+    let header = format!("[{table}]");
+    let mut in_section = false;
+    for (i, line) in text.lines().enumerate() {
+        let t = line.trim_start();
+        if t.starts_with('[') && t.ends_with(']') {
+            in_section = t == header;
+            continue;
+        }
+        if in_section {
+            let rest = t.split_once('=').map(|(k, _)| k.trim()).unwrap_or("");
+            if rest == name {
+                return i + 1;
+            }
+        }
+    }
+    1
+}
+
+// ---------------------------------------------------------------------------
+// Per-file scans
+// ---------------------------------------------------------------------------
+
+fn check_file(root: &Path, subsys: &str, path: &Path, out: &mut Vec<Violation>) -> Result<()> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    for (idx, line) in text.lines().enumerate() {
+        let n = idx + 1;
+        check_sibling_url(root, subsys, path, n, line, out);
+        check_serde_alias(root, path, n, line, out);
+        check_legacy_type_alias(root, path, n, line, &text, out);
+    }
+    Ok(())
+}
+
+// ---- sibling-subsystem URL / env-var ------------------------------------
+
+fn check_sibling_url(
+    root: &Path,
+    subsys: &str,
+    path: &Path,
+    line_no: usize,
+    line: &str,
+    out: &mut Vec<Violation>,
+) {
+    // Strip a trailing line comment so a `// seam-allow:` (or any other
+    // textual mention of the env var inside a comment) doesn't itself trip.
+    let code = strip_line_comment(line);
+
+    for sibling in SUBSYSTEMS {
+        if *sibling == subsys {
+            continue;
+        }
+        let upper = sibling.to_uppercase();
+        let url_var = format!("{upper}_URL");
+        let port_var = format!("{upper}_PORT");
+        let host = format!("{sibling}:");
+        if code.contains(&url_var) || code.contains(&port_var) {
+            out.push(Violation {
+                path: rel(root, path),
+                line: line_no,
+                kind: "sibling-env",
+                message: format!(
+                    "subsystem `{subsys}` references `{url_var}`/`{port_var}` — that's a `forge → stiglab/synodic`-style HTTP RPC; coordinate via the spine instead (Lever C)"
+                ),
+            });
+            continue;
+        }
+        // Only flag URL-shaped references: `http://forge:` / `https://forge:`.
+        // Bare `"forge:..."` strings are commonly stream IDs / tool names, not
+        // hostnames, and would generate noise.
+        if code.contains(&format!("http://{host}")) || code.contains(&format!("https://{host}")) {
+            out.push(Violation {
+                path: rel(root, path),
+                line: line_no,
+                kind: "sibling-host",
+                message: format!(
+                    "subsystem `{subsys}` constructs an HTTP URL targeting sibling host `{sibling}` — coordinate via the spine instead (Lever C)"
+                ),
+            });
+            continue;
+        }
+    }
+
+    if let Some(port) = sibling_localhost_port(code, subsys) {
+        out.push(Violation {
+            path: rel(root, path),
+            line: line_no,
+            kind: "sibling-port",
+            message: format!(
+                "subsystem `{subsys}` references `localhost:{port}` — that's another subsystem's well-known port; coordinate via the spine instead (Lever C)"
+            ),
+        });
+    }
+}
+
+fn sibling_localhost_port(line: &str, subsys: &str) -> Option<&'static str> {
+    for (sibling, port) in SUBSYSTEM_PORTS {
+        if *sibling == subsys {
+            continue;
+        }
+        let needle = format!("localhost:{port}");
+        if line.contains(&needle) {
+            return Some(port);
+        }
+    }
+    None
+}
+
+/// Strip a trailing `//` line comment, but **only** when the `//` is outside
+/// a string literal. Without this, `"http://host"` in a real URL is treated
+/// as a comment start and the rest of the line vanishes — which is exactly
+/// the case the sibling-host lint cares about.
+///
+/// Doesn't handle raw strings (`r"..."` / `r#"..."#`); those are rare in
+/// lint targets and the worst case is a few extra characters preserved.
+fn strip_line_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut in_str = false;
+    let mut prev_backslash = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if c == b'\\' && !prev_backslash {
+                prev_backslash = true;
+            } else {
+                if c == b'"' && !prev_backslash {
+                    in_str = false;
+                }
+                prev_backslash = false;
+            }
+            i += 1;
+            continue;
+        }
+        if c == b'"' {
+            in_str = true;
+        } else if c == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            return &line[..i];
+        }
+        i += 1;
+    }
+    line
+}
+
+// ---- serde(alias = ...) -------------------------------------------------
+
+fn check_serde_alias(
+    root: &Path,
+    path: &Path,
+    line_no: usize,
+    line: &str,
+    out: &mut Vec<Violation>,
+) {
+    let code = strip_line_comment(line);
+    if code.contains("serde(alias") || code.contains("serde( alias") {
+        out.push(Violation {
+            path: rel(root, path),
+            line: line_no,
+            kind: "serde-alias",
+            message: "`#[serde(alias = ...)]` ossifies; renames must land atomically — drop the alias and update call sites in the same PR (PR #107 drift pattern)".to_string(),
+        });
+    }
+}
+
+// ---- legacy `pub type X = Y;` -------------------------------------------
+
+fn check_legacy_type_alias(
+    root: &Path,
+    path: &Path,
+    line_no: usize,
+    line: &str,
+    full: &str,
+    out: &mut Vec<Violation>,
+) {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with("pub type ") {
+        return;
+    }
+    // Heuristic: look at up to the previous 5 lines for a doc-comment
+    // containing one of the legacy markers.
+    let lines: Vec<&str> = full.lines().collect();
+    let start = line_no.saturating_sub(5).max(1);
+    let mut legacy = false;
+    for back in start..line_no {
+        let prev = lines.get(back - 1).copied().unwrap_or("");
+        let s = prev.trim_start();
+        if !s.starts_with("///") && !s.starts_with("//") {
+            continue;
+        }
+        let lower = s.to_lowercase();
+        if lower.contains("legacy")
+            || lower.contains("deprecated")
+            || lower.contains("compat")
+            || lower.contains("alias for ")
+            || lower.contains("renamed")
+            || lower.contains("for backwards")
+            || lower.contains("until ")
+        {
+            legacy = true;
+            break;
+        }
+    }
+    if legacy {
+        out.push(Violation {
+            path: rel(root, path),
+            line: line_no,
+            kind: "legacy-type-alias",
+            message: format!(
+                "`{}` looks like a legacy/compat type alias — renames land in one PR; drop the alias and update call sites (PR #107 drift pattern)",
+                trimmed.trim_end_matches(';')
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Allow-list
+// ---------------------------------------------------------------------------
+
+/// Apply the `// seam-allow: <reason>` escape. A violation at line N is
+/// suppressed if line N-1 (after trimming) starts with `// seam-allow:` and
+/// has a non-empty reason. Cargo.toml violations are not exempt-able and
+/// always pass through (they're hard-fail per ADR 0004).
+fn apply_allow_list(violations: Vec<Violation>) -> (Vec<Violation>, Vec<(Violation, String)>) {
+    // Group by file to avoid re-reading.
+    let mut by_file: std::collections::BTreeMap<PathBuf, Vec<Violation>> = Default::default();
+    let mut cargo: Vec<Violation> = Vec::new();
+    for v in violations {
+        if v.kind == "arch-dep" {
+            cargo.push(v);
+        } else {
+            by_file.entry(v.path.clone()).or_default().push(v);
+        }
+    }
+
+    let mut kept: Vec<Violation> = cargo;
+    let mut allowed: Vec<(Violation, String)> = Vec::new();
+    let mut seen_pairs: BTreeSet<(PathBuf, usize, &'static str)> = BTreeSet::new();
+
+    for (path, vs) in by_file {
+        let abs = std::env::var("CARGO_MANIFEST_DIR")
+            .ok()
+            .and_then(|d| Path::new(&d).parent().map(|p| p.join(&path)))
+            .unwrap_or_else(|| path.clone());
+        let text = std::fs::read_to_string(&abs).unwrap_or_default();
+        let lines: Vec<&str> = text.lines().collect();
+
+        for v in vs {
+            // Dedupe identical (path, line, kind) — multiple checks may flag
+            // the same construct.
+            let key = (v.path.clone(), v.line, v.kind);
+            if !seen_pairs.insert(key) {
+                continue;
+            }
+            let prev_idx = v.line.saturating_sub(2);
+            let prev = lines.get(prev_idx).copied().unwrap_or("").trim_start();
+            if let Some(reason) = prev.strip_prefix("// seam-allow:") {
+                let reason = reason.trim();
+                if !reason.is_empty() {
+                    allowed.push((v, reason.to_string()));
+                    continue;
+                }
+            }
+            kept.push(v);
+        }
+    }
+    (kept, allowed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_path() -> &'static Path {
+        Path::new("crates/forge/src/test.rs")
+    }
+
+    fn fake_root() -> &'static Path {
+        Path::new("/")
+    }
+
+    #[test]
+    fn flags_sibling_env_var() {
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "forge",
+            fake_path(),
+            10,
+            r#"std::env::var("STIGLAB_URL")"#,
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, "sibling-env");
+    }
+
+    #[test]
+    fn flags_sibling_url_in_string() {
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "forge",
+            fake_path(),
+            10,
+            r#"let url = "http://stiglab:3000/api/x";"#,
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, "sibling-host");
+    }
+
+    #[test]
+    fn ignores_self_env_var() {
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "forge",
+            fake_path(),
+            10,
+            r#"std::env::var("FORGE_URL")"#,
+            &mut v,
+        );
+        assert!(v.is_empty(), "self-references must not fire: {:?}", v);
+    }
+
+    #[test]
+    fn ignores_stream_id_with_colon() {
+        // PR #131 false-positive regression: `format!("forge:{id}")` is a
+        // stream key, not a hostname. Tightened heuristic only matches URLs.
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "stiglab",
+            fake_path(),
+            10,
+            r#"format!("forge:{artifact_id}")"#,
+            &mut v,
+        );
+        assert!(v.is_empty(), "stream ids must not fire: {:?}", v);
+    }
+
+    #[test]
+    fn ignores_event_name_with_dot() {
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "stiglab",
+            fake_path(),
+            10,
+            r#"emit("forge.gate_requested", payload)"#,
+            &mut v,
+        );
+        assert!(v.is_empty(), "event names must not fire: {:?}", v);
+    }
+
+    #[test]
+    fn flags_localhost_sibling_port() {
+        let mut v = Vec::new();
+        check_sibling_url(
+            fake_root(),
+            "forge",
+            fake_path(),
+            10,
+            r#"let s = "http://localhost:3000";"#,
+            &mut v,
+        );
+        // Either sibling-host (URL form) or sibling-port (localhost form) is
+        // acceptable — both indicate the same problem.
+        assert_eq!(v.len(), 1);
+        assert!(matches!(v[0].kind, "sibling-host" | "sibling-port"));
+    }
+
+    #[test]
+    fn flags_serde_alias() {
+        let mut v = Vec::new();
+        check_serde_alias(
+            fake_root(),
+            fake_path(),
+            10,
+            r#"#[serde(alias = "old_name")]"#,
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, "serde-alias");
+    }
+
+    #[test]
+    fn ignores_serde_default() {
+        let mut v = Vec::new();
+        check_serde_alias(fake_root(), fake_path(), 10, r#"#[serde(default)]"#, &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn flags_legacy_type_alias_with_doc_keyword() {
+        let mut v = Vec::new();
+        let full = "/// Legacy alias for the new name.\npub type Old = New;\n";
+        let line = "pub type Old = New;";
+        check_legacy_type_alias(fake_root(), fake_path(), 2, line, full, &mut v);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, "legacy-type-alias");
+    }
+
+    #[test]
+    fn ignores_plain_type_alias() {
+        let mut v = Vec::new();
+        let full = "/// A reusable shorthand for a complex generic.\npub type Result<T> = std::result::Result<T, Error>;\n";
+        let line = "pub type Result<T> = std::result::Result<T, Error>;";
+        check_legacy_type_alias(fake_root(), fake_path(), 2, line, full, &mut v);
+        assert!(
+            v.is_empty(),
+            "non-legacy aliases must not fire: {:?}",
+            v.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn allow_list_suppresses_with_reason() {
+        // A violation at line 4 should look at lines.get(2) — i.e. line 3
+        // (1-indexed). That's where we put the `// seam-allow:` marker.
+        let lines = [
+            "// preamble",            // line 1
+            "fn before() {}",         // line 2
+            "// seam-allow: legacy",  // line 3 — the marker
+            "let x = STIGLAB_URL();", // line 4 — the violation
+        ];
+        let violation_line: usize = 4;
+        let prev_idx = violation_line.saturating_sub(2);
+        let prev = lines.get(prev_idx).copied().unwrap_or("").trim_start();
+        assert!(prev.starts_with("// seam-allow:"), "got {prev:?}");
+        let reason = prev.strip_prefix("// seam-allow:").unwrap().trim();
+        assert!(!reason.is_empty());
+    }
+
+    #[test]
+    fn allow_list_rejects_empty_reason() {
+        let bad = "// seam-allow:";
+        let reason = bad.strip_prefix("// seam-allow:").unwrap().trim();
+        assert!(reason.is_empty(), "empty-reason allow must NOT pass");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,12 +2,18 @@
 //!
 //!     cargo run -p xtask -- gen-event-docs           # write docs/events.md
 //!     cargo run -p xtask -- gen-event-docs --check   # verify in sync
+//!     cargo run -p xtask -- lint-seams               # check the seam rule
 //!
 //! The event catalog is derived from `crates/onsager-spine/src/factory_event.rs`
 //! by parsing the `FactoryEventKind` enum and the `event_type()` /
 //! `stream_type()` match arms. Adding a variant + its match arms automatically
 //! extends the catalog on the next run; CI runs `--check` so a missing run
 //! fails the build.
+//!
+//! `lint-seams` enforces the canonical seam rule from ADR 0004 / spec #131
+//! Lever B — see [`lint_seams`] for the full check list.
+
+mod lint_seams;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -25,9 +31,16 @@ fn main() -> ExitCode {
 
     let result = match cmd.as_deref() {
         Some("gen-event-docs") => parse_gen_event_docs_flags(args).and_then(run_gen_event_docs),
+        Some("lint-seams") => {
+            if args.next().is_some() {
+                Err(anyhow!("lint-seams takes no arguments"))
+            } else {
+                lint_seams::run()
+            }
+        }
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage: cargo run -p xtask -- <gen-event-docs> [--check]"
+            "usage: cargo run -p xtask -- <gen-event-docs|lint-seams> [--check]"
         )),
     };
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> ExitCode {
         }
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage: cargo run -p xtask -- <gen-event-docs|lint-seams> [--check]"
+            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams"
         )),
     };
 


### PR DESCRIPTION
Closes #147
Part of #131

Adds `cargo run -p xtask -- lint-seams`, wired into `just lint-rust`
and CI's `check` job. Hard-fails when a subsystem violates the
canonical seam rule (ADR 0004 / spec #131 Lever B). **No escape hatch
for Cargo.toml**; for source-line violations, the only escape is an
explicit `// seam-allow: <reason>` marker on the line above (with
non-empty reason; reviewers see every allow in the lint output).

## Delivers (from #147)

- [x] xtask scaffolding with the lint passes (extends the existing
  `xtask` crate from #145)
- [x] Architecture lint — sibling Cargo dep, sibling `*_URL`/`*_PORT`
  env reads, sibling-host URLs, `localhost:<sibling-port>` literals
- [x] Bridge-pattern lint — `#[serde(alias = ...)]`, `*_mirror.rs`,
  legacy `pub type X = Y` aliases (heuristic on adjacent
  doc-comment)
- [x] Producer-without-consumer — stubbed with explicit Lever E
  (#150) gating note; flips to hard-fail there
- [x] CI job: `Seam-rule lint (ADR 0004 / spec #131 Lever B)` runs
  in `.github/workflows/rust.yml`'s `check` job
- [x] Pre-push skill (`onsager-pre-push` step 6.5) replaced with
  pointer to `cargo xtask lint-seams` and a description of the
  lints + escape hatch

## Pre-existing violations: allow-listed with explicit lever pointer

The lint immediately fires on three real bits of architectural debt;
each is allow-listed pointing at the lever that removes it:

- `crates/forge/src/cmd/serve.rs:455-462` — `STIGLAB_URL` /
  `SYNODIC_URL` reads. Allow-listed with
  `legacy ADR 0001 sync RPC; replaced by spine events in Lever C (#148)`.
- `crates/stiglab/src/server/routes/governance.rs:15,17` — dashboard
  governance proxy reads `SYNODIC_URL`. **NEW finding**, not
  previously called out in #131. Allow-listed with
  `dashboard governance proxy; Railway only exposes stiglab. Tracked separately from spec #131; revisit once governance UI moves under Lever F.`.
  Reviewers: this is a real cross-subsystem HTTP call that exists
  because Railway only exposes stiglab; either (a) move the
  governance UI into stiglab + read from spine, (b) expose synodic
  externally, or (c) accept it as a permanent Railway-only proxy
  carve-out. Out of scope for this PR; flag for triage.
- `crates/stiglab/src/server/workflow_spine_mirror.rs:1` — Lever D
  target. Allow-listed with
  `removed in Lever D (#149) — collapses tenant_workflows into spine workflows with a tenant_id discriminator`.

7 allowed exemptions total, all explicit. Cargo.toml violations
would have no escape — currently zero exist (verified).

## Test plan

- [x] 12 unit tests in `xtask/src/lint_seams.rs` cover each pattern:
  positive flag, self-reference ignore, stream-id false-positive
  ignore, event-name false-positive ignore, plain-type-alias ignore,
  serde-alias positive, serde-default ignore, allow-list reason
  parsing.
- [x] Synthetic violation (a temp file with all three patterns)
  fired correctly: 3 violations reported with exact file/line/kind.
- [x] `cargo run -p xtask -- lint-seams` runs in <2s from cache;
  cleanly reports 7 allowed + 0 unallowed today.
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace --lib` — 113 passed.

## Notes for the next levers

- **Lever C (#148)**: deletes the four forge `seam-allow` markers
  along with the `HttpStiglabDispatcher`/`HttpSynodicGate` blocks;
  the lint then has zero forge exemptions.
- **Lever D (#149)**: deletes the `workflow_spine_mirror.rs`
  exemption when the file goes away.
- **Lever E (#150)**: replaces the producer-without-consumer note
  with a real check against the registry manifest, and flips Lever
  B's producer-without-consumer item from "stub" to "hard-fail".
- **Lever F (#151) or follow-up**: should resolve the
  stiglab→synodic governance proxy allow-list. Decision pending.



---
_Generated by [Claude Code](https://claude.ai/code/session_01TYFmw3yaMA4r6C9MVikimB)_