### PR TITLE
chore(gitignore): ignore agent worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp
 /.idea
 /.vscode/settings.json
+/.claude/worktrees
 **/dist
 **/.turbo
 **/.next


### PR DESCRIPTION
Background sub-agents create isolated worktrees under .claude/worktrees/;
keep them out of the working tree's untracked-files set.