### PR TITLE
feat(lever-c): listeners + enriched producers — phase 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,7 @@ name = "stiglab"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-extra",
  "base64",

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -16,12 +16,15 @@ use onsager_spine::protocol::{
 use onsager_spine::EventStore;
 
 use crate::core::artifact_store::ArtifactStore;
+use crate::core::gate_verdict_listener;
 use crate::core::insight_cache::InsightCache;
 use crate::core::insight_listener;
 use crate::core::kernel::BaselineKernel;
+use crate::core::pending::{PendingShapings, PendingVerdicts};
 use crate::core::persistence;
 use crate::core::pipeline::{ForgePipeline, PipelineEvent, StiglabDispatcher, SynodicGate};
 use crate::core::session_listener::{self, SessionCompleted, SessionCompletedHandler};
+use crate::core::shaping_result_listener;
 use crate::core::signal_cache::SignalCache;
 use crate::core::stage_runner::{self, StageEvent};
 use crate::core::trigger_subscriber::{
@@ -416,6 +419,17 @@ struct ForgeSharedState {
     /// endpoint exposes them.
     #[allow(dead_code)]
     signals: SignalCache,
+    /// Verdicts parked from `synodic.gate_verdict` by
+    /// [`gate_verdict_listener`] (spec #131 / ADR 0004 Lever C, phase 3).
+    /// Phase 4 wires the pipeline tick to claim entries on the resume
+    /// path. Held in shared state so the HTTP API and the tick loop see
+    /// the same map.
+    #[allow(dead_code)]
+    pending_verdicts: PendingVerdicts,
+    /// Shaping results parked from `stiglab.shaping_result_ready` by
+    /// [`shaping_result_listener`]. Same wiring story as above.
+    #[allow(dead_code)]
+    pending_shapings: PendingShapings,
 }
 
 type SharedForge = Arc<RwLock<ForgeSharedState>>;
@@ -534,11 +548,19 @@ pub fn run(database_url: &str, tick_ms: u64) {
         // branch that silently disagrees with the DB.
         let signals = SignalCache::new();
 
+        // Phase-3 parking maps for the Lever C event-driven flow. The
+        // listeners spawned below populate these; phase 4 wires the
+        // pipeline tick to consume them.
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+
         let shared = Arc::new(RwLock::new(ForgeSharedState {
             pipeline,
             kernel: BaselineKernel::new(),
             spine,
             signals: signals.clone(),
+            pending_verdicts: pending_verdicts.clone(),
+            pending_shapings: pending_shapings.clone(),
         }));
 
         // Start HTTP API.
@@ -820,6 +842,77 @@ pub fn run(database_url: &str, tick_ms: u64) {
             };
             if let Err(e) = workflow_signal_listener::run(store, signals_for_listener, None).await {
                 tracing::error!("forge: workflow signal listener exited: {e}");
+            }
+        });
+
+        // Spawn the Lever C verdict listener (spec #131 / ADR 0004 phase 3).
+        // Tails `synodic.gate_verdict`, parses the typed variant, and
+        // parks the embedded `GateVerdict` in `pending_verdicts` keyed by
+        // its `gate_id`. Phase 4 wires the pipeline tick's resume path
+        // to claim entries from this map; until then the listener
+        // accumulates verdicts so the schema is exercised end-to-end.
+        //
+        // Warm-start at `max_event_id` so a fresh boot doesn't replay
+        // every historical verdict — same rationale as the insight
+        // listener above. A phase-6 follow-up persists a per-process
+        // cursor so a crash doesn't drop in-flight verdicts.
+        let verdict_shared = shared.clone();
+        let pending_verdicts_for_listener = pending_verdicts.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = verdict_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: gate_verdict listener disabled (no spine connection)");
+                return;
+            };
+            let since = match store.max_event_id().await {
+                Ok(cursor) => cursor,
+                Err(e) => {
+                    tracing::warn!(
+                        "forge: max_event_id lookup failed ({e}); starting gate_verdict \
+                         listener from the beginning"
+                    );
+                    None
+                }
+            };
+            if let Err(e) =
+                gate_verdict_listener::run(store, pending_verdicts_for_listener, since).await
+            {
+                tracing::error!("forge: gate_verdict listener exited: {e}");
+            }
+        });
+
+        // Spawn the Lever C shaping-result listener. Tails
+        // `stiglab.shaping_result_ready`, parses the typed variant, and
+        // parks the embedded `ShapingResult` in `pending_shapings` keyed
+        // by its `request_id`. Same warm-start strategy.
+        let shaping_shared = shared.clone();
+        let pending_shapings_for_listener = pending_shapings.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = shaping_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: shaping_result listener disabled (no spine connection)");
+                return;
+            };
+            let since = match store.max_event_id().await {
+                Ok(cursor) => cursor,
+                Err(e) => {
+                    tracing::warn!(
+                        "forge: max_event_id lookup failed ({e}); starting shaping_result \
+                         listener from the beginning"
+                    );
+                    None
+                }
+            };
+            if let Err(e) =
+                shaping_result_listener::run(store, pending_shapings_for_listener, since).await
+            {
+                tracing::error!("forge: shaping_result listener exited: {e}");
             }
         });
 
@@ -1189,6 +1282,13 @@ async fn get_artifact(
 }
 
 /// Emit a pipeline event to the event spine.
+///
+/// Carrier events (`forge.shaping_dispatched`, `forge.gate_requested`)
+/// are serialized through the typed [`FactoryEventKind`] so the full
+/// `request` payload travels alongside the routing fields. Stiglab's
+/// shaping listener and Synodic's gate listener consume the embedded
+/// payload directly — phase 3 of spec #131 / ADR 0004 Lever C — instead
+/// of falling back to a sibling-subsystem HTTP roundtrip.
 async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
     let metadata = onsager_spine::EventMetadata {
         correlation_id: None,
@@ -1196,6 +1296,9 @@ async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
         actor: "forge".to_string(),
     };
 
+    // Match-and-serialize via FactoryEventKind variants where the schema
+    // exists; fall back to hand-rolled JSON for events that don't have a
+    // typed variant yet (forge.error, forge.gate_verdict, forge.shaping_returned).
     let (stream_id, event_type, data) = match event {
         PipelineEvent::DecisionMade(d) => (
             format!("forge:{}", d.artifact_id),
@@ -1210,15 +1313,21 @@ async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
             request_id,
             artifact_id,
             target_version,
-        } => (
-            format!("forge:{artifact_id}"),
-            "forge.shaping_dispatched",
-            serde_json::json!({
-                "request_id": request_id,
-                "artifact_id": artifact_id,
-                "target_version": target_version,
-            }),
-        ),
+            request,
+        } => {
+            let kind = onsager_spine::factory_event::FactoryEventKind::ForgeShapingDispatched {
+                request_id: request_id.clone(),
+                artifact_id: onsager_artifact::ArtifactId::new(artifact_id),
+                target_version: *target_version,
+                request: Some(request.clone()),
+            };
+            let data = serde_json::to_value(&kind).expect("FactoryEventKind must serialize");
+            (
+                format!("forge:{artifact_id}"),
+                "forge.shaping_dispatched",
+                data,
+            )
+        }
         PipelineEvent::ShapingReturned {
             request_id,
             artifact_id,
@@ -1233,16 +1342,20 @@ async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
             }),
         ),
         PipelineEvent::GateRequested {
+            gate_id,
             artifact_id,
             gate_point,
-        } => (
-            format!("forge:{artifact_id}"),
-            "forge.gate_requested",
-            serde_json::json!({
-                "artifact_id": artifact_id,
-                "gate_point": format!("{gate_point:?}"),
-            }),
-        ),
+            request,
+        } => {
+            let kind = onsager_spine::factory_event::FactoryEventKind::ForgeGateRequested {
+                gate_id: gate_id.clone(),
+                artifact_id: onsager_artifact::ArtifactId::new(artifact_id),
+                gate_point: *gate_point,
+                request: Some(request.clone()),
+            };
+            let data = serde_json::to_value(&kind).expect("FactoryEventKind must serialize");
+            (format!("forge:{artifact_id}"), "forge.gate_requested", data)
+        }
         PipelineEvent::GateVerdictReceived {
             artifact_id,
             gate_point,

--- a/crates/forge/src/core/gate_verdict_listener.rs
+++ b/crates/forge/src/core/gate_verdict_listener.rs
@@ -1,0 +1,171 @@
+//! Listener that records `synodic.gate_verdict` events into
+//! [`PendingVerdicts`] (spec #131 / ADR 0004 Lever C, phase 3).
+//!
+//! Mirrors the layout of [`crate::core::session_listener`] — filters on
+//! `event_type` rather than namespace prefix because the spine listener's
+//! namespace filter keys on a `stream_id` prefix that synodic does not
+//! currently use for these events.
+//!
+//! The listener parses each event into the typed [`FactoryEventKind`] and,
+//! when it's a `SynodicGateVerdict`, pushes the embedded `GateVerdict` into
+//! the shared map under its `gate_id` correlation key. Phase 4 wires the
+//! pipeline tick to `take()` that entry on the resume path.
+
+use async_trait::async_trait;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+
+use super::pending::PendingVerdicts;
+
+/// Run the verdict listener forever. Returns only if the underlying
+/// pg_notify channel closes.
+///
+/// `since` is the backfill cursor — forge can persist the last seen event
+/// id across restarts so a crash doesn't drop in-flight verdicts. Until
+/// phase 6 lands persistence, callers should pass `max_event_id()` so the
+/// listener doesn't replay history-wide on every boot.
+pub async fn run(
+    store: EventStore,
+    pending: PendingVerdicts,
+    since: Option<i64>,
+) -> anyhow::Result<()> {
+    let handler = Dispatcher {
+        store: store.clone(),
+        pending,
+    };
+    Listener::new(store).with_since(since).run(handler).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    pending: PendingVerdicts,
+}
+
+impl Dispatcher {
+    async fn load_kind(
+        &self,
+        notification: &EventNotification,
+    ) -> anyhow::Result<Option<FactoryEventKind>> {
+        match notification.table.as_str() {
+            "events" => {
+                let Some(row) = self.store.get_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let envelope: FactoryEvent = serde_json::from_value(row.data)?;
+                Ok(Some(envelope.event))
+            }
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let raw = row.data;
+                if let Ok(envelope) = serde_json::from_value::<FactoryEvent>(raw.clone()) {
+                    Ok(Some(envelope.event))
+                } else {
+                    let kind: FactoryEventKind = serde_json::from_value(raw)?;
+                    Ok(Some(kind))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// Pure classifier: extract the `(gate_id, verdict)` pair from a
+/// [`FactoryEventKind`], or `None` if the kind is not a gate verdict.
+///
+/// Split out so tests can exercise the typed branches without a spine.
+pub fn classify_verdict(
+    kind: FactoryEventKind,
+) -> Option<(String, onsager_spine::protocol::GateVerdict)> {
+    match kind {
+        FactoryEventKind::SynodicGateVerdict {
+            gate_id, verdict, ..
+        } => Some((gate_id, verdict)),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "synodic.gate_verdict" {
+            return Ok(());
+        }
+
+        let Some(kind) = self.load_kind(&notification).await? else {
+            return Ok(());
+        };
+
+        if let Some((gate_id, verdict)) = classify_verdict(kind) {
+            tracing::info!(
+                gate_id = %gate_id,
+                "forge: parking synodic.gate_verdict for pipeline resume"
+            );
+            self.pending.insert(&gate_id, verdict);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::ArtifactId;
+    use onsager_spine::factory_event::GatePoint;
+    use onsager_spine::protocol::GateVerdict;
+
+    #[test]
+    fn classify_extracts_gate_id_and_verdict() {
+        let kind = FactoryEventKind::SynodicGateVerdict {
+            gate_id: "g_42".into(),
+            artifact_id: ArtifactId::new("art_x"),
+            gate_point: GatePoint::PreDispatch,
+            verdict: GateVerdict::Allow,
+        };
+        let (gate_id, verdict) = classify_verdict(kind).expect("matches variant");
+        assert_eq!(gate_id, "g_42");
+        assert!(matches!(verdict, GateVerdict::Allow));
+    }
+
+    #[test]
+    fn classify_preserves_deny_payload() {
+        // Phase-4 will surface the reason on the pipeline event stream;
+        // the classifier must not lose it.
+        let kind = FactoryEventKind::SynodicGateVerdict {
+            gate_id: "g_deny".into(),
+            artifact_id: ArtifactId::new("art_x"),
+            gate_point: GatePoint::StateTransition,
+            verdict: GateVerdict::Deny {
+                reason: "policy violation: secrets in payload".into(),
+            },
+        };
+        match classify_verdict(kind).map(|(_, v)| v) {
+            Some(GateVerdict::Deny { reason }) => {
+                assert_eq!(reason, "policy violation: secrets in payload")
+            }
+            other => panic!("expected Deny payload preserved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_returns_none_for_unrelated_event() {
+        // The listener filters by event_type before reaching the
+        // classifier, but defense in depth: even if a different variant
+        // arrives, we must not park it as a verdict.
+        let kind = FactoryEventKind::ForgeIdleTick;
+        assert!(classify_verdict(kind).is_none());
+    }
+
+    #[test]
+    fn classify_returns_none_for_summary_variant() {
+        // SynodicGateEvaluated is the dashboard summary; it does not
+        // carry the full GateVerdict payload phase-4 will act on.
+        let kind = FactoryEventKind::SynodicGateEvaluated {
+            gate_id: "g_eval".into(),
+            artifact_id: ArtifactId::new("art_x"),
+            verdict: onsager_spine::factory_event::VerdictSummary::Allow,
+        };
+        assert!(classify_verdict(kind).is_none());
+    }
+}

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -1,12 +1,15 @@
 //! Core Forge logic — scheduling kernel, artifact store, pipeline, and state machine.
 
 pub mod artifact_store;
+pub mod gate_verdict_listener;
 pub mod insight_cache;
 pub mod insight_listener;
 pub mod kernel;
+pub mod pending;
 pub mod persistence;
 pub mod pipeline;
 pub mod session_listener;
+pub mod shaping_result_listener;
 pub mod signal_cache;
 pub mod stage_runner;
 pub mod state;

--- a/crates/forge/src/core/pending.rs
+++ b/crates/forge/src/core/pending.rs
@@ -1,0 +1,185 @@
+//! In-memory parking maps for non-blocking pipeline decisions
+//! (spec #131 / ADR 0004 Lever C, phase 3).
+//!
+//! Forge can no longer block on a synchronous HTTP roundtrip to ask Synodic
+//! for a verdict or wait on Stiglab to finish a shaping. Instead it emits an
+//! event (`forge.gate_requested`, `forge.shaping_dispatched`), parks the
+//! pipeline decision keyed by the request's correlation id, and the
+//! corresponding listener thread records the response into one of these
+//! maps when the matching event lands on the spine
+//! (`synodic.gate_verdict`, `stiglab.shaping_result_ready`).
+//!
+//! Phase-4 wires these maps into `ForgePipeline::tick`'s state machine so
+//! the resume path consults them. Phase-3 only populates them — keeping
+//! the change surface narrow.
+//!
+//! ## Persistence
+//!
+//! These maps are process-private and lost on restart. The phase-6 sub-issue
+//! covers a forge-private `pending_pipeline_decisions` table + replay so a
+//! mid-tick crash doesn't drop in-flight decisions; until then, a restart
+//! mid-decision stalls the artifact (the next tick re-emits the request,
+//! which Synodic / Stiglab observe as a duplicate keyed by the same
+//! correlation id).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use onsager_spine::protocol::{GateVerdict, ShapingResult};
+
+/// Verdicts pulled off the spine, keyed by `gate_id` (the correlation id
+/// Forge stamped on the originating `forge.gate_requested`).
+#[derive(Clone, Default)]
+pub struct PendingVerdicts {
+    inner: Arc<Mutex<HashMap<String, GateVerdict>>>,
+}
+
+impl PendingVerdicts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a verdict that the pipeline can claim later. Overwrites any
+    /// prior entry for the same id — Synodic shouldn't emit twice, but if
+    /// it does the latest wins (matches the dashboard's "most recent
+    /// verdict" rendering).
+    pub fn insert(&self, gate_id: &str, verdict: GateVerdict) {
+        self.inner
+            .lock()
+            .expect("PendingVerdicts mutex poisoned")
+            .insert(gate_id.to_string(), verdict);
+    }
+
+    /// Claim the verdict for `gate_id`, removing it from the map. Returns
+    /// `None` if no verdict has landed yet.
+    pub fn take(&self, gate_id: &str) -> Option<GateVerdict> {
+        self.inner
+            .lock()
+            .expect("PendingVerdicts mutex poisoned")
+            .remove(gate_id)
+    }
+
+    /// Number of parked verdicts. Used by tests; in production we'd want
+    /// a metric here once phase 4 lands the consumer side.
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("PendingVerdicts mutex poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Shaping results pulled off the spine, keyed by `request_id` (the id
+/// Forge stamped on the originating `forge.shaping_dispatched`).
+#[derive(Clone, Default)]
+pub struct PendingShapings {
+    inner: Arc<Mutex<HashMap<String, ShapingResult>>>,
+}
+
+impl PendingShapings {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, request_id: &str, result: ShapingResult) {
+        self.inner
+            .lock()
+            .expect("PendingShapings mutex poisoned")
+            .insert(request_id.to_string(), result);
+    }
+
+    pub fn take(&self, request_id: &str) -> Option<ShapingResult> {
+        self.inner
+            .lock()
+            .expect("PendingShapings mutex poisoned")
+            .remove(request_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("PendingShapings mutex poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::protocol::ShapingResult;
+
+    fn allow() -> GateVerdict {
+        GateVerdict::Allow
+    }
+
+    fn shaping_ok(req: &str) -> ShapingResult {
+        ShapingResult {
+            request_id: req.into(),
+            outcome: onsager_spine::factory_event::ShapingOutcome::Completed,
+            content_ref: None,
+            change_summary: String::new(),
+            quality_signals: vec![],
+            session_id: "sess".into(),
+            duration_ms: 0,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn pending_verdicts_round_trip() {
+        let m = PendingVerdicts::new();
+        assert!(m.is_empty());
+        m.insert("g1", allow());
+        assert_eq!(m.len(), 1);
+        let taken = m.take("g1").expect("verdict was parked");
+        assert!(matches!(taken, GateVerdict::Allow));
+        // Take is single-shot.
+        assert!(m.take("g1").is_none());
+    }
+
+    #[test]
+    fn pending_verdicts_overwrites_on_duplicate_insert() {
+        let m = PendingVerdicts::new();
+        m.insert("g1", allow());
+        m.insert(
+            "g1",
+            GateVerdict::Deny {
+                reason: "later".into(),
+            },
+        );
+        match m.take("g1").unwrap() {
+            GateVerdict::Deny { reason } => assert_eq!(reason, "later"),
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_shapings_round_trip() {
+        let m = PendingShapings::new();
+        m.insert("r1", shaping_ok("r1"));
+        let taken = m.take("r1").expect("result was parked");
+        assert_eq!(taken.request_id, "r1");
+        assert!(m.take("r1").is_none());
+    }
+
+    #[test]
+    fn pending_maps_are_independent_per_key() {
+        // Park two distinct requests; taking one must not affect the other.
+        let m = PendingShapings::new();
+        m.insert("r1", shaping_ok("r1"));
+        m.insert("r2", shaping_ok("r2"));
+        assert_eq!(m.len(), 2);
+        m.take("r1");
+        assert_eq!(m.len(), 1);
+        assert!(m.take("r2").is_some());
+        assert!(m.is_empty());
+    }
+}

--- a/crates/forge/src/core/pending.rs
+++ b/crates/forge/src/core/pending.rs
@@ -22,16 +22,99 @@
 //! which Synodic / Stiglab observe as a duplicate keyed by the same
 //! correlation id).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use onsager_spine::protocol::{GateVerdict, ShapingResult};
 
+/// Cap on parked entries per map. Each tick of phase 4's resume path
+/// drains exactly one entry per artifact, so steady-state size is
+/// bounded by the in-flight artifact count. The cap is a safety net
+/// for two failure modes:
+///
+/// 1. Producer bugs that emit verdicts/results for ids forge never
+///    parked (no consumer ever claims, entry leaks).
+/// 2. Phase-3 → phase-4 partial deploys: forge runs phase-3 binary
+///    (parks but never drains) for hours before the phase-4 binary
+///    rolls out.
+///
+/// 4096 fits a multi-day burst at typical factory volumes while
+/// keeping the worst-case footprint negligible. Eviction is FIFO on
+/// the order entries were inserted — a verdict that has been parked
+/// longer than 4096 newer arrivals is almost certainly orphaned and
+/// safe to drop. Phase 6 replaces this with persisted parking.
+const MAX_PENDING_ENTRIES: usize = 4096;
+
+/// Inner store backing both [`PendingVerdicts`] and [`PendingShapings`].
+/// Provides FIFO eviction once `max_entries` is exceeded so the maps
+/// can't grow without bound under the failure modes documented above.
+struct BoundedMap<V> {
+    inner: HashMap<String, V>,
+    /// Insertion order, used for FIFO eviction on overflow. Re-inserts
+    /// of an existing key reset its position.
+    order: VecDeque<String>,
+    max_entries: usize,
+}
+
+impl<V> BoundedMap<V> {
+    fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+            order: VecDeque::new(),
+            max_entries: MAX_PENDING_ENTRIES,
+        }
+    }
+
+    fn insert(&mut self, key: &str, value: V) {
+        // Re-insert: drop the old position so the new one lands at the
+        // back of the queue.
+        if self.inner.contains_key(key) {
+            self.order.retain(|existing| existing != key);
+        }
+        self.order.push_back(key.to_string());
+        self.inner.insert(key.to_string(), value);
+        while self.inner.len() > self.max_entries {
+            if let Some(oldest) = self.order.pop_front() {
+                if self.inner.remove(&oldest).is_some() {
+                    tracing::warn!(
+                        evicted_key = %oldest,
+                        "forge: pending map at capacity, evicted oldest entry"
+                    );
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn remove(&mut self, key: &str) -> Option<V> {
+        let removed = self.inner.remove(key);
+        if removed.is_some() {
+            self.order.retain(|existing| existing != key);
+        }
+        removed
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
 /// Verdicts pulled off the spine, keyed by `gate_id` (the correlation id
 /// Forge stamped on the originating `forge.gate_requested`).
-#[derive(Clone, Default)]
+///
+/// Bounded by [`MAX_PENDING_ENTRIES`] with FIFO eviction; see module doc.
+#[derive(Clone)]
 pub struct PendingVerdicts {
-    inner: Arc<Mutex<HashMap<String, GateVerdict>>>,
+    inner: Arc<Mutex<BoundedMap<GateVerdict>>>,
+}
+
+impl Default for PendingVerdicts {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(BoundedMap::new())),
+        }
+    }
 }
 
 impl PendingVerdicts {
@@ -47,7 +130,7 @@ impl PendingVerdicts {
         self.inner
             .lock()
             .expect("PendingVerdicts mutex poisoned")
-            .insert(gate_id.to_string(), verdict);
+            .insert(gate_id, verdict);
     }
 
     /// Claim the verdict for `gate_id`, removing it from the map. Returns
@@ -75,9 +158,19 @@ impl PendingVerdicts {
 
 /// Shaping results pulled off the spine, keyed by `request_id` (the id
 /// Forge stamped on the originating `forge.shaping_dispatched`).
-#[derive(Clone, Default)]
+///
+/// Bounded by [`MAX_PENDING_ENTRIES`] with FIFO eviction; see module doc.
+#[derive(Clone)]
 pub struct PendingShapings {
-    inner: Arc<Mutex<HashMap<String, ShapingResult>>>,
+    inner: Arc<Mutex<BoundedMap<ShapingResult>>>,
+}
+
+impl Default for PendingShapings {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(BoundedMap::new())),
+        }
+    }
 }
 
 impl PendingShapings {
@@ -89,7 +182,7 @@ impl PendingShapings {
         self.inner
             .lock()
             .expect("PendingShapings mutex poisoned")
-            .insert(request_id.to_string(), result);
+            .insert(request_id, result);
     }
 
     pub fn take(&self, request_id: &str) -> Option<ShapingResult> {
@@ -181,5 +274,45 @@ mod tests {
         assert_eq!(m.len(), 1);
         assert!(m.take("r2").is_some());
         assert!(m.is_empty());
+    }
+
+    #[test]
+    fn bounded_map_evicts_oldest_on_overflow() {
+        // Producer-bug guard: keep inserting orphaned verdicts and the
+        // map size must stay capped, not climb without bound. The
+        // oldest entry is the first one to go.
+        let mut m = BoundedMap::<u32>::new();
+        m.max_entries = 3;
+
+        m.insert("a", 1);
+        m.insert("b", 2);
+        m.insert("c", 3);
+        assert_eq!(m.len(), 3);
+
+        // Overflow → "a" evicted (FIFO).
+        m.insert("d", 4);
+        assert_eq!(m.len(), 3);
+        assert!(m.remove("a").is_none());
+        assert_eq!(m.remove("b"), Some(2));
+        assert_eq!(m.remove("c"), Some(3));
+        assert_eq!(m.remove("d"), Some(4));
+    }
+
+    #[test]
+    fn bounded_map_reinsert_resets_position() {
+        // Re-inserting an existing key moves it to the back of the
+        // queue, so it survives the next eviction wave.
+        let mut m = BoundedMap::<u32>::new();
+        m.max_entries = 2;
+
+        m.insert("a", 1);
+        m.insert("b", 2);
+        // Touch "a" — it's now newer than "b".
+        m.insert("a", 11);
+        // Insert "c" — evicts "b" (the oldest), not "a".
+        m.insert("c", 3);
+        assert!(m.remove("b").is_none());
+        assert_eq!(m.remove("a"), Some(11));
+        assert_eq!(m.remove("c"), Some(3));
     }
 }

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -36,19 +36,32 @@ pub struct TickOutput {
 #[derive(Debug)]
 pub enum PipelineEvent {
     DecisionMade(ShapingDecision),
+    /// A shaping request was sent to Stiglab. Carries the full
+    /// `ShapingRequest` payload so the spine emitter can populate the
+    /// `request` field on `forge.shaping_dispatched` (spec #131 / ADR
+    /// 0004 Lever C, phase 3) — Stiglab's listener spawns a session
+    /// directly off the event without a follow-up HTTP roundtrip.
     ShapingDispatched {
         request_id: String,
         artifact_id: String,
         target_version: u32,
+        request: ShapingRequest,
     },
     ShapingReturned {
         request_id: String,
         artifact_id: String,
         outcome: String,
     },
+    /// A gate request was sent to Synodic. Carries the full
+    /// `GateRequest` payload + the `gate_id` correlation key so the
+    /// spine emitter can populate `forge.gate_requested` and the
+    /// `synodic.gate_verdict` listener can resume the parked
+    /// pipeline decision keyed on the same id (phase 3).
     GateRequested {
+        gate_id: String,
         artifact_id: String,
         gate_point: GatePoint,
+        request: GateRequest,
     },
     GateVerdictReceived {
         artifact_id: String,
@@ -300,8 +313,10 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
         };
 
         output.events.push(PipelineEvent::GateRequested {
+            gate_id: ulid::Ulid::new().to_string(),
             artifact_id: decision.artifact_id.to_string(),
             gate_point: GatePoint::PreDispatch,
+            request: pre_dispatch_gate.clone(),
         });
 
         let verdict = self.synodic.evaluate(&pre_dispatch_gate);
@@ -355,6 +370,7 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             request_id: request_id.clone(),
             artifact_id: decision.artifact_id.to_string(),
             target_version: decision.target_version,
+            request: shaping_request.clone(),
         });
 
         let result = self.stiglab.dispatch(&shaping_request);
@@ -398,8 +414,10 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
         };
 
         output.events.push(PipelineEvent::GateRequested {
+            gate_id: ulid::Ulid::new().to_string(),
             artifact_id: decision.artifact_id.to_string(),
             gate_point: GatePoint::StateTransition,
+            request: transition_gate.clone(),
         });
 
         let transition_verdict = self.synodic.evaluate(&transition_gate);

--- a/crates/forge/src/core/shaping_result_listener.rs
+++ b/crates/forge/src/core/shaping_result_listener.rs
@@ -1,0 +1,164 @@
+//! Listener that records `stiglab.shaping_result_ready` events into
+//! [`PendingShapings`] (spec #131 / ADR 0004 Lever C, phase 3).
+//!
+//! Symmetric with [`crate::core::gate_verdict_listener`]: filters on
+//! `event_type`, parses the typed variant, and pushes the embedded
+//! `ShapingResult` into the shared map under its `request_id` key.
+//!
+//! The lifecycle event `stiglab.session_completed` keeps its existing
+//! `SessionLinker` consumer (vertical-lineage write) — that listener
+//! handles cluster-state, this one handles artifact-state. Phase 4 wires
+//! the pipeline tick's resume path to `take()` from this map.
+
+use async_trait::async_trait;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+
+use super::pending::PendingShapings;
+
+/// Run the shaping-result listener forever. Returns only if pg_notify
+/// closes. `since` is the backfill cursor (see
+/// [`crate::core::gate_verdict_listener::run`] for the same caveat).
+pub async fn run(
+    store: EventStore,
+    pending: PendingShapings,
+    since: Option<i64>,
+) -> anyhow::Result<()> {
+    let handler = Dispatcher {
+        store: store.clone(),
+        pending,
+    };
+    Listener::new(store).with_since(since).run(handler).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    pending: PendingShapings,
+}
+
+impl Dispatcher {
+    async fn load_kind(
+        &self,
+        notification: &EventNotification,
+    ) -> anyhow::Result<Option<FactoryEventKind>> {
+        match notification.table.as_str() {
+            "events" => {
+                let Some(row) = self.store.get_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let envelope: FactoryEvent = serde_json::from_value(row.data)?;
+                Ok(Some(envelope.event))
+            }
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let raw = row.data;
+                if let Ok(envelope) = serde_json::from_value::<FactoryEvent>(raw.clone()) {
+                    Ok(Some(envelope.event))
+                } else {
+                    let kind: FactoryEventKind = serde_json::from_value(raw)?;
+                    Ok(Some(kind))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// Pure classifier: extract the `(request_id, ShapingResult)` pair from a
+/// [`FactoryEventKind`], or `None` if the kind is not a shaping result.
+///
+/// Key is the `request_id` Forge stamped on the originating
+/// `forge.shaping_dispatched`. The duplicate top-level `artifact_id` on
+/// the event is kept for stream routing; we don't need it here.
+pub fn classify_shaping_result(
+    kind: FactoryEventKind,
+) -> Option<(String, onsager_spine::protocol::ShapingResult)> {
+    match kind {
+        FactoryEventKind::StiglabShapingResultReady { result, .. } => {
+            Some((result.request_id.clone(), result))
+        }
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "stiglab.shaping_result_ready" {
+            return Ok(());
+        }
+
+        let Some(kind) = self.load_kind(&notification).await? else {
+            return Ok(());
+        };
+
+        if let Some((request_id, result)) = classify_shaping_result(kind) {
+            tracing::info!(
+                request_id = %request_id,
+                "forge: parking stiglab.shaping_result_ready for pipeline resume"
+            );
+            self.pending.insert(&request_id, result);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::{ArtifactId, ContentRef};
+    use onsager_spine::factory_event::ShapingOutcome;
+    use onsager_spine::protocol::ShapingResult;
+
+    fn shaping_completed(req: &str) -> ShapingResult {
+        ShapingResult {
+            request_id: req.into(),
+            outcome: ShapingOutcome::Completed,
+            content_ref: Some(ContentRef {
+                uri: "git://repo@abc".into(),
+                checksum: None,
+            }),
+            change_summary: "ok".into(),
+            quality_signals: vec![],
+            session_id: "sess".into(),
+            duration_ms: 10,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn classify_extracts_request_id_and_full_result() {
+        let kind = FactoryEventKind::StiglabShapingResultReady {
+            artifact_id: ArtifactId::new("art_x"),
+            result: shaping_completed("req_42"),
+        };
+        let (request_id, result) = classify_shaping_result(kind).expect("matches variant");
+        assert_eq!(request_id, "req_42");
+        assert_eq!(result.outcome, ShapingOutcome::Completed);
+        assert_eq!(result.content_ref.unwrap().uri, "git://repo@abc");
+    }
+
+    #[test]
+    fn classify_returns_none_for_session_completed() {
+        // Lifecycle event — different consumer (SessionLinker writes
+        // vertical_lineage). Must not be parked as a shaping result.
+        let kind = FactoryEventKind::StiglabSessionCompleted {
+            session_id: "s".into(),
+            request_id: "r".into(),
+            duration_ms: 1,
+            artifact_id: Some("art_x".into()),
+            token_usage: None,
+            branch: None,
+            pr_number: None,
+        };
+        assert!(classify_shaping_result(kind).is_none());
+    }
+
+    #[test]
+    fn classify_returns_none_for_unrelated_event() {
+        let kind = FactoryEventKind::ForgeIdleTick;
+        assert!(classify_shaping_result(kind).is_none());
+    }
+}

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -191,6 +191,17 @@ pub enum FactoryEventKind {
         request_id: String,
         artifact_id: ArtifactId,
         target_version: u32,
+        /// Full shaping payload — the same shape Stiglab previously
+        /// consumed as the `POST /api/shaping` request body. `None` on
+        /// events written before this field was added (spec #131 / ADR
+        /// 0004 Lever C phase 3). When `None`, Stiglab's listener cannot
+        /// spawn a session and must skip the request.
+        ///
+        /// Top-level `request_id`, `artifact_id`, and `target_version`
+        /// are kept for stream indexing and dashboard filtering; the
+        /// duplication with `request` is intentional.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request: Option<crate::protocol::ShapingRequest>,
     },
 
     /// ShapingResult received from Stiglab.
@@ -1417,6 +1428,76 @@ mod tests {
         let back: FactoryEventKind = serde_json::from_value(json_with).unwrap();
         assert_eq!(back, event_with);
         assert_eq!(back.event_type(), "forge.gate_requested");
+    }
+
+    #[test]
+    fn forge_shaping_dispatched_request_field_serde_compat() {
+        use crate::protocol::ShapingRequest;
+
+        // 1. With request = None, the field is omitted from the wire form
+        //    (skip_serializing_if), keeping legacy JSON shape on emit.
+        let event_without = FactoryEventKind::ForgeShapingDispatched {
+            request_id: "req_no_payload".into(),
+            artifact_id: ArtifactId::new("art_legacy_shape"),
+            target_version: 3,
+            request: None,
+        };
+        let json_without = serde_json::to_value(&event_without).unwrap();
+        assert!(
+            json_without.get("request").is_none(),
+            "request: None must be omitted on serialization, got: {json_without}"
+        );
+
+        // 2. Legacy JSON lacking the `request` field deserializes with
+        //    request = None — the #[serde(default)] contract that lets
+        //    pre-Lever-C events still parse.
+        let legacy_json = serde_json::json!({
+            "type": "forge_shaping_dispatched",
+            "request_id": "req_legacy",
+            "artifact_id": "art_legacy_shape",
+            "target_version": 1,
+        });
+        let parsed: FactoryEventKind = serde_json::from_value(legacy_json).unwrap();
+        match parsed {
+            FactoryEventKind::ForgeShapingDispatched { request, .. } => {
+                assert!(
+                    request.is_none(),
+                    "legacy JSON must default request to None"
+                );
+            }
+            other => panic!("expected ForgeShapingDispatched, got {other:?}"),
+        }
+
+        // 3. With request = Some(...), full payload round-trips. The
+        //    Stiglab listener depends on the inner ShapingRequest staying
+        //    byte-stable across upgrades.
+        let event_with = FactoryEventKind::ForgeShapingDispatched {
+            request_id: "req_full".into(),
+            artifact_id: ArtifactId::new("art_full_shape"),
+            target_version: 5,
+            request: Some(ShapingRequest {
+                request_id: "req_full".into(),
+                artifact_id: ArtifactId::new("art_full_shape"),
+                target_version: 5,
+                shaping_intent: serde_json::json!({"prompt": "do the thing"}),
+                inputs: vec![],
+                constraints: vec![],
+                deadline: None,
+                created_by: Some("user_42".into()),
+            }),
+        };
+        let json_with = serde_json::to_value(&event_with).unwrap();
+        assert_eq!(json_with["type"], "forge_shaping_dispatched");
+        assert_eq!(json_with["request"]["request_id"], "req_full");
+        assert_eq!(
+            json_with["request"]["shaping_intent"]["prompt"],
+            "do the thing"
+        );
+        assert_eq!(json_with["request"]["created_by"], "user_42");
+
+        let back: FactoryEventKind = serde_json::from_value(json_with).unwrap();
+        assert_eq!(back, event_with);
+        assert_eq!(back.event_type(), "forge.shaping_dispatched");
     }
 
     #[test]

--- a/crates/onsager-spine/src/protocol.rs
+++ b/crates/onsager-spine/src/protocol.rs
@@ -20,7 +20,7 @@ use crate::factory_event::{GatePoint, InsightKind, InsightScope, ShapingOutcome}
 // ===========================================================================
 
 /// A reference to another artifact used as horizontal lineage input.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArtifactRef {
     pub artifact_id: ArtifactId,
     pub version: u32,
@@ -28,7 +28,7 @@ pub struct ArtifactRef {
 }
 
 /// A constraint that Stiglab must respect during shaping.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Constraint {
     /// Constraint type (e.g., "max_tokens", "tool_allowlist", "timeout_ms").
     #[serde(rename = "type")]
@@ -38,7 +38,7 @@ pub struct Constraint {
 }
 
 /// Shaping request from Forge to Stiglab (forge-v0.1 §5.2).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShapingRequest {
     /// Unique request ID (ULID). Forge never mutates this. Used for
     /// idempotent dispatch (forge invariant #6).

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -48,5 +48,6 @@ jsonwebtoken = { workspace = true }
 tokio-tungstenite = { workspace = true }
 clap = { workspace = true }
 hostname = "0.4"
+async-trait = { workspace = true }
 
 [dev-dependencies]

--- a/crates/stiglab/src/main.rs
+++ b/crates/stiglab/src/main.rs
@@ -130,6 +130,38 @@ async fn run_server(
         }
     }
 
+    // Spawn the forge.shaping_dispatched listener (spec #131 / ADR 0004
+    // Lever C, phase 3). Replaces the legacy `forge → POST /api/shaping`
+    // HTTP path with an event-driven flow: the listener consumes each
+    // request, calls the same dispatch core the HTTP route uses, and
+    // reuses idempotency via `request_id` so spine redelivery never
+    // produces a duplicate session. Result correlation flows back via
+    // `stiglab.shaping_result_ready` from the agent message handler.
+    //
+    // Warm-start at `max_event_id` so a fresh boot doesn't replay every
+    // historical request. Phase 6 will persist a per-process cursor.
+    if let Some(spine) = state.spine.as_ref() {
+        let listener_store = spine.store_clone();
+        let listener_state = state.clone();
+        tokio::spawn(async move {
+            let since = match listener_store.max_event_id().await {
+                Ok(cursor) => cursor,
+                Err(e) => {
+                    tracing::warn!(
+                        "stiglab: max_event_id lookup failed ({e}); starting \
+                         shaping_dispatched listener from the beginning"
+                    );
+                    None
+                }
+            };
+            if let Err(e) =
+                stiglab::server::shaping_listener::run(listener_store, listener_state, since).await
+            {
+                tracing::error!("stiglab: shaping_dispatched listener exited: {e}");
+            }
+        });
+    }
+
     // Start built-in runner if enabled
     if !no_runner {
         let runner_node_name = node_name.unwrap_or_else(|| "built-in-runner".to_string());

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -1,7 +1,7 @@
 //! Shared logic for processing AgentMessage events (used by both the WebSocket
 //! handler and the built-in runner).
 
-use crate::core::{AgentMessage, SessionState};
+use crate::core::{adapter, AgentMessage, SessionState};
 use sqlx::AnyPool;
 use tokio::sync::broadcast;
 
@@ -148,6 +148,23 @@ pub async fn handle_agent_message(
                 {
                     tracing::warn!("failed to emit session_completed spine event: {e}");
                 }
+
+                // Emit `stiglab.shaping_result_ready` carrying the full
+                // `ShapingResult` so Forge's pipeline can resume the
+                // parked decision (spec #131 / ADR 0004 Lever C, phase 3).
+                // The lifecycle event above stays for dashboard / node
+                // telemetry; this event is the actionable signal Forge
+                // consumes via `shaping_result_listener`. Sessions
+                // without an artifact link are direct task POSTs that
+                // never produced a shaping request — skip them so we
+                // don't fabricate result events with empty fields.
+                if let Some(artifact_id) = artifact_id.as_deref() {
+                    if let Err(e) =
+                        emit_shaping_result_for_session(pool, spine, &session_id, artifact_id).await
+                    {
+                        tracing::warn!("failed to emit shaping_result_ready spine event: {e}");
+                    }
+                }
             }
         }
         AgentMessage::SessionFailed { session_id, error } => {
@@ -253,6 +270,62 @@ async fn git_context_for_session(
         }
     });
     (branch, project_id, artifact_id)
+}
+
+/// Build a `ShapingResult` from a terminal session row and emit it as
+/// `stiglab.shaping_result_ready` (spec #131 / ADR 0004 Lever C, phase 3).
+///
+/// We synthesize a minimal `ShapingRequest` envelope from the session's
+/// stored `task_id` (= original request_id) and artifact link so the
+/// existing `session_to_shaping_result` adapter produces the same
+/// `ShapingResult` shape Forge previously consumed as the synchronous
+/// `POST /api/shaping` response body. Fields not stored on the session
+/// row (inputs, constraints, deadline) default to empty — Forge's
+/// pipeline never reads them off the result, only the request, so the
+/// adapter stays consistent with the HTTP path it replaces.
+async fn emit_shaping_result_for_session(
+    pool: &AnyPool,
+    spine: &SpineEmitter,
+    session_id: &str,
+    artifact_id: &str,
+) -> anyhow::Result<()> {
+    let Some(session) = db::get_session(pool, session_id).await? else {
+        // Session was deleted between message handling and this call —
+        // nothing to emit. Logged at debug to avoid noise on race.
+        tracing::debug!(
+            session_id,
+            "shaping_result emit: session row vanished before lookup"
+        );
+        return Ok(());
+    };
+
+    let synthesized_req = onsager_spine::protocol::ShapingRequest {
+        request_id: session.task_id.clone(),
+        artifact_id: onsager_artifact::ArtifactId::new(artifact_id),
+        target_version: session.artifact_version.unwrap_or(0).max(0) as u32,
+        shaping_intent: serde_json::json!({}),
+        inputs: vec![],
+        constraints: vec![],
+        deadline: None,
+        // Owner identity isn't persisted on the session row; not used
+        // by `session_to_shaping_result`, kept here to satisfy the
+        // struct shape.
+        created_by: None,
+    };
+
+    let duration_ms = session
+        .updated_at
+        .signed_duration_since(session.created_at)
+        .num_milliseconds()
+        .max(0) as u64;
+
+    let result = adapter::session_to_shaping_result(&synthesized_req, &session, duration_ms);
+
+    spine
+        .emit_shaping_result_ready(onsager_artifact::ArtifactId::new(artifact_id), result)
+        .await
+        .map_err(anyhow::Error::from)?;
+    Ok(())
 }
 
 /// Persist a `(session_id, branch, project_id)` row in the portal-managed

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod github_app;
 pub mod handler;
 pub mod proxy_cache;
 pub mod routes;
+pub mod shaping_listener;
 pub mod spine;
 pub mod sso;
 pub mod state;

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -65,6 +65,135 @@ pub struct StatusQuery {
     pub wait: Option<String>,
 }
 
+/// Outcome of [`dispatch_shaping_inner`] — distinguishes a freshly created
+/// session from one returned via the idempotency-key fast path.
+#[derive(Debug)]
+pub enum DispatchOutcome {
+    /// A new session was inserted and dispatched. The `Session` is the
+    /// version this server holds in memory (state may have been advanced
+    /// to `Dispatched` after the WS send).
+    Created(Session),
+    /// A previous request with the same idempotency key already produced
+    /// a session. The caller should return this session's identity rather
+    /// than spawning a duplicate.
+    Idempotent(Session),
+    /// No connected agent could pick up the dispatch — caller decides
+    /// whether to error (HTTP 503) or retry on the next event.
+    NoAvailableNode,
+}
+
+/// Core shaping-dispatch logic shared by the HTTP route and the
+/// `forge.shaping_dispatched` spine listener (spec #131 / ADR 0004
+/// Lever C, phase 3). No HTTP-level concerns leak in or out — security
+/// gating, header parsing, and response shaping stay in the HTTP wrapper.
+///
+/// `idempotency_key` is the durable handle the caller uses to collapse
+/// retries onto a single session. The HTTP route prefers the explicit
+/// `Idempotency-Key` header, falling back to `request_id`; the listener
+/// path keys on `request_id` directly since spine events are stable per
+/// emission.
+pub async fn dispatch_shaping_inner(
+    state: &AppState,
+    req: &onsager_spine::protocol::ShapingRequest,
+    idempotency_key: &str,
+) -> Result<DispatchOutcome, anyhow::Error> {
+    // Idempotency fast path — the definitive check is the conflict-aware
+    // insert below; this lookup just lets the common case skip the work.
+    if !idempotency_key.is_empty() {
+        match db::find_session_by_idempotency_key(&state.db, idempotency_key).await {
+            Ok(Some(existing)) => return Ok(DispatchOutcome::Idempotent(existing)),
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!("idempotency lookup failed: {e}");
+                // Fall through and treat as a new request.
+            }
+        }
+    }
+
+    let task = adapter::shaping_request_to_task(req);
+
+    let target_node = match db::find_least_loaded_node(&state.db).await? {
+        Some(node) => node,
+        None => return Ok(DispatchOutcome::NoAvailableNode),
+    };
+
+    let mut session = Session {
+        id: Uuid::new_v4().to_string(),
+        task_id: task.id.clone(),
+        node_id: target_node.id.clone(),
+        state: SessionState::Pending,
+        prompt: task.prompt.clone(),
+        output: None,
+        working_dir: task.working_dir.clone(),
+        artifact_id: Some(req.artifact_id.to_string()),
+        artifact_version: Some(req.target_version as i32),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+
+    if idempotency_key.is_empty() {
+        db::insert_session(&state.db, &session).await?;
+    } else {
+        match db::insert_session_with_idempotency_key(&state.db, &session, idempotency_key).await? {
+            true => { /* new session inserted */ }
+            false => {
+                // Concurrent insert with the same key won the race; load
+                // and return the persisted row so callers converge.
+                if let Some(existing) =
+                    db::find_session_by_idempotency_key(&state.db, idempotency_key).await?
+                {
+                    return Ok(DispatchOutcome::Idempotent(existing));
+                }
+                return Err(anyhow::anyhow!(
+                    "idempotency conflict on {idempotency_key} but no session visible"
+                ));
+            }
+        }
+    }
+
+    // Fetch user credentials when the request carries `created_by`. Direct
+    // callers that don't set it keep the legacy `None` behavior — the
+    // resulting session_failed event surfaces the broken state via
+    // forge's signal listener.
+    let credentials = match req.created_by.as_deref() {
+        Some(uid) => super::tasks::fetch_user_credentials(state, uid).await,
+        None => None,
+    };
+
+    // Dispatch to the agent over WebSocket.
+    {
+        let agents = state.agents.read().await;
+        if let Some(agent) = agents.get(&target_node.id) {
+            let msg = ServerMessage::DispatchTask {
+                task: Box::new(task.clone()),
+                session_id: session.id.clone(),
+                credentials,
+            };
+            if let Ok(json) = serde_json::to_string(&msg) {
+                let _ = agent
+                    .sender
+                    .send(axum::extract::ws::Message::Text(json.into()));
+            }
+            db::update_session_state(&state.db, &session.id, SessionState::Dispatched).await?;
+            session.state = SessionState::Dispatched;
+        } else {
+            tracing::warn!(
+                "agent for node {} not connected, session stays pending",
+                target_node.id
+            );
+        }
+    }
+
+    // Emit session-started spine event.
+    if let Some(ref spine) = state.spine {
+        let _ = spine
+            .emit_session_started(&session.id, &req.request_id, &target_node.id)
+            .await;
+    }
+
+    Ok(DispatchOutcome::Created(session))
+}
+
 /// `POST /api/shaping` — accept a shaping request and return immediately.
 pub async fn create_shaping(
     State(state): State<AppState>,
@@ -128,149 +257,29 @@ pub async fn create_shaping(
         .map(str::to_string)
         .unwrap_or_else(|| req.request_id.clone());
 
-    // Fast path: if a session for this key already exists, return it. The
-    // definitive check is performed on insert (ON CONFLICT DO NOTHING) to
-    // close the lookup/insert race. Echo the session's original request_id
-    // (persisted as task_id) rather than the caller's — a retry with a
-    // different request_id but the same Idempotency-Key should return the
-    // original request's identity.
-    if !idempotency_key.is_empty() {
-        match db::find_session_by_idempotency_key(&state.db, &idempotency_key).await {
-            Ok(Some(existing)) => {
-                let rid = existing.task_id.clone();
-                return accepted_response(&existing, &rid);
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!("idempotency lookup failed: {e}");
-                // Fall through and treat as a new request.
-            }
+    match dispatch_shaping_inner(&state, &req, &idempotency_key).await {
+        Ok(DispatchOutcome::Created(session)) => accepted_response(&session, &req.request_id),
+        Ok(DispatchOutcome::Idempotent(existing)) => {
+            // Echo the original request_id (persisted as task_id) so a
+            // retry with a different request_id but the same key
+            // converges on the original session's identity.
+            let rid = existing.task_id.clone();
+            accepted_response(&existing, &rid)
         }
-    }
-
-    let task = adapter::shaping_request_to_task(&req);
-
-    // Find target node (auto-assign to least loaded).
-    let target_node = match db::find_least_loaded_node(&state.db).await {
-        Ok(Some(node)) => node,
-        Ok(None) => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "no available nodes for dispatch" })),
-            )
-                .into_response();
-        }
+        Ok(DispatchOutcome::NoAvailableNode) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "no available nodes for dispatch" })),
+        )
+            .into_response(),
         Err(e) => {
-            tracing::error!("failed to find node: {e}");
-            return (
+            tracing::error!("shaping dispatch failed: {e}");
+            (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({ "error": e.to_string() })),
             )
-                .into_response();
-        }
-    };
-
-    let mut session = Session {
-        id: Uuid::new_v4().to_string(),
-        task_id: task.id.clone(),
-        node_id: target_node.id.clone(),
-        state: SessionState::Pending,
-        prompt: task.prompt.clone(),
-        output: None,
-        working_dir: task.working_dir.clone(),
-        artifact_id: Some(req.artifact_id.to_string()),
-        artifact_version: Some(req.target_version as i32),
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-    };
-
-    if idempotency_key.is_empty() {
-        if let Err(e) = db::insert_session(&state.db, &session).await {
-            tracing::error!("failed to insert session: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            )
-                .into_response();
-        }
-    } else {
-        match db::insert_session_with_idempotency_key(&state.db, &session, &idempotency_key).await {
-            Ok(true) => { /* new session inserted */ }
-            Ok(false) => {
-                // Concurrent POST with the same key won the race. Load and
-                // return whichever session is actually persisted so the
-                // caller converges on a single session id.
-                match db::find_session_by_idempotency_key(&state.db, &idempotency_key).await {
-                    Ok(Some(existing)) => {
-                        let rid = existing.task_id.clone();
-                        return accepted_response(&existing, &rid);
-                    }
-                    Ok(None) | Err(_) => {
-                        return (
-                            StatusCode::CONFLICT,
-                            Json(serde_json::json!({
-                                "error": "idempotency conflict but no session visible"
-                            })),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::error!("failed to insert session: {e}");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": e.to_string() })),
-                )
-                    .into_response();
-            }
+                .into_response()
         }
     }
-
-    // Fetch user credentials when the request carries a `created_by`
-    // (issue #156). Without this the spawned agent has no
-    // `CLAUDE_CODE_OAUTH_TOKEN` and exits immediately with "stdout closed
-    // without result event". Direct callers without `created_by` keep the
-    // legacy `None` behavior — the resulting session_failed event surfaces
-    // the broken state via forge's signal listener.
-    let credentials = match req.created_by.as_deref() {
-        Some(uid) => super::tasks::fetch_user_credentials(&state, uid).await,
-        None => None,
-    };
-
-    // Dispatch to agent via WebSocket.
-    {
-        let agents = state.agents.read().await;
-        if let Some(agent) = agents.get(&target_node.id) {
-            let msg = ServerMessage::DispatchTask {
-                task: Box::new(task.clone()),
-                session_id: session.id.clone(),
-                credentials,
-            };
-            if let Ok(json) = serde_json::to_string(&msg) {
-                let _ = agent
-                    .sender
-                    .send(axum::extract::ws::Message::Text(json.into()));
-            }
-            let _ =
-                db::update_session_state(&state.db, &session.id, SessionState::Dispatched).await;
-            session.state = SessionState::Dispatched;
-        } else {
-            tracing::warn!(
-                "agent for node {} not connected, session stays pending",
-                target_node.id
-            );
-        }
-    }
-
-    // Emit session started event to spine.
-    if let Some(ref spine) = state.spine {
-        let _ = spine
-            .emit_session_started(&session.id, &req.request_id, &target_node.id)
-            .await;
-    }
-
-    accepted_response(&session, &req.request_id)
 }
 
 /// `GET /api/shaping/{session_id}?wait=Ns` — return the current shaping

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -84,14 +84,26 @@ pub enum DispatchOutcome {
 
 /// Core shaping-dispatch logic shared by the HTTP route and the
 /// `forge.shaping_dispatched` spine listener (spec #131 / ADR 0004
-/// Lever C, phase 3). No HTTP-level concerns leak in or out — security
-/// gating, header parsing, and response shaping stay in the HTTP wrapper.
+/// Lever C, phase 3). HTTP-specific concerns — header parsing and
+/// response shaping — stay in the HTTP wrapper, but **trust decisions
+/// on request fields stay with the caller**. In particular,
+/// `req.created_by` drives credential lookup and the spawned agent's
+/// `CLAUDE_CODE_OAUTH_TOKEN` injection; the caller is responsible for
+/// ensuring that value came from a trusted source before calling here:
+///
+/// - `create_shaping` (HTTP) gates `created_by` behind the
+///   `X-Onsager-Internal-Dispatch` shared secret.
+/// - `shaping_listener` (spine) gates `created_by` behind a metadata
+///   `actor == "forge"` check on the spine event row.
+///
+/// Anything that doesn't pass its trust check must strip `created_by`
+/// to `None` before reaching this helper.
 ///
 /// `idempotency_key` is the durable handle the caller uses to collapse
 /// retries onto a single session. The HTTP route prefers the explicit
 /// `Idempotency-Key` header, falling back to `request_id`; the listener
-/// path keys on `request_id` directly since spine events are stable per
-/// emission.
+/// path uses the outer envelope's `request_id` after validating it
+/// matches the embedded payload.
 pub async fn dispatch_shaping_inner(
     state: &AppState,
     req: &onsager_spine::protocol::ShapingRequest,

--- a/crates/stiglab/src/server/shaping_listener.rs
+++ b/crates/stiglab/src/server/shaping_listener.rs
@@ -1,0 +1,159 @@
+//! Spine listener that consumes `forge.shaping_dispatched` events and
+//! spawns a session via the same path the `POST /api/shaping` HTTP route
+//! uses (spec #131 / ADR 0004 Lever C, phase 3).
+//!
+//! Replaces the legacy `forge → POST /api/shaping` HTTP call with an
+//! event-driven flow. The forge producer is enriched in the same phase
+//! to carry the full `ShapingRequest` payload as
+//! `FactoryEventKind::ForgeShapingDispatched.request`; the listener
+//! spawns a session and returns. Result correlation flows back via
+//! `stiglab.shaping_result_ready` from the agent message handler when
+//! the session reaches a terminal state.
+//!
+//! The HTTP route stays alive during phase 3 so existing forge
+//! deployments with the legacy synchronous dispatcher don't break;
+//! phase 5 deletes both the route and the legacy dispatcher.
+//!
+//! ## Idempotency
+//!
+//! Forge stamps a stable `request_id` on every emission (forge
+//! invariant #6). The listener uses it as the idempotency key, so
+//! redelivery of the same `forge.shaping_dispatched` event collapses
+//! onto a single session row instead of dispatching multiple agents.
+
+use async_trait::async_trait;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+
+use crate::server::routes::shaping::{dispatch_shaping_inner, DispatchOutcome};
+use crate::server::state::AppState;
+
+/// Run the shaping listener forever. Returns only if the underlying
+/// pg_notify channel closes.
+///
+/// `since` is the backfill cursor — pass `EventStore::max_event_id()` so
+/// a fresh boot doesn't replay every historical request. Phase 6 will
+/// persist a per-process cursor so a restart mid-decision doesn't drop
+/// in-flight shaping dispatches.
+pub async fn run(store: EventStore, app_state: AppState, since: Option<i64>) -> anyhow::Result<()> {
+    let handler = Dispatcher {
+        store: store.clone(),
+        app_state,
+    };
+    Listener::new(store).with_since(since).run(handler).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    app_state: AppState,
+}
+
+impl Dispatcher {
+    async fn load_kind(
+        &self,
+        notification: &EventNotification,
+    ) -> anyhow::Result<Option<FactoryEventKind>> {
+        match notification.table.as_str() {
+            "events" => {
+                let Some(row) = self.store.get_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let envelope: FactoryEvent = serde_json::from_value(row.data)?;
+                Ok(Some(envelope.event))
+            }
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(None);
+                };
+                let raw = row.data;
+                if let Ok(envelope) = serde_json::from_value::<FactoryEvent>(raw.clone()) {
+                    Ok(Some(envelope.event))
+                } else {
+                    let kind: FactoryEventKind = serde_json::from_value(raw)?;
+                    Ok(Some(kind))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "forge.shaping_dispatched" {
+            return Ok(());
+        }
+
+        let Some(kind) = self.load_kind(&notification).await? else {
+            return Ok(());
+        };
+
+        let FactoryEventKind::ForgeShapingDispatched {
+            request_id,
+            artifact_id,
+            request,
+            ..
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        let Some(request) = request else {
+            // Pre-phase-3 events lacked the embedded payload; without it
+            // we can't construct the dispatch. Skip and log so a replay
+            // of historical events doesn't hard-error.
+            tracing::warn!(
+                request_id = %request_id,
+                artifact_id = %artifact_id,
+                "stiglab: forge.shaping_dispatched has no embedded request payload, skipping"
+            );
+            return Ok(());
+        };
+
+        // Idempotency key = request_id. Forge promises stability across
+        // retries (forge invariant #6); a redelivered spine notification
+        // resolves to the same session row instead of dispatching twice.
+        match dispatch_shaping_inner(&self.app_state, &request, &request.request_id).await {
+            Ok(DispatchOutcome::Created(session)) => {
+                tracing::info!(
+                    request_id = %request_id,
+                    artifact_id = %artifact_id,
+                    session_id = %session.id,
+                    "stiglab: dispatched session from forge.shaping_dispatched"
+                );
+            }
+            Ok(DispatchOutcome::Idempotent(session)) => {
+                tracing::debug!(
+                    request_id = %request_id,
+                    artifact_id = %artifact_id,
+                    session_id = %session.id,
+                    "stiglab: forge.shaping_dispatched is idempotent hit on existing session"
+                );
+            }
+            Ok(DispatchOutcome::NoAvailableNode) => {
+                // No agent connected — nothing parks the dispatch yet.
+                // The artifact stays at its current stage; the next
+                // emission (or a follow-up `forge` tick that re-issues
+                // the dispatch) will retry once an agent comes online.
+                // Phase 6 plans to persist parked dispatches; for now,
+                // log loudly so operators can correlate with stalled
+                // workflow artifacts.
+                tracing::warn!(
+                    request_id = %request_id,
+                    artifact_id = %artifact_id,
+                    "stiglab: forge.shaping_dispatched dropped (no available nodes)"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    request_id = %request_id,
+                    artifact_id = %artifact_id,
+                    "stiglab: forge.shaping_dispatched dispatch failed: {e}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/stiglab/src/server/shaping_listener.rs
+++ b/crates/stiglab/src/server/shaping_listener.rs
@@ -17,9 +17,22 @@
 //! ## Idempotency
 //!
 //! Forge stamps a stable `request_id` on every emission (forge
-//! invariant #6). The listener uses it as the idempotency key, so
-//! redelivery of the same `forge.shaping_dispatched` event collapses
-//! onto a single session row instead of dispatching multiple agents.
+//! invariant #6). The listener uses the **outer envelope's**
+//! `request_id` as the idempotency key after validating it matches the
+//! embedded payload — see `handle` for the divergence check.
+//!
+//! ## Trust model for `created_by`
+//!
+//! The HTTP `POST /api/shaping` route gates `created_by` behind a
+//! shared secret (`X-Onsager-Internal-Dispatch`) because the endpoint
+//! is publicly reachable on Railway. The listener path has no headers
+//! and no shared secret — but events on the spine come from
+//! processes inside the trust boundary. We require the event metadata
+//! `actor == "forge"` before honoring `created_by`. Anything else
+//! gets `created_by` stripped to `None` (which downgrades the dispatch
+//! to a no-credentials session that fails loudly via
+//! `stiglab.session_failed` rather than executing an unauthenticated
+//! request the operator didn't intend).
 
 use async_trait::async_trait;
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
@@ -43,23 +56,48 @@ pub async fn run(store: EventStore, app_state: AppState, since: Option<i64>) -> 
     Listener::new(store).with_since(since).run(handler).await
 }
 
+/// Parsed envelope: the typed event payload plus the `actor` extracted
+/// from the spine row's metadata. The actor is the trust handle used
+/// to gate sensitive request fields — see module-level "Trust model".
+struct ParsedEvent {
+    kind: FactoryEventKind,
+    actor: Option<String>,
+}
+
 struct Dispatcher {
     store: EventStore,
     app_state: AppState,
 }
 
 impl Dispatcher {
-    async fn load_kind(
+    /// Load the event payload + actor for a notification. Mirrors
+    /// `session_listener::Dispatcher::load_session_completed` in
+    /// `forge`: malformed payloads return `Ok(None)` with a structured
+    /// `warn!` instead of bubbling an error, so a single bad event
+    /// doesn't spam `EventHandler error` lines.
+    async fn load_event(
         &self,
         notification: &EventNotification,
-    ) -> anyhow::Result<Option<FactoryEventKind>> {
+    ) -> anyhow::Result<Option<ParsedEvent>> {
         match notification.table.as_str() {
             "events" => {
                 let Some(row) = self.store.get_event_by_id(notification.id).await? else {
                     return Ok(None);
                 };
-                let envelope: FactoryEvent = serde_json::from_value(row.data)?;
-                Ok(Some(envelope.event))
+                match serde_json::from_value::<FactoryEvent>(row.data) {
+                    Ok(envelope) => Ok(Some(ParsedEvent {
+                        kind: envelope.event,
+                        actor: extract_actor(&row.metadata),
+                    })),
+                    Err(e) => {
+                        tracing::warn!(
+                            id = notification.id,
+                            event_type = %notification.event_type,
+                            "stiglab: forge.shaping_dispatched (events table) parse failed: {e}"
+                        );
+                        Ok(None)
+                    }
+                }
             }
             "events_ext" => {
                 let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
@@ -67,15 +105,40 @@ impl Dispatcher {
                 };
                 let raw = row.data;
                 if let Ok(envelope) = serde_json::from_value::<FactoryEvent>(raw.clone()) {
-                    Ok(Some(envelope.event))
-                } else {
-                    let kind: FactoryEventKind = serde_json::from_value(raw)?;
-                    Ok(Some(kind))
+                    return Ok(Some(ParsedEvent {
+                        kind: envelope.event,
+                        actor: extract_actor(&row.metadata),
+                    }));
+                }
+                match serde_json::from_value::<FactoryEventKind>(raw) {
+                    Ok(kind) => Ok(Some(ParsedEvent {
+                        kind,
+                        actor: extract_actor(&row.metadata),
+                    })),
+                    Err(e) => {
+                        tracing::warn!(
+                            id = notification.id,
+                            event_type = %notification.event_type,
+                            "stiglab: forge.shaping_dispatched (events_ext) parse failed: {e}"
+                        );
+                        Ok(None)
+                    }
                 }
             }
             _ => Ok(None),
         }
     }
+}
+
+/// Pull the `actor` field out of an `EventMetadata` JSON blob. Returns
+/// `None` if the metadata is missing the field or isn't an object;
+/// callers treat absence the same as "unknown actor" for the trust
+/// gate below.
+fn extract_actor(metadata: &serde_json::Value) -> Option<String> {
+    metadata
+        .get("actor")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
 }
 
 #[async_trait]
@@ -85,7 +148,7 @@ impl EventHandler for Dispatcher {
             return Ok(());
         }
 
-        let Some(kind) = self.load_kind(&notification).await? else {
+        let Some(parsed) = self.load_event(&notification).await? else {
             return Ok(());
         };
 
@@ -94,12 +157,12 @@ impl EventHandler for Dispatcher {
             artifact_id,
             request,
             ..
-        } = kind
+        } = parsed.kind
         else {
             return Ok(());
         };
 
-        let Some(request) = request else {
+        let Some(mut request) = request else {
             // Pre-phase-3 events lacked the embedded payload; without it
             // we can't construct the dispatch. Skip and log so a replay
             // of historical events doesn't hard-error.
@@ -111,10 +174,44 @@ impl EventHandler for Dispatcher {
             return Ok(());
         };
 
-        // Idempotency key = request_id. Forge promises stability across
-        // retries (forge invariant #6); a redelivered spine notification
-        // resolves to the same session row instead of dispatching twice.
-        match dispatch_shaping_inner(&self.app_state, &request, &request.request_id).await {
+        // Envelope ↔ payload divergence guard: the outer event already
+        // carries `request_id`. If it disagrees with the embedded
+        // payload, refuse the dispatch — a buggy producer or a partial
+        // upgrade could otherwise create multiple sessions or log
+        // misleading correlation.
+        if request.request_id != request_id {
+            tracing::error!(
+                request_id = %request_id,
+                embedded_request_id = %request.request_id,
+                artifact_id = %artifact_id,
+                "stiglab: forge.shaping_dispatched request_id mismatch between envelope \
+                 and embedded payload, skipping"
+            );
+            return Ok(());
+        }
+
+        // Trust gate for `created_by` — see module-level "Trust model".
+        // Strip it unless the spine row's metadata actor proves the
+        // event came from forge. The ACL is intentionally a string
+        // match: any subsystem can invent its own actor string, so the
+        // check is necessary but not sufficient — the deploy
+        // boundary is the actual security boundary. We log the
+        // strip so an operator can see when a misbehaving producer
+        // tried to elevate.
+        if request.created_by.is_some() && parsed.actor.as_deref() != Some("forge") {
+            tracing::warn!(
+                request_id = %request_id,
+                artifact_id = %artifact_id,
+                actor = ?parsed.actor,
+                "stiglab: stripping created_by on spine-sourced shaping_dispatched \
+                 (actor != \"forge\")"
+            );
+            request.created_by = None;
+        }
+
+        // Idempotency key = outer envelope `request_id`. The
+        // embedded payload has been verified to agree with it above.
+        match dispatch_shaping_inner(&self.app_state, &request, &request_id).await {
             Ok(DispatchOutcome::Created(session)) => {
                 tracing::info!(
                     request_id = %request_id,
@@ -155,5 +252,37 @@ impl EventHandler for Dispatcher {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_actor_from_typical_metadata() {
+        let meta = serde_json::json!({"actor": "forge", "correlation_id": "x"});
+        assert_eq!(extract_actor(&meta), Some("forge".into()));
+    }
+
+    #[test]
+    fn extract_actor_returns_none_for_missing_field() {
+        let meta = serde_json::json!({"correlation_id": "x"});
+        assert_eq!(extract_actor(&meta), None);
+    }
+
+    #[test]
+    fn extract_actor_returns_none_for_non_object() {
+        // Defense in depth: a producer that wrote `null` for metadata
+        // must not crash the listener.
+        assert_eq!(extract_actor(&serde_json::Value::Null), None);
+    }
+
+    #[test]
+    fn extract_actor_returns_none_for_non_string_actor() {
+        // Defense in depth: a producer that wrote `actor: 42` shouldn't
+        // be accepted as a trusted forge call.
+        let meta = serde_json::json!({"actor": 42});
+        assert_eq!(extract_actor(&meta), None);
     }
 }

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -39,6 +39,14 @@ impl SpineEmitter {
         self.store.pool()
     }
 
+    /// Clone the underlying [`EventStore`] handle so listener tasks can
+    /// own a handle without borrowing through the emitter. `EventStore`
+    /// is internally `Clone` over the `PgPool` it wraps, so this is
+    /// cheap (one `Arc` clone per pool).
+    pub fn store_clone(&self) -> EventStore {
+        self.store.clone()
+    }
+
     /// Emit a raw event to the extension event table under a given namespace.
     /// Used for events that don't map to a `FactoryEventKind` variant (e.g.,
     /// artifact registration from the dashboard).
@@ -112,6 +120,27 @@ impl SpineEmitter {
             token_usage,
             branch: branch.map(str::to_owned),
             pr_number,
+        })
+        .await
+    }
+
+    /// Emit a `stiglab.shaping_result_ready` event carrying the full
+    /// `ShapingResult` payload so Forge's `shaping_result_listener` can
+    /// resume the parked pipeline decision (spec #131 / ADR 0004
+    /// Lever C, phase 3). Emitted alongside `stiglab.session_completed`:
+    /// the lifecycle event signals "this session finished" (used by the
+    /// dashboard); this event signals "the artifact outputs are ready
+    /// for the next pipeline stage" (used by Forge's state machine).
+    /// Sessions without an artifact link skip this — see
+    /// `handler.rs::handle_agent_message` for the gate.
+    pub async fn emit_shaping_result_ready(
+        &self,
+        artifact_id: onsager_artifact::ArtifactId,
+        result: onsager_spine::protocol::ShapingResult,
+    ) -> Result<i64, sqlx::Error> {
+        self.emit(FactoryEventKind::StiglabShapingResultReady {
+            artifact_id,
+            result,
         })
         .await
     }

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -148,7 +148,7 @@ impl ServeCmd {
         // handle (issue #36 Step 2). A missing spine handle is non-fatal —
         // the HTTP API stays up and operators can attach the spine later
         // by restarting with a postgres `DATABASE_URL`.
-        if let Some(spine_arc) = spine {
+        if let Some(spine_arc) = spine.clone() {
             let listener_storage = Arc::clone(&state.storage);
             let spine_for_listener = (*spine_arc).clone();
             tokio::spawn(async move {
@@ -157,6 +157,45 @@ impl ServeCmd {
                         .await
                 {
                     tracing::error!("synodic: rule_proposed listener exited: {e}");
+                }
+            });
+        }
+
+        // Spawn the forge.gate_requested listener (spec #131 / ADR 0004
+        // Lever C, phase 3). Replaces the legacy `forge → POST /api/gate`
+        // HTTP path with an event-driven flow: the listener consumes
+        // each request, runs the cached `InterceptEngine`, and emits
+        // `synodic.gate_verdict` keyed on the same `gate_id` so Forge
+        // can match the verdict back to its parked pipeline decision.
+        //
+        // Warm-start at `max_event_id` so a fresh boot doesn't replay
+        // every historical request — same rationale as the proposal
+        // listener above. A phase-6 follow-up persists a per-process
+        // cursor so a crash mid-decision doesn't drop in-flight gates.
+        if let Some(spine_arc) = spine {
+            let listener_storage = Arc::clone(&state.storage);
+            let listener_engine_cache = Arc::clone(&state.engine_cache);
+            let spine_for_listener = (*spine_arc).clone();
+            tokio::spawn(async move {
+                let since = match spine_for_listener.max_event_id().await {
+                    Ok(cursor) => cursor,
+                    Err(e) => {
+                        tracing::warn!(
+                            "synodic: max_event_id lookup failed ({e}); starting \
+                             gate_requested listener from the beginning"
+                        );
+                        None
+                    }
+                };
+                if let Err(e) = crate::core::gate_listener::run(
+                    spine_for_listener,
+                    listener_storage,
+                    listener_engine_cache,
+                    since,
+                )
+                .await
+                {
+                    tracing::error!("synodic: gate_requested listener exited: {e}");
                 }
             });
         }

--- a/crates/synodic/src/core/gate_listener.rs
+++ b/crates/synodic/src/core/gate_listener.rs
@@ -1,0 +1,206 @@
+//! Gate-request spine listener (spec #131 / ADR 0004 Lever C, phase 3).
+//!
+//! Tails `forge.gate_requested` events off the spine, deserializes the
+//! payload into the typed [`FactoryEventKind`] variant, calls the
+//! existing [`InterceptEngine`] (cached via [`EngineCache`]) to produce a
+//! [`GateVerdict`], and emits the verdict back to the spine as
+//! `synodic.gate_verdict` keyed on the same `gate_id` correlation handle.
+//!
+//! Replaces the legacy synchronous `forge → POST /api/gate` HTTP path
+//! with an event-driven flow. The listener is the producer side of the
+//! parking pattern: Forge parks the pipeline decision keyed by `gate_id`
+//! when it emits `forge.gate_requested`, and the
+//! `gate_verdict_listener` on Forge claims the parked decision when this
+//! listener emits `synodic.gate_verdict`.
+//!
+//! ## Skipped events
+//!
+//! - Events written before phase 2 lacked the embedded `request` payload
+//!   (`#[serde(default)]` decoded as `None`); we cannot evaluate without
+//!   a request, so we skip and log. This only matters for replay of pre-
+//!   phase-2 history; the steady-state contract is producer + this
+//!   consumer always travel together.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::protocol::{GateRequest, GateVerdict};
+use onsager_spine::{EventHandler, EventMetadata, EventNotification, EventStore, Listener};
+
+use crate::core::engine_cache::EngineCache;
+use crate::core::gate_adapter;
+use crate::core::storage::Storage;
+
+/// Run the gate-request listener forever. Returns only if the underlying
+/// pg_notify channel closes.
+///
+/// `since` is the backfill cursor — pass `EventStore::max_event_id()` so
+/// a fresh boot doesn't replay the entire spine. Phase 6 will persist a
+/// per-process cursor so a crash mid-decision doesn't drop in-flight
+/// gate requests.
+pub async fn run(
+    store: EventStore,
+    storage: Arc<dyn Storage>,
+    engine_cache: Arc<EngineCache>,
+    since: Option<i64>,
+) -> anyhow::Result<()> {
+    let dispatcher = Dispatcher {
+        store: store.clone(),
+        storage,
+        engine_cache,
+    };
+    Listener::new(store).with_since(since).run(dispatcher).await
+}
+
+struct Dispatcher {
+    store: EventStore,
+    storage: Arc<dyn Storage>,
+    engine_cache: Arc<EngineCache>,
+}
+
+impl Dispatcher {
+    /// Pure: evaluate a [`GateRequest`] against the cached engine. Split
+    /// out so the producer side can be tested without owning a spine.
+    async fn evaluate(&self, request: &GateRequest) -> anyhow::Result<GateVerdict> {
+        let engine = self.engine_cache.get_or_refresh(&*self.storage).await?;
+        let intercept_req = gate_adapter::gate_request_to_intercept(request);
+        let resp = engine.evaluate(&intercept_req);
+        Ok(gate_adapter::intercept_to_gate_verdict(&resp))
+    }
+
+    async fn emit_verdict(
+        &self,
+        gate_id: &str,
+        artifact_id: onsager_artifact::ArtifactId,
+        gate_point: onsager_spine::factory_event::GatePoint,
+        verdict: GateVerdict,
+    ) -> anyhow::Result<()> {
+        let event = FactoryEventKind::SynodicGateVerdict {
+            gate_id: gate_id.to_string(),
+            artifact_id,
+            gate_point,
+            verdict,
+        };
+        let data = serde_json::to_value(&event).expect("FactoryEventKind must serialize");
+        let metadata = EventMetadata {
+            actor: "synodic".into(),
+            ..Default::default()
+        };
+        self.store
+            .append_ext(
+                gate_id,
+                "synodic",
+                event.event_type(),
+                data,
+                &metadata,
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EventHandler for Dispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "forge.gate_requested" {
+            return Ok(());
+        }
+
+        // Phase-3 producers always write into events_ext via append_ext.
+        // The events table path is left unwired for now to avoid coupling
+        // to a write site that doesn't exist; a future variant of the
+        // emitter that writes there can extend this branch.
+        if notification.table != "events_ext" {
+            return Ok(());
+        }
+
+        let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+            return Ok(());
+        };
+
+        let kind: FactoryEventKind = match serde_json::from_value(row.data.clone()) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::warn!(
+                    id = row.id,
+                    "synodic: forge.gate_requested payload parse failed: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        let FactoryEventKind::ForgeGateRequested {
+            gate_id,
+            artifact_id,
+            gate_point,
+            request,
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        let Some(request) = request else {
+            // Pre-phase-2 events lack the embedded payload; nothing to
+            // evaluate. Emitting a verdict without a request would be
+            // policy-blind, so we skip and log.
+            tracing::warn!(
+                gate_id = %gate_id,
+                artifact_id = %artifact_id,
+                "synodic: forge.gate_requested has no embedded request payload, skipping"
+            );
+            return Ok(());
+        };
+
+        let verdict = self.evaluate(&request).await?;
+
+        if let Err(e) = self
+            .emit_verdict(&gate_id, artifact_id.clone(), gate_point, verdict)
+            .await
+        {
+            tracing::error!(
+                gate_id = %gate_id,
+                artifact_id = %artifact_id,
+                "synodic: failed to emit gate_verdict: {e}"
+            );
+        } else {
+            tracing::info!(
+                gate_id = %gate_id,
+                artifact_id = %artifact_id,
+                "synodic: emitted gate_verdict for forge.gate_requested"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Listener-side tests focus on the typed-variant matching and
+    //! request extraction. The evaluation pipeline (`gate_request_to_intercept`
+    //! → engine → `intercept_to_gate_verdict`) is already covered by
+    //! `gate_adapter::tests`; we test the listener glue separately.
+
+    use onsager_artifact::ArtifactId;
+    use onsager_spine::factory_event::{FactoryEventKind, GatePoint};
+
+    /// Confirms that a [`FactoryEventKind::ForgeGateRequested`] without
+    /// an embedded `request` is observably distinguishable from one with
+    /// — the listener uses this branch to skip pre-phase-2 events
+    /// instead of emitting a request-less verdict.
+    #[test]
+    fn forge_gate_requested_with_no_request_is_skip_signal() {
+        let event = FactoryEventKind::ForgeGateRequested {
+            gate_id: "g_legacy".into(),
+            artifact_id: ArtifactId::new("art_x"),
+            gate_point: GatePoint::PreDispatch,
+            request: None,
+        };
+        match event {
+            FactoryEventKind::ForgeGateRequested { request: None, .. } => {}
+            other => panic!("expected request: None, got {other:?}"),
+        }
+    }
+}

--- a/crates/synodic/src/core/mod.rs
+++ b/crates/synodic/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub mod clustering;
 pub mod engine_cache;
 pub mod gate_adapter;
+pub mod gate_listener;
 pub mod intercept;
 pub mod llm;
 pub mod pipeline;

--- a/docs/events.md
+++ b/docs/events.md
@@ -341,6 +341,7 @@ ShapingRequest sent to Stiglab.
 | `request_id` | `String` |  |
 | `artifact_id` | `ArtifactId` |  |
 | `target_version` | `u32` |  |
+| `request` | `Option<crate::protocol::ShapingRequest>` | Full shaping payload — the same shape Stiglab previously consumed as the `POST /api/shaping` request body. `None` on events written before this field was added (spec #131 / ADR 0004 Lever C phase 3). When `None`, Stiglab's listener cannot spawn a session and must skip the request.  Top-level `request_id`, `artifact_id`, and `target_version` are kept for stream indexing and dashboard filtering; the duplication with `request` is intentional. _(optional)_ |
 
 ### `forge.shaping_returned`
 


### PR DESCRIPTION
## Summary

Phase 3 of Lever C (spec #131 / ADR 0004 — see #148). Lands the
event-driven `forge ↔ stiglab` and `forge ↔ synodic` flow alongside
the legacy HTTP path; phase 4 wires the pipeline tick to the parking
maps and phase 5 deletes the HTTP types.

### Spine
- `ForgeShapingDispatched` gains optional `request: ShapingRequest`
  (additive, `#[serde(default)]`, `skip_serializing_if`). Mirrors the
  phase-2 enrichment of `ForgeGateRequested`. Wire-format regression
  test pins round-trip and legacy-default behavior.
- `PartialEq` derived on `ArtifactRef` and `Constraint` to satisfy the
  enum's existing derive.

### Forge
- New `core::pending` module with `PendingVerdicts` / `PendingShapings`
  — `Arc<Mutex<HashMap>>` parking maps the listeners populate, keyed by
  `gate_id` and `request_id` respectively.
- New `gate_verdict_listener` (`synodic.gate_verdict` → `PendingVerdicts`)
  and `shaping_result_listener` (`stiglab.shaping_result_ready` →
  `PendingShapings`). Each ships a pure `classify_*` fn and unit tests.
- Wired in `cmd/serve.rs` next to existing listener patterns. Both
  warm-start at `max_event_id` so a fresh boot doesn't replay history.
- `PipelineEvent::GateRequested` now carries `gate_id` + full
  `GateRequest`; `PipelineEvent::ShapingDispatched` carries the full
  `ShapingRequest`. `emit_pipeline_event` populates the typed
  `FactoryEventKind` variants so the request payload travels with
  the carrier event.

### Synodic
- New `gate_listener` consumes `forge.gate_requested`, calls the
  cached `InterceptEngine` via `engine_cache.get_or_refresh +
  engine.evaluate`, emits `synodic.gate_verdict` keyed on `gate_id`.
  Wired in `cmd/serve.rs` next to the existing `proposal_listener`.

### Stiglab
- `create_shaping` body refactored into a reusable
  `dispatch_shaping_inner` helper (returns `DispatchOutcome`) so the
  HTTP route and the listener share one dispatch core.
- New `shaping_listener` consumes `forge.shaping_dispatched` and calls
  the helper with `request_id` as the idempotency key.
- `handler.rs` `SessionCompleted` branch additionally emits
  `stiglab.shaping_result_ready` when the session has an artifact
  link, alongside the existing `session_completed` lifecycle event.
- `emit_shaping_result_ready` helper added on `SpineEmitter`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p onsager-spine --lib` — 34 passed
- [x] `cargo test -p forge --lib` — 118 passed
- [x] `cargo test -p synodic --lib` — 114 passed
- [x] `cargo test -p stiglab --lib` — 156 passed
- [x] `cargo run -p xtask -- gen-event-docs` — 75 events (was 74; the
      `ForgeShapingDispatched` variant gains its `request` field row)
- [x] `cargo run -p xtask -- lint-seams` — clean; exemption count
      unchanged. Phase 5 removes the four forge entries.
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Part of #148

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLiAAvfpHXMaQ9BkmAACfp)_