### PR TITLE
feat(dashboard): tighten workflow creation UX

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/RepoCombobox.tsx
+++ b/apps/dashboard/src/components/factory/workflows/RepoCombobox.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from "react"
+import { useQueries } from "@tanstack/react-query"
+import { Check, ChevronsUpDown, ExternalLink, Folder, Lock } from "lucide-react"
+import { api, type GitHubAppInstallation } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+export interface RepoComboboxProps {
+  tenantId: string
+  installations: GitHubAppInstallation[]
+  installId: string
+  repoOwner: string
+  repoName: string
+  onChange: (next: {
+    install_id: string
+    repo_owner: string
+    repo_name: string
+  }) => void
+}
+
+/**
+ * One picker for "what GitHub repo triggers this workflow." Replaces the
+ * cascading install + repo selects: we fan out across every workspace
+ * install in parallel, group results under each install's account login,
+ * and emit all three identifiers (install record id, owner, name) on
+ * select. Linkable fields stay un-typed, per the dashboard-ui rules.
+ */
+export function RepoCombobox({
+  tenantId,
+  installations,
+  installId,
+  repoOwner,
+  repoName,
+  onChange,
+}: RepoComboboxProps) {
+  const [open, setOpen] = useState(false)
+
+  const queries = useQueries({
+    queries: installations.map((inst) => ({
+      queryKey: ["installation-repos", tenantId, inst.id],
+      queryFn: () => api.listInstallationRepos(tenantId, inst.id),
+      enabled: !!tenantId,
+      staleTime: 30_000,
+      retry: false,
+    })),
+  })
+
+  const grouped = useMemo(
+    () =>
+      installations.map((install, i) => ({
+        install,
+        repos: queries[i]?.data?.repos ?? [],
+      })),
+    [installations, queries],
+  )
+
+  const totalRepos = grouped.reduce((sum, g) => sum + g.repos.length, 0)
+  const isLoading = queries.some((q) => q.isLoading)
+  const isError = queries.length > 0 && queries.every((q) => q.isError)
+
+  const selectedLabel =
+    repoOwner && repoName ? `${repoOwner}/${repoName}` : null
+
+  const selectedInstall = installations.find((i) => i.id === installId)
+  const configureInstall = selectedInstall ?? installations[0] ?? null
+  const configureUrl = configureInstall
+    ? configureInstall.account_type === "organization"
+      ? `https://github.com/organizations/${configureInstall.account_login}/settings/installations/${configureInstall.install_id}`
+      : `https://github.com/settings/installations/${configureInstall.install_id}`
+    : null
+
+  const commit = (
+    install: GitHubAppInstallation,
+    repo: { owner: string; name: string },
+  ) => {
+    onChange({
+      install_id: install.id,
+      repo_owner: repo.owner,
+      repo_name: repo.name,
+    })
+    setOpen(false)
+  }
+
+  const disabled = installations.length === 0
+  const placeholder = disabled
+    ? "No GitHub App installs yet"
+    : "Pick a repository"
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between"
+            disabled={disabled}
+          >
+            <span className="flex min-w-0 items-center gap-2 truncate">
+              <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+              {selectedLabel ? (
+                <span className="truncate">{selectedLabel}</span>
+              ) : (
+                <span className="truncate text-muted-foreground">
+                  {placeholder}
+                </span>
+              )}
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        }
+      />
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] min-w-72 p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search repositories…" />
+          <CommandList>
+            {isLoading && totalRepos === 0 && (
+              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                Loading repositories…
+              </div>
+            )}
+            {!isLoading && isError && (
+              <div className="px-3 py-6 text-center text-sm text-destructive">
+                Couldn&apos;t load repositories. Check the GitHub install.
+              </div>
+            )}
+            {!isLoading && !isError && totalRepos === 0 && (
+              <CommandEmpty>
+                No repositories accessible to this install.
+              </CommandEmpty>
+            )}
+            {grouped.map(({ install, repos }) =>
+              repos.length === 0 ? null : (
+                <CommandGroup
+                  key={install.id}
+                  heading={`${install.account_login} (${install.account_type})`}
+                >
+                  {repos.map((repo) => {
+                    const isSelected =
+                      install.id === installId &&
+                      repo.owner === repoOwner &&
+                      repo.name === repoName
+                    return (
+                      <CommandItem
+                        key={`${install.id}:${repo.owner}/${repo.name}`}
+                        value={`${install.account_login} ${repo.owner}/${repo.name}`}
+                        onSelect={() => commit(install, repo)}
+                      >
+                        <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">
+                          {repo.owner}/{repo.name}
+                        </span>
+                        {repo.private && (
+                          <Lock className="h-3 w-3 shrink-0 text-muted-foreground" />
+                        )}
+                        {isSelected && (
+                          <Check className="ml-auto h-4 w-4" />
+                        )}
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              ),
+            )}
+            {configureUrl && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    value="__configure-github-access"
+                    onSelect={() => {
+                      window.open(
+                        configureUrl,
+                        "_blank",
+                        "noopener,noreferrer",
+                      )
+                      setOpen(false)
+                    }}
+                  >
+                    <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="truncate">
+                      Configure repository access on GitHub
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/RepoCombobox.tsx
+++ b/apps/dashboard/src/components/factory/workflows/RepoCombobox.tsx
@@ -44,11 +44,15 @@ export function RepoCombobox({
 }: RepoComboboxProps) {
   const [open, setOpen] = useState(false)
 
+  // Gate the fan-out on the popover being open: workspaces with many
+  // installs would otherwise issue N parallel requests on every render
+  // of the trigger sheet, even before the user touches the picker.
+  // staleTime keeps subsequent opens snappy via the React Query cache.
   const queries = useQueries({
     queries: installations.map((inst) => ({
       queryKey: ["installation-repos", tenantId, inst.id],
       queryFn: () => api.listInstallationRepos(tenantId, inst.id),
-      enabled: !!tenantId,
+      enabled: !!tenantId && open,
       staleTime: 30_000,
       retry: false,
     })),
@@ -65,7 +69,11 @@ export function RepoCombobox({
 
   const totalRepos = grouped.reduce((sum, g) => sum + g.repos.length, 0)
   const isLoading = queries.some((q) => q.isLoading)
-  const isError = queries.length > 0 && queries.every((q) => q.isError)
+  // Partial-failure aware: surface a banner when *any* install errored,
+  // but still render the groups that came back successfully so a single
+  // bad install doesn't hide the rest.
+  const hasError = queries.some((q) => q.isError)
+  const allErrored = queries.length > 0 && queries.every((q) => q.isError)
 
   const selectedLabel =
     repoOwner && repoName ? `${repoOwner}/${repoName}` : null
@@ -132,14 +140,21 @@ export function RepoCombobox({
                 Loading repositories…
               </div>
             )}
-            {!isLoading && isError && (
+            {!isLoading && allErrored && (
               <div className="px-3 py-6 text-center text-sm text-destructive">
                 Couldn&apos;t load repositories. Check the GitHub install.
               </div>
             )}
-            {!isLoading && !isError && totalRepos === 0 && (
+            {!isLoading && hasError && !allErrored && (
+              <div className="px-3 py-2 text-xs text-destructive">
+                Couldn&apos;t load some installs — list may be incomplete.
+              </div>
+            )}
+            {!isLoading && !allErrored && (
               <CommandEmpty>
-                No repositories accessible to this install.
+                {totalRepos === 0
+                  ? "No repositories accessible to this install."
+                  : "No matching repositories."}
               </CommandEmpty>
             )}
             {grouped.map(({ install, repos }) =>

--- a/apps/dashboard/src/components/factory/workflows/StageCard.tsx
+++ b/apps/dashboard/src/components/factory/workflows/StageCard.tsx
@@ -91,7 +91,7 @@ export function StageCard({ stage, index, onChange, onRemove }: StageCardProps) 
       <Sheet open={editing} onOpenChange={setEditing}>
         <SheetContent
           side={isMobile ? "bottom" : "right"}
-          className={isMobile ? "h-[85dvh] rounded-t-xl" : ""}
+          className={isMobile ? "h-[85dvh] rounded-t-xl" : "sm:max-w-lg"}
         >
           <SheetHeader>
             <SheetTitle>Edit stage</SheetTitle>

--- a/apps/dashboard/src/components/factory/workflows/TriggerCard.tsx
+++ b/apps/dashboard/src/components/factory/workflows/TriggerCard.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react"
-import { useQuery } from "@tanstack/react-query"
 import { ChevronRight, GitBranch, Tag } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { api, type AccessibleRepo, type GitHubAppInstallation } from "@/lib/api"
+import { type GitHubAppInstallation } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import {
@@ -13,14 +12,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { LabelCombobox } from "./LabelCombobox"
+import { RepoCombobox } from "./RepoCombobox"
 import type { WorkflowTriggerDraft } from "./workflow-draft"
 
 export interface TriggerCardProps {
@@ -77,12 +70,12 @@ export function TriggerCard({
       <Sheet open={editing} onOpenChange={setEditing}>
         <SheetContent
           side={isMobile ? "bottom" : "right"}
-          className={isMobile ? "h-[85dvh] rounded-t-xl" : ""}
+          className={isMobile ? "h-[85dvh] rounded-t-xl" : "sm:max-w-lg"}
         >
           <SheetHeader>
             <SheetTitle>Edit trigger</SheetTitle>
             <SheetDescription>
-              Pick the install, repo, and label that starts the workflow.
+              Pick the repo and label that starts the workflow.
             </SheetDescription>
           </SheetHeader>
           <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain px-4">
@@ -115,89 +108,31 @@ function TriggerForm({
   value: WorkflowTriggerDraft
   onChange: (next: WorkflowTriggerDraft) => void
 }) {
-  const installItems = installations.map((i) => ({
-    value: i.id,
-    label: `${i.account_login} (${i.account_type})`,
-  }))
-  const { data: reposData } = useQuery({
-    queryKey: ["installation-repos", tenantId, value.install_id],
-    queryFn: () =>
-      value.install_id
-        ? api.listInstallationRepos(tenantId, value.install_id)
-        : Promise.resolve({ repos: [] as AccessibleRepo[] }),
-    enabled: !!tenantId && !!value.install_id,
-    staleTime: 30_000,
-  })
-  const repos = reposData?.repos ?? []
-  const repoItems = repos.map((r) => ({
-    value: `${r.owner}/${r.name}`,
-    label: `${r.owner}/${r.name}`,
-  }))
-  const repoValue =
-    value.repo_owner && value.repo_name
-      ? `${value.repo_owner}/${value.repo_name}`
-      : ""
-
   return (
     <>
       <div className="space-y-1.5">
-        <span className="text-sm font-medium">GitHub install</span>
-        <Select
-          value={value.install_id}
-          onValueChange={(v) =>
+        <span className="text-sm font-medium">Repository</span>
+        <RepoCombobox
+          tenantId={tenantId}
+          installations={installations}
+          installId={value.install_id}
+          repoOwner={value.repo_owner}
+          repoName={value.repo_name}
+          onChange={(next) =>
             onChange({
               ...value,
-              install_id: v ?? "",
-              repo_owner: "",
-              repo_name: "",
-              label: "",
+              install_id: next.install_id,
+              repo_owner: next.repo_owner,
+              repo_name: next.repo_name,
+              label:
+                next.install_id === value.install_id &&
+                next.repo_owner === value.repo_owner &&
+                next.repo_name === value.repo_name
+                  ? value.label
+                  : "",
             })
           }
-          items={installItems}
-          disabled={installations.length === 0}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder={installations.length ? "Pick an install" : "No GitHub App installs yet"} />
-          </SelectTrigger>
-          <SelectContent>
-            {installItems.map((i) => (
-              <SelectItem key={i.value} value={i.value}>
-                {i.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="space-y-1.5">
-        <span className="text-sm font-medium">Repository</span>
-        <Select
-          value={repoValue}
-          onValueChange={(v) => {
-            const [owner, name] = (v ?? "").split("/")
-            onChange({
-              ...value,
-              repo_owner: owner ?? "",
-              repo_name: name ?? "",
-              label: "",
-            })
-          }}
-          items={repoItems}
-          disabled={!value.install_id || repos.length === 0}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue
-              placeholder={value.install_id ? "Pick a repository" : "Pick an install first"}
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {repoItems.map((i) => (
-              <SelectItem key={i.value} value={i.value}>
-                {i.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        />
       </div>
 
       <div className="space-y-1.5">
@@ -214,7 +149,7 @@ function TriggerForm({
         ) : (
           <p className="flex items-center gap-2 text-xs text-muted-foreground">
             <GitBranch className="h-3.5 w-3.5" />
-            Pick an install and repo above.
+            Pick a repository above.
           </p>
         )}
       </div>
@@ -226,14 +161,11 @@ function summarizeTrigger(t: WorkflowTriggerDraft): {
   title: string
   detail: string
 } {
-  if (!t.install_id) {
+  if (!t.install_id || !t.repo_owner || !t.repo_name) {
     return {
-      title: "Pick an install",
+      title: "Pick a repository",
       detail: "GitHub issue label will start the workflow",
     }
-  }
-  if (!t.repo_owner || !t.repo_name) {
-    return { title: "Pick a repository", detail: "Install selected" }
   }
   if (!t.label) {
     return {

--- a/apps/dashboard/src/components/factory/workflows/WorkflowBuilderSheet.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowBuilderSheet.tsx
@@ -44,7 +44,11 @@ export function WorkflowBuilderSheet({ open, onOpenChange }: WorkflowBuilderShee
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side={isMobile ? "bottom" : "right"}
-        className={isMobile ? "h-[90dvh] rounded-t-xl" : "sm:max-w-xl"}
+        className={
+          isMobile
+            ? "h-[90dvh] rounded-t-xl"
+            : "sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl"
+        }
       >
         <SheetHeader>
           <SheetTitle>Create workflow</SheetTitle>

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/dashboard/tests/smoke/workflow-repo-combobox.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-repo-combobox.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { RepoCombobox } from "@/components/factory/workflows/RepoCombobox"
+import type {
+  AccessibleRepo,
+  GitHubAppInstallation,
+} from "@/lib/api"
+
+const installations: GitHubAppInstallation[] = [
+  {
+    id: "inst_one",
+    tenant_id: "t1",
+    install_id: 1001,
+    account_login: "onsager-ai",
+    account_type: "organization",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "inst_two",
+    tenant_id: "t1",
+    install_id: 1002,
+    account_login: "tikazyq",
+    account_type: "user",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+]
+
+const reposByInstall: Record<string, AccessibleRepo[]> = {
+  inst_one: [
+    {
+      owner: "onsager-ai",
+      name: "onsager",
+      default_branch: "main",
+      private: false,
+    },
+    {
+      owner: "onsager-ai",
+      name: "spec-bot",
+      default_branch: "main",
+      private: true,
+    },
+  ],
+  inst_two: [
+    {
+      owner: "tikazyq",
+      name: "playground",
+      default_branch: "main",
+      private: false,
+    },
+  ],
+}
+
+function mount(node: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // Pre-seed the per-install repo queries so opening the popover reads
+  // cached data without firing real network calls.
+  for (const inst of installations) {
+    qc.setQueryData(
+      ["installation-repos", "t1", inst.id],
+      { repos: reposByInstall[inst.id] },
+    )
+  }
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>)
+}
+
+describe("RepoCombobox", () => {
+  it("groups repos under each install's account login", async () => {
+    mount(
+      <RepoCombobox
+        tenantId="t1"
+        installations={installations}
+        installId=""
+        repoOwner=""
+        repoName=""
+        onChange={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("combobox"))
+    await waitFor(() =>
+      expect(screen.getByText("onsager-ai/onsager")).toBeInTheDocument(),
+    )
+    expect(screen.getByText("onsager-ai/spec-bot")).toBeInTheDocument()
+    expect(screen.getByText("tikazyq/playground")).toBeInTheDocument()
+    expect(
+      screen.getByText(/onsager-ai \(organization\)/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/tikazyq \(user\)/)).toBeInTheDocument()
+  })
+
+  it("emits install_id, repo_owner, and repo_name in one shot on select", async () => {
+    const onChange = vi.fn()
+    mount(
+      <RepoCombobox
+        tenantId="t1"
+        installations={installations}
+        installId=""
+        repoOwner=""
+        repoName=""
+        onChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByRole("combobox"))
+    const item = await screen.findByText("onsager-ai/spec-bot")
+    fireEvent.click(item)
+    expect(onChange).toHaveBeenCalledWith({
+      install_id: "inst_one",
+      repo_owner: "onsager-ai",
+      repo_name: "spec-bot",
+    })
+  })
+
+  it("offers a deep-link to configure repository access on GitHub", async () => {
+    mount(
+      <RepoCombobox
+        tenantId="t1"
+        installations={installations}
+        installId="inst_one"
+        repoOwner=""
+        repoName=""
+        onChange={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("combobox"))
+    await waitFor(() =>
+      expect(
+        screen.getByText("Configure repository access on GitHub"),
+      ).toBeInTheDocument(),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Three UX wins on the workflow creation flow:

- **One repo picker, not two.** Replace the cascading GitHub install + repo `Select` pair in `TriggerCard` with a single `RepoCombobox` (Popover + Command). Fans out to every workspace install in parallel via `useQueries`, groups results by account login, and emits all three identifiers (install record id, owner, name) in one shot. Includes a deep-link to the install's GitHub settings ("Configure repository access on GitHub →") for the "I don't see my repo" case, per the dashboard-ui linkable-fields rule.
- **Wider drawer on desktop.** `WorkflowBuilderSheet` steps up to `sm:max-w-2xl / lg:max-w-3xl / xl:max-w-4xl`; the nested `TriggerCard` and `StageCard` edit sheets pick up `sm:max-w-lg`. Mobile sizing is unchanged.
- **Buttons get a cursor.** Add `cursor-pointer` to the base `Button` variant class. `disabled:pointer-events-none` still wins on disabled state, so disabled buttons keep the default cursor.

## Test plan

- [x] `pnpm exec tsc -b` clean
- [x] `pnpm exec eslint` clean on touched files
- [x] `pnpm test` — all 86 dashboard unit tests pass
- [ ] Manual: create a workflow, pick a repo from the new combobox, confirm install_id / owner / name all populate from one click and the trigger summary updates
- [ ] Manual: confirm desktop drawer feels noticeably less cramped, mobile bottom-sheet unchanged
- [ ] Manual: hover any button in the workflow builder — pointer cursor

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTuAJ6nd5SPqgA59DU1Y6V)_