### PR TITLE
docs(pr-lifecycle): persist GitHub ops as reference + audit script

### DIFF
--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -17,6 +17,27 @@ routines aren't configured.
 - Don't open PRs unless the user explicitly asks. Creating one is a
   one-way door in this project's workflow.
 
+For exact tool names, params, and the easy-to-miss gotchas (body
+replace-vs-merge, label replace-vs-merge, the spec-link regex), see
+[`references/github-ops.md`](references/github-ops.md). The prose below
+explains *why*; the reference is the *how*.
+
+## Bundled scripts
+
+For Claude, all GitHub ops go through `mcp__github__*` — see the reference
+above. The `scripts/` folder is for **human and CI** use, where MCP isn't
+available, and is deliberately limited to read-only audits.
+
+| Script | Purpose | Auth |
+|--------|---------|------|
+| [`scripts/audit-open-prs.sh`](scripts/audit-open-prs.sh) | List every open PR and flag those missing a spec link / `trivial` label. Mirrors `pr-spec-sync.yml`'s regex. | `GITHUB_TOKEN` |
+
+Don't add write-side scripts here. Anything that mutates GitHub state for
+Claude belongs as an `mcp__github__*` call documented in
+`references/github-ops.md`; anything that mutates state for humans
+belongs in a Claude routine or workflow under `.github/workflows/`,
+not in this skill's `scripts/`.
+
 ## Spec-issue linking (mandatory)
 
 Every PR must either:

--- a/.claude/skills/onsager-pr-lifecycle/references/github-ops.md
+++ b/.claude/skills/onsager-pr-lifecycle/references/github-ops.md
@@ -1,0 +1,207 @@
+# GitHub Operations Reference
+
+Canonical `mcp__github__*` tool-call sequences for the recurring PR/issue
+flows in the Onsager dev process. The prose lives in
+[`../SKILL.md`](../SKILL.md); this file is the cheat sheet — exact tool
+name, minimum params, and the one thing that's easy to get wrong.
+
+Scope is `onsager-ai/onsager`. Every call below assumes
+`owner: "onsager-ai"`, `repo: "onsager"` unless noted.
+
+## Conventions
+
+- `repo` / `owner` are required on most calls — don't omit them.
+- PR / issue numbers are integers, not `"#42"`.
+- Body strings use real newlines, not `\n` escapes.
+- All keyword detection follows `pr-spec-sync.yml`:
+  - Closing: `close[sd]?` / `fix(e[sd])?` / `resolve[sd]?` + `#N`
+  - Reference: `part of` / `refs` / `related` + `#N`
+
+## Opening a PR with a spec link
+
+Run the spec-vs-trivial gate **before** calling `create_pull_request` and
+bake the answer into the body / labels at creation time. This is the
+upstream answer to `pr-spec-sync`'s `<!-- pr-spec-sync:no-spec-link -->`
+reminder.
+
+```
+mcp__github__create_pull_request
+  owner: "onsager-ai"
+  repo: "onsager"
+  title: "<short imperative — under 70 chars>"
+  head: "<branch>"
+  base: "main"
+  body: |
+    Closes #N            # or "Part of #N" for scaffolding slices
+
+    ## Delivers          # required for Part-of PRs; recommended for Closes
+    - [x] <Plan item copied verbatim from spec>
+
+    ## Summary
+    <1-3 sentences of why>
+  labels: []             # add ["trivial"] only if no spec issue is warranted
+  draft: false           # always open as ready-for-review
+```
+
+Get the spec-link line wrong and `pr-spec-sync` posts a bot comment within
+seconds. See SKILL.md → "Spec-issue linking" for the keyword table and
+multi-issue rules.
+
+## Updating an existing PR's body
+
+Use this to fix a missing spec link, add a `## Delivers` block, or tighten
+the summary. Don't open a new PR for a body fix.
+
+```
+mcp__github__update_pull_request
+  owner: "onsager-ai"
+  repo: "onsager"
+  pullNumber: <int>
+  body: "<full new body>"   # replaces, doesn't merge
+```
+
+The body parameter **replaces** the whole body. Read the current PR first
+(`pull_request_read` with `method: get`) and patch the string locally
+before sending it back.
+
+## Reading PR state and CI status
+
+```
+mcp__github__pull_request_read
+  owner: "onsager-ai"
+  repo: "onsager"
+  pullNumber: <int>
+  method: "get"             # full PR object: body, labels, mergeable, head sha
+```
+
+```
+mcp__github__pull_request_read
+  ...
+  method: "get_check_runs"  # per-step CI status; replaces parsing logs by hand
+```
+
+`WebFetch` cannot read authenticated GitHub Actions logs (403 / login page).
+For CI failures, work from `get_check_runs` + local reproduction — see
+SKILL.md → "Accessing logs".
+
+## Replying to a review comment
+
+```
+mcp__github__add_reply_to_pull_request_comment
+  owner: "onsager-ai"
+  repo: "onsager"
+  pullNumber: <int>
+  commentId: <int>          # the original review comment id
+  body: "<reply>"
+```
+
+Default behavior: **don't reply, fix the code.** Reply only when declining
+a suggestion, the comment is a question, or you need clarification before
+acting. See SKILL.md → "Review comments".
+
+## Subscribing to PR activity
+
+Call once per PR after creating it (or when a user asks you to watch one).
+CI failures and review comments arrive wrapped in `<github-webhook-activity>`
+tags as user messages.
+
+```
+mcp__github__subscribe_pr_activity
+  owner: "onsager-ai"
+  repo: "onsager"
+  pullNumber: <int>
+```
+
+```
+mcp__github__unsubscribe_pr_activity
+  owner: "onsager-ai"
+  repo: "onsager"
+  pullNumber: <int>
+```
+
+Routine-triggered events (label flips, Plan checkbox ticks) do **not** flow
+through this subscription — they run in the routine's own session.
+
+## Ticking an umbrella tracker checkbox
+
+When a PR closes a sub-issue, the tracker doesn't update itself. For each
+auto-closed or explicitly-closed issue:
+
+1. Find the trackers that reference it.
+
+   ```
+   mcp__github__search_issues
+     query: "repo:onsager-ai/onsager #N in:body is:issue is:open"
+   ```
+
+2. Read the tracker's current body.
+
+   ```
+   mcp__github__issue_read
+     owner: "onsager-ai"
+     repo: "onsager"
+     issueNumber: <tracker int>
+     method: "get"
+   ```
+
+3. Flip `- [ ] ... #N ...` → `- [x] ... #N ...` in the body string locally,
+   then write it back. **Replace** the whole body; don't try to patch.
+
+   ```
+   mcp__github__issue_write
+     owner: "onsager-ai"
+     repo: "onsager"
+     issueNumber: <tracker int>
+     method: "update"
+     body: "<full new body>"
+   ```
+
+4. Post **one** comment summarizing the delta, not one per sub-issue.
+
+   ```
+   mcp__github__add_issue_comment
+     owner: "onsager-ai"
+     repo: "onsager"
+     issueNumber: <tracker int>
+     body: "PR #<pr> landed #N1, #N2, #N3; ticked in Progress."
+   ```
+
+5. If every sub-issue in Progress is now closed, **flag** the tracker as a
+   closure candidate — don't close it unilaterally. Author/human decides.
+
+## Spec-issue label transitions (manual fallback)
+
+The `pr-spec-sync.yml` workflow handles open/close-unmerged automatically.
+Use this only when the workflow is disabled or you're flipping `draft → planned`
+intentionally (the latter is **always a human call** — don't do it from a
+session).
+
+```
+mcp__github__issue_write
+  owner: "onsager-ai"
+  repo: "onsager"
+  issueNumber: <int>
+  method: "update"
+  labels: ["spec", "in-progress", ...]   # full label set; replaces
+```
+
+The `labels` field is a **replace**, not a merge — include every label the
+issue should still have, or you'll strip area/priority labels by accident.
+Prefer `add_labels` / `remove_labels` if available on this MCP server;
+otherwise read first, mutate the array, write back.
+
+## Listing open PRs missing a spec link (audit)
+
+Bulk read-only audits are cheaper as a single API loop than dozens of MCP
+calls. See [`../scripts/audit-open-prs.sh`](../scripts/audit-open-prs.sh) —
+runs from a human shell or CI with `GITHUB_TOKEN`. Claude should not call
+this script for normal flows; use the per-PR MCP calls above.
+
+## Things deliberately not in this list
+
+- **Force-pushing**, branch deletion, repo settings — not Claude's job.
+- **Merging a PR** — `mcp__github__merge_pull_request` exists, but per
+  CLAUDE.md "Executing actions with care", merge is a one-way door that
+  needs explicit user confirmation in-session.
+- **Enabling auto-merge** — same caveat. Both are listed here so you know
+  they exist, not so you reach for them.

--- a/.claude/skills/onsager-pr-lifecycle/scripts/audit-open-prs.sh
+++ b/.claude/skills/onsager-pr-lifecycle/scripts/audit-open-prs.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Audit open PRs on onsager-ai/onsager for spec-link discipline.
+# Read-only. For human / CI use; Claude should use mcp__github__* per-PR.
+#
+# For each open PR, reports:
+#   OK       — body has Closes/Fixes/Resolves/Part-of/Refs #N
+#   OK       — labelled `trivial`
+#   MISSING  — neither (the bot will / has commented on this PR)
+#
+# Requires: GITHUB_TOKEN with `repo` scope, curl, jq.
+# Usage:    GITHUB_TOKEN=... sh audit-open-prs.sh
+# Exit:     0 if every open PR is OK, 1 if any is MISSING.
+set -e
+
+OWNER="onsager-ai"
+REPO="onsager"
+API="https://api.github.com"
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "ERROR: GITHUB_TOKEN not set" >&2
+    exit 2
+fi
+
+for tool in curl jq; do
+    if ! command -v "$tool" > /dev/null 2>&1; then
+        echo "ERROR: $tool not installed" >&2
+        exit 2
+    fi
+done
+
+# Same regex as .github/workflows/pr-spec-sync.yml — keep in sync.
+SPEC_LINK_RE='\b(close[sd]?|fix(e[sd])?|resolve[sd]?|part of|refs|related)[[:space:]]+#[0-9]+\b'
+
+ok=0
+missing=0
+page=1
+
+echo "=== Auditing open PRs on $OWNER/$REPO ==="
+echo ""
+
+while :; do
+    response=$(curl -sS \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$API/repos/$OWNER/$REPO/pulls?state=open&per_page=100&page=$page")
+
+    count=$(echo "$response" | jq 'length')
+    [ "$count" -eq 0 ] && break
+
+    echo "$response" | jq -c '.[] | {number, title, body: (.body // ""), labels: [.labels[].name]}' \
+        | while IFS= read -r pr; do
+            num=$(echo "$pr" | jq -r '.number')
+            title=$(echo "$pr" | jq -r '.title')
+            body=$(echo "$pr" | jq -r '.body')
+            trivial=$(echo "$pr" | jq -r '.labels | index("trivial") // empty')
+
+            if echo "$body" | grep -Eqi "$SPEC_LINK_RE"; then
+                printf "  OK       #%-5s  %s\n" "$num" "$title"
+                echo "ok" >> /tmp/audit-prs.$$
+            elif [ -n "$trivial" ]; then
+                printf "  OK       #%-5s  %s  [trivial]\n" "$num" "$title"
+                echo "ok" >> /tmp/audit-prs.$$
+            else
+                printf "  MISSING  #%-5s  %s\n" "$num" "$title"
+                echo "missing" >> /tmp/audit-prs.$$
+            fi
+        done
+
+    [ "$count" -lt 100 ] && break
+    page=$((page + 1))
+done
+
+if [ -f /tmp/audit-prs.$$ ]; then
+    ok=$(grep -c '^ok$' /tmp/audit-prs.$$ || true)
+    missing=$(grep -c '^missing$' /tmp/audit-prs.$$ || true)
+    rm -f /tmp/audit-prs.$$
+fi
+
+echo ""
+echo "=== Results: $ok ok, $missing missing ==="
+[ "$missing" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #178

## Delivers
- [x] `references/github-ops.md` — canonical `mcp__github__*` sequences for the recurring PR / issue flows (open PR with spec link, update PR body, read PR + CI check runs, reply to review comment, subscribe / unsubscribe to PR activity, tick umbrella tracker, label transitions), with the easy-to-miss replace-vs-merge gotchas inline.
- [x] `scripts/audit-open-prs.sh` — read-only `curl` + `jq` audit of every open PR, flagging those missing a spec-link keyword or `trivial` label. Mirrors `SPEC_LINK_RE` from `.github/workflows/pr-spec-sync.yml`. Requires `GITHUB_TOKEN`; for human / CI use.
- [x] `SKILL.md` update: link the reference from "Tool discipline" and add a "Bundled scripts" section that explicitly restricts `scripts/` to read-only audits (write-side mutations stay in `mcp__github__*` for Claude or in `.github/workflows/` for automation).

## Summary

The skill currently explains *why* and *when* for the recurring GitHub flows but not the exact tool name + parameter shape — re-derived per session today. This persists the cheat sheet next to the prose so the easy-to-miss bits (body / labels are *replace* not merge, spec-link regex must match the workflow) stop drifting. The audit script covers the gap MCP doesn't fit: a single paginated API loop is much cheaper than dozens of per-PR MCP calls for the read-only "which PRs are missing a spec link" question, and slots into CI without an MCP server in the loop.

Scope is deliberately narrow — read-only script only — so the skill doesn't grow a parallel write path that bypasses the MCP server's `onsager-ai/onsager` scope restriction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7dxARqASuA1e9LbuC5m28)_