### PR TITLE
feat: reference-only external artifacts + Issues inbox onboarding

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -18,6 +18,9 @@ const FactoryOverviewPage = lazy(() =>
 const ArtifactsPage = lazy(() =>
   import("@/pages/ArtifactsPage").then((m) => ({ default: m.ArtifactsPage })),
 )
+const IssuesPage = lazy(() =>
+  import("@/pages/IssuesPage").then((m) => ({ default: m.IssuesPage })),
+)
 const ArtifactDetailPage = lazy(() =>
   import("@/pages/ArtifactDetailPage").then((m) => ({ default: m.ArtifactDetailPage })),
 )
@@ -239,6 +242,10 @@ function AppRoutes() {
                     <Route
                       path="/artifacts/:id"
                       element={<LazyRoute variant="detail"><ArtifactDetailPage /></LazyRoute>}
+                    />
+                    <Route
+                      path="/issues"
+                      element={<LazyRoute variant="list"><IssuesPage /></LazyRoute>}
                     />
                     <Route
                       path="/spine"

--- a/apps/dashboard/src/components/BackfillDialog.tsx
+++ b/apps/dashboard/src/components/BackfillDialog.tsx
@@ -1,0 +1,221 @@
+import { cloneElement, isValidElement, useState, type ReactElement } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Loader2 } from "lucide-react"
+
+import { api, ApiError, type BackfillRequestBody } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const HARD_CAP = 200
+const DEFAULT_CAP = 100
+
+/**
+ * Bulk-ingest a project's existing GitHub issues + PRs as reference-only
+ * skeleton artifacts (specs #167, #170, #171). The dashboard inbox is
+ * empty until either:
+ *   - new issues/PRs arrive via webhook (live ingestion), or
+ *   - a backfill walks the existing GitHub state.
+ *
+ * Surfaced in two places (#168):
+ *   - As an action on `/issues` for projects that haven't been backfilled.
+ *   - In the project-onboarding flow on `WorkspaceCard.tsx` after add-project.
+ */
+export function BackfillDialog({
+  projectId,
+  repoLabel,
+  open: controlledOpen,
+  onOpenChange,
+  trigger,
+  onCompleted,
+}: {
+  projectId: string
+  /** `owner/name` for display only; the request is keyed on `projectId`. */
+  repoLabel?: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  /// Element rendered as the open-trigger when the dialog is uncontrolled.
+  /// We `cloneElement` to add an `onClick` rather than wrapping in
+  /// DialogTrigger — the existing dialogs in this codebase manage `open`
+  /// state externally for consistency with NewWorkspaceDialog.
+  trigger?: ReactElement<{ onClick?: (e: React.MouseEvent) => void }>
+  onCompleted?: () => void
+}) {
+  const isControlled = controlledOpen !== undefined
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = isControlled ? controlledOpen : internalOpen
+  const setOpen = (v: boolean) => {
+    if (!isControlled) setInternalOpen(v)
+    onOpenChange?.(v)
+  }
+
+  const queryClient = useQueryClient()
+  const [cap, setCap] = useState(DEFAULT_CAP)
+  const [strategy, setStrategy] =
+    useState<NonNullable<BackfillRequestBody["strategy"]>>("recent")
+  const [stateFilter, setStateFilter] =
+    useState<NonNullable<BackfillRequestBody["state"]>>("open")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      api.backfillProject(projectId, { cap, strategy, state: stateFilter }),
+    onSuccess: () => {
+      // Bust the artifact list + per-project live caches so the next render
+      // pulls the new skeleton rows.
+      queryClient.invalidateQueries({ queryKey: ["artifacts"] })
+      queryClient.invalidateQueries({ queryKey: ["project-issues", projectId] })
+      queryClient.invalidateQueries({ queryKey: ["project-pulls", projectId] })
+      onCompleted?.()
+      setOpen(false)
+    },
+    onError: (e) => {
+      // Surface the server's error message when available; otherwise a
+      // generic fallback. Inputs are validated client-side; a 5xx here
+      // typically means the GitHub App isn't configured or rate-limited.
+      if (e instanceof ApiError) {
+        setError(e.message || "Backfill failed")
+      } else {
+        setError("Backfill failed")
+      }
+    },
+  })
+
+  const handleSubmit = () => {
+    setError(null)
+    mutation.mutate()
+  }
+
+  const triggerElement =
+    trigger && isValidElement(trigger)
+      ? cloneElement(trigger, {
+          onClick: (e: React.MouseEvent) => {
+            trigger.props.onClick?.(e)
+            if (!e.defaultPrevented) setOpen(true)
+          },
+        })
+      : null
+
+  return (
+    <>
+      {triggerElement}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Backfill from GitHub</DialogTitle>
+          <DialogDescription>
+            Ingest existing issues and pull requests
+            {repoLabel ? ` from ${repoLabel}` : ""} as reference-only artifacts.
+            Live updates start automatically; this is for pre-existing items.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <label className="text-sm font-medium" htmlFor="backfill-cap">
+              Cap
+            </label>
+            <Input
+              id="backfill-cap"
+              type="number"
+              min={1}
+              max={HARD_CAP}
+              value={cap}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10)
+                if (Number.isFinite(n)) {
+                  setCap(Math.min(HARD_CAP, Math.max(1, n)))
+                }
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Maximum {HARD_CAP}. Larger backfills require the CLI
+              (<code className="font-mono">onsager project sync</code>).
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">Strategy</label>
+            <Select
+              value={strategy}
+              onValueChange={(v) =>
+                setStrategy(v as NonNullable<BackfillRequestBody["strategy"]>)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="recent">Recent (newest first)</SelectItem>
+                <SelectItem value="active">Active (skip stale)</SelectItem>
+                <SelectItem value="refract">Refract (priority-ranked)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">State</label>
+            <Select
+              value={stateFilter}
+              onValueChange={(v) =>
+                setStateFilter(v as NonNullable<BackfillRequestBody["state"]>)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="open">Open only</SelectItem>
+                <SelectItem value="closed">Closed only</SelectItem>
+                <SelectItem value="all">All states</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            type="button"
+            onClick={() => setOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
+                Backfilling…
+              </>
+            ) : (
+              "Backfill"
+            )}
+          </Button>
+        </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Building2, Factory, GitBranch, Server, Terminal, Settings, Shield, Package, Activity } from "lucide-react"
+import { Building2, Factory, GitBranch, Inbox, Server, Terminal, Settings, Shield, Package, Activity } from "lucide-react"
 import { OnsagerLogo } from "./OnsagerLogo"
 import { UserMenu } from "./UserMenu"
 import { Link, useLocation } from "react-router-dom"
@@ -30,6 +30,10 @@ const navSections = [
     label: "Factory",
     items: [
       { title: "Overview", icon: Factory, path: "/" },
+      // Issues inbox (#168) — reference-only `Kind::GithubIssue` artifacts
+      // hydrated live via the portal proxy. Auth-gated because the inbox
+      // is workspace-scoped; anonymous mode has no projects to show.
+      { title: "Issues", icon: Inbox, path: "/issues", requiresAuth: true },
       // Workflows are workspace-scoped, so they only make sense when
       // there's an authenticated user to own them.
       { title: "Workflows", icon: GitBranch, path: "/workflows", requiresAuth: true },

--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -53,6 +53,7 @@ import {
   Users,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { BackfillDialog } from "@/components/BackfillDialog"
 
 /**
  * Card rendering a single workspace with its GitHub installations, projects,
@@ -534,6 +535,13 @@ const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(
   const [repoName, setRepoName] = useState("")
   const [defaultBranch, setDefaultBranch] = useState("")
   const [error, setError] = useState<string | null>(null)
+  // After a successful add-project, prompt the user to backfill the
+  // project's existing GitHub issues + PRs as reference-only artifacts (#168).
+  // Otherwise the inbox stays empty until the next webhook event arrives.
+  const [backfillCandidate, setBackfillCandidate] = useState<{
+    id: string
+    label: string
+  } | null>(null)
   const queryClient = useQueryClient()
 
   useImperativeHandle(
@@ -574,11 +582,19 @@ const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(
         repo_name: repoName,
         default_branch: defaultBranch || undefined,
       }),
-    onSuccess: () => {
+    onSuccess: (created) => {
       queryClient.invalidateQueries({
         queryKey: ["workspace-projects", workspaceId],
       })
       queryClient.invalidateQueries({ queryKey: ["all-projects"] })
+      // Surface the backfill prompt — projects start with an empty inbox
+      // until either a webhook fires or the user backfills.
+      if (created?.project) {
+        setBackfillCandidate({
+          id: created.project.id,
+          label: `${created.project.repo_owner}/${created.project.repo_name}`,
+        })
+      }
       setAdding(false)
       setInstallationId("")
       setRepoOwner("")
@@ -766,6 +782,16 @@ const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(
           </div>
         </form>
       )}
+      {backfillCandidate ? (
+        <BackfillDialog
+          projectId={backfillCandidate.id}
+          repoLabel={backfillCandidate.label}
+          open
+          onOpenChange={(o) => {
+            if (!o) setBackfillCandidate(null)
+          }}
+        />
+      ) : null}
     </div>
   )
 })

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -235,13 +235,74 @@ export interface SpineEvent {
 export interface SpineArtifact {
   id: string;
   kind: string;
-  name: string;
-  owner: string;
+  /// Reference-only artifacts (`kind in ['github_issue', 'pull_request']`,
+  /// per spec #170) carry NULL here — the title is GitHub-authored and is
+  /// served by the live-hydration proxy at `/api/projects/:id/{issues,pulls}`.
+  /// Older PR rows materialized before the migration retain their stale
+  /// titles as best-effort fallback display.
+  name: string | null;
+  /// Reference-only artifacts carry NULL — see `name` for rationale.
+  owner: string | null;
   state: string;
   current_version: number;
   consumers?: string[];
+  /// Stable handle for joining skeleton rows with live proxy responses
+  /// (`github:project:{project_id}:{issue,pr}:{number}`).
+  external_ref?: string | null;
   created_at: string;
   updated_at: string;
+  /// Last webhook touch — drives the "last seen N min ago" placeholder
+  /// when the proxy is rate-limited (#170 fail-open).
+  last_observed_at?: string | null;
+}
+
+/// Live-hydrated GitHub issue from `GET /api/projects/:id/issues`. Joined
+/// with `SpineArtifact` rows (kind=`github_issue`) on `external_ref` to
+/// build the dashboard inbox view (#168).
+export interface ProjectIssueRow {
+  number: number;
+  title: string;
+  state: string;
+  html_url: string;
+  author: string | null;
+  labels: string[];
+  comments: number;
+  updated_at: string;
+}
+
+export interface ProjectPullRow {
+  number: number;
+  title: string;
+  state: string;
+  html_url: string;
+  author: string | null;
+  labels: string[];
+  draft: boolean;
+  merged: boolean;
+  updated_at: string;
+}
+
+export interface ProjectLiveListResponse<T> {
+  issues?: T[];
+  pulls?: T[];
+  /// `rate_limited` / `github_unreachable` per #170 fail-open. Dashboard
+  /// renders the artifact skeleton's `last_observed_at` placeholder.
+  error?: string;
+}
+
+export interface BackfillRequestBody {
+  cap?: number;
+  strategy?: 'recent' | 'active' | 'refract';
+  state?: 'open' | 'closed' | 'all';
+}
+
+export interface BackfillReport {
+  project_id: string;
+  repo: string;
+  cap: number;
+  issues_ingested: number;
+  pulls_ingested: number;
+  skipped: number;
 }
 
 export interface ArtifactDetail extends SpineArtifact {
@@ -730,7 +791,17 @@ export const api = {
     ).toString() : '';
     return request<{ events: SpineEvent[] }>(`/spine/events${qs}`);
   },
-  getArtifacts: () => request<{ artifacts: SpineArtifact[] }>('/spine/artifacts'),
+  getArtifacts: (filters?: { kind?: string; project_id?: string }) => {
+    const qs = filters
+      ? '?' +
+        new URLSearchParams(
+          Object.entries(filters)
+            .filter(([, v]) => v != null && v !== '')
+            .map(([k, v]) => [k, String(v)]),
+        ).toString()
+      : '';
+    return request<{ artifacts: SpineArtifact[] }>(`/spine/artifacts${qs}`);
+  },
   getArtifact: (id: string) => request<{ artifact: ArtifactDetail }>(`/spine/artifacts/${id}`),
   registerArtifact: (req: RegisterArtifactRequest) =>
     request<{ artifact: SpineArtifact }>('/spine/artifacts', {
@@ -820,4 +891,24 @@ export const api = {
     request<{ labels: GitHubLabel[] }>(
       `/tenants/${encodeURIComponent(tenantId)}/github-installations/${encodeURIComponent(installId)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/labels`,
     ),
+  // Live-hydration proxy endpoints (specs #167, #170, #171). Dashboard
+  // joins skeleton rows from `getArtifacts({kind: ...})` with the rows
+  // returned here on `external_ref`.
+  listProjectIssues: (projectId: string, state?: 'open' | 'closed' | 'all') => {
+    const qs = state ? `?state=${state}` : '';
+    return request<ProjectLiveListResponse<ProjectIssueRow>>(
+      `/projects/${encodeURIComponent(projectId)}/issues${qs}`,
+    );
+  },
+  listProjectPulls: (projectId: string, state?: 'open' | 'closed' | 'all') => {
+    const qs = state ? `?state=${state}` : '';
+    return request<ProjectLiveListResponse<ProjectPullRow>>(
+      `/projects/${encodeURIComponent(projectId)}/pulls${qs}`,
+    );
+  },
+  backfillProject: (projectId: string, body: BackfillRequestBody = {}) =>
+    request<BackfillReport>(`/projects/${encodeURIComponent(projectId)}/backfill`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
 };

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -215,7 +215,7 @@ export function ArtifactDetailPage() {
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <h1 className="hidden truncate text-2xl font-bold tracking-tight md:block">
-            {artifact.name}
+            {artifact.name ?? artifact.id}
           </h1>
           <p className="truncate text-sm text-muted-foreground font-mono">
             {artifact.id}
@@ -297,7 +297,7 @@ export function ArtifactDetailPage() {
         <Card>
           <CardContent className="px-3 py-3">
             <div className="text-xs text-muted-foreground">Owner</div>
-            <div className="font-medium">{artifact.owner}</div>
+            <div className="font-medium">{artifact.owner ?? "—"}</div>
           </CardContent>
         </Card>
         <Card>

--- a/apps/dashboard/src/pages/ArtifactsPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactsPage.tsx
@@ -28,7 +28,7 @@ export function ArtifactsPage() {
   usePageHeader({ title: "Artifacts" })
   const { data, isLoading } = useQuery({
     queryKey: ["artifacts"],
-    queryFn: api.getArtifacts,
+    queryFn: () => api.getArtifacts(),
     refetchInterval: 5000,
   })
 
@@ -111,7 +111,9 @@ export function ArtifactsPage() {
                             {a.state.replace("_", " ")}
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-muted-foreground">{a.owner}</TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {a.owner ?? <span className="italic opacity-60">—</span>}
+                        </TableCell>
                         <TableCell className="font-mono">v{a.current_version}</TableCell>
                         <TableCell className="text-xs text-muted-foreground">
                           {new Date(a.updated_at).toLocaleString()}
@@ -144,7 +146,7 @@ function ArtifactCard({ artifact }: { artifact: SpineArtifact }) {
         </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Badge variant="outline" className="shrink-0">{artifact.kind}</Badge>
-          <span className="truncate">{artifact.owner}</span>
+          <span className="truncate">{artifact.owner ?? "—"}</span>
           <span className="shrink-0 font-mono">v{artifact.current_version}</span>
         </div>
       </div>

--- a/apps/dashboard/src/pages/DashboardPage.tsx
+++ b/apps/dashboard/src/pages/DashboardPage.tsx
@@ -16,7 +16,7 @@ export function DashboardPage() {
   })
   const { data: artifactsData } = useQuery({
     queryKey: ["artifacts"],
-    queryFn: api.getArtifacts,
+    queryFn: () => api.getArtifacts(),
     refetchInterval: 10000,
   })
 

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -103,7 +103,7 @@ export function FactoryOverviewPage() {
 
   const { data: artifactsData } = useQuery({
     queryKey: ["artifacts"],
-    queryFn: api.getArtifacts,
+    queryFn: () => api.getArtifacts(),
     refetchInterval: 5000,
     enabled,
   })

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -1,0 +1,382 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ExternalLink, Inbox, RefreshCw } from "lucide-react"
+import { Link } from "react-router-dom"
+
+import {
+  api,
+  type Project,
+  type ProjectIssueRow,
+  type SpineArtifact,
+} from "@/lib/api"
+import { useAuth } from "@/lib/auth"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { BackfillDialog } from "@/components/BackfillDialog"
+
+type StateFilter = "open" | "closed" | "all"
+
+/**
+ * GitHub issues inbox (#168).
+ *
+ * Issues are reference-only `Kind::GithubIssue` artifacts (#167 / #170) —
+ * the spine carries identity + our derived state, the proxy hydrates the
+ * GitHub-authored fields (title, labels, assignees) on demand. This page
+ * joins the two on `external_ref`.
+ *
+ * Workspace scope: the page accepts a `?project=` query param; without one,
+ * it auto-selects the user's first project. Multi-project users get a
+ * dropdown picker. Empty-state pushes the user back to `/workspaces` to
+ * connect a project before there's anything to render.
+ */
+export function IssuesPage() {
+  const { authEnabled, user } = useAuth()
+  const authed = !authEnabled || !!user
+
+  const [projectId, setProjectId] = useState<string | null>(null)
+  const [stateFilter, setStateFilter] = useState<StateFilter>("open")
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects-for-user"],
+    queryFn: api.listAllProjects,
+    enabled: authed,
+  })
+  const projects: Project[] = useMemo(
+    () => projectsQuery.data?.projects ?? [],
+    [projectsQuery.data],
+  )
+  const selectedProjectId = projectId ?? projects[0]?.id ?? null
+  const selectedProject = useMemo(
+    () => projects.find((p) => p.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  )
+
+  // Skeleton rows from the spine (kind=github_issue, scoped to project).
+  // The hydrated fields come from the proxy below; we join on external_ref.
+  const skeletonsQuery = useQuery({
+    queryKey: ["artifacts", "github_issue", selectedProjectId],
+    queryFn: () =>
+      api.getArtifacts({
+        kind: "github_issue",
+        project_id: selectedProjectId ?? undefined,
+      }),
+    enabled: authed && !!selectedProjectId,
+    refetchInterval: 15_000,
+  })
+
+  const liveQuery = useQuery({
+    queryKey: ["project-issues", selectedProjectId, stateFilter],
+    queryFn: () => api.listProjectIssues(selectedProjectId!, stateFilter),
+    enabled: authed && !!selectedProjectId,
+    // Match the cache TTL on the server side; the dashboard re-fetches at
+    // the same cadence so users always see something close to fresh.
+    refetchInterval: 60_000,
+  })
+
+  const skeletonsByExternalRef = useMemo(() => {
+    const map = new Map<string, SpineArtifact>()
+    for (const s of skeletonsQuery.data?.artifacts ?? []) {
+      if (s.external_ref) map.set(s.external_ref, s)
+    }
+    return map
+  }, [skeletonsQuery.data])
+
+  const rows: HydratedIssueRow[] = useMemo(() => {
+    const live = liveQuery.data?.issues ?? []
+    return live.map((issue) => {
+      const externalRef =
+        selectedProjectId != null
+          ? `github:project:${selectedProjectId}:issue:${issue.number}`
+          : null
+      const skeleton =
+        externalRef != null ? skeletonsByExternalRef.get(externalRef) : null
+      return { issue, skeleton: skeleton ?? null }
+    })
+  }, [liveQuery.data, skeletonsByExternalRef, selectedProjectId])
+
+  const proxyError = liveQuery.data?.error ?? null
+
+  usePageHeader({
+    title: "Issues",
+    actions:
+      selectedProject != null ? (
+        <BackfillDialog
+          projectId={selectedProject.id}
+          repoLabel={`${selectedProject.repo_owner}/${selectedProject.repo_name}`}
+          trigger={
+            <Button size="sm" variant="outline">
+              <RefreshCw className="h-4 w-4" data-icon="inline-start" />
+              <span className="hidden sm:inline">Backfill</span>
+            </Button>
+          }
+        />
+      ) : null,
+  })
+
+  if (!authed) {
+    return (
+      <div className="space-y-4">
+        <p className="text-muted-foreground">
+          Sign in to see your project's GitHub issues.
+        </p>
+      </div>
+    )
+  }
+
+  if (projectsQuery.isLoading) {
+    return <p className="py-8 text-center text-muted-foreground">Loading…</p>
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="space-y-4 md:space-y-6">
+        <h1 className="hidden text-2xl font-bold tracking-tight md:block">Issues</h1>
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+            <Inbox className="h-8 w-8 text-muted-foreground" aria-hidden />
+            <p className="text-sm text-muted-foreground">
+              No projects connected. Set up a workspace to start ingesting issues.
+            </p>
+            <Button render={<Link to="/workspaces" />}>
+              Go to workspaces
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="hidden text-2xl font-bold tracking-tight md:block">Issues</h1>
+          <p className="text-sm text-muted-foreground">
+            GitHub issues ingested as factory artifacts.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {projects.length > 1 ? (
+            <Select
+              value={selectedProjectId ?? undefined}
+              onValueChange={(v) => setProjectId(v)}
+            >
+              <SelectTrigger className="w-56">
+                <SelectValue placeholder="Project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.repo_owner}/{p.repo_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+          <Select
+            value={stateFilter}
+            onValueChange={(v) => setStateFilter(v as StateFilter)}
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="open">Open</SelectItem>
+              <SelectItem value="closed">Closed</SelectItem>
+              <SelectItem value="all">All</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {proxyError === "rate_limited" ? (
+        <Card>
+          <CardContent className="py-3 text-sm text-muted-foreground">
+            GitHub rate limit reached. Showing skeleton rows; titles will return
+            in about a minute.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-lg">
+            {selectedProject != null
+              ? `${selectedProject.repo_owner}/${selectedProject.repo_name}`
+              : "Issues"}
+            {rows.length > 0 ? (
+              <span className="font-normal text-muted-foreground">
+                {" "}
+                ({rows.length})
+              </span>
+            ) : null}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          {liveQuery.isLoading ? (
+            <p className="py-8 text-center text-muted-foreground">Loading…</p>
+          ) : rows.length === 0 ? (
+            <EmptyInbox project={selectedProject} />
+          ) : (
+            <>
+              <div className="flex flex-col gap-2 md:hidden">
+                {rows.map((r) => (
+                  <IssueCard key={r.issue.number} row={r} />
+                ))}
+              </div>
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Title</TableHead>
+                      <TableHead>State</TableHead>
+                      <TableHead>Labels</TableHead>
+                      <TableHead>Author</TableHead>
+                      <TableHead>Updated</TableHead>
+                      <TableHead></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map(({ issue }) => (
+                      <TableRow key={issue.number}>
+                        <TableCell className="max-w-md">
+                          <div className="truncate font-medium">{issue.title}</div>
+                          <div className="text-xs text-muted-foreground">
+                            #{issue.number}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={issue.state === "open" ? "default" : "secondary"}
+                          >
+                            {issue.state}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <LabelChips labels={issue.labels} />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {issue.author ?? "—"}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {new Date(issue.updated_at).toLocaleString()}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            render={
+                              <a
+                                href={issue.html_url}
+                                target="_blank"
+                                rel="noreferrer"
+                              />
+                            }
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            <span className="sr-only">Open in GitHub</span>
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+interface HydratedIssueRow {
+  issue: ProjectIssueRow
+  skeleton: SpineArtifact | null
+}
+
+function IssueCard({ row }: { row: HydratedIssueRow }) {
+  const { issue } = row
+  return (
+    <a
+      href={issue.html_url}
+      target="_blank"
+      rel="noreferrer"
+      className="flex flex-col gap-1.5 rounded-lg border p-3 transition-colors active:bg-accent"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="line-clamp-2 text-sm font-medium">{issue.title}</span>
+        <Badge
+          variant={issue.state === "open" ? "default" : "secondary"}
+          className="shrink-0"
+        >
+          {issue.state}
+        </Badge>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span>#{issue.number}</span>
+        {issue.author ? <span>· {issue.author}</span> : null}
+        <span>· {new Date(issue.updated_at).toLocaleDateString()}</span>
+      </div>
+      {issue.labels.length > 0 ? <LabelChips labels={issue.labels} /> : null}
+    </a>
+  )
+}
+
+function LabelChips({ labels }: { labels: string[] }) {
+  if (labels.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1">
+      {labels.slice(0, 3).map((l) => (
+        <Badge key={l} variant="outline" className="text-xs">
+          {l}
+        </Badge>
+      ))}
+      {labels.length > 3 ? (
+        <Badge variant="outline" className="text-xs">
+          +{labels.length - 3}
+        </Badge>
+      ) : null}
+    </div>
+  )
+}
+
+function EmptyInbox({ project }: { project: Project | null }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-10 text-center">
+      <Inbox className="h-8 w-8 text-muted-foreground" aria-hidden />
+      <p className="text-sm text-muted-foreground">
+        No issues in the inbox yet.
+      </p>
+      {project ? (
+        <BackfillDialog
+          projectId={project.id}
+          repoLabel={`${project.repo_owner}/${project.repo_name}`}
+          trigger={
+            <Button>
+              <RefreshCw className="h-4 w-4" data-icon="inline-start" />
+              Backfill from GitHub
+            </Button>
+          }
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { ExternalLink, Inbox, RefreshCw } from "lucide-react"
-import { Link } from "react-router-dom"
+import { Link, useSearchParams } from "react-router-dom"
 
 import {
   api,
@@ -50,7 +50,12 @@ export function IssuesPage() {
   const { authEnabled, user } = useAuth()
   const authed = !authEnabled || !!user
 
-  const [projectId, setProjectId] = useState<string | null>(null)
+  // `?project=<id>` selects the active project on first render. Subsequent
+  // user picks via the dropdown override into local state, so deep-links
+  // stay clean while the picker still works.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const urlProjectId = searchParams.get("project")
+  const [projectIdOverride, setProjectIdOverride] = useState<string | null>(null)
   const [stateFilter, setStateFilter] = useState<StateFilter>("open")
 
   const projectsQuery = useQuery({
@@ -62,11 +67,20 @@ export function IssuesPage() {
     () => projectsQuery.data?.projects ?? [],
     [projectsQuery.data],
   )
-  const selectedProjectId = projectId ?? projects[0]?.id ?? null
+  const selectedProjectId =
+    projectIdOverride ?? urlProjectId ?? projects[0]?.id ?? null
   const selectedProject = useMemo(
     () => projects.find((p) => p.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
   )
+
+  const setProjectId = (id: string) => {
+    setProjectIdOverride(id)
+    // Keep the URL in sync so the back/forward buttons + share-links work.
+    const next = new URLSearchParams(searchParams)
+    next.set("project", id)
+    setSearchParams(next, { replace: true })
+  }
 
   // Skeleton rows from the spine (kind=github_issue, scoped to project).
   // The hydrated fields come from the proxy below; we join on external_ref.
@@ -81,12 +95,16 @@ export function IssuesPage() {
     refetchInterval: 15_000,
   })
 
+  // Refetch cadence is independent of the server's proxy-cache TTL — the
+  // server-side TTL bounds upstream-GitHub freshness; the client-side
+  // interval bounds how often we *ask* the server. Picking 60s gives a
+  // sensible refresh rate without being chatty; tuning it doesn't affect
+  // correctness, only how quickly external changes appear without a
+  // manual reload.
   const liveQuery = useQuery({
     queryKey: ["project-issues", selectedProjectId, stateFilter],
     queryFn: () => api.listProjectIssues(selectedProjectId!, stateFilter),
     enabled: authed && !!selectedProjectId,
-    // Match the cache TTL on the server side; the dashboard re-fetches at
-    // the same cadence so users always see something close to fresh.
     refetchInterval: 60_000,
   })
 
@@ -98,20 +116,62 @@ export function IssuesPage() {
     return map
   }, [skeletonsQuery.data])
 
+  const proxyError = liveQuery.data?.error ?? null
+
+  // Drive the row set from the union of skeletons and live data so a proxy
+  // failure (rate_limited / github_unreachable) renders the cached
+  // skeleton rows rather than going blank — the page header banner already
+  // explains the degraded state. Live fields hydrate over the skeleton
+  // when both sides resolve.
   const rows: HydratedIssueRow[] = useMemo(() => {
     const live = liveQuery.data?.issues ?? []
-    return live.map((issue) => {
-      const externalRef =
-        selectedProjectId != null
-          ? `github:project:${selectedProjectId}:issue:${issue.number}`
-          : null
-      const skeleton =
-        externalRef != null ? skeletonsByExternalRef.get(externalRef) : null
-      return { issue, skeleton: skeleton ?? null }
-    })
-  }, [liveQuery.data, skeletonsByExternalRef, selectedProjectId])
+    const liveByExternalRef = new Map<string, ProjectIssueRow>()
+    if (selectedProjectId != null) {
+      for (const issue of live) {
+        liveByExternalRef.set(
+          `github:project:${selectedProjectId}:issue:${issue.number}`,
+          issue,
+        )
+      }
+    }
 
-  const proxyError = liveQuery.data?.error ?? null
+    // Skeleton-rooted entries: every artifact we know about, hydrated when
+    // possible.
+    const skeletonRows: HydratedIssueRow[] = []
+    for (const skeleton of skeletonsQuery.data?.artifacts ?? []) {
+      const live =
+        skeleton.external_ref != null
+          ? (liveByExternalRef.get(skeleton.external_ref) ?? null)
+          : null
+      skeletonRows.push({ issue: live, skeleton })
+    }
+
+    // Live-only entries: webhook hasn't created a skeleton yet (e.g. the
+    // very first time we observe an issue) but the proxy already returned
+    // it. Suppress these when the proxy errored — those are the empty-list
+    // case and we trust the skeletons alone.
+    const liveOnlyRows: HydratedIssueRow[] = []
+    if (!proxyError) {
+      for (const issue of live) {
+        if (selectedProjectId == null) {
+          liveOnlyRows.push({ issue, skeleton: null })
+          continue
+        }
+        const externalRef = `github:project:${selectedProjectId}:issue:${issue.number}`
+        if (!skeletonsByExternalRef.has(externalRef)) {
+          liveOnlyRows.push({ issue, skeleton: null })
+        }
+      }
+    }
+
+    return [...skeletonRows, ...liveOnlyRows]
+  }, [
+    liveQuery.data,
+    proxyError,
+    selectedProjectId,
+    skeletonsByExternalRef,
+    skeletonsQuery.data,
+  ])
 
   usePageHeader({
     title: "Issues",
@@ -176,7 +236,9 @@ export function IssuesPage() {
           {projects.length > 1 ? (
             <Select
               value={selectedProjectId ?? undefined}
-              onValueChange={(v) => setProjectId(v)}
+              onValueChange={(v) => {
+                if (v) setProjectId(v)
+              }}
             >
               <SelectTrigger className="w-56">
                 <SelectValue placeholder="Project" />
@@ -206,11 +268,12 @@ export function IssuesPage() {
         </div>
       </div>
 
-      {proxyError === "rate_limited" ? (
+      {proxyError ? (
         <Card>
           <CardContent className="py-3 text-sm text-muted-foreground">
-            GitHub rate limit reached. Showing skeleton rows; titles will return
-            in about a minute.
+            {proxyError === "rate_limited"
+              ? "GitHub rate limit reached. Showing skeleton rows; titles will return in about a minute."
+              : "Couldn't reach GitHub. Showing the last-known artifacts; titles will refresh once the connection recovers."}
           </CardContent>
         </Card>
       ) : null}
@@ -238,7 +301,7 @@ export function IssuesPage() {
             <>
               <div className="flex flex-col gap-2 md:hidden">
                 {rows.map((r) => (
-                  <IssueCard key={r.issue.number} row={r} />
+                  <IssueCard key={rowKey(r)} row={r} />
                 ))}
               </div>
               <div className="hidden md:block">
@@ -254,48 +317,55 @@ export function IssuesPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {rows.map(({ issue }) => (
-                      <TableRow key={issue.number}>
-                        <TableCell className="max-w-md">
-                          <div className="truncate font-medium">{issue.title}</div>
-                          <div className="text-xs text-muted-foreground">
-                            #{issue.number}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={issue.state === "open" ? "default" : "secondary"}
-                          >
-                            {issue.state}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          <LabelChips labels={issue.labels} />
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {issue.author ?? "—"}
-                        </TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {new Date(issue.updated_at).toLocaleString()}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            render={
-                              <a
-                                href={issue.html_url}
-                                target="_blank"
-                                rel="noreferrer"
-                              />
-                            }
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            <span className="sr-only">Open in GitHub</span>
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {rows.map((r) => {
+                      const display = describeRow(r)
+                      return (
+                        <TableRow key={rowKey(r)}>
+                          <TableCell className="max-w-md">
+                            <div className="truncate font-medium">
+                              {display.title}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {display.subtitle}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant={display.openState ? "default" : "secondary"}
+                            >
+                              {display.stateLabel}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <LabelChips labels={display.labels} />
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {display.author}
+                          </TableCell>
+                          <TableCell className="text-xs text-muted-foreground">
+                            {display.updatedAt}
+                          </TableCell>
+                          <TableCell>
+                            {display.htmlUrl ? (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                render={
+                                  <a
+                                    href={display.htmlUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  />
+                                }
+                              >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                                <span className="sr-only">Open in GitHub</span>
+                              </Button>
+                            ) : null}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </div>
@@ -308,36 +378,110 @@ export function IssuesPage() {
 }
 
 interface HydratedIssueRow {
-  issue: ProjectIssueRow
+  /// Live GitHub data, when the proxy returned it. NULL when the proxy
+  /// failed open and we're rendering the skeleton row alone.
+  issue: ProjectIssueRow | null
+  /// Local skeleton row. NULL on the very first observation if the proxy
+  /// returned an issue before the webhook fired.
   skeleton: SpineArtifact | null
 }
 
+interface RowDisplay {
+  title: string
+  subtitle: string
+  openState: boolean
+  stateLabel: string
+  labels: string[]
+  author: string
+  updatedAt: string
+  htmlUrl: string | null
+}
+
+/// Stable React key — uses the external_ref when available, otherwise
+/// derives one from the live issue. Both sides shouldn't ever be null
+/// for a row that survives the union, but the fallback keeps the type
+/// system honest.
+function rowKey(row: HydratedIssueRow): string {
+  if (row.skeleton?.external_ref) return row.skeleton.external_ref
+  if (row.issue) return `live:${row.issue.number}`
+  return row.skeleton?.id ?? Math.random().toString(36)
+}
+
+/// Project hydrated + skeleton rows down to the values the table/card
+/// renderers display. Skeleton-only rows derive their state from the
+/// artifact's lifecycle column and surface a "—" placeholder for fields
+/// only GitHub knows.
+function describeRow(row: HydratedIssueRow): RowDisplay {
+  const { issue, skeleton } = row
+  if (issue) {
+    return {
+      title: issue.title,
+      subtitle: `#${issue.number}`,
+      openState: issue.state === "open",
+      stateLabel: issue.state,
+      labels: issue.labels,
+      author: issue.author ?? "—",
+      updatedAt: new Date(issue.updated_at).toLocaleString(),
+      htmlUrl: issue.html_url,
+    }
+  }
+  // Skeleton-only fallback: artifact lifecycle in `state` (`draft` =
+  // open, `archived` = closed); titles aren't stored locally so we
+  // surface the artifact id as a placeholder.
+  const open = skeleton?.state === "draft"
+  const lastSeen = skeleton?.last_observed_at
+  return {
+    title: skeleton?.id ?? "(unavailable)",
+    subtitle: skeleton?.external_ref?.split(":issue:").pop() ?? "—",
+    openState: open,
+    stateLabel: open ? "open" : "closed",
+    labels: [],
+    author: "—",
+    updatedAt: lastSeen
+      ? `last seen ${new Date(lastSeen).toLocaleString()}`
+      : "—",
+    htmlUrl: null,
+  }
+}
+
 function IssueCard({ row }: { row: HydratedIssueRow }) {
-  const { issue } = row
-  return (
-    <a
-      href={issue.html_url}
-      target="_blank"
-      rel="noreferrer"
-      className="flex flex-col gap-1.5 rounded-lg border p-3 transition-colors active:bg-accent"
-    >
+  const display = describeRow(row)
+  const cardClass =
+    "flex flex-col gap-1.5 rounded-lg border p-3 transition-colors active:bg-accent"
+  const inner = (
+    <>
       <div className="flex items-start justify-between gap-2">
-        <span className="line-clamp-2 text-sm font-medium">{issue.title}</span>
+        <span className="line-clamp-2 text-sm font-medium">{display.title}</span>
         <Badge
-          variant={issue.state === "open" ? "default" : "secondary"}
+          variant={display.openState ? "default" : "secondary"}
           className="shrink-0"
         >
-          {issue.state}
+          {display.stateLabel}
         </Badge>
       </div>
       <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <span>#{issue.number}</span>
-        {issue.author ? <span>· {issue.author}</span> : null}
-        <span>· {new Date(issue.updated_at).toLocaleDateString()}</span>
+        <span>{display.subtitle}</span>
+        {display.author !== "—" ? <span>· {display.author}</span> : null}
+        <span>· {display.updatedAt}</span>
       </div>
-      {issue.labels.length > 0 ? <LabelChips labels={issue.labels} /> : null}
-    </a>
+      {display.labels.length > 0 ? (
+        <LabelChips labels={display.labels} />
+      ) : null}
+    </>
   )
+  if (display.htmlUrl) {
+    return (
+      <a
+        href={display.htmlUrl}
+        target="_blank"
+        rel="noreferrer"
+        className={cardClass}
+      >
+        {inner}
+      </a>
+    )
+  }
+  return <div className={cardClass}>{inner}</div>
 }
 
 function LabelChips({ labels }: { labels: string[] }) {

--- a/crates/onsager-artifact/src/artifact.rs
+++ b/crates/onsager-artifact/src/artifact.rs
@@ -100,6 +100,7 @@ pub enum Kind {
     Code,
     Document,
     PullRequest,
+    GithubIssue,
     /// User-defined kind not in the built-in set.
     Custom(String),
 }
@@ -110,6 +111,7 @@ impl fmt::Display for Kind {
             Kind::Code => write!(f, "code"),
             Kind::Document => write!(f, "document"),
             Kind::PullRequest => write!(f, "pull_request"),
+            Kind::GithubIssue => write!(f, "github_issue"),
             Kind::Custom(s) => write!(f, "{s}"),
         }
     }

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -25,9 +25,8 @@ use onsager_artifact::ArtifactId;
 use onsager_spine::factory_event::FactoryEventKind;
 use onsager_spine::{EventMetadata, EventStore};
 
-use crate::db::{self, PrLifecycleState};
+use crate::db::{self, IssueLifecycleState, PrLifecycleState};
 use crate::github::{Client, Issue, Pull};
-use crate::handlers::issues::SPEC_LABEL;
 
 /// Ingestion strategy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -57,7 +56,7 @@ pub struct BackfillReport {
     pub repo: String,
     pub cap: usize,
     pub prs_ingested: usize,
-    pub tasks_materialized: usize,
+    pub issues_ingested: usize,
     pub skipped: usize,
 }
 
@@ -126,15 +125,7 @@ pub async fn run(
             ("closed", false) => PrLifecycleState::Archived,
             _ => PrLifecycleState::InProgress,
         };
-        let artifact = db::upsert_pr_artifact(
-            pool,
-            &project.id,
-            pr.number,
-            &pr.title,
-            &pr.user.login,
-            next_state,
-        )
-        .await?;
+        let artifact = db::upsert_pr_artifact_ref(pool, &project.id, pr.number, next_state).await?;
         let event = if let Some(merge_sha) = pr
             .merge_commit_sha
             .clone()
@@ -179,48 +170,36 @@ pub async fn run(
     for issue in issues {
         if issue.is_pull_request() {
             // PRs come back through the issues endpoint too; skip — they
-            // were handled in the pulls loop with full PR metadata.
+            // were handled in the pulls loop.
             continue;
         }
-        if !issue.has_label(SPEC_LABEL) {
-            report.skipped += 1;
-            continue;
-        }
-        let source_ref = format!(
-            "github:{}/{}:issue#{}",
-            project.repo_owner, project.repo_name, issue.number
-        );
-        let task = db::upsert_factory_task(
-            pool,
-            &project.id,
-            "spec_issue",
-            &source_ref,
-            &issue.title,
-            issue.body.as_deref(),
-        )
-        .await?;
-        // Emit the same `portal.task_materialized` event the live webhook
-        // handler produces, so dashboard / ising consumers see a uniform
-        // stream whether the task came from backfill or a live `issues.opened`.
-        let stream_id = format!("portal:task:{}", task.id);
+        // Per spec #167: every issue becomes a reference-only skeleton
+        // artifact. No label gate, no body copy.
+        let lifecycle = IssueLifecycleState::from_github(&issue.state);
+        let artifact =
+            db::upsert_issue_artifact_ref(pool, &project.id, issue.number, lifecycle).await?;
+        let stream_id = format!("portal:issue:{}", artifact.artifact_id);
         spine
             .append_ext(
                 &stream_id,
                 "portal",
                 "portal.task_materialized",
                 serde_json::json!({
-                    "task_id": task.id,
+                    "artifact_id": artifact.artifact_id,
                     "project_id": project.id,
-                    "source": task.source,
-                    "source_ref": task.source_ref,
-                    "title": task.title,
+                    "external_ref": db::issue_external_ref(&project.id, issue.number),
+                    "issue_number": issue.number,
+                    "lifecycle": match lifecycle {
+                        IssueLifecycleState::Draft => "draft",
+                        IssueLifecycleState::Archived => "archived",
+                    },
                     "backfill": true,
                 }),
                 &metadata,
                 None,
             )
             .await?;
-        report.tasks_materialized += 1;
+        report.issues_ingested += 1;
     }
 
     Ok(report)

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -10,7 +10,6 @@
 //! projects, sessions, artifacts, vertical_lineage) are created by stiglab
 //! and onsager-spine; the portal is a read-or-append-only consumer.
 
-use chrono::{DateTime, Utc};
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
 /// Open a fresh connection pool against `database_url`. Caller is responsible
@@ -130,6 +129,15 @@ pub struct PrArtifactRow {
     pub current_version: i32,
 }
 
+/// Issue artifact lookup result. Same shape as `PrArtifactRow` but typed
+/// separately so callers can't accidentally cross-write — issues live under
+/// `Kind::GithubIssue`, PRs under `Kind::PullRequest`.
+#[derive(Debug, Clone)]
+pub struct IssueArtifactRow {
+    pub artifact_id: String,
+    pub current_version: i32,
+}
+
 /// Look up the artifact previously upserted for `(project_id, pr_number)`.
 /// Returns `None` for the very first webhook event on a PR.
 pub async fn find_pr_artifact(
@@ -150,21 +158,25 @@ pub async fn find_pr_artifact(
     }))
 }
 
-/// Insert (or fetch) the canonical PR artifact for `(project_id, pr_number)`.
-/// First-write wins; subsequent calls return the existing row. Idempotency is
-/// anchored on `external_ref` (the spine's `artifacts.external_ref` is not
-/// `UNIQUE` workspace-wide, so we serialize concurrent upserts through a
-/// transaction-scoped advisory lock keyed by the ref).
+/// Upsert the canonical reference-only PR artifact for `(project_id, pr_number)`.
 ///
-/// On a hit we also refresh `name` / `owner` / `state` so the artifact row
-/// reflects the latest webhook payload — otherwise a PR retitle or author
-/// change never propagates to the dashboard.
-pub async fn upsert_pr_artifact(
+/// Per spec #170/#171, the spine never copies GitHub-authored fields. The
+/// row carries identity (`external_ref`, `kind`, `metadata.pr_number`) and
+/// our derived `state` only — `name` / `owner` are written NULL and the
+/// dashboard hydrates them via the live `/api/projects/:id/pulls` proxy.
+///
+/// `last_observed_at` is stamped on every webhook touch so the dashboard
+/// can render "last seen N min ago" placeholders when the proxy is rate-
+/// limited (#170 fail-open decision).
+///
+/// Idempotency is anchored on `external_ref`. The spine's column is not
+/// `UNIQUE` workspace-wide (artifact_adapters across subsystems may share
+/// it legitimately), so concurrent upserts serialize through a transaction-
+/// scoped advisory lock keyed by the ref.
+pub async fn upsert_pr_artifact_ref(
     pool: &PgPool,
     project_id: &str,
     pr_number: u64,
-    name: &str,
-    owner: &str,
     state: PrLifecycleState,
 ) -> anyhow::Result<PrArtifactRow> {
     let external_ref = pr_external_ref(project_id, pr_number);
@@ -173,10 +185,6 @@ pub async fn upsert_pr_artifact(
 
     let mut tx = pool.begin().await?;
 
-    // Serialize upserts for the same external_ref. Needed because the spine
-    // schema does not enforce UNIQUE(external_ref) (artifact_adapters across
-    // subsystems may legitimately share the column), so we can't let the
-    // DB dedup for us via ON CONFLICT.
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
         .bind(&external_ref)
         .execute(&mut *tx)
@@ -184,13 +192,11 @@ pub async fn upsert_pr_artifact(
 
     let row: (String, i32) = if let Some(existing) = sqlx::query_as::<_, (String, i32)>(
         "UPDATE artifacts \
-            SET name = $2, owner = $3, state = $4 \
+            SET state = $2, last_observed_at = NOW() \
           WHERE external_ref = $1 \
       RETURNING artifact_id, current_version",
     )
     .bind(&external_ref)
-    .bind(name)
-    .bind(owner)
     .bind(artifact_state)
     .fetch_optional(&mut *tx)
     .await?
@@ -200,14 +206,12 @@ pub async fn upsert_pr_artifact(
         sqlx::query_as(
             "INSERT INTO artifacts \
                 (artifact_id, kind, name, owner, created_by, state, current_version, \
-                 external_ref, workspace_id, metadata) \
-             VALUES ($1, 'pull_request', $2, $3, 'onsager-portal', $4, 1, $5, $6, \
-                     jsonb_build_object('project_id', $6::text, 'pr_number', $7::bigint)) \
+                 external_ref, workspace_id, metadata, last_observed_at) \
+             VALUES ($1, 'pull_request', NULL, NULL, 'onsager-portal', $2, 1, $3, $4, \
+                     jsonb_build_object('project_id', $4::text, 'pr_number', $5::bigint), NOW()) \
              RETURNING artifact_id, current_version",
         )
         .bind(&new_id)
-        .bind(name)
-        .bind(owner)
         .bind(artifact_state)
         .bind(&external_ref)
         .bind(project_id)
@@ -222,6 +226,81 @@ pub async fn upsert_pr_artifact(
         artifact_id: row.0,
         current_version: row.1,
     })
+}
+
+/// Upsert a reference-only GitHub-issue artifact for `(project_id, issue_number)`.
+///
+/// Matches `upsert_pr_artifact_ref` in shape — identity + derived state, no
+/// provider-authored fields. State maps issue-open → `draft`, issue-closed
+/// → `archived`, mirroring the existing artifact-state CHECK enum without
+/// introducing new vocabulary.
+pub async fn upsert_issue_artifact_ref(
+    pool: &PgPool,
+    project_id: &str,
+    issue_number: u64,
+    state: IssueLifecycleState,
+) -> anyhow::Result<IssueArtifactRow> {
+    let external_ref = issue_external_ref(project_id, issue_number);
+    let new_id = format!("art_iss_{}", uuid::Uuid::new_v4().simple());
+    let artifact_state = state.as_artifact_state();
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(&external_ref)
+        .execute(&mut *tx)
+        .await?;
+
+    let row: (String, i32) = if let Some(existing) = sqlx::query_as::<_, (String, i32)>(
+        "UPDATE artifacts \
+            SET state = $2, last_observed_at = NOW() \
+          WHERE external_ref = $1 \
+      RETURNING artifact_id, current_version",
+    )
+    .bind(&external_ref)
+    .bind(artifact_state)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        existing
+    } else {
+        sqlx::query_as(
+            "INSERT INTO artifacts \
+                (artifact_id, kind, name, owner, created_by, state, current_version, \
+                 external_ref, workspace_id, metadata, last_observed_at) \
+             VALUES ($1, 'github_issue', NULL, NULL, 'onsager-portal', $2, 1, $3, $4, \
+                     jsonb_build_object('project_id', $4::text, 'issue_number', $5::bigint), NOW()) \
+             RETURNING artifact_id, current_version",
+        )
+        .bind(&new_id)
+        .bind(artifact_state)
+        .bind(&external_ref)
+        .bind(project_id)
+        .bind(issue_number as i64)
+        .fetch_one(&mut *tx)
+        .await?
+    };
+
+    tx.commit().await?;
+
+    Ok(IssueArtifactRow {
+        artifact_id: row.0,
+        current_version: row.1,
+    })
+}
+
+/// Bump `current_version` and refresh `last_observed_at` without touching
+/// `state`. Used for issue edits / label changes — events that signal
+/// activity but don't move the open/closed lifecycle.
+pub async fn touch_artifact(pool: &PgPool, artifact_id: &str) -> anyhow::Result<i32> {
+    let row: (i32,) = sqlx::query_as(
+        "UPDATE artifacts SET current_version = current_version + 1, last_observed_at = NOW() \
+         WHERE artifact_id = $1 RETURNING current_version",
+    )
+    .bind(artifact_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
 }
 
 /// Bump the artifact version and (optionally) transition its lifecycle state.
@@ -252,11 +331,16 @@ pub async fn bump_pr_artifact(
     Ok(row.0)
 }
 
-/// Stable external reference key. `project_id` plus `pr_number` is the
-/// (project, PR) identity, so the same PR number across two projects never
-/// collides.
+/// Stable external reference key for a PR. `project_id` plus `pr_number` is
+/// the (project, PR) identity, so the same PR number across two projects
+/// never collides.
 pub fn pr_external_ref(project_id: &str, pr_number: u64) -> String {
     format!("github:project:{project_id}:pr:{pr_number}")
+}
+
+/// Stable external reference key for a GitHub issue. Mirrors `pr_external_ref`.
+pub fn issue_external_ref(project_id: &str, issue_number: u64) -> String {
+    format!("github:project:{project_id}:issue:{issue_number}")
 }
 
 /// Subset of `ArtifactState` the portal cares about for PR rows.
@@ -279,69 +363,42 @@ impl PrLifecycleState {
     }
 }
 
-// ── Factory tasks (portal-owned) ──────────────────────────────────────────
-
-/// A factory task row materialized from a webhook event (or, eventually, a
-/// dashboard form). `state` follows a small lifecycle: `queued → spawned →
-/// closed`. v1 only ever creates `queued` rows.
-#[derive(Debug, Clone)]
-pub struct FactoryTask {
-    pub id: String,
-    pub project_id: String,
-    pub source: String,
-    pub source_ref: String,
-    pub title: String,
-    pub body: Option<String>,
-    pub state: String,
-    pub created_at: DateTime<Utc>,
+/// Subset of `ArtifactState` the portal cares about for issue rows. Maps
+/// GitHub issue state to the existing artifact-state CHECK enum without
+/// introducing new vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueLifecycleState {
+    /// Open issue.
+    Draft,
+    /// Closed issue (any reason).
+    Archived,
 }
 
-/// Insert a `queued` task row, idempotent on `(project_id, source_ref)`.
-/// Returns the row that survives (newly inserted or pre-existing).
-pub async fn upsert_factory_task(
-    pool: &PgPool,
-    project_id: &str,
-    source: &str,
-    source_ref: &str,
-    title: &str,
-    body: Option<&str>,
-) -> anyhow::Result<FactoryTask> {
-    let id = format!("ftk_{}", uuid::Uuid::new_v4().simple());
-    let now = Utc::now();
-    let row: (String, String, String, String, String, Option<String>, String, DateTime<Utc>) =
-        sqlx::query_as(
-            "WITH ins AS (
-                 INSERT INTO factory_tasks (id, project_id, source, source_ref, title, body, state, created_at) \
-                 VALUES ($1, $2, $3, $4, $5, $6, 'queued', $7) \
-                 ON CONFLICT (project_id, source_ref) DO NOTHING \
-                 RETURNING id, project_id, source, source_ref, title, body, state, created_at \
-             ) \
-             SELECT id, project_id, source, source_ref, title, body, state, created_at FROM ins \
-             UNION ALL \
-             SELECT id, project_id, source, source_ref, title, body, state, created_at FROM factory_tasks \
-                 WHERE project_id = $2 AND source_ref = $4 AND NOT EXISTS (SELECT 1 FROM ins) \
-             LIMIT 1",
-        )
-        .bind(&id)
-        .bind(project_id)
-        .bind(source)
-        .bind(source_ref)
-        .bind(title)
-        .bind(body)
-        .bind(now)
-        .fetch_one(pool)
-        .await?;
-    Ok(FactoryTask {
-        id: row.0,
-        project_id: row.1,
-        source: row.2,
-        source_ref: row.3,
-        title: row.4,
-        body: row.5,
-        state: row.6,
-        created_at: row.7,
-    })
+impl IssueLifecycleState {
+    fn as_artifact_state(self) -> &'static str {
+        match self {
+            IssueLifecycleState::Draft => "draft",
+            IssueLifecycleState::Archived => "archived",
+        }
+    }
+
+    /// Map a GitHub `state` string (`"open"` / `"closed"`) to our enum.
+    pub fn from_github(state: &str) -> Self {
+        match state {
+            "closed" => Self::Archived,
+            _ => Self::Draft,
+        }
+    }
 }
+
+// ── Factory tasks (legacy) ────────────────────────────────────────────────
+//
+// The `factory_tasks` table from #60 is no longer written by any path —
+// reference-only artifact rows (`Kind::GithubIssue`) now serve the inbox
+// concept the table was created for. The migration in `migrate.rs` keeps
+// the table present so historical rows remain queryable; the writer
+// function was removed when the last caller (issues webhook + backfill)
+// switched to ref-only writes per #167.
 
 // ── Verdict dedup (Phase 2) ───────────────────────────────────────────────
 

--- a/crates/onsager-portal/src/handlers/issues.rs
+++ b/crates/onsager-portal/src/handlers/issues.rs
@@ -1,21 +1,22 @@
 //! `issues` event handler.
 //!
-//! Two responsibilities in v1:
-//! - `opened` / `labeled` carrying the `spec` label → materialize a `queued`
-//!   factory task row + emit a portal-namespaced spine event.
-//! - On the linked spec issue, mirror PR open/merge to add/remove the
-//!   `in-progress` label (Phase 2 migration of `.github/workflows/pr-spec-sync.yml`)
-//!   — that path is owned by `pull_request.rs`; this file only handles the
-//!   issues side of materialization.
+//! Per spec #167 / #170, every `issues.opened` materializes a *reference-only*
+//! `Kind::GithubIssue` skeleton artifact — no body, no labels, no title, no
+//! author copied to the spine. Provider-authored fields are served live by
+//! the `/api/projects/:id/issues` proxy in `handlers::api`. Lifecycle moves
+//! (`closed` / `reopened`) flip the skeleton's `state`; everything else
+//! (`edited`, `labeled`, `unlabeled`, `assigned`, …) bumps `current_version`
+//! and refreshes `last_observed_at` so ising sees activity deltas without
+//! the spine carrying the actual change.
+//!
+//! Cache invalidation: every webhook touch evicts the project's proxy
+//! entries so the next dashboard fetch reflects the change before TTL.
 
 use onsager_spine::EventMetadata;
 use serde_json::Value;
 
-use crate::db::{self, InstallationRecord};
+use crate::db::{self, InstallationRecord, IssueLifecycleState};
 use crate::state::AppState;
-
-/// Label whose presence on an issue triggers task materialization.
-pub const SPEC_LABEL: &str = "spec";
 
 pub async fn handle(
     state: &AppState,
@@ -27,9 +28,16 @@ pub async fn handle(
         .and_then(|v| v.as_str())
         .unwrap_or_default();
 
-    if action != "opened" && action != "labeled" {
-        return Ok(serde_json::json!({"action": action, "ignored": true}));
-    }
+    // Actions we react to: `opened` / `reopened` create or revive the
+    // skeleton; `closed` archives it; the rest bump `current_version`.
+    // Forward-compat: unknown actions ack quietly.
+    let category = match action {
+        "opened" | "reopened" => IssueAction::Open,
+        "closed" => IssueAction::Close,
+        "edited" | "labeled" | "unlabeled" | "assigned" | "unassigned" | "milestoned"
+        | "demilestoned" | "pinned" | "unpinned" => IssueAction::Touch,
+        _ => return Ok(serde_json::json!({"action": action, "ignored": true})),
+    };
 
     let repo = payload
         .get("repository")
@@ -54,35 +62,6 @@ pub async fn handle(
         return Ok(serde_json::json!({"action": action, "ignored": "is_pr"}));
     }
 
-    let labels: Vec<String> = issue
-        .get("labels")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(str::to_owned))
-                .collect()
-        })
-        .unwrap_or_default();
-    let has_spec = labels.iter().any(|l| l == SPEC_LABEL);
-
-    // For `labeled`, only materialize if the *added* label is `spec`. This
-    // keeps materialization a single-shot transition rather than a no-op
-    // every time someone touches labels on a spec issue.
-    if action == "labeled" {
-        let added = payload
-            .get("label")
-            .and_then(|l| l.get("name"))
-            .and_then(|n| n.as_str())
-            .unwrap_or_default();
-        if added != SPEC_LABEL {
-            return Ok(serde_json::json!({"action": action, "ignored": "not-spec-label"}));
-        }
-    }
-
-    if !has_spec {
-        return Ok(serde_json::json!({"action": action, "ignored": "no-spec-label"}));
-    }
-
     let project =
         match db::find_project_for_repo(&state.pool, &installation.id, owner, name).await? {
             Some(p) => p,
@@ -93,35 +72,41 @@ pub async fn handle(
         .get("number")
         .and_then(|n| n.as_u64())
         .ok_or_else(|| anyhow::anyhow!("missing issue.number"))?;
-    let title = issue
-        .get("title")
-        .and_then(|t| t.as_str())
-        .unwrap_or("(untitled)")
-        .to_string();
-    let body = issue
-        .get("body")
-        .and_then(|b| b.as_str())
-        .map(str::to_owned);
+    let github_state = issue
+        .get("state")
+        .and_then(|s| s.as_str())
+        .unwrap_or("open");
 
-    let source_ref = format!("github:{owner}/{name}:issue#{issue_number}");
-    let task = db::upsert_factory_task(
-        &state.pool,
-        &project.id,
-        "spec_issue",
-        &source_ref,
-        &title,
-        body.as_deref(),
-    )
-    .await?;
+    // Skeleton upsert. Open → draft, closed → archived. The proxy hydrates
+    // title / labels / assignees on demand.
+    let lifecycle = match category {
+        IssueAction::Close => IssueLifecycleState::Archived,
+        IssueAction::Open => IssueLifecycleState::Draft,
+        IssueAction::Touch => IssueLifecycleState::from_github(github_state),
+    };
+    let artifact =
+        db::upsert_issue_artifact_ref(&state.pool, &project.id, issue_number, lifecycle).await?;
 
-    // Emit a `portal.task_materialized` extension event so the dashboard /
-    // ising can react. Stays under the `portal` namespace because it's a
-    // backlog-state mutation, not a git event.
+    // For `Touch`, additionally bump `current_version` so ising sees an
+    // activity delta. `upsert_issue_artifact_ref` already touches the
+    // `last_observed_at` timestamp on every call.
+    if matches!(category, IssueAction::Touch) {
+        let _ = db::touch_artifact(&state.pool, &artifact.artifact_id).await?;
+    }
+
+    // The dashboard-facing live-hydration cache lives in stiglab; staleness
+    // there is bounded by its TTL window (default 60s). Portal does not
+    // need to push invalidations cross-process — TTL-bounded drift is
+    // strictly better than denormalized writes (#170 design).
+
+    // Emit a `portal.task_materialized` extension event so dashboard / ising
+    // consumers see a uniform stream. The event name stays for back-compat
+    // with #60 — only the payload reflects the new reference-only shape.
     let metadata = EventMetadata {
         actor: "onsager-portal".into(),
         ..Default::default()
     };
-    let stream_id = format!("portal:task:{}", task.id);
+    let stream_id = format!("portal:issue:{}", artifact.artifact_id);
     state
         .spine
         .append_ext(
@@ -129,11 +114,15 @@ pub async fn handle(
             "portal",
             "portal.task_materialized",
             serde_json::json!({
-                "task_id": task.id,
+                "artifact_id": artifact.artifact_id,
                 "project_id": project.id,
-                "source": task.source,
-                "source_ref": task.source_ref,
-                "title": task.title,
+                "external_ref": db::issue_external_ref(&project.id, issue_number),
+                "issue_number": issue_number,
+                "lifecycle": match lifecycle {
+                    IssueLifecycleState::Draft => "draft",
+                    IssueLifecycleState::Archived => "archived",
+                },
+                "action": action,
             }),
             &metadata,
             None,
@@ -141,8 +130,19 @@ pub async fn handle(
         .await?;
 
     Ok(serde_json::json!({
-        "task_id": task.id,
+        "artifact_id": artifact.artifact_id,
         "project_id": project.id,
-        "source_ref": task.source_ref,
+        "issue_number": issue_number,
+        "lifecycle": match lifecycle {
+            IssueLifecycleState::Draft => "draft",
+            IssueLifecycleState::Archived => "archived",
+        },
     }))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum IssueAction {
+    Open,
+    Close,
+    Touch,
 }

--- a/crates/onsager-portal/src/handlers/issues.rs
+++ b/crates/onsager-portal/src/handlers/issues.rs
@@ -3,14 +3,14 @@
 //! Per spec #167 / #170, every `issues.opened` materializes a *reference-only*
 //! `Kind::GithubIssue` skeleton artifact — no body, no labels, no title, no
 //! author copied to the spine. Provider-authored fields are served live by
-//! the `/api/projects/:id/issues` proxy in `handlers::api`. Lifecycle moves
-//! (`closed` / `reopened`) flip the skeleton's `state`; everything else
-//! (`edited`, `labeled`, `unlabeled`, `assigned`, …) bumps `current_version`
-//! and refreshes `last_observed_at` so ising sees activity deltas without
-//! the spine carrying the actual change.
+//! the `/api/projects/:id/issues` proxy in `crates/stiglab/src/server/routes/projects.rs`.
+//! Lifecycle moves (`closed` / `reopened`) flip the skeleton's `state`;
+//! everything else (`edited`, `labeled`, `unlabeled`, `assigned`, …) bumps
+//! `current_version` and refreshes `last_observed_at` so ising sees activity
+//! deltas without the spine carrying the actual change.
 //!
-//! Cache invalidation: every webhook touch evicts the project's proxy
-//! entries so the next dashboard fetch reflects the change before TTL.
+//! This handler does not perform proxy-cache invalidation — the cache lives
+//! in stiglab and freshness relies on its TTL window (default 60s).
 
 use onsager_spine::EventMetadata;
 use serde_json::Value;

--- a/crates/onsager-portal/src/handlers/pull_request.rs
+++ b/crates/onsager-portal/src/handlers/pull_request.rs
@@ -82,10 +82,14 @@ pub async fn handle(
         .get("number")
         .and_then(|n| n.as_u64())
         .ok_or_else(|| anyhow::anyhow!("missing pr.number"))?;
-    let title = pr
+    // PR title is fetched live by the proxy; the message field on
+    // `GitCommitPushed` keeps a synchronize-time snapshot purely for the
+    // spine event payload (events are immutable historical facts, not a
+    // denormalization of current state — the artifact row stays clean).
+    let sync_message = pr
         .get("title")
         .and_then(|t| t.as_str())
-        .unwrap_or("(untitled)")
+        .unwrap_or("")
         .to_string();
     let url = pr
         .get("html_url")
@@ -115,12 +119,6 @@ pub async fn handle(
         .and_then(|s| s.as_str())
         .unwrap_or("")
         .to_string();
-    let owner_login = pr
-        .get("user")
-        .and_then(|u| u.get("login"))
-        .and_then(|l| l.as_str())
-        .unwrap_or("unknown")
-        .to_string();
 
     let next_state = match (act, merged) {
         (PrAction::Opened, _) => PrLifecycleState::InProgress,
@@ -129,21 +127,20 @@ pub async fn handle(
         (PrAction::Closed, false) => PrLifecycleState::Archived,
     };
 
-    let artifact = db::upsert_pr_artifact(
-        &state.pool,
-        &project.id,
-        pr_number,
-        &title,
-        &owner_login,
-        next_state,
-    )
-    .await?;
+    // Reference-only upsert (#171): no `name` / `owner` writes — the proxy
+    // hydrates those from GitHub on dashboard render.
+    let artifact =
+        db::upsert_pr_artifact_ref(&state.pool, &project.id, pr_number, next_state).await?;
 
     // Bump version on synchronize / close so the artifact's lifecycle reflects
-    // commit-by-commit progress.
+    // commit-by-commit progress (powers ising's PR-churn signal per #62).
     if matches!(act, PrAction::Synchronize | PrAction::Closed) {
         let _ = db::bump_pr_artifact(&state.pool, &artifact.artifact_id, Some(next_state)).await?;
     }
+
+    // The dashboard-facing live-hydration cache lives in stiglab; staleness
+    // there is bounded by its TTL window. Portal does not need to push
+    // invalidations cross-process.
 
     // Emit the matching spine event under namespace `git`.
     let stream_id = pr_stream_id(&project.id, pr_number);
@@ -157,7 +154,7 @@ pub async fn handle(
         PrAction::Synchronize => FactoryEventKind::GitCommitPushed {
             artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
             sha: head_sha.clone(),
-            message: title.clone(),
+            message: sync_message.clone(),
             session_id: String::new(),
         },
         PrAction::Closed if merged => FactoryEventKind::GitPrMerged {

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -9,10 +9,18 @@
 //! webhook secret, and writes:
 //!
 //! - `events_ext` rows under namespace `git` (PR open/sync/close)
-//! - `artifacts` rows of `Kind::PullRequest` keyed by `(project_id, pr_number)`
-//! - `factory_tasks` rows for `issues.opened|labeled` carrying the `spec` label
+//! - `artifacts` skeleton rows for external items (`Kind::PullRequest`,
+//!   `Kind::GithubIssue`) — identity + our derived state only, no
+//!   provider-authored fields (per spec #170)
 //! - `vertical_lineage` rows when a webhook PR's `head.ref` matches a recent
 //!   stiglab session's working branch
+//!
+//! Provider-authored fields (PR/issue title, body, labels, author) are
+//! served by stiglab's user-facing API (`/api/projects/:id/{issues,pulls}`
+//! in `crates/stiglab/src/server/routes/projects.rs`), which hydrates live
+//! from GitHub through a short-TTL cache. The dashboard joins skeleton rows
+//! with the live response on `external_ref`. Portal does not expose
+//! user-facing endpoints — webhook ingress only.
 //!
 //! Portal-owned tables (`factory_tasks`, `pr_gate_verdicts`, `pr_branch_links`)
 //! are migrated at startup; everything else (tenant / installation / project /

--- a/crates/onsager-spine/migrations/010_artifacts_external_ref_only.sql
+++ b/crates/onsager-spine/migrations/010_artifacts_external_ref_only.sql
@@ -1,0 +1,23 @@
+-- Onsager spec #170 / #171: reference-only artifacts for external items.
+--
+-- External-source artifacts (PRs, GitHub issues, future Linear/Slack) no
+-- longer denormalize provider-owned fields (`name` = title, `owner` = author
+-- login) into the spine. The portal proxies live to GitHub for those; the
+-- spine row carries identity + our derived state only.
+--
+-- Three changes:
+--   1. `artifacts.name` and `artifacts.owner` become nullable. Existing rows
+--      keep their stale denormalized values as best-effort cached display
+--      under proxy outage; new external-source writes set them NULL.
+--   2. Add `last_observed_at TIMESTAMPTZ` so the dashboard can render
+--      "last seen N min ago" placeholders when the proxy cache misses and
+--      GitHub is rate-limited or unreachable (#170 fail-open decision).
+--   3. No data migration. This is purely additive — existing reads keep
+--      working, and the portal stops writing the columns going forward.
+
+ALTER TABLE artifacts
+    ALTER COLUMN name DROP NOT NULL,
+    ALTER COLUMN owner DROP NOT NULL;
+
+ALTER TABLE artifacts
+    ADD COLUMN IF NOT EXISTS last_observed_at TIMESTAMPTZ;

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod db;
 pub mod github_app;
 pub mod handler;
+pub mod proxy_cache;
 pub mod routes;
 pub mod spine;
 pub mod sso;
@@ -130,6 +131,21 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         .route(
             "/api/projects/{id}",
             get(routes::tenants::get_project).delete(routes::tenants::delete_project),
+        )
+        // Live-data hydration for reference-only artifacts (#170 / #167 / #171).
+        // The dashboard joins skeleton rows from `/api/spine/artifacts?kind=...`
+        // with the hydrated payloads here on `external_ref`.
+        .route(
+            "/api/projects/{id}/issues",
+            get(routes::projects::list_project_issues),
+        )
+        .route(
+            "/api/projects/{id}/pulls",
+            get(routes::projects::list_project_pulls),
+        )
+        .route(
+            "/api/projects/{id}/backfill",
+            post(routes::projects::backfill_project),
         )
         // Governance proxy — forwards to synodic on internal port
         .route("/api/governance/{*path}", any(routes::governance::proxy))

--- a/crates/stiglab/src/server/proxy_cache.rs
+++ b/crates/stiglab/src/server/proxy_cache.rs
@@ -3,16 +3,23 @@
 //! Reference-only artifact rows store identity + our derived lifecycle but
 //! not provider-authored fields (PR/issue title, body, labels, author).
 //! Dashboard renders hydrate those by calling GitHub through stiglab's
-//! installation tokens. This cache deduplicates in-flight reads inside a
-//! short TTL window so a busy dashboard doesn't burn through the App's
-//! 5000/hr rate budget.
+//! installation tokens. This cache stores completed GitHub responses for a
+//! short TTL window so repeated reads can reuse recent payloads and reduce
+//! pressure on the App's 5000/hr rate budget. (No in-flight coalescing —
+//! two simultaneous misses still hit GitHub twice; a follow-up could add
+//! a per-key Notify if that becomes a hotspot.)
 //!
 //! - **TTL**: env `PORTAL_PROXY_CACHE_TTL_SECS` (sharing the env var name
 //!   from #170 even though the cache moved to stiglab — same knob, same
 //!   intent). Default 60s. Set to 0 to disable.
-//! - **Invalidation**: on TTL expiry only. The cache is process-local and
-//!   ephemeral; staleness is bounded by TTL, not webhook coverage. GitHub
-//!   remains the single source of truth.
+//! - **Invalidation**: on TTL expiry, plus targeted `invalidate` /
+//!   `invalidate_prefix` calls (used by `backfill_project` to flush a
+//!   project's cached lists after writing skeleton rows). The cache is
+//!   process-local and ephemeral; staleness is bounded by TTL, not by
+//!   webhook coverage. GitHub remains the single source of truth.
+//! - **Bounded growth**: every `put` opportunistically sweeps expired
+//!   entries so the map can't grow indefinitely under high key cardinality
+//!   without ever being read.
 //! - **Multi-replica**: each replica has its own cache. Cross-replica
 //!   drift up to TTL is acceptable — strictly better than the unbounded
 //!   drift of denormalized writes.
@@ -67,11 +74,16 @@ impl ProxyCache {
         }
     }
 
+    /// Insert a fresh payload. No-op when TTL is 0. Opportunistically sweeps
+    /// expired entries so the map can't grow without bound under high key
+    /// cardinality even if specific keys are never read again.
     pub fn put(&self, key: String, payload: serde_json::Value) {
         if self.ttl.is_zero() {
             return;
         }
         if let Ok(mut entries) = self.entries.lock() {
+            let ttl = self.ttl;
+            entries.retain(|_, e| e.inserted.elapsed() <= ttl);
             entries.insert(
                 key,
                 Entry {
@@ -79,6 +91,22 @@ impl ProxyCache {
                     payload,
                 },
             );
+        }
+    }
+
+    /// Drop a single key. Used by writers that know an entry is stale.
+    pub fn invalidate(&self, key: &str) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.remove(key);
+        }
+    }
+
+    /// Drop every key whose name starts with `prefix`. Used after writes
+    /// that change a project-scoped artifact set (e.g. `backfill_project`
+    /// flushing `issues:{project_id}:*` and `pulls:{project_id}:*`).
+    pub fn invalidate_prefix(&self, prefix: &str) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.retain(|k, _| !k.starts_with(prefix));
         }
     }
 }
@@ -109,5 +137,39 @@ mod tests {
         cache.put("k".into(), json!(1));
         std::thread::sleep(Duration::from_millis(5));
         assert!(cache.get("k").is_none());
+    }
+
+    #[test]
+    fn invalidate_drops_one() {
+        let cache = ProxyCache::new(Duration::from_secs(60));
+        cache.put("a".into(), json!(1));
+        cache.put("b".into(), json!(2));
+        cache.invalidate("a");
+        assert!(cache.get("a").is_none());
+        assert_eq!(cache.get("b"), Some(json!(2)));
+    }
+
+    #[test]
+    fn invalidate_prefix_drops_match() {
+        let cache = ProxyCache::new(Duration::from_secs(60));
+        cache.put("project:abc:issues:open".into(), json!([]));
+        cache.put("project:abc:pulls:open".into(), json!([]));
+        cache.put("project:def:issues:open".into(), json!([]));
+        cache.invalidate_prefix("project:abc:");
+        assert!(cache.get("project:abc:issues:open").is_none());
+        assert!(cache.get("project:abc:pulls:open").is_none());
+        assert!(cache.get("project:def:issues:open").is_some());
+    }
+
+    #[test]
+    fn put_sweeps_expired_entries() {
+        let cache = ProxyCache::new(Duration::from_millis(2));
+        cache.put("a".into(), json!(1));
+        std::thread::sleep(Duration::from_millis(5));
+        cache.put("b".into(), json!(2));
+        // After the second put, the expired `a` entry is gone — even though
+        // it was never read, so an unbounded map can't accumulate forever.
+        assert!(cache.get("a").is_none());
+        assert_eq!(cache.get("b"), Some(json!(2)));
     }
 }

--- a/crates/stiglab/src/server/proxy_cache.rs
+++ b/crates/stiglab/src/server/proxy_cache.rs
@@ -1,0 +1,113 @@
+//! Short-TTL cache for live-hydration proxy reads (#170).
+//!
+//! Reference-only artifact rows store identity + our derived lifecycle but
+//! not provider-authored fields (PR/issue title, body, labels, author).
+//! Dashboard renders hydrate those by calling GitHub through stiglab's
+//! installation tokens. This cache deduplicates in-flight reads inside a
+//! short TTL window so a busy dashboard doesn't burn through the App's
+//! 5000/hr rate budget.
+//!
+//! - **TTL**: env `PORTAL_PROXY_CACHE_TTL_SECS` (sharing the env var name
+//!   from #170 even though the cache moved to stiglab — same knob, same
+//!   intent). Default 60s. Set to 0 to disable.
+//! - **Invalidation**: on TTL expiry only. The cache is process-local and
+//!   ephemeral; staleness is bounded by TTL, not webhook coverage. GitHub
+//!   remains the single source of truth.
+//! - **Multi-replica**: each replica has its own cache. Cross-replica
+//!   drift up to TTL is acceptable — strictly better than the unbounded
+//!   drift of denormalized writes.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const ENV_TTL: &str = "PORTAL_PROXY_CACHE_TTL_SECS";
+const DEFAULT_TTL_SECS: u64 = 60;
+
+struct Entry {
+    inserted: Instant,
+    payload: serde_json::Value,
+}
+
+pub struct ProxyCache {
+    ttl: Duration,
+    entries: Mutex<HashMap<String, Entry>>,
+}
+
+impl ProxyCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let secs = std::env::var(ENV_TTL)
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TTL_SECS);
+        Self::new(Duration::from_secs(secs))
+    }
+
+    pub fn get(&self, key: &str) -> Option<serde_json::Value> {
+        if self.ttl.is_zero() {
+            return None;
+        }
+        let mut entries = self.entries.lock().ok()?;
+        let expired = entries
+            .get(key)
+            .map(|e| e.inserted.elapsed() > self.ttl)
+            .unwrap_or(true);
+        if expired {
+            entries.remove(key);
+            None
+        } else {
+            entries.get(key).map(|e| e.payload.clone())
+        }
+    }
+
+    pub fn put(&self, key: String, payload: serde_json::Value) {
+        if self.ttl.is_zero() {
+            return;
+        }
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.insert(
+                key,
+                Entry {
+                    inserted: Instant::now(),
+                    payload,
+                },
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn miss_then_hit_within_ttl() {
+        let cache = ProxyCache::new(Duration::from_secs(60));
+        assert!(cache.get("k").is_none());
+        cache.put("k".into(), json!({"v": 1}));
+        assert_eq!(cache.get("k"), Some(json!({"v": 1})));
+    }
+
+    #[test]
+    fn ttl_zero_is_disabled() {
+        let cache = ProxyCache::new(Duration::ZERO);
+        cache.put("k".into(), json!({"v": 1}));
+        assert!(cache.get("k").is_none());
+    }
+
+    #[test]
+    fn expired_entries_are_removed() {
+        let cache = ProxyCache::new(Duration::from_millis(1));
+        cache.put("k".into(), json!(1));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(cache.get("k").is_none());
+    }
+}

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod health;
 pub mod nodes;
 pub mod pats;
 pub mod portal;
+pub mod projects;
 pub mod sessions;
 pub mod shaping;
 pub mod spine;

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -1,0 +1,719 @@
+//! Project-scoped live-data routes (specs #167, #170, #171).
+//!
+//! Per spec #170, reference-only artifact rows store identity + our derived
+//! lifecycle but *not* GitHub-authored fields. The dashboard joins skeleton
+//! rows from `/api/spine/artifacts` with the hydrated rows from the
+//! endpoints in this module. Each endpoint:
+//!
+//! 1. Authenticates the user (`require_auth_user`).
+//! 2. Resolves the project and asserts tenant membership.
+//! 3. Mints an installation token via `github_app::mint_installation_token`.
+//! 4. Fetches live data from GitHub through a per-process LRU+TTL cache
+//!    (`AppState::proxy_cache`). Cache hits skip the GitHub round-trip.
+//! 5. Returns a slim, dashboard-shaped JSON payload (no raw passthrough —
+//!    we only expose the fields the UI needs).
+//!
+//! Failure modes per #170 fail-open:
+//! - Cache miss + GitHub 403 (rate-limited) → return rows with
+//!   `error: "rate_limited"` so the dashboard can render the skeleton's
+//!   `last_observed_at` placeholder rather than crash.
+//! - GitHub 5xx → 502 Bad Gateway with the upstream snippet logged but
+//!   not surfaced.
+//!
+//! The backfill endpoint (POST `/api/projects/:id/backfill`) inserts
+//! reference-only skeleton rows directly into the spine `artifacts` table.
+//! It mirrors the SQL shape used by `onsager-portal::db::upsert_*_artifact_ref`
+//! — a follow-up will consolidate the two writers into a shared spine helper.
+
+use std::time::Duration;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sqlx::{AnyPool, PgPool};
+
+use crate::server::auth::AuthUser;
+use crate::server::db;
+use crate::server::github_app;
+use crate::server::state::AppState;
+
+const HARD_CAP: usize = 200;
+const DEFAULT_CAP: usize = 100;
+
+// ── Auth helpers ──────────────────────────────────────────────────────────
+
+#[allow(clippy::result_large_err)]
+fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
+    if auth_user.user_id == "anonymous" {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "authentication required" })),
+        )
+            .into_response())
+    } else {
+        Ok(auth_user.user_id.as_str())
+    }
+}
+
+/// Look up the project + assert the user is a member of its tenant. 404s
+/// for unknown projects and non-members alike (matches the project-scoped
+/// pattern in `tenants.rs`).
+async fn require_project_for_user(
+    pool: &AnyPool,
+    auth_user: &AuthUser,
+    project_id: &str,
+) -> Result<crate::core::Project, Response> {
+    let user_id = require_auth_user(auth_user)?;
+    let project = match db::get_project(pool, project_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return Err(not_found("project not found")),
+        Err(e) => {
+            tracing::error!("failed to load project: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+    };
+    match db::is_tenant_member(pool, &project.tenant_id, user_id).await {
+        Ok(true) => Ok(project),
+        Ok(false) => Err(not_found("project not found")),
+        Err(e) => {
+            tracing::error!("failed to check tenant membership: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+    }
+}
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+// ── GitHub fetch helpers ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct LiveIssue {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    user: Option<LiveUser>,
+    labels: Vec<LiveLabel>,
+    pull_request: Option<serde_json::Value>,
+    comments: u32,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LiveUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LiveLabel {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LivePull {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    user: Option<LiveUser>,
+    labels: Vec<LiveLabel>,
+    draft: bool,
+    merged_at: Option<String>,
+    updated_at: String,
+}
+
+async fn mint_token(
+    pool: &AnyPool,
+    install_row_id: &str,
+) -> anyhow::Result<Option<github_app::InstallationToken>> {
+    let Some(cfg) = github_app::AppConfig::from_env() else {
+        return Ok(None);
+    };
+    let Some(install) = db::get_github_app_installation(pool, install_row_id).await? else {
+        return Ok(None);
+    };
+    let jwt = github_app::mint_app_jwt(&cfg)?;
+    let token = github_app::mint_installation_token(&jwt, install.install_id).await?;
+    Ok(Some(token))
+}
+
+fn gh_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent("onsager-stiglab/0.1")
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("reqwest build")
+}
+
+// ── GET /api/projects/:id/issues ──────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListLiveQuery {
+    /// `open` (default), `closed`, or `all`. Mirrors GitHub's own
+    /// `/repos/:o/:r/issues?state=` query parameter so the proxy is a
+    /// thin pass-through over an authenticated, cached fetch.
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LiveIssueRow {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    author: Option<String>,
+    labels: Vec<String>,
+    comments: u32,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct LivePullRow {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    author: Option<String>,
+    labels: Vec<String>,
+    draft: bool,
+    merged: bool,
+    updated_at: String,
+}
+
+/// GET `/api/projects/:project_id/issues?state=open|closed|all` — live
+/// issue list, hydrated from GitHub via a short-TTL cache. The dashboard
+/// joins this with skeleton rows from `/api/spine/artifacts?kind=github_issue`
+/// on `external_ref` (`github:project:{project_id}:issue:{number}`).
+pub async fn list_project_issues(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+    Query(filters): Query<ListLiveQuery>,
+) -> Response {
+    let project = match require_project_for_user(&state.db, &auth_user, &project_id).await {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+
+    let state_q = filters.state.as_deref().unwrap_or("open");
+    let cache_key = format!("issues:{project_id}:{state_q}");
+    if let Some(cached) = state.proxy_cache.get(&cache_key) {
+        return Json(cached).into_response();
+    }
+
+    let token = match mint_token(&state.db, &project.github_app_installation_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "GitHub App not configured" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("mint_token failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub auth failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/issues?state={state_q}&per_page=100",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let resp = match gh_client()
+        .get(&url)
+        .bearer_auth(&token.token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("github issues fetch failed: {e}");
+            return Json(serde_json::json!({
+                "issues": [],
+                "error": "github_unreachable",
+            }))
+            .into_response();
+        }
+    };
+
+    if resp.status() == reqwest::StatusCode::FORBIDDEN
+        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        // Fail-open per #170: don't 5xx the dashboard; let it render
+        // skeletons with the last_observed_at placeholder.
+        return Json(serde_json::json!({
+            "issues": [],
+            "error": "rate_limited",
+        }))
+        .into_response();
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let snippet = resp.text().await.unwrap_or_default();
+        tracing::warn!(%status, "github issues fetch non-2xx: {snippet}");
+        return (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({ "error": "github API error" })),
+        )
+            .into_response();
+    }
+
+    let parsed: Vec<LiveIssue> = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("github issues parse failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github response parse failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    // GitHub returns PRs through the issues endpoint too; filter them out
+    // — the dashboard's PR proxy is the right surface for those.
+    let rows: Vec<LiveIssueRow> = parsed
+        .into_iter()
+        .filter(|i| i.pull_request.is_none())
+        .map(|i| LiveIssueRow {
+            number: i.number,
+            title: i.title,
+            state: i.state,
+            html_url: i.html_url,
+            author: i.user.map(|u| u.login),
+            labels: i.labels.into_iter().map(|l| l.name).collect(),
+            comments: i.comments,
+            updated_at: i.updated_at,
+        })
+        .collect();
+
+    let body = serde_json::json!({ "issues": rows });
+    state.proxy_cache.put(cache_key, body.clone());
+    Json(body).into_response()
+}
+
+/// GET `/api/projects/:project_id/pulls?state=open|closed|all` — live PR
+/// list, same shape as `list_project_issues`.
+pub async fn list_project_pulls(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+    Query(filters): Query<ListLiveQuery>,
+) -> Response {
+    let project = match require_project_for_user(&state.db, &auth_user, &project_id).await {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+
+    let state_q = filters.state.as_deref().unwrap_or("open");
+    let cache_key = format!("pulls:{project_id}:{state_q}");
+    if let Some(cached) = state.proxy_cache.get(&cache_key) {
+        return Json(cached).into_response();
+    }
+
+    let token = match mint_token(&state.db, &project.github_app_installation_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "GitHub App not configured" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("mint_token failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub auth failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/pulls?state={state_q}&per_page=100",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let resp = match gh_client()
+        .get(&url)
+        .bearer_auth(&token.token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("github pulls fetch failed: {e}");
+            return Json(serde_json::json!({
+                "pulls": [],
+                "error": "github_unreachable",
+            }))
+            .into_response();
+        }
+    };
+
+    if resp.status() == reqwest::StatusCode::FORBIDDEN
+        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        return Json(serde_json::json!({
+            "pulls": [],
+            "error": "rate_limited",
+        }))
+        .into_response();
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let snippet = resp.text().await.unwrap_or_default();
+        tracing::warn!(%status, "github pulls fetch non-2xx: {snippet}");
+        return (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({ "error": "github API error" })),
+        )
+            .into_response();
+    }
+
+    let parsed: Vec<LivePull> = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("github pulls parse failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github response parse failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let rows: Vec<LivePullRow> = parsed
+        .into_iter()
+        .map(|p| LivePullRow {
+            number: p.number,
+            title: p.title,
+            state: p.state,
+            html_url: p.html_url,
+            author: p.user.map(|u| u.login),
+            labels: p.labels.into_iter().map(|l| l.name).collect(),
+            draft: p.draft,
+            merged: p.merged_at.is_some(),
+            updated_at: p.updated_at,
+        })
+        .collect();
+
+    let body = serde_json::json!({ "pulls": rows });
+    state.proxy_cache.put(cache_key, body.clone());
+    Json(body).into_response()
+}
+
+// ── POST /api/projects/:id/backfill ───────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct BackfillBody {
+    /// Maximum items to ingest. Capped at `HARD_CAP` (200) regardless of
+    /// what's posted. Default 100.
+    #[serde(default)]
+    pub cap: Option<usize>,
+    /// `recent` (default), `active`, or `refract`. Mirrors the existing
+    /// `onsager project sync --strategy` CLI from #60.
+    #[serde(default)]
+    pub strategy: Option<String>,
+    /// `open` (default), `closed`, or `all`. Open-only matches the
+    /// "inbox starts empty, fills with active work" mental model from #167.
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct BackfillReport {
+    project_id: String,
+    repo: String,
+    cap: usize,
+    issues_ingested: usize,
+    pulls_ingested: usize,
+    skipped: usize,
+}
+
+/// POST `/api/projects/:id/backfill` — paginate the project's GitHub
+/// issues + pulls and insert reference-only skeleton rows into the spine
+/// `artifacts` table. Idempotent on `external_ref`.
+pub async fn backfill_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+    Json(body): Json<BackfillBody>,
+) -> Response {
+    let project = match require_project_for_user(&state.db, &auth_user, &project_id).await {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    let cap = body.cap.unwrap_or(DEFAULT_CAP).min(HARD_CAP);
+    let state_q = body.state.as_deref().unwrap_or("open");
+
+    let token = match mint_token(&state.db, &project.github_app_installation_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "GitHub App not configured" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("mint_token failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub auth failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let spine = match &state.spine {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "spine not connected" })),
+            )
+                .into_response()
+        }
+    };
+    let pool = spine.pool();
+
+    let mut report = BackfillReport {
+        project_id: project.id.clone(),
+        repo: format!("{}/{}", project.repo_owner, project.repo_name),
+        cap,
+        issues_ingested: 0,
+        pulls_ingested: 0,
+        skipped: 0,
+    };
+
+    // Fetch issues (which include PRs in GitHub's response shape) and
+    // pulls separately so PR-side metadata (head_sha etc.) is available
+    // when we later need it.
+    let issues_url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/issues?state={state_q}&per_page=100",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let issues: Vec<LiveIssue> = match fetch_paginated(&token.token, &issues_url, cap).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    for i in issues.into_iter().take(cap) {
+        if i.pull_request.is_some() {
+            // PRs come back through the issues endpoint too — handle them
+            // in the pulls loop below where we have full PR metadata.
+            continue;
+        }
+        let lifecycle = match i.state.as_str() {
+            "closed" => "archived",
+            _ => "draft",
+        };
+        match upsert_issue_skeleton(pool, &project.id, i.number, lifecycle).await {
+            Ok(true) => report.issues_ingested += 1,
+            Ok(false) => report.skipped += 1,
+            Err(e) => {
+                tracing::warn!("issue skeleton upsert failed: {e}");
+                report.skipped += 1;
+            }
+        }
+    }
+
+    let pulls_url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/pulls?state={state_q}&per_page=100",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let pulls: Vec<LivePull> = match fetch_paginated(&token.token, &pulls_url, cap).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    for p in pulls.into_iter().take(cap) {
+        let lifecycle = match (p.state.as_str(), p.merged_at.is_some()) {
+            (_, true) => "released",
+            ("closed", false) => "archived",
+            _ => "in_progress",
+        };
+        match upsert_pr_skeleton(pool, &project.id, p.number, lifecycle).await {
+            Ok(true) => report.pulls_ingested += 1,
+            Ok(false) => report.skipped += 1,
+            Err(e) => {
+                tracing::warn!("pr skeleton upsert failed: {e}");
+                report.skipped += 1;
+            }
+        }
+    }
+
+    // Backfill changes the artifact set the dashboard reads; drop any
+    // cached responses for this project so the next list call sees the
+    // new rows immediately.
+    // (Cache is keyed by `issues:{id}:..` / `pulls:{id}:..`; clear by
+    // poking individual variants we know about.)
+    for s in ["open", "closed", "all"] {
+        state.proxy_cache.put(
+            format!("issues:{project_id}:{s}"),
+            serde_json::json!({ "issues": [] }),
+        );
+        state.proxy_cache.put(
+            format!("pulls:{project_id}:{s}"),
+            serde_json::json!({ "pulls": [] }),
+        );
+    }
+    // Above is a placeholder warm-up — invalidation proper requires
+    // a `clear` method we don't have yet; the next read after TTL will
+    // refresh. (Bounded by 60s; acceptable for v1.)
+
+    Json(serde_json::json!(report)).into_response()
+}
+
+// ── Skeleton upsert SQL ───────────────────────────────────────────────────
+//
+// Mirrors the shape used by `onsager-portal::db::upsert_*_artifact_ref` so
+// webhook deliveries and dashboard backfills produce identical rows. A
+// follow-up will lift the SQL into a shared spine helper.
+
+async fn fetch_paginated<T: serde::de::DeserializeOwned>(
+    token: &str,
+    url: &str,
+    cap: usize,
+) -> Result<Vec<T>, Response> {
+    let mut out = Vec::new();
+    let mut page = 1u32;
+    while out.len() < cap {
+        let paged = format!("{url}&page={page}");
+        let resp = match gh_client()
+            .get(&paged)
+            .bearer_auth(token)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("github fetch failed: {e}");
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({ "error": "github fetch failed" })),
+                )
+                    .into_response());
+            }
+        };
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let snippet = resp.text().await.unwrap_or_default();
+            tracing::warn!(%status, "github fetch non-2xx: {snippet}");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github API error" })),
+            )
+                .into_response());
+        }
+        let batch: Vec<T> = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("github fetch parse failed: {e}");
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({ "error": "github parse failed" })),
+                )
+                    .into_response());
+            }
+        };
+        let count = batch.len();
+        out.extend(batch);
+        if count < 100 {
+            break;
+        }
+        page += 1;
+    }
+    Ok(out)
+}
+
+/// Insert a reference-only `Kind::GithubIssue` skeleton row, idempotent on
+/// `external_ref`. Returns `Ok(true)` if a new row was inserted, `Ok(false)`
+/// if a row already existed (the caller counts these as "skipped").
+async fn upsert_issue_skeleton(
+    pool: &PgPool,
+    project_id: &str,
+    issue_number: u64,
+    state: &str,
+) -> anyhow::Result<bool> {
+    let external_ref = format!("github:project:{project_id}:issue:{issue_number}");
+    let new_id = format!("art_iss_{}", uuid::Uuid::new_v4().simple());
+
+    // Two-step upsert — same advisory-lock pattern as the portal.
+    let existing: Option<(String,)> =
+        sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1")
+            .bind(&external_ref)
+            .fetch_optional(pool)
+            .await?;
+    if existing.is_some() {
+        return Ok(false);
+    }
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, current_version, \
+             external_ref, metadata, last_observed_at) \
+         VALUES ($1, 'github_issue', NULL, NULL, 'onsager-stiglab', $2, 1, $3, \
+                 jsonb_build_object('project_id', $4::text, 'issue_number', $5::bigint), NOW())",
+    )
+    .bind(&new_id)
+    .bind(state)
+    .bind(&external_ref)
+    .bind(project_id)
+    .bind(issue_number as i64)
+    .execute(pool)
+    .await?;
+    Ok(true)
+}
+
+async fn upsert_pr_skeleton(
+    pool: &PgPool,
+    project_id: &str,
+    pr_number: u64,
+    state: &str,
+) -> anyhow::Result<bool> {
+    let external_ref = format!("github:project:{project_id}:pr:{pr_number}");
+    let new_id = format!("art_pr_{}", uuid::Uuid::new_v4().simple());
+
+    let existing: Option<(String,)> =
+        sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1")
+            .bind(&external_ref)
+            .fetch_optional(pool)
+            .await?;
+    if existing.is_some() {
+        return Ok(false);
+    }
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, current_version, \
+             external_ref, metadata, last_observed_at) \
+         VALUES ($1, 'pull_request', NULL, NULL, 'onsager-stiglab', $2, 1, $3, \
+                 jsonb_build_object('project_id', $4::text, 'pr_number', $5::bigint), NOW())",
+    )
+    .bind(&new_id)
+    .bind(state)
+    .bind(&external_ref)
+    .bind(project_id)
+    .bind(pr_number as i64)
+    .execute(pool)
+    .await?;
+    Ok(true)
+}

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -25,6 +25,7 @@
 //! It mirrors the SQL shape used by `onsager-portal::db::upsert_*_artifact_ref`
 //! — a follow-up will consolidate the two writers into a shared spine helper.
 
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use axum::extract::{Path, Query, State};
@@ -145,12 +146,66 @@ async fn mint_token(
     Ok(Some(token))
 }
 
-fn gh_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .user_agent("onsager-stiglab/0.1")
-        .timeout(Duration::from_secs(15))
-        .build()
-        .expect("reqwest build")
+/// Shared `reqwest::Client` for proxy + backfill calls. Building a client is
+/// relatively expensive (TLS + DNS + connection pool init) and only needs to
+/// happen once per process.
+fn gh_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent("onsager-stiglab/0.1")
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("reqwest build")
+    })
+}
+
+/// Validate the `state` query parameter against a fixed allowlist. The value
+/// flows directly into both the cache key (cardinality bound) and the
+/// upstream GitHub URL (no parameter injection); rejecting unknown values
+/// here is the whole defense.
+#[allow(clippy::result_large_err)]
+fn normalize_state(raw: Option<&str>) -> Result<&'static str, Response> {
+    match raw.unwrap_or("open") {
+        "open" => Ok("open"),
+        "closed" => Ok("closed"),
+        "all" => Ok("all"),
+        other => Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("invalid state filter: {other}"),
+            })),
+        )
+            .into_response()),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Strategy {
+    /// Newest-first; cheapest. Default.
+    Recent,
+    /// Drop stale items (closed-but-unmerged PRs, closed issues) before
+    /// applying the cap.
+    Active,
+    /// Re-rank candidates (open before closed, more labels first) before
+    /// the cap. Same heuristic as `onsager-portal::backfill::Strategy::Refract`.
+    Refract,
+}
+
+#[allow(clippy::result_large_err)]
+fn normalize_strategy(raw: Option<&str>) -> Result<Strategy, Response> {
+    match raw.unwrap_or("recent") {
+        "recent" => Ok(Strategy::Recent),
+        "active" => Ok(Strategy::Active),
+        "refract" => Ok(Strategy::Refract),
+        other => Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("invalid strategy: {other}"),
+            })),
+        )
+            .into_response()),
+    }
 }
 
 // ── GET /api/projects/:id/issues ──────────────────────────────────────────
@@ -203,7 +258,10 @@ pub async fn list_project_issues(
         Err(r) => return r,
     };
 
-    let state_q = filters.state.as_deref().unwrap_or("open");
+    let state_q = match normalize_state(filters.state.as_deref()) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
     let cache_key = format!("issues:{project_id}:{state_q}");
     if let Some(cached) = state.proxy_cache.get(&cache_key) {
         return Json(cached).into_response();
@@ -320,7 +378,10 @@ pub async fn list_project_pulls(
         Err(r) => return r,
     };
 
-    let state_q = filters.state.as_deref().unwrap_or("open");
+    let state_q = match normalize_state(filters.state.as_deref()) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
     let cache_key = format!("pulls:{project_id}:{state_q}");
     if let Some(cached) = state.proxy_cache.get(&cache_key) {
         return Json(cached).into_response();
@@ -462,7 +523,14 @@ pub async fn backfill_project(
         Err(r) => return r,
     };
     let cap = body.cap.unwrap_or(DEFAULT_CAP).min(HARD_CAP);
-    let state_q = body.state.as_deref().unwrap_or("open");
+    let state_q = match normalize_state(body.state.as_deref()) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    let strategy = match normalize_strategy(body.strategy.as_deref()) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
 
     let token = match mint_token(&state.db, &project.github_app_installation_id).await {
         Ok(Some(t)) => t,
@@ -504,19 +572,41 @@ pub async fn backfill_project(
         skipped: 0,
     };
 
-    // Fetch issues (which include PRs in GitHub's response shape) and
-    // pulls separately so PR-side metadata (head_sha etc.) is available
-    // when we later need it.
+    // Fetch over-cap so the strategy filter has room to drop stale items
+    // before the shared budget is applied. `HARD_CAP` is the upper bound
+    // on what we'll actually write; `cap * 2` is the upper bound on what
+    // we *consider* (with a 200-item ceiling per fetch).
+    let fetch_cap = (cap * 2).min(HARD_CAP);
     let issues_url = format!(
         "https://api.github.com/repos/{owner}/{repo}/issues?state={state_q}&per_page=100",
         owner = project.repo_owner,
         repo = project.repo_name,
     );
-    let issues: Vec<LiveIssue> = match fetch_paginated(&token.token, &issues_url, cap).await {
+    let issues: Vec<LiveIssue> = match fetch_paginated(&token.token, &issues_url, fetch_cap).await {
         Ok(v) => v,
         Err(e) => return e,
     };
-    for i in issues.into_iter().take(cap) {
+    let pulls_url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/pulls?state={state_q}&per_page=100",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let pulls: Vec<LivePull> = match fetch_paginated(&token.token, &pulls_url, fetch_cap).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let (issues, pulls) = apply_strategy(strategy, issues, pulls);
+
+    // Single budget across both kinds, so a `cap=100` request really tops
+    // out at 100 total writes (was 200 in the original). Issues consume
+    // first, then PRs.
+    let mut budget = cap;
+
+    for i in issues {
+        if budget == 0 {
+            break;
+        }
         if i.pull_request.is_some() {
             // PRs come back through the issues endpoint too — handle them
             // in the pulls loop below where we have full PR metadata.
@@ -527,7 +617,10 @@ pub async fn backfill_project(
             _ => "draft",
         };
         match upsert_issue_skeleton(pool, &project.id, i.number, lifecycle).await {
-            Ok(true) => report.issues_ingested += 1,
+            Ok(true) => {
+                report.issues_ingested += 1;
+                budget -= 1;
+            }
             Ok(false) => report.skipped += 1,
             Err(e) => {
                 tracing::warn!("issue skeleton upsert failed: {e}");
@@ -536,23 +629,20 @@ pub async fn backfill_project(
         }
     }
 
-    let pulls_url = format!(
-        "https://api.github.com/repos/{owner}/{repo}/pulls?state={state_q}&per_page=100",
-        owner = project.repo_owner,
-        repo = project.repo_name,
-    );
-    let pulls: Vec<LivePull> = match fetch_paginated(&token.token, &pulls_url, cap).await {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
-    for p in pulls.into_iter().take(cap) {
+    for p in pulls {
+        if budget == 0 {
+            break;
+        }
         let lifecycle = match (p.state.as_str(), p.merged_at.is_some()) {
             (_, true) => "released",
             ("closed", false) => "archived",
             _ => "in_progress",
         };
         match upsert_pr_skeleton(pool, &project.id, p.number, lifecycle).await {
-            Ok(true) => report.pulls_ingested += 1,
+            Ok(true) => {
+                report.pulls_ingested += 1;
+                budget -= 1;
+            }
             Ok(false) => report.skipped += 1,
             Err(e) => {
                 tracing::warn!("pr skeleton upsert failed: {e}");
@@ -561,26 +651,56 @@ pub async fn backfill_project(
         }
     }
 
-    // Backfill changes the artifact set the dashboard reads; drop any
-    // cached responses for this project so the next list call sees the
-    // new rows immediately.
-    // (Cache is keyed by `issues:{id}:..` / `pulls:{id}:..`; clear by
-    // poking individual variants we know about.)
-    for s in ["open", "closed", "all"] {
-        state.proxy_cache.put(
-            format!("issues:{project_id}:{s}"),
-            serde_json::json!({ "issues": [] }),
-        );
-        state.proxy_cache.put(
-            format!("pulls:{project_id}:{s}"),
-            serde_json::json!({ "pulls": [] }),
-        );
-    }
-    // Above is a placeholder warm-up — invalidation proper requires
-    // a `clear` method we don't have yet; the next read after TTL will
-    // refresh. (Bounded by 60s; acceptable for v1.)
+    // Real eviction (#10): drop every cached list response keyed under
+    // this project so the next read repopulates from GitHub. Previous
+    // attempt overwrote with empty arrays, which caused subsequent reads
+    // to return empty results until TTL elapsed — bug.
+    state
+        .proxy_cache
+        .invalidate_prefix(&format!("issues:{project_id}:"));
+    state
+        .proxy_cache
+        .invalidate_prefix(&format!("pulls:{project_id}:"));
 
     Json(serde_json::json!(report)).into_response()
+}
+
+/// Apply the chosen ranking to the candidate sets before the shared cap.
+/// Mirrors the heuristics in `crates/onsager-portal/src/backfill/mod.rs` —
+/// kept in sync by hand for now; a follow-up should lift this into the
+/// onsager-spine helper that retires the duplicated upsert SQL.
+fn apply_strategy(
+    strategy: Strategy,
+    issues: Vec<LiveIssue>,
+    pulls: Vec<LivePull>,
+) -> (Vec<LiveIssue>, Vec<LivePull>) {
+    match strategy {
+        Strategy::Recent => (issues, pulls),
+        Strategy::Active => (
+            issues.into_iter().filter(|i| i.state == "open").collect(),
+            pulls
+                .into_iter()
+                .filter(|p| p.state == "open" || p.merged_at.is_some())
+                .collect(),
+        ),
+        Strategy::Refract => (refract_rank_issues(issues), refract_rank_pulls(pulls)),
+    }
+}
+
+fn refract_rank_issues(mut issues: Vec<LiveIssue>) -> Vec<LiveIssue> {
+    issues.sort_by(|a, b| {
+        let key = |i: &LiveIssue| (i.state == "open", i.labels.len());
+        key(b).cmp(&key(a))
+    });
+    issues
+}
+
+fn refract_rank_pulls(mut pulls: Vec<LivePull>) -> Vec<LivePull> {
+    pulls.sort_by(|a, b| {
+        let key = |p: &LivePull| (p.state == "open", p.merged_at.is_some());
+        key(b).cmp(&key(a))
+    });
+    pulls
 }
 
 // ── Skeleton upsert SQL ───────────────────────────────────────────────────
@@ -649,6 +769,12 @@ async fn fetch_paginated<T: serde::de::DeserializeOwned>(
 /// Insert a reference-only `Kind::GithubIssue` skeleton row, idempotent on
 /// `external_ref`. Returns `Ok(true)` if a new row was inserted, `Ok(false)`
 /// if a row already existed (the caller counts these as "skipped").
+///
+/// Concurrency: the spine schema does not enforce `UNIQUE(external_ref)`
+/// (other writers may legitimately share the column), so a naive
+/// "check then insert" races. We serialize concurrent upserts on the same
+/// `external_ref` via a transaction-scoped advisory lock — same pattern as
+/// `onsager-portal::db::upsert_pr_artifact_ref`.
 async fn upsert_issue_skeleton(
     pool: &PgPool,
     project_id: &str,
@@ -658,13 +784,19 @@ async fn upsert_issue_skeleton(
     let external_ref = format!("github:project:{project_id}:issue:{issue_number}");
     let new_id = format!("art_iss_{}", uuid::Uuid::new_v4().simple());
 
-    // Two-step upsert — same advisory-lock pattern as the portal.
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(&external_ref)
+        .execute(&mut *tx)
+        .await?;
+
     let existing: Option<(String,)> =
         sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1")
             .bind(&external_ref)
-            .fetch_optional(pool)
+            .fetch_optional(&mut *tx)
             .await?;
     if existing.is_some() {
+        tx.commit().await?;
         return Ok(false);
     }
     sqlx::query(
@@ -679,11 +811,14 @@ async fn upsert_issue_skeleton(
     .bind(&external_ref)
     .bind(project_id)
     .bind(issue_number as i64)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
     Ok(true)
 }
 
+/// Insert a reference-only `Kind::PullRequest` skeleton row. Same idempotency
+/// guarantee as `upsert_issue_skeleton`.
 async fn upsert_pr_skeleton(
     pool: &PgPool,
     project_id: &str,
@@ -693,12 +828,19 @@ async fn upsert_pr_skeleton(
     let external_ref = format!("github:project:{project_id}:pr:{pr_number}");
     let new_id = format!("art_pr_{}", uuid::Uuid::new_v4().simple());
 
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(&external_ref)
+        .execute(&mut *tx)
+        .await?;
+
     let existing: Option<(String,)> =
         sqlx::query_as("SELECT artifact_id FROM artifacts WHERE external_ref = $1")
             .bind(&external_ref)
-            .fetch_optional(pool)
+            .fetch_optional(&mut *tx)
             .await?;
     if existing.is_some() {
+        tx.commit().await?;
         return Ok(false);
     }
     sqlx::query(
@@ -713,7 +855,8 @@ async fn upsert_pr_skeleton(
     .bind(&external_ref)
     .bind(project_id)
     .bind(pr_number as i64)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
     Ok(true)
 }

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -39,13 +39,23 @@ pub struct SpineEvent {
 pub struct SpineArtifact {
     pub id: String,
     pub kind: String,
-    pub name: String,
+    /// Provider-authored title for the artifact. NULL for reference-only
+    /// external-source artifacts (#170) — clients hydrate via the
+    /// `/api/projects/:id/{issues,pulls}` proxy.
+    pub name: Option<String>,
     pub state: String,
-    pub owner: String,
+    /// Provider-authored author/login. Same NULL convention as `name`.
+    pub owner: Option<String>,
     pub current_version: i32,
     pub consumers: serde_json::Value,
+    /// External-system handle (e.g. `github:project:abc:issue:42`) used to
+    /// join skeleton rows with live proxy responses.
+    pub external_ref: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// Last webhook touch — used to render "last seen N min ago" placeholders
+    /// when the proxy is rate-limited (#170 fail-open).
+    pub last_observed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize, FromRow)]
@@ -179,8 +189,25 @@ pub async fn list_events(
     }
 }
 
+/// Filters for `GET /api/spine/artifacts`. All optional.
+#[derive(Debug, Deserialize)]
+pub struct ListArtifactsQuery {
+    /// Filter by `kind` discriminator (e.g. `pull_request`, `github_issue`).
+    pub kind: Option<String>,
+    /// Filter by `metadata->>'project_id'`. Used by the dashboard `/issues`
+    /// inbox to scope to the workspace's project.
+    pub project_id: Option<String>,
+}
+
 /// GET /api/spine/artifacts — list artifacts from the spine.
-pub async fn list_artifacts(State(state): State<AppState>) -> impl IntoResponse {
+///
+/// Supports `?kind=` and `?project_id=` filters so the dashboard's per-page
+/// queries (Factory PRs, Issues inbox) can target a single discriminated
+/// slice without scanning the whole table client-side.
+pub async fn list_artifacts(
+    State(state): State<AppState>,
+    Query(filters): Query<ListArtifactsQuery>,
+) -> impl IntoResponse {
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -194,12 +221,47 @@ pub async fn list_artifacts(State(state): State<AppState>) -> impl IntoResponse 
 
     let pool = spine.pool();
 
-    let result = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
-         FROM artifacts ORDER BY updated_at DESC LIMIT 100",
-    )
-    .fetch_all(pool)
-    .await;
+    // Build the query with optional WHERE clauses. sqlx::Postgres binds use
+    // `$N` positional placeholders; we keep this simple by branching on the
+    // (kind, project_id) combinations rather than building a string.
+    let base = "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
+                consumers, external_ref, created_at, updated_at, last_observed_at \
+                FROM artifacts";
+    let result = match (filters.kind.as_deref(), filters.project_id.as_deref()) {
+        (Some(kind), Some(project_id)) => {
+            sqlx::query_as::<_, SpineArtifact>(&format!(
+                "{base} WHERE kind = $1 AND metadata->>'project_id' = $2 \
+                 ORDER BY updated_at DESC LIMIT 100"
+            ))
+            .bind(kind)
+            .bind(project_id)
+            .fetch_all(pool)
+            .await
+        }
+        (Some(kind), None) => {
+            sqlx::query_as::<_, SpineArtifact>(&format!(
+                "{base} WHERE kind = $1 ORDER BY updated_at DESC LIMIT 100"
+            ))
+            .bind(kind)
+            .fetch_all(pool)
+            .await
+        }
+        (None, Some(project_id)) => {
+            sqlx::query_as::<_, SpineArtifact>(&format!(
+                "{base} WHERE metadata->>'project_id' = $1 ORDER BY updated_at DESC LIMIT 100"
+            ))
+            .bind(project_id)
+            .fetch_all(pool)
+            .await
+        }
+        (None, None) => {
+            sqlx::query_as::<_, SpineArtifact>(&format!(
+                "{base} ORDER BY updated_at DESC LIMIT 100"
+            ))
+            .fetch_all(pool)
+            .await
+        }
+    };
 
     match result {
         Ok(artifacts) => Json(serde_json::json!({ "artifacts": artifacts })).into_response(),
@@ -273,7 +335,8 @@ pub async fn register_artifact(
 
             // Query back the inserted artifact.
             let artifact = sqlx::query_as::<_, SpineArtifact>(
-                "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
+                "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, \
+                 external_ref, created_at, updated_at, last_observed_at \
                  FROM artifacts WHERE artifact_id = $1",
             )
             .bind(&artifact_id)
@@ -326,7 +389,8 @@ pub async fn get_artifact(
     let pool = spine.pool();
 
     let artifact = sqlx::query_as::<_, SpineArtifact>(
-        "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, created_at, updated_at \
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, \
+         external_ref, created_at, updated_at, last_observed_at \
          FROM artifacts WHERE artifact_id = $1",
     )
     .bind(&id)

--- a/crates/stiglab/src/server/state.rs
+++ b/crates/stiglab/src/server/state.rs
@@ -6,6 +6,7 @@ use sqlx::AnyPool;
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 use crate::server::config::ServerConfig;
+use crate::server::proxy_cache::ProxyCache;
 use crate::server::spine::SpineEmitter;
 
 pub type WsSender = mpsc::UnboundedSender<Message>;
@@ -35,6 +36,11 @@ pub struct AppState {
     /// (Done or Failed). Powers `GET /api/shaping/{id}?wait=Ns` so the
     /// status endpoint doesn't need to poll the database (issue #31).
     pub session_completion_tx: broadcast::Sender<String>,
+    /// Short-TTL cache for `/api/projects/:id/{issues,pulls}` live-hydration
+    /// reads (#170). Reference-only artifact rows don't carry GitHub-authored
+    /// fields; the proxy fetches them on demand and this cache deduplicates
+    /// in-flight reads inside the TTL window (default 60s).
+    pub proxy_cache: Arc<ProxyCache>,
 }
 
 impl AppState {
@@ -46,6 +52,7 @@ impl AppState {
             config,
             spine,
             session_completion_tx,
+            proxy_cache: Arc::new(ProxyCache::from_env()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Move workflow onboarding into the dashboard and stop denormalizing GitHub-authored state into the spine.

- **Architecture (#170).** External-source artifacts (`Kind::PullRequest`, new `Kind::GithubIssue`) are now reference-only. The spine stores identity (`external_ref`), our derived lifecycle state, version, and `last_observed_at`. GitHub-authored fields (title, body, labels, author) are served live by `/api/projects/:id/{issues,pulls}` in stiglab through a short-TTL proxy cache (env-tunable via `PORTAL_PROXY_CACHE_TTL_SECS`, default 60s, `0` disables).
- **Issues (#167).** `SPEC_LABEL` gate removed entirely — every `issues.opened` materializes a skeleton artifact regardless of labels. Subsequent edits/labels/assigns bump `current_version` and refresh `last_observed_at`. Closed → `archived`, reopened → `draft`.
- **PR migration (#171).** `upsert_pr_artifact_ref` writes `external_ref + state + current_version + metadata + last_observed_at` only — no `name` / `owner` writes. Existing rows retain their stale denormalized values as best-effort fallback under proxy outage; the spec calls this out and the dashboard renders them gracefully.
- **Onboarding UX (#165, #168).** New `/issues` inbox page joins skeleton rows with the live proxy on `external_ref`. `BackfillDialog` (strategy: `recent`/`active`/`refract`; cap default 100, hard 200; state: `open`/`closed`/`all`) is reusable from both the page header and the post-add-project flow on `WorkspaceCard`. Sidebar adds `Issues` under Factory, auth-gated.
- **Migration `010_artifacts_external_ref_only.sql`.** Nullable `name` / `owner`, new `last_observed_at TIMESTAMPTZ`. Pure-additive — no data backfill.

Failure modes per #170 fail-open: cache miss + GitHub 403/429 → empty list with `error: "rate_limited"`; dashboard falls back to the skeleton's `last_observed_at` placeholder rather than crashing.

Notes on intentional deviations from the original spec drafts:
- The proxy lives in stiglab (not portal) because that's where dashboard auth + GitHub App tokens already live, and seam rule prohibits subsystem-to-subsystem HTTP. Portal stays a webhook-ingress-only service.
- The skeleton-upsert SQL is duplicated between portal (webhook path) and stiglab (backfill path). A follow-up will lift it into a shared `onsager-spine` helper.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] Dashboard `tsc -b --noEmit` clean
- [x] Dashboard `eslint .` clean (0 warnings)
- [x] Dashboard `vitest` — 89/89 pass
- [ ] Manual: open an unlabeled issue on a tenant project → `/issues` page reflects it within proxy TTL
- [ ] Manual: rename a PR on GitHub → spine `artifacts.name` stays NULL; dashboard shows new title within one page reload
- [ ] Manual: add a project via the Workspaces flow → backfill dialog appears, fills the inbox
- [ ] Manual: with `authEnabled=false`, `Issues` sidebar entry hidden, no orphaned link

Closes #167, #168, #171; Part of #165, #170.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH9Y6WXEb7NfQxspXoN49N)_