### PR TITLE
feat(stiglab): scope every list/detail endpoint + credentials by workspace

### DIFF
--- a/crates/stiglab/migrations/002_workspace_credentials.sql
+++ b/crates/stiglab/migrations/002_workspace_credentials.sql
@@ -1,0 +1,87 @@
+-- 002_workspace_credentials.sql (issue #164, child of #161)
+--
+-- Per-workspace credential scope. Credentials (CLAUDE_CODE_OAUTH_TOKEN,
+-- ANTHROPIC_API_KEY, etc.) were stored as global per-(user, name) rows
+-- and silently shipped to every agent session that user launched —
+-- regardless of which workspace the session belonged to. After this
+-- migration each row is tied to exactly one workspace, the route moves
+-- under `/api/workspaces/:workspace/credentials`, and stiglab's session
+-- launcher looks up the credential by `(user_id, session.workspace_id)`
+-- instead of "any of the user's credentials of this name".
+--
+-- Webhook ingress: this same migration installs the
+-- `UNIQUE(install_id)` invariant on `github_app_installations` (1:1
+-- install→workspace, per the parent #161 open question). The
+-- fresh-DB CREATE TABLE in `run_migrations` already declares the
+-- column UNIQUE; the unique-index added below covers existing
+-- Postgres deployments that shipped without the constraint.
+--
+-- Sessions also gain a `workspace_id` column so `/api/sessions?workspace=`
+-- can filter directly without joining through projects (sessions without
+-- a project — direct/personal sessions — keep `workspace_id IS NULL` and
+-- aren't surfaced by any workspace-scoped list).
+--
+-- Backfill rule mirrors the PAT rule from #163:
+--   * `user_credentials.workspace_id IS NULL` rows get pinned to the
+--     user's first `workspace_members` membership (lowest `joined_at`,
+--     ties broken by `workspace_id`).
+--   * Rows for users with zero memberships are deleted — they're
+--     unreachable from the new route shape.
+--   * The column is then tightened to `NOT NULL`.
+--   * The legacy `UNIQUE(user_id, name)` is replaced with
+--     `UNIQUE(user_id, workspace_id, name)` so two workspaces may
+--     legitimately host the same credential name for the same user.
+--
+-- This file is the canonical documentation of the migration. The live
+-- migration is the inlined DDL in
+-- `crates/stiglab/src/server/db.rs::run_migrations`, wrapped in
+-- idempotent guards so a re-run is a no-op.
+
+-- ── Per-workspace credentials ──
+
+ALTER TABLE user_credentials ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+
+UPDATE user_credentials
+SET workspace_id = (
+    SELECT m.workspace_id
+    FROM workspace_members m
+    WHERE m.user_id = user_credentials.user_id
+    ORDER BY m.joined_at ASC, m.workspace_id ASC
+    LIMIT 1
+)
+WHERE workspace_id IS NULL;
+
+DELETE FROM user_credentials WHERE workspace_id IS NULL;
+
+ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL;
+
+-- Drop the legacy unique key (created by the original
+-- `UNIQUE(user_id, name)` table definition) and replace it with the
+-- workspace-aware shape.  The exact constraint name is Postgres-default
+-- (`<table>_<col>_<col>_key`); SQLite uses an implicit index that the
+-- new CREATE TABLE supersedes on rebuild.
+ALTER TABLE user_credentials
+    DROP CONSTRAINT IF EXISTS user_credentials_user_id_name_key;
+DROP INDEX IF EXISTS user_credentials_user_id_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_user_workspace_name
+    ON user_credentials (user_id, workspace_id, name);
+
+-- ── Sessions: workspace_id ──
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+
+UPDATE sessions
+SET workspace_id = (
+    SELECT p.workspace_id FROM projects p
+    WHERE p.id = sessions.project_id
+)
+WHERE workspace_id IS NULL AND project_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id
+    ON sessions (workspace_id);
+
+-- ── Webhook → workspace 1:1 invariant ──
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_github_app_installations_install_id
+    ON github_app_installations (install_id);

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -152,11 +152,12 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
         "CREATE TABLE IF NOT EXISTS user_credentials (
             id TEXT PRIMARY KEY,
             user_id TEXT NOT NULL,
+            workspace_id TEXT,
             name TEXT NOT NULL,
             encrypted_value TEXT NOT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
-            UNIQUE(user_id, name)
+            UNIQUE(user_id, workspace_id, name)
         )",
     )
     .execute(pool)
@@ -506,6 +507,108 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // ── Per-workspace credentials (issue #164).
+    //
+    // Credentials were originally global per (user, name).  Issue #164 ties
+    // each credential row to a specific workspace so a user with access to
+    // multiple workspaces no longer ships the same OAuth token to agent
+    // sessions launched in unrelated workspaces.  See the canonical SQL at
+    // `migrations/0NN_workspace_credentials.sql` (human documentation; the
+    // live migration is the inlined DDL below).
+    //
+    // The CREATE TABLE above already declares the column on a fresh DB; the
+    // ALTERs here cover existing installs.  Backfill rule mirrors the PAT
+    // backfill from #163: rows get pinned to the user's first workspace
+    // membership; rows for users with zero memberships are deleted (an
+    // unscoped credential post-migration is unreachable from the new
+    // route shape and would be permanently orphaned).
+    let _ = sqlx::query("ALTER TABLE user_credentials ADD COLUMN workspace_id TEXT")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "UPDATE user_credentials \
+         SET workspace_id = ( \
+             SELECT m.workspace_id FROM workspace_members m \
+             WHERE m.user_id = user_credentials.user_id \
+             ORDER BY m.joined_at ASC, m.workspace_id ASC \
+             LIMIT 1 \
+         ) \
+         WHERE workspace_id IS NULL",
+    )
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM user_credentials WHERE workspace_id IS NULL")
+        .execute(pool)
+        .await;
+    // Postgres-only NOT NULL tightening; SQLite tests rebuild fresh from the
+    // CREATE TABLE above so the column is already typed correctly there.
+    let _ = sqlx::query("ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL")
+        .execute(pool)
+        .await;
+    // The legacy unique constraint was UNIQUE(user_id, name).  After the
+    // workspace split, two different workspaces may legitimately host the
+    // same credential name for the same user — drop the legacy index and
+    // re-create it as UNIQUE(user_id, workspace_id, name).  The fresh-DB
+    // CREATE TABLE above already uses the new shape.
+    let _ = sqlx::query(
+        "ALTER TABLE user_credentials DROP CONSTRAINT user_credentials_user_id_name_key",
+    )
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DROP INDEX IF EXISTS user_credentials_user_id_name_key")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_user_workspace_name \
+         ON user_credentials (user_id, workspace_id, name)",
+    )
+    .execute(pool)
+    .await;
+
+    // ── Sessions: workspace_id (issue #164).
+    //
+    // Sessions were workspace-scoped only transitively, via the optional
+    // `project_id` column.  That left direct/personal sessions unfilterable
+    // and made the parent #161 contract test (W1 user must not see W2
+    // sessions) unprovable.  Backfill from the project's workspace where
+    // possible; sessions with no project stay NULL and the API filter just
+    // doesn't surface them in any workspace-scoped list.
+    let _ = sqlx::query("ALTER TABLE sessions ADD COLUMN workspace_id TEXT")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "UPDATE sessions \
+         SET workspace_id = ( \
+             SELECT p.workspace_id FROM projects p \
+             WHERE p.id = sessions.project_id \
+         ) \
+         WHERE workspace_id IS NULL AND project_id IS NOT NULL",
+    )
+    .execute(pool)
+    .await;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id \
+         ON sessions (workspace_id)",
+    )
+    .execute(pool)
+    .await?;
+
+    // ── github_app_installations: enforce 1:1 install_id → workspace_id
+    //    (issue #164).
+    //
+    // The fresh-DB CREATE TABLE above already declares
+    // `install_id BIGINT NOT NULL UNIQUE`, so this is a no-op for new
+    // deploys.  Older Postgres installs may have shipped without the
+    // UNIQUE — re-installing the same GitHub App into a different
+    // workspace must be a re-install flow, not a row update, and the
+    // database is the right place to enforce that contract.
+    let _ = sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_github_app_installations_install_id \
+         ON github_app_installations (install_id)",
+    )
+    .execute(pool)
+    .await;
+
     Ok(())
 }
 
@@ -707,10 +810,27 @@ pub async fn insert_session_with_idempotency_key(
     session: &Session,
     idempotency_key: &str,
 ) -> anyhow::Result<bool> {
+    insert_session_with_idempotency_key_and_workspace(pool, session, idempotency_key, None, None)
+        .await
+}
+
+/// Variant of `insert_session_with_idempotency_key` that also persists
+/// `user_id` and `workspace_id` (issue #164).  The shaping path uses
+/// this so workspace-scoped session listing has a non-NULL column to
+/// filter on, and so credential lookup at agent dispatch can run
+/// against the same workspace.
+pub async fn insert_session_with_idempotency_key_and_workspace(
+    pool: &AnyPool,
+    session: &Session,
+    idempotency_key: &str,
+    user_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> anyhow::Result<bool> {
     let affected = sqlx::query(
         "INSERT INTO sessions (id, task_id, node_id, state, prompt, output, working_dir, \
-                               artifact_id, artifact_version, idempotency_key, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) \
+                               user_id, workspace_id, artifact_id, artifact_version, \
+                               idempotency_key, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) \
          ON CONFLICT (idempotency_key) DO NOTHING",
     )
     .bind(&session.id)
@@ -720,6 +840,8 @@ pub async fn insert_session_with_idempotency_key(
     .bind(&session.prompt)
     .bind(&session.output)
     .bind(&session.working_dir)
+    .bind(user_id)
+    .bind(workspace_id)
     .bind(&session.artifact_id)
     .bind(session.artifact_version)
     .bind(idempotency_key)
@@ -1063,18 +1185,22 @@ pub struct UserCredential {
 pub async fn set_user_credential(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
     name: &str,
     encrypted_value: &str,
 ) -> anyhow::Result<()> {
     let id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO user_credentials (id, user_id, name, encrypted_value, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $5)
-         ON CONFLICT(user_id, name) DO UPDATE SET encrypted_value = $4, updated_at = $5",
+        "INSERT INTO user_credentials \
+            (id, user_id, workspace_id, name, encrypted_value, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $6) \
+         ON CONFLICT(user_id, workspace_id, name) \
+            DO UPDATE SET encrypted_value = $5, updated_at = $6",
     )
     .bind(&id)
     .bind(user_id)
+    .bind(workspace_id)
     .bind(name)
     .bind(encrypted_value)
     .bind(&now)
@@ -1086,11 +1212,14 @@ pub async fn set_user_credential(
 pub async fn get_user_credentials(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
 ) -> anyhow::Result<Vec<UserCredential>> {
     let rows = sqlx::query_as::<_, UserCredentialRow>(
-        "SELECT name, created_at, updated_at FROM user_credentials WHERE user_id = $1 ORDER BY name",
+        "SELECT name, created_at, updated_at FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2 ORDER BY name",
     )
     .bind(user_id)
+    .bind(workspace_id)
     .fetch_all(pool)
     .await?;
     Ok(rows
@@ -1106,12 +1235,15 @@ pub async fn get_user_credentials(
 pub async fn get_user_credential_value(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
     name: &str,
 ) -> anyhow::Result<Option<String>> {
     let row = sqlx::query_scalar::<_, String>(
-        "SELECT encrypted_value FROM user_credentials WHERE user_id = $1 AND name = $2",
+        "SELECT encrypted_value FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2 AND name = $3",
     )
     .bind(user_id)
+    .bind(workspace_id)
     .bind(name)
     .fetch_optional(pool)
     .await?;
@@ -1121,11 +1253,14 @@ pub async fn get_user_credential_value(
 pub async fn get_all_user_credential_values(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let rows = sqlx::query_as::<_, CredentialKvRow>(
-        "SELECT name, encrypted_value FROM user_credentials WHERE user_id = $1",
+        "SELECT name, encrypted_value FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2",
     )
     .bind(user_id)
+    .bind(workspace_id)
     .fetch_all(pool)
     .await?;
     Ok(rows
@@ -1137,25 +1272,33 @@ pub async fn get_all_user_credential_values(
 pub async fn delete_user_credential(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
     name: &str,
 ) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM user_credentials WHERE user_id = $1 AND name = $2")
-        .bind(user_id)
-        .bind(name)
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "DELETE FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2 AND name = $3",
+    )
+    .bind(user_id)
+    .bind(workspace_id)
+    .bind(name)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
 pub async fn user_credential_exists(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
     name: &str,
 ) -> anyhow::Result<bool> {
     let row = sqlx::query_scalar::<_, String>(
-        "SELECT name FROM user_credentials WHERE user_id = $1 AND name = $2",
+        "SELECT name FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2 AND name = $3",
     )
     .bind(user_id)
+    .bind(workspace_id)
     .bind(name)
     .fetch_optional(pool)
     .await?;
@@ -1163,10 +1306,11 @@ pub async fn user_credential_exists(
 }
 
 /// True if the user has at least one credential row matching one of
-/// `names`. Used by the workflow-activate gate (issue #156) to refuse
-/// activation when the owner has no Claude auth credential — without
-/// this check, the workflow would be active but every session would
-/// fail with "stdout closed without result event".
+/// `names` in `workspace_id`. Used by the workflow-activate gate
+/// (issue #156) to refuse activation when the owner has no Claude auth
+/// credential in the workflow's workspace — without this check, the
+/// workflow would be active but every session would fail with "stdout
+/// closed without result event".
 ///
 /// Checks by exact name match because the Claude CLI keys on specific
 /// env var names (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`).
@@ -1175,20 +1319,24 @@ pub async fn user_credential_exists(
 pub async fn user_has_credential_in(
     pool: &AnyPool,
     user_id: &str,
+    workspace_id: &str,
     names: &[&str],
 ) -> anyhow::Result<bool> {
     if names.is_empty() {
         return Ok(false);
     }
-    // Build `name IN ($2, $3, ...)` with placeholders matched to the
+    // Build `name IN ($3, $4, ...)` with placeholders matched to the
     // sqlx binding count — sqlx-AnyPool doesn't speak Postgres array
-    // params portably across SQLite.
-    let placeholders: Vec<String> = (2..=names.len() + 1).map(|i| format!("${i}")).collect();
+    // params portably across SQLite.  $1 = user_id, $2 = workspace_id.
+    let placeholders: Vec<String> = (3..=names.len() + 2).map(|i| format!("${i}")).collect();
     let sql = format!(
-        "SELECT name FROM user_credentials WHERE user_id = $1 AND name IN ({}) LIMIT 1",
+        "SELECT name FROM user_credentials \
+         WHERE user_id = $1 AND workspace_id = $2 AND name IN ({}) LIMIT 1",
         placeholders.join(", ")
     );
-    let mut q = sqlx::query_scalar::<_, String>(&sql).bind(user_id);
+    let mut q = sqlx::query_scalar::<_, String>(&sql)
+        .bind(user_id)
+        .bind(workspace_id);
     for n in names {
         q = q.bind(*n);
     }
@@ -1396,23 +1544,29 @@ pub async fn insert_session_with_user(
     session: &Session,
     user_id: Option<&str>,
 ) -> anyhow::Result<()> {
-    insert_session_with_user_and_project(pool, session, user_id, None).await
+    insert_session_with_user_and_project(pool, session, user_id, None, None).await
 }
 
 /// Variant that also binds a `project_id` when the session is scoped to a
 /// workspace-owned project (issue #59). Pre-existing sessions with a null
 /// `project_id` remain personal sessions forever.
+///
+/// `workspace_id` was added in issue #164 so list endpoints can filter
+/// without joining through projects. Sessions with no workspace context
+/// (legacy direct-shaping callers) keep `workspace_id IS NULL` and never
+/// surface in any workspace-scoped list.
 pub async fn insert_session_with_user_and_project(
     pool: &AnyPool,
     session: &Session,
     user_id: Option<&str>,
     project_id: Option<&str>,
+    workspace_id: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO sessions (id, task_id, node_id, state, prompt, output, working_dir, \
-                               user_id, project_id, artifact_id, artifact_version, \
+                               user_id, project_id, workspace_id, artifact_id, artifact_version, \
                                created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
     )
     .bind(&session.id)
     .bind(&session.task_id)
@@ -1423,6 +1577,7 @@ pub async fn insert_session_with_user_and_project(
     .bind(&session.working_dir)
     .bind(user_id)
     .bind(project_id)
+    .bind(workspace_id)
     .bind(&session.artifact_id)
     .bind(session.artifact_version)
     .bind(session.created_at.to_rfc3339())
@@ -1444,6 +1599,27 @@ pub async fn list_sessions_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Re
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// List sessions scoped to a workspace (issue #164).
+///
+/// Returns only sessions whose `workspace_id` column matches.  Sessions
+/// without a workspace (legacy/direct-dispatch — see
+/// `insert_session_with_user_and_project`) are not surfaced by any
+/// workspace-scoped list.
+pub async fn list_sessions_for_workspace(
+    pool: &AnyPool,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<Session>> {
+    let rows = sqlx::query_as::<_, SessionRow>(
+        "SELECT id, task_id, node_id, state, prompt, output, working_dir, \
+                artifact_id, artifact_version, created_at, updated_at \
+         FROM sessions WHERE workspace_id = $1 ORDER BY created_at DESC",
+    )
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 pub async fn get_session_owner(pool: &AnyPool, session_id: &str) -> anyhow::Result<Option<String>> {
     let row = sqlx::query_scalar::<_, String>(
         "SELECT user_id FROM sessions WHERE id = $1 AND user_id IS NOT NULL",
@@ -1452,6 +1628,23 @@ pub async fn get_session_owner(pool: &AnyPool, session_id: &str) -> anyhow::Resu
     .fetch_optional(pool)
     .await?;
     Ok(row)
+}
+
+/// Look up the workspace a session is scoped to. `Ok(None)` covers two
+/// cases that callers handle the same way: the session row doesn't exist
+/// (404 from the route), or it exists but predates the workspace_id
+/// column / was created without workspace context (also 404 from any
+/// workspace-scoped route — there's no workspace to authz against).
+pub async fn get_session_workspace_id(
+    pool: &AnyPool,
+    session_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let row =
+        sqlx::query_scalar::<_, Option<String>>("SELECT workspace_id FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.flatten())
 }
 
 // ── Row types for sqlx ──
@@ -2249,9 +2442,15 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        insert_session_with_user_and_project(&pool, &session, Some("u1"), Some(&project.id))
-            .await
-            .unwrap();
+        insert_session_with_user_and_project(
+            &pool,
+            &session,
+            Some("u1"),
+            Some(&project.id),
+            Some(&project.workspace_id),
+        )
+        .await
+        .unwrap();
 
         let live = count_live_sessions_for_project(&pool, &project.id)
             .await

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -152,7 +152,7 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
         "CREATE TABLE IF NOT EXISTS user_credentials (
             id TEXT PRIMARY KEY,
             user_id TEXT NOT NULL,
-            workspace_id TEXT,
+            workspace_id TEXT NOT NULL,
             name TEXT NOT NULL,
             encrypted_value TEXT NOT NULL,
             created_at TEXT NOT NULL,

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -94,13 +94,16 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         //   OAuth app directly.
         .route("/api/auth/sso/redeem", post(routes::auth::sso_redeem))
         .route("/api/auth/sso/finish", get(routes::auth::sso_finish))
-        // Credential routes
+        // Credential routes — per-workspace as of issue #164.  The
+        // unscoped `/api/credentials` and `/api/credentials/{name}`
+        // surfaces are removed (not aliased), per CLAUDE.md "no dangling
+        // wires" / "compat aliases that ossify".
         .route(
-            "/api/credentials",
+            "/api/workspaces/{workspace}/credentials",
             get(routes::credentials::list_credentials),
         )
         .route(
-            "/api/credentials/{name}",
+            "/api/workspaces/{workspace}/credentials/{name}",
             put(routes::credentials::set_credential).delete(routes::credentials::delete_credential),
         )
         // Personal Access Tokens (issue #143)

--- a/crates/stiglab/src/server/routes/credentials.rs
+++ b/crates/stiglab/src/server/routes/credentials.rs
@@ -1,3 +1,18 @@
+//! Per-workspace credential routes (issue #164).
+//!
+//! All routes nest under `/api/workspaces/:workspace/credentials` so each
+//! credential row is bound to exactly one workspace. The unscoped
+//! `/api/credentials` surface that this module used to host has been
+//! removed, not aliased — per CLAUDE.md "no dangling wires" / "compat
+//! aliases that ossify". Dashboards and CLIs must address the
+//! workspace-scoped path.
+//!
+//! Authorization is funnelled through the shared `require_workspace_access`
+//! helper, which handles both PAT scope (403 with
+//! `pat_workspace_scope_mismatch`) and membership (404). PAT principals
+//! retain the destructive-action block (PUT-overwrite + DELETE map to
+//! `pat_destructive_blocked`) — those are still session-only operations.
+
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -7,6 +22,8 @@ use serde::Deserialize;
 use crate::server::auth::{encrypt_credential, AuthUser, RequestPrincipal};
 use crate::server::db;
 use crate::server::state::AppState;
+
+use super::require_workspace_access;
 
 /// Standard 403 body for the PAT destructive-credential guardrail (issue
 /// #143). PATs may read and create credentials, but deleting an existing
@@ -29,12 +46,17 @@ pub struct SetCredentialBody {
     pub value: String,
 }
 
-/// GET /api/credentials — List credential names for the current user (no values).
+/// GET /api/workspaces/:workspace/credentials — list credential names
+/// (no values) bound to this workspace for the current user.
 pub async fn list_credentials(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
 ) -> impl IntoResponse {
-    match db::get_user_credentials(&state.db, &auth_user.user_id).await {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
+    match db::get_user_credentials(&state.db, &auth_user.user_id, &workspace_id).await {
         Ok(creds) => {
             let items: Vec<_> = creds
                 .into_iter()
@@ -55,18 +77,23 @@ pub async fn list_credentials(
     }
 }
 
-/// PUT /api/credentials/{name} — Set or update a credential.
+/// PUT /api/workspaces/:workspace/credentials/:name — set or update a
+/// credential bound to this workspace.
 pub async fn set_credential(
     State(state): State<AppState>,
     auth_user: AuthUser,
-    Path(name): Path<String>,
+    Path((workspace_id, name)): Path<(String, String)>,
     Json(body): Json<SetCredentialBody>,
 ) -> impl IntoResponse {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
     // PAT principals can create new credentials but not overwrite existing
     // ones — silently rotating a secret over the API while the dashboard
     // still shows the old one would be confusing and a footgun.
     if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
-        match db::user_credential_exists(&state.db, &auth_user.user_id, &name).await {
+        match db::user_credential_exists(&state.db, &auth_user.user_id, &workspace_id, &name).await
+        {
             Ok(true) => return pat_destructive_blocked(),
             Ok(false) => {}
             Err(e) => {
@@ -92,7 +119,15 @@ pub async fn set_credential(
         }
     };
 
-    match db::set_user_credential(&state.db, &auth_user.user_id, &name, &encrypted).await {
+    match db::set_user_credential(
+        &state.db,
+        &auth_user.user_id,
+        &workspace_id,
+        &name,
+        &encrypted,
+    )
+    .await
+    {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => {
             tracing::error!("failed to set credential: {e}");
@@ -101,18 +136,22 @@ pub async fn set_credential(
     }
 }
 
-/// DELETE /api/credentials/{name} — Delete a credential.
+/// DELETE /api/workspaces/:workspace/credentials/:name — delete a
+/// workspace-scoped credential.
 pub async fn delete_credential(
     State(state): State<AppState>,
     auth_user: AuthUser,
-    Path(name): Path<String>,
+    Path((workspace_id, name)): Path<(String, String)>,
 ) -> impl IntoResponse {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
     // The destructive guard is unconditional for PATs — deletion is always
     // a session-only operation regardless of whether the credential exists.
     if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
         return pat_destructive_blocked();
     }
-    match db::delete_user_credential(&state.db, &auth_user.user_id, &name).await {
+    match db::delete_user_credential(&state.db, &auth_user.user_id, &workspace_id, &name).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => {
             tracing::error!("failed to delete credential: {e}");

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -46,6 +46,9 @@ pub async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
+    if workspace_id.trim().is_empty() {
+        return Err(missing_workspace_query());
+    }
     if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
         if pinned != workspace_id {
             return Err((
@@ -70,4 +73,35 @@ pub async fn require_workspace_access(
             Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
         }
     }
+}
+
+/// 400 response for list endpoints called without `?workspace=`.
+///
+/// Per #164 the list-endpoint contract is "explicit workspace, always".  A
+/// missing or blank `?workspace=` is a client bug, not a "default to
+/// everything" — that was the parent #161 leak shape.  This helper keeps
+/// the response body shape uniform across every list route so the
+/// dashboard can match on `error == "missing_workspace_query"` without a
+/// per-route table.
+pub fn missing_workspace_query() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "missing_workspace_query",
+            "detail": "?workspace= is required",
+        })),
+    )
+        .into_response()
+}
+
+/// Standard 404 for "this row exists but you can't see it".  Defined here
+/// so detail routes (`GET/PATCH/DELETE /api/.../:id`) emit the same shape
+/// when the helper above isn't directly callable (e.g. when the row needs
+/// to load *first* and *then* be authz'd against its `workspace_id`).
+pub fn workspace_scoped_not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
 }

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -25,14 +25,20 @@ use crate::server::db;
 
 /// Authorize an `AuthUser` against a target workspace.
 ///
-/// Two checks, in order:
+/// Three checks, in order:
 ///
-/// 1. **PAT scope (403 on mismatch).** If the principal is a PAT pinned to
+/// 1. **Anonymous bypass.** When auth is disabled the extractor returns
+///    a synthetic `anonymous` principal that will never appear in
+///    `workspace_members`.  Spec #161 states that `authEnabled=false`
+///    mode stays unchanged, so we treat the anonymous principal as
+///    blanket-authorized.  Auth-enabled deployments keep the strict
+///    checks below.
+/// 2. **PAT scope (403 on mismatch).** If the principal is a PAT pinned to
 ///    a workspace, the request must target that exact workspace. The
 ///    caller already proved membership at PAT-mint time, so hiding the
 ///    workspace's existence is moot — surface `pat_workspace_scope_mismatch`
 ///    so client tooling can react.
-/// 2. **Membership (404 on miss).** Otherwise the caller must be a member
+/// 3. **Membership (404 on miss).** Otherwise the caller must be a member
 ///    of the workspace; non-members get a flat 404 to avoid leaking
 ///    workspace existence.
 ///
@@ -48,6 +54,9 @@ pub async fn require_workspace_access(
 ) -> Result<(), Response> {
     if workspace_id.trim().is_empty() {
         return Err(missing_workspace_query());
+    }
+    if auth_user.user_id == "anonymous" {
+        return Ok(());
     }
     if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
         if pinned != workspace_id {

--- a/crates/stiglab/src/server/routes/nodes.rs
+++ b/crates/stiglab/src/server/routes/nodes.rs
@@ -1,13 +1,48 @@
-use axum::extract::State;
+//! Node listing — `GET /api/nodes` (issue #59 / #164).
+//!
+//! Nodes are platform-wide infrastructure (the agent fleet), not
+//! workspace data per se, but the listing endpoint still requires
+//! `?workspace=` (issue #164) so:
+//!   1. The authz check funnels through the same helper as every other
+//!      list endpoint (no per-route variation), and
+//!   2. PAT scope (`pat_workspace_scope_mismatch`) and membership (404)
+//!      are enforced uniformly — a PAT pinned to W1 cannot use a
+//!      workspace W2 the user is also a member of as a back door to the
+//!      node fleet.
+//!
+//! The result set is unfiltered (every member of any workspace sees the
+//! same fleet status) — node capacity is shared, not partitioned.
+
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use serde::Deserialize;
 
 use crate::server::auth::AuthUser;
 use crate::server::db;
 use crate::server::state::AppState;
 
-pub async fn list_nodes(State(state): State<AppState>, _auth_user: AuthUser) -> impl IntoResponse {
+use super::require_workspace_access;
+
+#[derive(Debug, Deserialize)]
+pub struct ListNodesQuery {
+    #[serde(default)]
+    pub workspace: Option<String>,
+}
+
+pub async fn list_nodes(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Query(q): Query<ListNodesQuery>,
+) -> impl IntoResponse {
+    let workspace_id = match q.workspace.as_deref() {
+        Some(w) if !w.trim().is_empty() => w,
+        _ => return super::missing_workspace_query(),
+    };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
     match db::list_nodes(&state.db).await {
         Ok(nodes) => Json(serde_json::json!({ "nodes": nodes })).into_response(),
         Err(e) => {

--- a/crates/stiglab/src/server/routes/sessions.rs
+++ b/crates/stiglab/src/server/routes/sessions.rs
@@ -132,16 +132,18 @@ pub async fn session_logs(
                 ));
             }
         };
-        if let Err(_resp) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            // The helper already produced the right status (403 PAT vs
-            // 404 non-member); the SSE-typed return forces us to map it
-            // back into a JSON tuple.  We err on the side of 404 here
-            // for the same existence-leak reason — a caller that can't
-            // see the workspace shouldn't see the session id either.
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "session not found" })),
-            ));
+        if let Err(resp) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            // Preserve the helper's 403-vs-404 split — 403 carries the
+            // pat_workspace_scope_mismatch contract, 404 is the
+            // existence-hiding default.  The SSE return type forces us
+            // to remap into a JSON tuple, but the status must stay.
+            let status = resp.status();
+            let body = if status == StatusCode::FORBIDDEN {
+                serde_json::json!({ "error": "pat_workspace_scope_mismatch" })
+            } else {
+                serde_json::json!({ "error": "session not found" })
+            };
+            return Err((status, Json(body)));
         }
     }
 

--- a/crates/stiglab/src/server/routes/sessions.rs
+++ b/crates/stiglab/src/server/routes/sessions.rs
@@ -1,9 +1,10 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use axum::Json;
 use futures_util::stream;
+use serde::Deserialize;
 use std::convert::Infallible;
 use std::time::Duration;
 
@@ -11,17 +12,34 @@ use crate::server::auth::AuthUser;
 use crate::server::db;
 use crate::server::state::AppState;
 
+use super::{require_workspace_access, workspace_scoped_not_found};
+
+/// Query string for `GET /api/sessions`.
+///
+/// Per issue #164, every workspace-scoped list endpoint requires
+/// `?workspace=` and rejects missing/blank values with 400 — explicit is
+/// better than "default to everything", which was the parent #161 leak
+/// shape.  Validation funnels through `require_workspace_access` which
+/// also enforces PAT pinning (403) and membership (404).
+#[derive(Debug, Deserialize)]
+pub struct ListSessionsQuery {
+    #[serde(default)]
+    pub workspace: Option<String>,
+}
+
 pub async fn list_sessions(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    Query(q): Query<ListSessionsQuery>,
 ) -> impl IntoResponse {
-    let result = if auth_user.user_id == "anonymous" {
-        db::list_sessions(&state.db).await
-    } else {
-        db::list_sessions_for_user(&state.db, &auth_user.user_id).await
+    let workspace_id = match q.workspace.as_deref() {
+        Some(w) if !w.trim().is_empty() => w,
+        _ => return super::missing_workspace_query(),
     };
-
-    match result {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
+    match db::list_sessions_for_workspace(&state.db, workspace_id).await {
         Ok(sessions) => Json(serde_json::json!({ "sessions": sessions })).into_response(),
         Err(e) => {
             tracing::error!("failed to list sessions: {e}");
@@ -30,26 +48,29 @@ pub async fn list_sessions(
     }
 }
 
+/// `GET /api/sessions/:id` — Detail view for a single session.
+///
+/// Authz contract per issue #164: load the row first, then funnel the
+/// session's `workspace_id` through `require_workspace_access` so PAT
+/// pinning (403) and membership (404) are enforced uniformly.  Sessions
+/// without a workspace (legacy/anonymous direct dispatch) are 404 to
+/// any authenticated caller — they have no workspace to authz against.
 pub async fn get_session(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
-    // Verify ownership if auth is enabled
     if auth_user.user_id != "anonymous" {
-        match db::get_session_owner(&state.db, &session_id).await {
-            Ok(Some(owner)) if owner != auth_user.user_id => {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "error": "access denied" })),
-                )
-                    .into_response();
-            }
-            Ok(_) => {}
+        let workspace_id = match db::get_session_workspace_id(&state.db, &session_id).await {
+            Ok(Some(w)) => w,
+            Ok(None) => return workspace_scoped_not_found("session not found"),
             Err(e) => {
-                tracing::error!("failed to verify session ownership: {e}");
+                tracing::error!("failed to load session workspace: {e}");
                 return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
             }
+        };
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            return r;
         }
     }
 
@@ -81,11 +102,7 @@ pub async fn get_session(
             }))
             .into_response()
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "session not found" })),
-        )
-            .into_response(),
+        Ok(None) => workspace_scoped_not_found("session not found"),
         Err(e) => {
             tracing::error!("failed to get session: {e}");
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
@@ -98,23 +115,33 @@ pub async fn session_logs(
     auth_user: AuthUser,
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
-    // Verify ownership if auth is enabled
     if auth_user.user_id != "anonymous" {
-        match db::get_session_owner(&state.db, &session_id).await {
-            Ok(Some(owner)) if owner != auth_user.user_id => {
+        let workspace_id = match db::get_session_workspace_id(&state.db, &session_id).await {
+            Ok(Some(w)) => w,
+            Ok(None) => {
                 return Err((
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "error": "access denied" })),
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "session not found" })),
                 ));
             }
-            Ok(_) => {}
             Err(e) => {
-                tracing::error!("failed to verify session ownership: {e}");
+                tracing::error!("failed to load session workspace: {e}");
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({ "error": e.to_string() })),
                 ));
             }
+        };
+        if let Err(_resp) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            // The helper already produced the right status (403 PAT vs
+            // 404 non-member); the SSE-typed return forces us to map it
+            // back into a JSON tuple.  We err on the side of 404 here
+            // for the same existence-leak reason — a caller that can't
+            // see the workspace shouldn't see the session id either.
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "session not found" })),
+            ));
         }
     }
 

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -184,8 +184,24 @@ pub async fn create_shaping(
         updated_at: Utc::now(),
     };
 
+    // Resolve the session's workspace from the spine artifact row so the
+    // session row carries `workspace_id` (issue #164) and the credential
+    // lookup below is workspace-scoped.  `None` is fine: shaping tests
+    // and dev environments without a spine pool stay personal sessions
+    // (legacy behaviour), but the production flow always has a spine.
+    let session_workspace_id =
+        lookup_artifact_workspace(&state, &req.artifact_id.to_string()).await;
+
     if idempotency_key.is_empty() {
-        if let Err(e) = db::insert_session(&state.db, &session).await {
+        if let Err(e) = db::insert_session_with_user_and_project(
+            &state.db,
+            &session,
+            req.created_by.as_deref(),
+            None,
+            session_workspace_id.as_deref(),
+        )
+        .await
+        {
             tracing::error!("failed to insert session: {e}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -194,7 +210,15 @@ pub async fn create_shaping(
                 .into_response();
         }
     } else {
-        match db::insert_session_with_idempotency_key(&state.db, &session, &idempotency_key).await {
+        match db::insert_session_with_idempotency_key_and_workspace(
+            &state.db,
+            &session,
+            &idempotency_key,
+            req.created_by.as_deref(),
+            session_workspace_id.as_deref(),
+        )
+        .await
+        {
             Ok(true) => { /* new session inserted */ }
             Ok(false) => {
                 // Concurrent POST with the same key won the race. Load and
@@ -228,14 +252,14 @@ pub async fn create_shaping(
     }
 
     // Fetch user credentials when the request carries a `created_by`
-    // (issue #156). Without this the spawned agent has no
-    // `CLAUDE_CODE_OAUTH_TOKEN` and exits immediately with "stdout closed
-    // without result event". Direct callers without `created_by` keep the
-    // legacy `None` behavior — the resulting session_failed event surfaces
-    // the broken state via forge's signal listener.
-    let credentials = match req.created_by.as_deref() {
-        Some(uid) => super::tasks::fetch_user_credentials(&state, uid).await,
-        None => None,
+    // (issue #156). Per issue #164 the lookup is workspace-scoped — we
+    // need both `created_by` *and* a resolved workspace. Direct callers
+    // without `created_by` keep the legacy `None` behavior — the
+    // resulting session_failed event surfaces the broken state via
+    // forge's signal listener.
+    let credentials = match (req.created_by.as_deref(), session_workspace_id.as_deref()) {
+        (Some(uid), Some(ws)) => super::tasks::fetch_user_credentials(&state, uid, ws).await,
+        _ => None,
     };
 
     // Dispatch to agent via WebSocket.
@@ -379,6 +403,26 @@ pub async fn get_shaping_status(
                 .into_response(),
         }
     }
+}
+
+/// Resolve the workspace for a shaping artifact via the spine
+/// `artifacts.workspace_id` column (issue #164).
+///
+/// `None` is returned when the spine is not connected (dev/test path
+/// without a Postgres pool), the artifact isn't yet persisted, or the
+/// row carries the schema-default `'default'` workspace.  Production
+/// flow always has a spine + a real workspace; the fallback keeps the
+/// legacy direct-shaping caller path intact (no credentials, no
+/// privilege).
+async fn lookup_artifact_workspace(state: &AppState, artifact_id: &str) -> Option<String> {
+    let spine = state.spine.as_ref()?;
+    sqlx::query_scalar::<_, String>("SELECT workspace_id FROM artifacts WHERE artifact_id = $1")
+        .bind(artifact_id)
+        .fetch_optional(spine.pool())
+        .await
+        .ok()
+        .flatten()
+        .filter(|w| w != "default")
 }
 
 fn accepted_response(session: &Session, request_id: &str) -> axum::response::Response {

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -6,15 +6,22 @@
 
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+use crate::server::auth::AuthUser;
 use crate::server::state::AppState;
+
+use super::{require_workspace_access, workspace_scoped_not_found};
 
 #[derive(Debug, Deserialize)]
 pub struct EventsQuery {
+    /// Required (issue #164).  The list-endpoint contract is "explicit
+    /// workspace, always".  A missing/blank `?workspace=` returns 400.
+    #[serde(default)]
+    pub workspace: Option<String>,
     pub stream_type: Option<String>,
     pub event_type: Option<String>,
     /// Exact-match filter on `stream_id`. Used by per-artifact and
@@ -86,6 +93,9 @@ pub struct HorizontalLineageRow {
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterArtifactRequest {
+    /// Required (issue #164) — every artifact registered through the
+    /// dashboard must be scoped to a specific workspace.
+    pub workspace_id: String,
     pub kind: String,
     pub name: String,
     pub owner: String,
@@ -137,8 +147,16 @@ pub struct OverrideGateRequest {
 /// GET /api/spine/events — query the events_ext table.
 pub async fn list_events(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Query(params): Query<EventsQuery>,
 ) -> impl IntoResponse {
+    let workspace_id = match params.workspace.as_deref() {
+        Some(w) if !w.trim().is_empty() => w.to_string(),
+        _ => return super::missing_workspace_query(),
+    };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -156,24 +174,32 @@ pub async fn list_events(
     // `events_ext` stores the partition key in `namespace` and the actor inside
     // `metadata`. The API surfaces them as `stream_type` / `actor` for clients,
     // so we alias on the way out.
+    //
+    // Workspace filter (issue #164): `events_ext` rows do not carry an
+    // explicit `workspace_id` column.  Until they do, scope the result
+    // set by joining through the spine `artifacts` table on the
+    // namespace events that reference an artifact id (the bulk of
+    // factory traffic).  Cross-workspace event types (e.g. global
+    // `agent.*` heartbeats) are intentionally elided from per-workspace
+    // dashboards — they live on a separate ops surface.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
-        "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
-                COALESCE(metadata->>'actor', '') AS actor, created_at \
-         FROM events_ext",
+        "SELECT e.id, e.stream_id, e.namespace AS stream_type, e.event_type, e.data, \
+                COALESCE(e.metadata->>'actor', '') AS actor, e.created_at \
+         FROM events_ext e \
+         JOIN artifacts a ON a.artifact_id = e.stream_id \
+         WHERE a.workspace_id = ",
     );
-    let mut sep = " WHERE ";
+    qb.push_bind(workspace_id.clone());
     if let Some(st) = params.stream_type.as_deref() {
-        qb.push(sep).push("namespace = ").push_bind(st.to_string());
-        sep = " AND ";
+        qb.push(" AND e.namespace = ").push_bind(st.to_string());
     }
     if let Some(et) = params.event_type.as_deref() {
-        qb.push(sep).push("event_type = ").push_bind(et.to_string());
-        sep = " AND ";
+        qb.push(" AND e.event_type = ").push_bind(et.to_string());
     }
     if let Some(sid) = params.stream_id.as_deref() {
-        qb.push(sep).push("stream_id = ").push_bind(sid.to_string());
+        qb.push(" AND e.stream_id = ").push_bind(sid.to_string());
     }
-    qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
+    qb.push(" ORDER BY e.id DESC LIMIT ").push_bind(limit);
     let result = qb.build_query_as::<SpineEvent>().fetch_all(pool).await;
 
     match result {
@@ -189,9 +215,13 @@ pub async fn list_events(
     }
 }
 
-/// Filters for `GET /api/spine/artifacts`. All optional.
+/// Filters for `GET /api/spine/artifacts`. `workspace` is required
+/// (issue #164); the rest are optional.
 #[derive(Debug, Deserialize)]
 pub struct ListArtifactsQuery {
+    /// Required workspace filter — issue #164.
+    #[serde(default)]
+    pub workspace: Option<String>,
     /// Filter by `kind` discriminator (e.g. `pull_request`, `github_issue`).
     pub kind: Option<String>,
     /// Filter by `metadata->>'project_id'`. Used by the dashboard `/issues`
@@ -206,8 +236,16 @@ pub struct ListArtifactsQuery {
 /// slice without scanning the whole table client-side.
 pub async fn list_artifacts(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Query(filters): Query<ListArtifactsQuery>,
 ) -> impl IntoResponse {
+    let workspace_id = match filters.workspace.as_deref() {
+        Some(w) if !w.trim().is_empty() => w.to_string(),
+        _ => return super::missing_workspace_query(),
+    };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -230,9 +268,11 @@ pub async fn list_artifacts(
     let result = match (filters.kind.as_deref(), filters.project_id.as_deref()) {
         (Some(kind), Some(project_id)) => {
             sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE kind = $1 AND metadata->>'project_id' = $2 \
+                "{base} WHERE workspace_id = $1 AND kind = $2 \
+                 AND metadata->>'project_id' = $3 \
                  ORDER BY updated_at DESC LIMIT 100"
             ))
+            .bind(&workspace_id)
             .bind(kind)
             .bind(project_id)
             .fetch_all(pool)
@@ -240,24 +280,29 @@ pub async fn list_artifacts(
         }
         (Some(kind), None) => {
             sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE kind = $1 ORDER BY updated_at DESC LIMIT 100"
+                "{base} WHERE workspace_id = $1 AND kind = $2 \
+                 ORDER BY updated_at DESC LIMIT 100"
             ))
+            .bind(&workspace_id)
             .bind(kind)
             .fetch_all(pool)
             .await
         }
         (None, Some(project_id)) => {
             sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE metadata->>'project_id' = $1 ORDER BY updated_at DESC LIMIT 100"
+                "{base} WHERE workspace_id = $1 AND metadata->>'project_id' = $2 \
+                 ORDER BY updated_at DESC LIMIT 100"
             ))
+            .bind(&workspace_id)
             .bind(project_id)
             .fetch_all(pool)
             .await
         }
         (None, None) => {
             sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} ORDER BY updated_at DESC LIMIT 100"
+                "{base} WHERE workspace_id = $1 ORDER BY updated_at DESC LIMIT 100"
             ))
+            .bind(&workspace_id)
             .fetch_all(pool)
             .await
         }
@@ -279,8 +324,12 @@ pub async fn list_artifacts(
 /// POST /api/spine/artifacts — register a new artifact in Draft state.
 pub async fn register_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Json(req): Json<RegisterArtifactRequest>,
 ) -> impl IntoResponse {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &req.workspace_id).await {
+        return r;
+    }
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -296,14 +345,16 @@ pub async fn register_artifact(
     let artifact_id = format!("art_{}", ulid::Ulid::new());
 
     let result = sqlx::query(
-        "INSERT INTO artifacts (artifact_id, kind, name, owner, created_by, state, current_version) \
-         VALUES ($1, $2, $3, $4, $5, 'draft', 0)",
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, current_version, workspace_id) \
+         VALUES ($1, $2, $3, $4, $5, 'draft', 0, $6)",
     )
     .bind(&artifact_id)
     .bind(&req.kind)
     .bind(&req.name)
     .bind(&req.owner)
     .bind("dashboard") // created_by
+    .bind(&req.workspace_id)
     .execute(pool)
     .await;
 
@@ -373,6 +424,7 @@ pub async fn register_artifact(
 /// GET /api/spine/artifacts/:id — single artifact detail with versions and lineage.
 pub async fn get_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let spine = match &state.spine {
@@ -388,6 +440,10 @@ pub async fn get_artifact(
 
     let pool = spine.pool();
 
+    if let Err(r) = require_artifact_workspace_access(pool, &state, &auth_user, &id).await {
+        return r;
+    }
+
     let artifact = sqlx::query_as::<_, SpineArtifact>(
         "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, \
          external_ref, created_at, updated_at, last_observed_at \
@@ -399,13 +455,7 @@ pub async fn get_artifact(
 
     let artifact = match artifact {
         Ok(Some(a)) => a,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "artifact not found" })),
-            )
-                .into_response()
-        }
+        Ok(None) => return workspace_scoped_not_found("artifact not found"),
         Err(e) => {
             tracing::error!("spine artifact query failed: {e}");
             return (
@@ -518,6 +568,37 @@ pub async fn get_artifact(
     .into_response()
 }
 
+/// Look up `artifacts.workspace_id` for a spine-scoped detail or
+/// mutation route, then funnel through `require_workspace_access` so
+/// the same authz contract (PAT pin → 403, non-member → 404) applies.
+///
+/// Missing artifact rows return a flat 404 — same shape as a non-member
+/// hit, so the existence of an artifact id can't be probed by a
+/// workspace mismatch test.
+#[allow(clippy::result_large_err)]
+async fn require_artifact_workspace_access(
+    pool: &sqlx::PgPool,
+    state: &AppState,
+    auth_user: &AuthUser,
+    artifact_id: &str,
+) -> Result<(), Response> {
+    let workspace_id = sqlx::query_scalar::<_, String>(
+        "SELECT workspace_id FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(artifact_id)
+    .fetch_optional(pool)
+    .await;
+    let workspace_id = match workspace_id {
+        Ok(Some(w)) => w,
+        Ok(None) => return Err(workspace_scoped_not_found("artifact not found")),
+        Err(e) => {
+            tracing::error!("artifact workspace lookup failed: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+    };
+    require_workspace_access(&state.db, auth_user, &workspace_id).await
+}
+
 /// Fetch spine events related to an artifact for the per-run DAG (issue #14
 /// phase 3). Filters on `stream_id = forge:<artifact_id>` (the convention
 /// forge follows) and on session completions whose payload references this
@@ -546,6 +627,7 @@ async fn fetch_related_events(
 /// POST /api/spine/artifacts/:id/retry
 pub async fn retry_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<RetryRequest>,
 ) -> impl IntoResponse {
@@ -561,6 +643,9 @@ pub async fn retry_artifact(
     };
 
     let pool = spine.pool();
+    if let Err(r) = require_artifact_workspace_access(pool, &state, &auth_user, &id).await {
+        return r;
+    }
 
     // Confirm the artifact exists and is not archived.
     let current_state: Option<String> =
@@ -620,6 +705,7 @@ pub async fn retry_artifact(
 /// POST /api/spine/artifacts/:id/abort
 pub async fn abort_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<AbortRequest>,
 ) -> impl IntoResponse {
@@ -635,6 +721,9 @@ pub async fn abort_artifact(
     };
 
     let pool = spine.pool();
+    if let Err(r) = require_artifact_workspace_access(pool, &state, &auth_user, &id).await {
+        return r;
+    }
 
     let previous_state: Option<String> =
         sqlx::query_scalar("SELECT state FROM artifacts WHERE artifact_id = $1")
@@ -713,6 +802,7 @@ pub async fn abort_artifact(
 /// POST /api/spine/artifacts/:id/override-gate
 pub async fn override_gate(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<OverrideGateRequest>,
 ) -> impl IntoResponse {
@@ -728,6 +818,9 @@ pub async fn override_gate(
     };
 
     let pool = spine.pool();
+    if let Err(r) = require_artifact_workspace_access(pool, &state, &auth_user, &id).await {
+        return r;
+    }
 
     let exists: Option<String> =
         sqlx::query_scalar("SELECT artifact_id FROM artifacts WHERE artifact_id = $1")

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -176,17 +176,23 @@ pub async fn list_events(
     // so we alias on the way out.
     //
     // Workspace filter (issue #164): `events_ext` rows do not carry an
-    // explicit `workspace_id` column.  Until they do, scope the result
-    // set by joining through the spine `artifacts` table on the
-    // namespace events that reference an artifact id (the bulk of
-    // factory traffic).  Cross-workspace event types (e.g. global
+    // explicit `workspace_id` column today.  Scope by joining through
+    // the spine `artifacts` table.  Forge-emitted events use a
+    // namespaced `stream_id` of the form `forge:{artifact_id}` (see
+    // `register_artifact` / `fetch_related_events` below), while
+    // spine-direct writes use the bare `{artifact_id}` — the JOIN's OR
+    // clause matches both.  Cross-workspace event types (e.g. global
     // `agent.*` heartbeats) are intentionally elided from per-workspace
-    // dashboards — they live on a separate ops surface.
+    // dashboards.
+    //
+    // The proper fix is to add `workspace_id` to `events_ext` directly;
+    // tracked as a follow-up so the join goes away.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT e.id, e.stream_id, e.namespace AS stream_type, e.event_type, e.data, \
                 COALESCE(e.metadata->>'actor', '') AS actor, e.created_at \
          FROM events_ext e \
-         JOIN artifacts a ON a.artifact_id = e.stream_id \
+         JOIN artifacts a ON e.stream_id = a.artifact_id \
+                          OR e.stream_id LIKE '%:' || a.artifact_id \
          WHERE a.workspace_id = ",
     );
     qb.push_bind(workspace_id.clone());

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -105,7 +105,7 @@ pub async fn create_task(
     // Validate project membership if the caller scoped the session to a
     // workspace-owned project (issue #59). Non-members get 404 via
     // `assert_workspace_member` so project IDs can't be enumerated.
-    if let Some(ref project_id) = request.project_id {
+    let session_workspace_id = if let Some(ref project_id) = request.project_id {
         if user_id.is_none() {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -138,13 +138,17 @@ pub async fn create_task(
         {
             return r;
         }
-    }
+        Some(project.workspace_id)
+    } else {
+        None
+    };
 
     if let Err(e) = db::insert_session_with_user_and_project(
         &state.db,
         &session,
         user_id,
         request.project_id.as_deref(),
+        session_workspace_id.as_deref(),
     )
     .await
     {
@@ -152,11 +156,12 @@ pub async fn create_task(
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
 
-    // Fetch user credentials to pass to the agent
-    let credentials = if let Some(uid) = user_id {
-        fetch_user_credentials(&state, uid).await
-    } else {
-        None
+    // Fetch user credentials scoped to the session's workspace (issue
+    // #164).  Sessions without a workspace (no project_id) get no
+    // credentials — the legacy global-credential fallback is gone.
+    let credentials = match (user_id, session_workspace_id.as_deref()) {
+        (Some(uid), Some(ws)) => fetch_user_credentials(&state, uid, ws).await,
+        _ => None,
     };
 
     // Dispatch to agent via WebSocket
@@ -193,18 +198,22 @@ pub async fn create_task(
         .into_response()
 }
 
-/// Fetch all user credentials, decrypt them, and return as a HashMap.
+/// Fetch a user's credentials for a specific workspace, decrypt them,
+/// and return as a HashMap.
 ///
 /// Used by both `POST /api/tasks` (direct user-triggered sessions) and
 /// `POST /api/shaping` (forge-dispatched workflow sessions, see issue
-/// #156). Visible to sibling route modules; not part of the public API.
+/// #156). Per issue #164 credentials are workspace-scoped — passing the
+/// session's `workspace_id` is mandatory; there is no global fallback.
+/// Visible to sibling route modules; not part of the public API.
 pub(super) async fn fetch_user_credentials(
     state: &AppState,
     user_id: &str,
+    workspace_id: &str,
 ) -> Option<HashMap<String, String>> {
     let key = state.config.credential_key.as_deref()?;
 
-    let encrypted_creds = db::get_all_user_credential_values(&state.db, user_id)
+    let encrypted_creds = db::get_all_user_credential_values(&state.db, user_id, workspace_id)
         .await
         .ok()?;
 
@@ -219,7 +228,9 @@ pub(super) async fn fetch_user_credentials(
                 result.insert(name, value);
             }
             Err(e) => {
-                tracing::error!("failed to decrypt credential {name} for user {user_id}: {e}");
+                tracing::error!(
+                    "failed to decrypt credential {name} for user {user_id} in workspace {workspace_id}: {e}"
+                );
             }
         }
     }

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -102,6 +102,25 @@ pub async fn create_task(
         Some(auth_user.user_id.as_str())
     };
 
+    // Authenticated callers must scope the session to a workspace via
+    // `project_id` (issue #164).  A NULL-workspace session would be
+    // invisible to its own creator under the new workspace-filtered
+    // list/detail surface — better to reject up front than to mint
+    // unreachable rows.  The only path that may legitimately omit
+    // `project_id` is anonymous / `authEnabled=false` mode, which
+    // bypasses workspace filtering entirely (see
+    // `routes::require_workspace_access`).
+    if user_id.is_some() && request.project_id.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "project_id is required",
+                "detail": "authenticated sessions must be scoped to a project (and therefore a workspace) — pick one to dispatch into"
+            })),
+        )
+            .into_response();
+    }
+
     // Validate project membership if the caller scoped the session to a
     // workspace-owned project (issue #59). Non-members get 404 via
     // `assert_workspace_member` so project IDs can't be enumerated.

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -93,17 +93,27 @@ fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
 }
 
 /// Issue #156: ensure the workflow's owner has at least one Claude
-/// auth credential before activating. Returns a 4xx response when
-/// missing so the dashboard can surface a "connect Claude credentials"
-/// CTA.
+/// auth credential **scoped to the workflow's workspace** (issue #164)
+/// before activating. Returns a 4xx response when missing so the
+/// dashboard can surface a "connect Claude credentials" CTA.
 ///
 /// Checks by exact credential name (not "any credential row") because
 /// the Claude CLI only honors specific env vars; a user with only
 /// custom-named secrets would silently activate into a workflow whose
 /// every session fails with "stdout closed without result event".
 #[allow(clippy::result_large_err)]
-async fn require_owner_credentials(state: &AppState, owner_user_id: &str) -> Result<(), Response> {
-    match db::user_has_credential_in(&state.db, owner_user_id, CLAUDE_AUTH_CREDENTIAL_NAMES).await
+async fn require_owner_credentials(
+    state: &AppState,
+    owner_user_id: &str,
+    workspace_id: &str,
+) -> Result<(), Response> {
+    match db::user_has_credential_in(
+        &state.db,
+        owner_user_id,
+        workspace_id,
+        CLAUDE_AUTH_CREDENTIAL_NAMES,
+    )
+    .await
     {
         Ok(true) => Ok(()),
         Ok(false) => Err((
@@ -111,11 +121,12 @@ async fn require_owner_credentials(state: &AppState, owner_user_id: &str) -> Res
             Json(serde_json::json!({
                 "error": "no_credentials_for_workflow",
                 "message": format!(
-                    "Workflow owner has no Claude credentials. Connect one of {:?} in Settings before activating.",
+                    "Workflow owner has no Claude credentials in this workspace. Connect one of {:?} in Settings before activating.",
                     CLAUDE_AUTH_CREDENTIAL_NAMES
                 ),
                 "required_one_of": CLAUDE_AUTH_CREDENTIAL_NAMES,
                 "owner_user_id": owner_user_id,
+                "workspace_id": workspace_id,
             })),
         )
             .into_response()),
@@ -303,7 +314,9 @@ pub async fn create_workflow(
         // the caller themselves (just set above), so this in practice
         // surfaces the case where a user creates+activates without ever
         // having connected Claude credentials.
-        if let Err(r) = require_owner_credentials(&state, &workflow.created_by).await {
+        if let Err(r) =
+            require_owner_credentials(&state, &workflow.created_by, &workflow.workspace_id).await
+        {
             return r;
         }
         if let Err(r) = activate_workflow(&state, &workflow.id, &headers).await {
@@ -587,7 +600,9 @@ pub async fn patch_workflow(
         // surfaces the broken state in the UX layer (a 4xx the dashboard
         // can render as "connect Claude credentials") instead of in the
         // spine event stream where users won't see it.
-        if let Err(r) = require_owner_credentials(&state, &workflow.created_by).await {
+        if let Err(r) =
+            require_owner_credentials(&state, &workflow.created_by, &workflow.workspace_id).await
+        {
             return r;
         }
         if let Err(r) = activate_workflow(&state, &workflow_id, &headers).await {

--- a/crates/stiglab/src/server/routes/workspaces.rs
+++ b/crates/stiglab/src/server/routes/workspaces.rs
@@ -513,8 +513,8 @@ pub async fn list_all_projects_for_user(
     auth_user: AuthUser,
     axum::extract::Query(q): axum::extract::Query<ListProjectsQuery>,
 ) -> Response {
-    if require_auth_user(&auth_user).is_err() {
-        return require_auth_user(&auth_user).err().unwrap();
+    if let Err(r) = require_auth_user(&auth_user) {
+        return r;
     }
     let workspace_id = match q.workspace.as_deref() {
         Some(w) if !w.trim().is_empty() => w,

--- a/crates/stiglab/src/server/routes/workspaces.rs
+++ b/crates/stiglab/src/server/routes/workspaces.rs
@@ -497,18 +497,33 @@ pub async fn list_projects(
     }
 }
 
-/// GET /api/projects — List every project the current user can access,
-/// across all their workspaces. Powers the cross-workspace project
-/// selector in `CreateSessionSheet`.
+#[derive(Debug, serde::Deserialize)]
+pub struct ListProjectsQuery {
+    #[serde(default)]
+    pub workspace: Option<String>,
+}
+
+/// GET /api/projects?workspace=W — List projects in `W` the current
+/// user can access (issue #164).  Per the list-endpoint contract,
+/// `?workspace=` is required and validated through
+/// `require_workspace_access`; cross-workspace project listing is no
+/// longer a single-call surface.
 pub async fn list_all_projects_for_user(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    axum::extract::Query(q): axum::extract::Query<ListProjectsQuery>,
 ) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
+    if require_auth_user(&auth_user).is_err() {
+        return require_auth_user(&auth_user).err().unwrap();
+    }
+    let workspace_id = match q.workspace.as_deref() {
+        Some(w) if !w.trim().is_empty() => w,
+        _ => return super::missing_workspace_query(),
     };
-    match db::list_projects_for_user(&state.db, user_id).await {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
+    match db::list_projects_for_workspace(&state.db, workspace_id).await {
         Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
         Err(e) => {
             tracing::error!("failed to list projects: {e}");

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -694,15 +694,17 @@ async fn delete_pat_revokes_so_subsequent_use_401s() {
 async fn pat_can_create_credential_but_not_overwrite() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
-    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-cred-put").await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     let state = AppState::new(pool, auth_enabled_config(), None);
     let app_ = app(state);
+    let put_uri = format!("/api/workspaces/{}/credentials/CI_TOKEN", workspace.id);
 
     // PUT to a brand-new credential name succeeds.
     let create = bearer(
         Request::builder()
             .method("PUT")
-            .uri("/api/credentials/CI_TOKEN")
+            .uri(&put_uri)
             .header(header::CONTENT_TYPE, "application/json"),
         &token,
     )
@@ -717,7 +719,7 @@ async fn pat_can_create_credential_but_not_overwrite() {
     let overwrite = bearer(
         Request::builder()
             .method("PUT")
-            .uri("/api/credentials/CI_TOKEN")
+            .uri(&put_uri)
             .header(header::CONTENT_TYPE, "application/json"),
         &token,
     )
@@ -735,22 +737,24 @@ async fn pat_can_create_credential_but_not_overwrite() {
 async fn pat_cannot_delete_credential() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-cred-del").await;
     // Pre-create a credential via the DB so the DELETE actually has
     // something to refer to.
     let key = stiglab::server::auth::generate_credential_key();
     let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
-    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+    db::set_user_credential(&pool, &user.id, &workspace.id, "CI_TOKEN", &enc)
         .await
         .unwrap();
-    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     let state = AppState::new(pool, auth_enabled_config(), None);
 
     let resp = app(state)
         .oneshot(
             bearer(
-                Request::builder()
-                    .method("DELETE")
-                    .uri("/api/credentials/CI_TOKEN"),
+                Request::builder().method("DELETE").uri(format!(
+                    "/api/workspaces/{}/credentials/CI_TOKEN",
+                    workspace.id
+                )),
                 &token,
             )
             .body(Body::empty())
@@ -768,9 +772,10 @@ async fn session_can_still_delete_credential_after_guardrail_added() {
     // Regression guard: the destructive guardrail must only fire for PATs.
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-cred-sess").await;
     let key = stiglab::server::auth::generate_credential_key();
     let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
-    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+    db::set_user_credential(&pool, &user.id, &workspace.id, "CI_TOKEN", &enc)
         .await
         .unwrap();
     let session_token = stiglab::server::auth::generate_session_token();
@@ -788,7 +793,10 @@ async fn session_can_still_delete_credential_after_guardrail_added() {
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri("/api/credentials/CI_TOKEN")
+                .uri(format!(
+                    "/api/workspaces/{}/credentials/CI_TOKEN",
+                    workspace.id
+                ))
                 .header(header::COOKIE, format!("stiglab_session={session_token}"))
                 .body(Body::empty())
                 .unwrap(),


### PR DESCRIPTION
## Summary

Child C of #161 — wires the `workspace_id` columns from #162/#163 into the HTTP surface so list endpoints filter and detail endpoints validate.

- **List endpoints** (`/api/sessions`, `/api/nodes`, `/api/projects`, `/api/github_app_installations`, `/api/workflows`, `/api/governance/*`, `/api/spine/*`, plus shaping/artifact lookups) now require `?workspace=` and filter SQL by it. Missing → **400**. `/api/workspaces` stays unscoped (lists memberships); `/api/pats` stays principal-scoped.
- **Detail endpoints** load the row then call `require_workspace_access` (the helper introduced in #163). Non-member → **404** to avoid existence leaks; PAT scope mismatch → **403** `pat_workspace_scope_mismatch`. No per-route ad-hoc checks.
- **Per-workspace credentials**:
  - Runtime DDL adds `user_credentials.workspace_id NOT NULL`, backfills to the user's first membership, and drops rows for users with no membership (mirrors the #163 PAT rule). Documented at `crates/stiglab/migrations/002_workspace_credentials.sql`.
  - New `/api/workspaces/:workspace/credentials` route. The legacy `/api/credentials` surface is **removed entirely** — no compat alias (CLAUDE.md "no dangling wires").
  - Session launch passes the credential bound to `session.workspace_id`, not a global user credential.
- **Webhook → workspace 1:1**: `github_app_installations` gains `UNIQUE(install_id)` and the webhook router resolves the workspace from the install row, tagging emitted events with `workspace_id`. Re-installing into a different workspace is a re-install flow, not a row update.
- **Forge audit**: forge's HTTP surface in `cmd/serve.rs` is only the seam-rule violation already tracked by #131 Lever C — sibling-subsystem RPC, no user-facing list/detail endpoints. **`area:forge` dropped** from this spec; nothing to scope.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p stiglab` — 156 lib + 23 PAT integration + workflow_webhook + sso suites all green (201 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run -p xtask -- lint-seams` — clean (only pre-existing exemptions)
- [x] Parent #161 contract test: W1 caller cannot see W2 sessions
- [x] Missing `?workspace=` → 400; detail mismatch → 404; PAT-pinned-to-W1 calling `?workspace=W2` → 403
- [ ] Manual smoke (deferred to deploy preview): launching a session in W1 uses W1's credential, not a global one

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RCHKjRLrgmCH8wHov8M6V)_