### PR TITLE
refactor(forge): non-blocking pipeline tick — Lever C phase 4

### DIFF
--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -410,7 +410,7 @@ impl SynodicGate for HttpSynodicGate {
 
 /// Shared Forge state accessible from both the HTTP API and the tick loop.
 struct ForgeSharedState {
-    pipeline: ForgePipeline<HttpStiglabDispatcher, HttpSynodicGate>,
+    pipeline: ForgePipeline,
     kernel: BaselineKernel,
     spine: Option<EventStore>,
     /// Shared signal cache populated by the workflow signal listener and
@@ -509,20 +509,11 @@ pub fn run(database_url: &str, tick_ms: u64) {
             );
         }
 
-        let stiglab = HttpStiglabDispatcher {
-            client: client.clone(),
-            stiglab_url: stiglab_url.clone(),
-            internal_dispatch_token: internal_dispatch_token.clone(),
-        };
-        let synodic = HttpSynodicGate {
-            client: client.clone(),
-            synodic_url: synodic_url.clone(),
-            fail_policy,
-        };
-        // A second pair for the workflow gate evaluator (issue #80). It
-        // lives inside the spawned tick task and uses its own reqwest
-        // handles so the pipeline and the stage runner can dispatch in
-        // parallel without sharing mutable state.
+        // Phase 4 (Lever C): the main pipeline tick no longer dispatches
+        // synchronously to stiglab / synodic — it emits spine events and
+        // parks on the matching response. The HTTP types stay alive only
+        // for `LiveGateEvaluator` (the workflow-stage-runner gate path);
+        // phase 5 converts that path to events too and deletes them.
         let evaluator_stiglab = HttpStiglabDispatcher {
             client: client.clone(),
             stiglab_url: stiglab_url.clone(),
@@ -534,9 +525,15 @@ pub fn run(database_url: &str, tick_ms: u64) {
             fail_policy,
         };
 
+        // Phase-3 parking maps for the Lever C event-driven flow. The
+        // listeners spawned below populate these; the pipeline tick
+        // consumes them on its resume path.
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+
         let insight_cache = InsightCache::default();
-        let mut pipeline =
-            ForgePipeline::new(stiglab, synodic).with_insight_cache(insight_cache.clone());
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone())
+            .with_insight_cache(insight_cache.clone());
         pipeline.store = artifact_store;
 
         // Workflows are read from the spine DB on demand — both at the top
@@ -547,12 +544,6 @@ pub fn run(database_url: &str, tick_ms: u64) {
         // picked up without a restart and without risking a stale-cache
         // branch that silently disagrees with the DB.
         let signals = SignalCache::new();
-
-        // Phase-3 parking maps for the Lever C event-driven flow. The
-        // listeners spawned below populate these; phase 4 wires the
-        // pipeline tick to consume them.
-        let pending_verdicts = PendingVerdicts::new();
-        let pending_shapings = PendingShapings::new();
 
         let shared = Arc::new(RwLock::new(ForgeSharedState {
             pipeline,

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -1,16 +1,26 @@
 //! Forge pipeline — the core loop that drives the factory (forge-v0.1 §3).
 //!
+//! Phase 4 of Lever C (spec #131 / ADR 0004 — see #148) replaced the
+//! synchronous loop with a non-blocking parked state machine: each
+//! decision emits a request event (`forge.gate_requested`,
+//! `forge.shaping_dispatched`), parks itself keyed by the request's
+//! correlation id, and resumes on a later tick once the corresponding
+//! response (`synodic.gate_verdict`, `stiglab.shaping_result_ready`)
+//! lands in the [`PendingVerdicts`] / [`PendingShapings`] maps the
+//! event listeners populate.
+//!
 //! ```text
-//! loop:
-//!     decision = scheduling_kernel.decide(world_state)
-//!     shaping_result = stiglab.dispatch(decision)
-//!     verdict = synodic.gate(shaping_result, target_state)
-//!     if verdict.allow:
-//!         forge.advance(artifact, shaping_result, target_state)
-//!         if target_state == RELEASED:
-//!             forge.route(artifact, consumers)
-//!     emit_factory_events()
+//! tick:
+//!     if parked:
+//!         resume_parked()        // drain pending_* maps; advance one stage
+//!     else if scheduling_kernel.decide(world_state):
+//!         start_decision()       // emit pre-dispatch gate, park
 //! ```
+//!
+//! The pipeline owns at most one parked decision (the legacy
+//! one-decision-per-tick model). A future iteration can lift this to
+//! per-artifact concurrency by promoting `parked: Option<...>` to
+//! `parked: HashMap<ArtifactId, ParkedDecision>`.
 
 use onsager_artifact::{ArtifactState, BundleId};
 use onsager_spine::factory_event::{GatePoint, ShapingOutcome, VerdictSummary};
@@ -20,9 +30,12 @@ use onsager_spine::protocol::{
 };
 use onsager_warehouse::{Outputs, SealError, SealRequest, Warehouse};
 
+use onsager_artifact::Artifact;
+
 use super::artifact_store::ArtifactStore;
 use super::insight_cache::InsightCache;
 use super::kernel::{SchedulingKernel, WorldState};
+use super::pending::{PendingShapings, PendingVerdicts};
 use super::state::ForgeState;
 
 /// Events emitted by a single pipeline tick.
@@ -204,12 +217,48 @@ impl<W: Warehouse + 'static> SealSink for WarehouseSealSink<W> {
     }
 }
 
+/// A decision the pipeline kicked off but hasn't finished. The
+/// pipeline parks one of these per tick when it emits a request event;
+/// the next tick consults the parking maps and advances the stage.
+///
+/// Process-private and lost on restart. Phase 6 (#148 follow-up) moves
+/// this into a forge-private `pending_pipeline_decisions` table with
+/// replay on boot so a mid-tick crash doesn't drop in-flight decisions.
+#[derive(Debug, Clone)]
+pub struct ParkedDecision {
+    pub decision: ShapingDecision,
+    /// Snapshot of the artifact at the moment the decision was made.
+    /// Held so the pipeline can build follow-up gate requests with the
+    /// same `current_state` / `artifact_kind` it used initially —
+    /// reading the live store mid-decision could surface a state
+    /// changed by an out-of-band write.
+    pub artifact_snapshot: Artifact,
+    pub stage: ParkStage,
+}
+
+/// Where a parked decision is in the lifecycle. Each variant carries
+/// the correlation id the resume path uses to claim the matching
+/// response from the parking maps. The `result` payload on the
+/// transition variant is `Box`ed so the enum's stack footprint stays
+/// small (the other variants are short strings).
+#[derive(Debug, Clone)]
+pub enum ParkStage {
+    AwaitingPreDispatchVerdict {
+        gate_id: String,
+    },
+    AwaitingShapingResult {
+        request_id: String,
+    },
+    AwaitingTransitionVerdict {
+        gate_id: String,
+        result: Box<ShapingResult>,
+    },
+}
+
 /// The Forge pipeline — orchestrates one tick of the factory loop.
-pub struct ForgePipeline<S: StiglabDispatcher, G: SynodicGate> {
+pub struct ForgePipeline {
     pub store: ArtifactStore,
     pub state: ForgeState,
-    stiglab: S,
-    synodic: G,
     /// Optional sealing sink. When set, the pipeline seals a bundle on
     /// successful `Released` transitions (warehouse-and-delivery-v0.1 §5.1).
     /// Absent in legacy deployments; seals are skipped in that case.
@@ -219,18 +268,37 @@ pub struct ForgePipeline<S: StiglabDispatcher, G: SynodicGate> {
     /// holding the pipeline lock. Always present — the default cache is
     /// empty, which preserves the pre-issue-#36 behavior.
     insights: InsightCache,
+    /// At-most-one in-flight decision (legacy one-per-tick model).
+    /// Phase 4: the resume path drains parking maps keyed by the
+    /// correlation ids stored in [`ParkStage`].
+    parked: Option<ParkedDecision>,
+    /// Verdicts the `gate_verdict_listener` parks for the pipeline to
+    /// claim on resume. Cloned in from `ForgeSharedState` so the
+    /// listener task and the pipeline see the same map.
+    pending_verdicts: PendingVerdicts,
+    /// Shaping results the `shaping_result_listener` parks. Same
+    /// sharing model as [`Self::pending_verdicts`].
+    pending_shapings: PendingShapings,
 }
 
-impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
-    pub fn new(stiglab: S, synodic: G) -> Self {
+impl ForgePipeline {
+    pub fn new(pending_verdicts: PendingVerdicts, pending_shapings: PendingShapings) -> Self {
         Self {
             store: ArtifactStore::new(),
             state: ForgeState::new(),
-            stiglab,
-            synodic,
             warehouse: None,
             insights: InsightCache::default(),
+            parked: None,
+            pending_verdicts,
+            pending_shapings,
         }
+    }
+
+    /// Whether the pipeline is currently parked on a decision. Used by
+    /// tests to assert the state machine reached the expected park
+    /// without poking at private fields.
+    pub fn is_parked(&self) -> bool {
+        self.parked.is_some()
     }
 
     /// Attach a [`SealSink`]. Calls to `tick` will seal a bundle on every
@@ -254,6 +322,12 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
     }
 
     /// Execute one tick of the scheduling loop.
+    ///
+    /// Two branches: drain a parked decision if one is in-flight, or
+    /// (if the process state allows scheduling) ask the kernel for a
+    /// fresh decision and park it. Both paths emit `PipelineEvent`s
+    /// describing what the tick observed; the caller in `cmd/serve.rs`
+    /// translates those into spine events.
     pub fn tick(&mut self, kernel: &dyn SchedulingKernel) -> TickOutput {
         let mut output = TickOutput::default();
 
@@ -262,9 +336,14 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             return output;
         }
 
-        // Build world state. `insights` is populated from the shared cache
-        // the ising-event listener writes into (issue #36); the vec was
-        // previously hardcoded empty.
+        if self.parked.is_some() {
+            // A decision is in-flight; try to advance it. If the
+            // matching response hasn't arrived yet, the resume path
+            // emits `IdleTick` and leaves the parked state intact.
+            self.resume_parked(&mut output);
+            return output;
+        }
+
         let world = WorldState {
             artifacts: self.store.active_artifacts().into_iter().cloned().collect(),
             insights: self.insights.recent(),
@@ -272,7 +351,6 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             max_in_flight: 5,
         };
 
-        // Ask the kernel for a decision.
         let decision = match kernel.decide(&world) {
             Some(d) => d,
             None => {
@@ -285,7 +363,6 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             .events
             .push(PipelineEvent::DecisionMade(decision.clone()));
 
-        // Gate check: pre-dispatch.
         let artifact = match self.store.get(&decision.artifact_id) {
             Some(a) => a.clone(),
             None => {
@@ -297,214 +374,349 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
             }
         };
 
-        let pre_dispatch_gate = GateRequest {
-            context: GateContext {
-                gate_point: GatePoint::PreDispatch,
-                artifact_id: decision.artifact_id.clone(),
-                artifact_kind: artifact.kind.clone(),
-                current_state: artifact.state,
-                target_state: Some(decision.target_state),
-                extra: None,
-            },
-            proposed_action: ProposedAction {
-                description: format!("dispatch shaping for {}", decision.artifact_id),
-                payload: decision.shaping_intent.clone(),
-            },
-        };
+        self.start_decision(decision, artifact, &mut output);
+        output
+    }
+
+    /// Begin a new decision: emit the pre-dispatch gate request and
+    /// park. The `synodic.gate_verdict` listener resolves the parked
+    /// decision on a future tick once Synodic emits the matching verdict.
+    fn start_decision(
+        &mut self,
+        decision: ShapingDecision,
+        artifact_snapshot: Artifact,
+        output: &mut TickOutput,
+    ) {
+        let gate_id = ulid::Ulid::new().to_string();
+        let gate_request = build_pre_dispatch_gate(&decision, &artifact_snapshot);
 
         output.events.push(PipelineEvent::GateRequested {
-            gate_id: ulid::Ulid::new().to_string(),
+            gate_id: gate_id.clone(),
             artifact_id: decision.artifact_id.to_string(),
             gate_point: GatePoint::PreDispatch,
-            request: pre_dispatch_gate.clone(),
+            request: gate_request,
         });
 
-        let verdict = self.synodic.evaluate(&pre_dispatch_gate);
-        let verdict_summary = match &verdict {
-            GateVerdict::Allow => VerdictSummary::Allow,
-            GateVerdict::Deny { .. } => VerdictSummary::Deny,
-            GateVerdict::Modify { .. } => VerdictSummary::Modify,
-            GateVerdict::Escalate { .. } => VerdictSummary::Escalate,
+        self.parked = Some(ParkedDecision {
+            decision,
+            artifact_snapshot,
+            stage: ParkStage::AwaitingPreDispatchVerdict { gate_id },
+        });
+    }
+}
+
+impl ForgePipeline {
+    /// Resume a parked decision: claim the matching response from the
+    /// parking maps and advance one stage. If no response has arrived,
+    /// re-park unchanged and emit `IdleTick` so the caller can
+    /// distinguish "waiting" from "decided but did nothing".
+    fn resume_parked(&mut self, output: &mut TickOutput) {
+        let Some(parked) = self.parked.take() else {
+            output.events.push(PipelineEvent::IdleTick);
+            return;
         };
 
+        match parked.stage {
+            ParkStage::AwaitingPreDispatchVerdict { ref gate_id } => {
+                let Some(verdict) = self.pending_verdicts.take(gate_id) else {
+                    self.parked = Some(parked);
+                    output.events.push(PipelineEvent::IdleTick);
+                    return;
+                };
+                self.advance_after_pre_dispatch(parked, verdict, output);
+            }
+            ParkStage::AwaitingShapingResult { ref request_id } => {
+                let Some(result) = self.pending_shapings.take(request_id) else {
+                    self.parked = Some(parked);
+                    output.events.push(PipelineEvent::IdleTick);
+                    return;
+                };
+                self.advance_after_shaping(parked, result, output);
+            }
+            ParkStage::AwaitingTransitionVerdict { ref gate_id, .. } => {
+                let Some(verdict) = self.pending_verdicts.take(gate_id) else {
+                    self.parked = Some(parked);
+                    output.events.push(PipelineEvent::IdleTick);
+                    return;
+                };
+                self.advance_after_transition(parked, verdict, output);
+            }
+        }
+    }
+
+    /// Apply a pre-dispatch verdict.
+    fn advance_after_pre_dispatch(
+        &mut self,
+        parked: ParkedDecision,
+        verdict: GateVerdict,
+        output: &mut TickOutput,
+    ) {
         output.events.push(PipelineEvent::GateVerdictReceived {
-            artifact_id: decision.artifact_id.to_string(),
+            artifact_id: parked.decision.artifact_id.to_string(),
             gate_point: GatePoint::PreDispatch,
-            verdict: verdict_summary,
+            verdict: summarize(&verdict),
         });
 
         match verdict {
             GateVerdict::Deny { reason } => {
                 output.events.push(PipelineEvent::Error(format!(
                     "pre-dispatch gate denied for {}: {}",
-                    decision.artifact_id, reason
+                    parked.decision.artifact_id, reason
                 )));
-                return output;
+                // Park cleared — kernel may re-propose next tick.
             }
             GateVerdict::Escalate { .. } => {
-                // Park the decision (non-blocking — forge invariant #5).
-                return output;
+                // forge invariant #5: park non-blockingly. We clear our
+                // own park so the kernel can re-propose; the escalation
+                // sits on the spine waiting for a delegate.
             }
-            GateVerdict::Allow | GateVerdict::Modify { .. } => {}
+            GateVerdict::Allow | GateVerdict::Modify { .. } => {
+                self.kick_off_shaping(parked, output);
+            }
         }
+    }
 
-        // Dispatch to Stiglab.
+    /// Pre-dispatch passed: emit the shaping request and re-park
+    /// awaiting the result.
+    fn kick_off_shaping(&mut self, parked: ParkedDecision, output: &mut TickOutput) {
         let request_id = ulid::Ulid::new().to_string();
         let shaping_request = ShapingRequest {
             request_id: request_id.clone(),
-            artifact_id: decision.artifact_id.clone(),
-            target_version: decision.target_version,
-            shaping_intent: decision.shaping_intent.clone(),
-            inputs: decision.inputs.clone(),
-            constraints: decision.constraints.clone(),
-            deadline: decision.deadline,
+            artifact_id: parked.decision.artifact_id.clone(),
+            target_version: parked.decision.target_version,
+            shaping_intent: parked.decision.shaping_intent.clone(),
+            inputs: parked.decision.inputs.clone(),
+            constraints: parked.decision.constraints.clone(),
+            deadline: parked.decision.deadline,
             // Legacy kernel path predates per-workflow ownership (issue
-            // #156). These are direct-shaping decisions that don't flow
-            // through a workflow, so there's no `workflow.created_by` to
-            // forward; stiglab will spawn the agent without OAuth and
-            // the resulting failure surfaces via session_failed.
+            // #156). Direct-shaping decisions don't flow through a
+            // workflow, so there's no `workflow.created_by` to forward;
+            // stiglab will spawn the agent without OAuth and the
+            // resulting failure surfaces via session_failed.
             created_by: None,
         };
 
         output.events.push(PipelineEvent::ShapingDispatched {
             request_id: request_id.clone(),
-            artifact_id: decision.artifact_id.to_string(),
-            target_version: decision.target_version,
-            request: shaping_request.clone(),
+            artifact_id: parked.decision.artifact_id.to_string(),
+            target_version: parked.decision.target_version,
+            request: shaping_request,
         });
 
-        let result = self.stiglab.dispatch(&shaping_request);
+        self.parked = Some(ParkedDecision {
+            decision: parked.decision,
+            artifact_snapshot: parked.artifact_snapshot,
+            stage: ParkStage::AwaitingShapingResult { request_id },
+        });
+    }
+
+    /// Apply a shaping result.
+    fn advance_after_shaping(
+        &mut self,
+        parked: ParkedDecision,
+        result: ShapingResult,
+        output: &mut TickOutput,
+    ) {
+        let request_id = match &parked.stage {
+            ParkStage::AwaitingShapingResult { request_id } => request_id.clone(),
+            _ => unreachable!("advance_after_shaping called from non-shaping stage"),
+        };
 
         output.events.push(PipelineEvent::ShapingReturned {
-            request_id: request_id.clone(),
-            artifact_id: decision.artifact_id.to_string(),
+            request_id,
+            artifact_id: parked.decision.artifact_id.to_string(),
             outcome: format!("{:?}", result.outcome),
         });
 
         // Short-circuit on unsuccessful outcomes — don't advance state
-        // (forge-v0.1 §5.4: Failed/Aborted → artifact stays in previous state).
+        // (forge-v0.1 §5.4: Failed/Aborted → artifact stays in previous
+        // state). Park cleared so the kernel can re-propose.
         if matches!(
             result.outcome,
             ShapingOutcome::Failed | ShapingOutcome::Aborted
         ) {
             output.events.push(PipelineEvent::Error(format!(
                 "shaping {:?} for {}: not advancing state",
-                result.outcome, decision.artifact_id
+                result.outcome, parked.decision.artifact_id
             )));
-            return output;
+            return;
         }
 
-        // Gate check: state transition.
-        let transition_gate = GateRequest {
-            context: GateContext {
-                gate_point: GatePoint::StateTransition,
-                artifact_id: decision.artifact_id.clone(),
-                artifact_kind: artifact.kind.clone(),
-                current_state: artifact.state,
-                target_state: Some(decision.target_state),
-                extra: None,
-            },
-            proposed_action: ProposedAction {
-                description: format!(
-                    "advance {} from {} to {}",
-                    decision.artifact_id, artifact.state, decision.target_state
-                ),
-                payload: serde_json::to_value(&result).expect("ShapingResult must be serializable"),
-            },
-        };
-
+        // Pre-dispatch passed and shaping succeeded; emit the
+        // state-transition gate and re-park.
+        let gate_id = ulid::Ulid::new().to_string();
+        let gate_request =
+            build_transition_gate(&parked.decision, &parked.artifact_snapshot, &result);
         output.events.push(PipelineEvent::GateRequested {
-            gate_id: ulid::Ulid::new().to_string(),
-            artifact_id: decision.artifact_id.to_string(),
+            gate_id: gate_id.clone(),
+            artifact_id: parked.decision.artifact_id.to_string(),
             gate_point: GatePoint::StateTransition,
-            request: transition_gate.clone(),
+            request: gate_request,
         });
+        self.parked = Some(ParkedDecision {
+            decision: parked.decision,
+            artifact_snapshot: parked.artifact_snapshot,
+            stage: ParkStage::AwaitingTransitionVerdict {
+                gate_id,
+                result: Box::new(result),
+            },
+        });
+    }
 
-        let transition_verdict = self.synodic.evaluate(&transition_gate);
-        let transition_verdict_summary = match &transition_verdict {
-            GateVerdict::Allow => VerdictSummary::Allow,
-            GateVerdict::Deny { .. } => VerdictSummary::Deny,
-            GateVerdict::Modify { .. } => VerdictSummary::Modify,
-            GateVerdict::Escalate { .. } => VerdictSummary::Escalate,
+    /// Apply a state-transition verdict — the terminal stage of a
+    /// successful pipeline run.
+    fn advance_after_transition(
+        &mut self,
+        parked: ParkedDecision,
+        verdict: GateVerdict,
+        output: &mut TickOutput,
+    ) {
+        let result = match parked.stage {
+            ParkStage::AwaitingTransitionVerdict { ref result, .. } => (**result).clone(),
+            _ => unreachable!("advance_after_transition called from non-transition stage"),
         };
 
         output.events.push(PipelineEvent::GateVerdictReceived {
-            artifact_id: decision.artifact_id.to_string(),
+            artifact_id: parked.decision.artifact_id.to_string(),
             gate_point: GatePoint::StateTransition,
-            verdict: transition_verdict_summary,
+            verdict: summarize(&verdict),
         });
 
-        match transition_verdict {
+        match verdict {
             GateVerdict::Allow | GateVerdict::Modify { .. } => {
-                let from_state = artifact.state;
-
-                // Seal before advancing to Released (warehouse-and-delivery-v0.1
-                // §5.1: "Released" implies a sealed bundle exists). If sealing
-                // fails, abort the transition — the artifact stays in its
-                // prior state and a follow-up tick can retry.
-                let sealing_release = decision.target_state == ArtifactState::Released
-                    && result.outcome == ShapingOutcome::Completed;
-                let sealed = if sealing_release {
-                    match &self.warehouse {
-                        Some(warehouse) => {
-                            match warehouse.seal_release(&decision.artifact_id, &result) {
-                                Ok(s) => Some(s),
-                                Err(e) => {
-                                    output.events.push(PipelineEvent::Error(format!(
-                                        "warehouse seal failed for {}: {}",
-                                        decision.artifact_id, e
-                                    )));
-                                    return output;
-                                }
-                            }
-                        }
-                        None => None,
-                    }
-                } else {
-                    None
-                };
-
-                match self
-                    .store
-                    .advance(&decision.artifact_id, decision.target_state, &result)
-                {
-                    Ok(()) => {
-                        output.events.push(PipelineEvent::ArtifactAdvanced {
-                            artifact_id: decision.artifact_id.to_string(),
-                            from_state,
-                            to_state: decision.target_state,
-                        });
-
-                        if let Some(sealed) = sealed {
-                            self.store
-                                .record_version(&decision.artifact_id, sealed.bundle_id.clone());
-                            output.events.push(PipelineEvent::BundleSealed {
-                                artifact_id: decision.artifact_id.to_string(),
-                                bundle_id: sealed.bundle_id,
-                                version: sealed.version,
-                            });
-                        }
-                    }
-                    Err(e) => {
-                        output.events.push(PipelineEvent::Error(format!(
-                            "failed to advance {}: {}",
-                            decision.artifact_id, e
-                        )));
-                    }
-                }
+                self.apply_transition(parked, result, output);
             }
             GateVerdict::Deny { reason } => {
                 output.events.push(PipelineEvent::Error(format!(
                     "state transition gate denied for {}: {}",
-                    decision.artifact_id, reason
+                    parked.decision.artifact_id, reason
                 )));
             }
             GateVerdict::Escalate { .. } => {
-                // Park — non-blocking.
+                // forge invariant #5: clear park, let kernel re-propose.
             }
         }
+    }
 
-        output
+    /// Seal-if-Released and advance the artifact. Called only from
+    /// the Allow/Modify branch of [`Self::advance_after_transition`].
+    fn apply_transition(
+        &mut self,
+        parked: ParkedDecision,
+        result: ShapingResult,
+        output: &mut TickOutput,
+    ) {
+        let from_state = parked.artifact_snapshot.state;
+        let target_state = parked.decision.target_state;
+
+        // warehouse-and-delivery-v0.1 §5.1: Released implies a sealed
+        // bundle. Seal before advancing — if it fails the transition
+        // aborts and the artifact stays in its prior state (kernel
+        // re-proposes on a follow-up tick).
+        let sealing_release =
+            target_state == ArtifactState::Released && result.outcome == ShapingOutcome::Completed;
+        let sealed = if sealing_release {
+            match &self.warehouse {
+                Some(warehouse) => {
+                    match warehouse.seal_release(&parked.decision.artifact_id, &result) {
+                        Ok(s) => Some(s),
+                        Err(e) => {
+                            output.events.push(PipelineEvent::Error(format!(
+                                "warehouse seal failed for {}: {}",
+                                parked.decision.artifact_id, e
+                            )));
+                            return;
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        match self
+            .store
+            .advance(&parked.decision.artifact_id, target_state, &result)
+        {
+            Ok(()) => {
+                output.events.push(PipelineEvent::ArtifactAdvanced {
+                    artifact_id: parked.decision.artifact_id.to_string(),
+                    from_state,
+                    to_state: target_state,
+                });
+
+                if let Some(sealed) = sealed {
+                    self.store
+                        .record_version(&parked.decision.artifact_id, sealed.bundle_id.clone());
+                    output.events.push(PipelineEvent::BundleSealed {
+                        artifact_id: parked.decision.artifact_id.to_string(),
+                        bundle_id: sealed.bundle_id,
+                        version: sealed.version,
+                    });
+                }
+            }
+            Err(e) => {
+                output.events.push(PipelineEvent::Error(format!(
+                    "failed to advance {}: {}",
+                    parked.decision.artifact_id, e
+                )));
+            }
+        }
+    }
+}
+
+/// Build the standard pre-dispatch [`GateRequest`] for a decision.
+fn build_pre_dispatch_gate(decision: &ShapingDecision, artifact: &Artifact) -> GateRequest {
+    GateRequest {
+        context: GateContext {
+            gate_point: GatePoint::PreDispatch,
+            artifact_id: decision.artifact_id.clone(),
+            artifact_kind: artifact.kind.clone(),
+            current_state: artifact.state,
+            target_state: Some(decision.target_state),
+            extra: None,
+        },
+        proposed_action: ProposedAction {
+            description: format!("dispatch shaping for {}", decision.artifact_id),
+            payload: decision.shaping_intent.clone(),
+        },
+    }
+}
+
+/// Build the state-transition [`GateRequest`] sent after a successful
+/// shaping. The `payload` carries the full `ShapingResult` so Synodic
+/// can branch on the artifact's actual outputs.
+fn build_transition_gate(
+    decision: &ShapingDecision,
+    artifact: &Artifact,
+    result: &ShapingResult,
+) -> GateRequest {
+    GateRequest {
+        context: GateContext {
+            gate_point: GatePoint::StateTransition,
+            artifact_id: decision.artifact_id.clone(),
+            artifact_kind: artifact.kind.clone(),
+            current_state: artifact.state,
+            target_state: Some(decision.target_state),
+            extra: None,
+        },
+        proposed_action: ProposedAction {
+            description: format!(
+                "advance {} from {} to {}",
+                decision.artifact_id, artifact.state, decision.target_state
+            ),
+            payload: serde_json::to_value(result).expect("ShapingResult must be serializable"),
+        },
+    }
+}
+
+fn summarize(verdict: &GateVerdict) -> VerdictSummary {
+    match verdict {
+        GateVerdict::Allow => VerdictSummary::Allow,
+        GateVerdict::Deny { .. } => VerdictSummary::Deny,
+        GateVerdict::Modify { .. } => VerdictSummary::Modify,
+        GateVerdict::Escalate { .. } => VerdictSummary::Escalate,
     }
 }
 
@@ -514,61 +726,104 @@ impl<S: StiglabDispatcher, G: SynodicGate> ForgePipeline<S, G> {
 
 #[cfg(test)]
 mod tests {
+    //! Tests are written around the parked-state-machine event flow that
+    //! phase 4 introduced. Tick semantics are now: emit a request event +
+    //! park, then resume on a later tick once the test harness pushes a
+    //! response into the parking maps. Each scenario walks the pipeline
+    //! through the relevant park stages explicitly so a regression in the
+    //! resume logic surfaces as a wrong event sequence rather than a
+    //! silent missed advance.
+
     use super::*;
     use crate::core::kernel::BaselineKernel;
-    use onsager_artifact::ContentRef;
-    use onsager_artifact::Kind;
+    use onsager_artifact::{ContentRef, Kind};
     use onsager_spine::factory_event::ShapingOutcome;
 
-    /// Mock Stiglab dispatcher that always succeeds.
-    struct MockStiglab;
-    impl StiglabDispatcher for MockStiglab {
-        fn dispatch(&self, req: &ShapingRequest) -> ShapingResult {
-            ShapingResult {
-                request_id: req.request_id.clone(),
-                outcome: ShapingOutcome::Completed,
-                content_ref: Some(ContentRef {
-                    uri: "git://test@abc".into(),
-                    checksum: None,
-                }),
-                change_summary: "mock shaping completed".into(),
-                quality_signals: vec![],
-                session_id: "mock_session".into(),
-                duration_ms: 100,
-                error: None,
+    fn fresh_pipeline() -> ForgePipeline {
+        ForgePipeline::new(PendingVerdicts::new(), PendingShapings::new())
+    }
+
+    fn shaping_completed(req: &str) -> ShapingResult {
+        ShapingResult {
+            request_id: req.into(),
+            outcome: ShapingOutcome::Completed,
+            content_ref: Some(ContentRef {
+                uri: "git://test@abc".into(),
+                checksum: None,
+            }),
+            change_summary: "mock shaping completed".into(),
+            quality_signals: vec![],
+            session_id: "mock_session".into(),
+            duration_ms: 100,
+            error: None,
+        }
+    }
+
+    fn shaping_failed(req: &str) -> ShapingResult {
+        ShapingResult {
+            request_id: req.into(),
+            outcome: ShapingOutcome::Failed,
+            content_ref: None,
+            change_summary: "shaping failed".into(),
+            quality_signals: vec![],
+            session_id: "mock_session".into(),
+            duration_ms: 100,
+            error: Some(onsager_spine::protocol::ErrorDetail {
+                code: "test_failure".into(),
+                message: "mock failure".into(),
+                retriable: Some(true),
+            }),
+        }
+    }
+
+    /// Pull the `gate_id` off whichever pre-dispatch GateRequested
+    /// event the tick emitted. Tests use this to address the matching
+    /// pending_verdicts entry.
+    fn pre_dispatch_gate_id(output: &TickOutput) -> String {
+        for ev in &output.events {
+            if let PipelineEvent::GateRequested {
+                gate_id,
+                gate_point: GatePoint::PreDispatch,
+                ..
+            } = ev
+            {
+                return gate_id.clone();
             }
         }
+        panic!("no pre-dispatch GateRequested event in tick output");
     }
 
-    /// Mock Synodic gate that always allows.
-    struct MockSynodicAllow;
-    impl SynodicGate for MockSynodicAllow {
-        fn evaluate(&self, _req: &GateRequest) -> GateVerdict {
-            GateVerdict::Allow
-        }
-    }
-
-    /// Mock Synodic gate that always denies.
-    struct MockSynodicDeny;
-    impl SynodicGate for MockSynodicDeny {
-        fn evaluate(&self, _req: &GateRequest) -> GateVerdict {
-            GateVerdict::Deny {
-                reason: "policy violation".into(),
+    fn transition_gate_id(output: &TickOutput) -> String {
+        for ev in &output.events {
+            if let PipelineEvent::GateRequested {
+                gate_id,
+                gate_point: GatePoint::StateTransition,
+                ..
+            } = ev
+            {
+                return gate_id.clone();
             }
         }
+        panic!("no state-transition GateRequested event in tick output");
     }
 
-    /// Mock kernel that snapshots the `WorldState.insights` it sees on every
-    /// call. Tests use this to verify the pipeline threads insights from
-    /// the shared cache into the scheduling kernel (issue #36).
+    fn shaping_request_id(output: &TickOutput) -> String {
+        for ev in &output.events {
+            if let PipelineEvent::ShapingDispatched { request_id, .. } = ev {
+                return request_id.clone();
+            }
+        }
+        panic!("no ShapingDispatched event in tick output");
+    }
+
+    /// Mock kernel that snapshots `WorldState.insights` to verify the
+    /// pipeline threads insights from the shared cache (issue #36).
     struct CapturingKernel {
         seen: std::sync::Mutex<Vec<Vec<onsager_spine::protocol::Insight>>>,
     }
     impl SchedulingKernel for CapturingKernel {
         fn decide(&self, world: &WorldState) -> Option<ShapingDecision> {
             self.seen.lock().unwrap().push(world.insights.clone());
-            // Return None so the tick ends early; we only care about what the
-            // kernel observed, not about driving a full lifecycle.
             None
         }
         fn observe(&mut self, _event: &onsager_spine::factory_event::FactoryEvent) {}
@@ -593,8 +848,7 @@ mod tests {
             confidence: 0.8,
         });
 
-        let mut pipeline =
-            ForgePipeline::new(MockStiglab, MockSynodicAllow).with_insight_cache(cache.clone());
+        let mut pipeline = fresh_pipeline().with_insight_cache(cache.clone());
         pipeline.store.register(Kind::Code, "x", "marvin");
 
         let kernel = CapturingKernel {
@@ -609,16 +863,89 @@ mod tests {
     }
 
     #[test]
-    fn tick_advances_artifact_when_allowed() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+    fn first_tick_emits_pre_dispatch_gate_and_parks() {
+        let mut pipeline = fresh_pipeline();
+        pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let output = pipeline.tick(&BaselineKernel::new());
+
+        // The new flow emits a single GateRequested + parks. No
+        // synchronous ShapingDispatched / advance on the first tick.
+        let gate_count = output
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    PipelineEvent::GateRequested {
+                        gate_point: GatePoint::PreDispatch,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(gate_count, 1, "exactly one pre-dispatch gate emitted");
+        assert!(
+            !output
+                .events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::ShapingDispatched { .. })),
+            "shaping must not dispatch until pre-dispatch verdict arrives"
+        );
+        assert!(pipeline.is_parked(), "pipeline must park awaiting verdict");
+    }
+
+    #[test]
+    fn parked_tick_idles_until_verdict_lands() {
+        // Re-ticking while parked with no incoming verdict must emit
+        // IdleTick and leave the park untouched.
+        let mut pipeline = fresh_pipeline();
+        pipeline.store.register(Kind::Code, "test-art", "marvin");
+        pipeline.tick(&BaselineKernel::new());
+        assert!(pipeline.is_parked());
+
+        let output = pipeline.tick(&BaselineKernel::new());
+        assert!(
+            output
+                .events
+                .iter()
+                .all(|e| matches!(e, PipelineEvent::IdleTick)),
+            "parked tick without pending verdict must only emit IdleTick"
+        );
+        assert!(pipeline.is_parked(), "park survives an empty resume");
+    }
+
+    #[test]
+    fn full_lifecycle_drives_artifact_to_in_progress() {
+        // Three ticks: emit pre-dispatch gate, then resume after Allow
+        // (emits shaping_dispatched + parks), then resume after the
+        // shaping result lands (emits the transition gate + parks),
+        // then a final tick after the transition verdict advances state.
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone());
         let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
 
-        let kernel = BaselineKernel::new();
-        let output = pipeline.tick(&kernel);
+        // Tick 1: emit pre-dispatch gate, park.
+        let out = pipeline.tick(&BaselineKernel::new());
+        let gate_id = pre_dispatch_gate_id(&out);
 
-        // Should have: decision, pre-dispatch gate+verdict, dispatch, return,
-        // transition gate+verdict, advance
-        assert!(output.events.len() >= 7);
+        // Park drained: Allow.
+        pending_verdicts.insert(&gate_id, GateVerdict::Allow);
+        let out = pipeline.tick(&BaselineKernel::new());
+        let req_id = shaping_request_id(&out);
+        assert!(pipeline.is_parked());
+
+        // Park drained: shaping result lands.
+        pending_shapings.insert(&req_id, shaping_completed(&req_id));
+        let out = pipeline.tick(&BaselineKernel::new());
+        let transition_gate = transition_gate_id(&out);
+        assert!(pipeline.is_parked(), "still parked on transition verdict");
+
+        // Park drained: Allow on the transition gate → advance.
+        pending_verdicts.insert(&transition_gate, GateVerdict::Allow);
+        pipeline.tick(&BaselineKernel::new());
+        assert!(!pipeline.is_parked(), "park cleared after advance");
 
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::InProgress);
@@ -626,28 +953,129 @@ mod tests {
     }
 
     #[test]
-    fn tick_blocks_when_gate_denies() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicDeny);
+    fn pre_dispatch_deny_clears_park_and_emits_error() {
+        let pending_verdicts = PendingVerdicts::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), PendingShapings::new());
         pipeline.store.register(Kind::Code, "test-art", "marvin");
 
-        let kernel = BaselineKernel::new();
-        let output = pipeline.tick(&kernel);
+        let out = pipeline.tick(&BaselineKernel::new());
+        let gate_id = pre_dispatch_gate_id(&out);
 
-        // Should have error event from denied pre-dispatch gate
-        let has_error = output
+        pending_verdicts.insert(
+            &gate_id,
+            GateVerdict::Deny {
+                reason: "policy violation".into(),
+            },
+        );
+        let out = pipeline.tick(&BaselineKernel::new());
+
+        assert!(
+            out.events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::Error(_))),
+            "Deny on pre-dispatch must emit an error event"
+        );
+        assert!(!pipeline.is_parked(), "Deny clears the park");
+    }
+
+    #[test]
+    fn pre_dispatch_escalate_clears_park_silently() {
+        // forge invariant #5: park non-blockingly. The pipeline drops its
+        // own park so the kernel can re-propose; the escalation itself
+        // sits on the spine for a delegate.
+        let pending_verdicts = PendingVerdicts::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), PendingShapings::new());
+        pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let out = pipeline.tick(&BaselineKernel::new());
+        let gate_id = pre_dispatch_gate_id(&out);
+
+        pending_verdicts.insert(
+            &gate_id,
+            GateVerdict::Escalate {
+                context: onsager_spine::protocol::EscalationContext {
+                    escalation_id: "esc_1".into(),
+                    reason: "human pls".into(),
+                    target: "supervisor".into(),
+                    timeout_at: chrono::Utc::now(),
+                },
+            },
+        );
+        pipeline.tick(&BaselineKernel::new());
+        assert!(
+            !pipeline.is_parked(),
+            "Escalate releases the pipeline's own park"
+        );
+    }
+
+    #[test]
+    fn shaping_failure_clears_park_and_does_not_advance() {
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone());
+        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let out = pipeline.tick(&BaselineKernel::new());
+        let gate_id = pre_dispatch_gate_id(&out);
+
+        pending_verdicts.insert(&gate_id, GateVerdict::Allow);
+        let out = pipeline.tick(&BaselineKernel::new());
+        let req_id = shaping_request_id(&out);
+
+        pending_shapings.insert(&req_id, shaping_failed(&req_id));
+        let out = pipeline.tick(&BaselineKernel::new());
+
+        assert!(out
             .events
             .iter()
-            .any(|e| matches!(e, PipelineEvent::Error(_)));
-        assert!(has_error);
+            .any(|e| matches!(e, PipelineEvent::Error(_))));
+        assert!(!pipeline.is_parked());
+        let art = pipeline.store.get(&id).unwrap();
+        assert_eq!(
+            art.state,
+            ArtifactState::Draft,
+            "Failed shaping must not advance the artifact"
+        );
+        assert_eq!(art.current_version, 0);
+    }
+
+    #[test]
+    fn transition_deny_clears_park_and_does_not_advance() {
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone());
+        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+
+        let out = pipeline.tick(&BaselineKernel::new());
+        let gate_id = pre_dispatch_gate_id(&out);
+        pending_verdicts.insert(&gate_id, GateVerdict::Allow);
+        let out = pipeline.tick(&BaselineKernel::new());
+        let req_id = shaping_request_id(&out);
+
+        pending_shapings.insert(&req_id, shaping_completed(&req_id));
+        let out = pipeline.tick(&BaselineKernel::new());
+        let transition_gate = transition_gate_id(&out);
+
+        pending_verdicts.insert(
+            &transition_gate,
+            GateVerdict::Deny {
+                reason: "no go".into(),
+            },
+        );
+        let out = pipeline.tick(&BaselineKernel::new());
+        assert!(out
+            .events
+            .iter()
+            .any(|e| matches!(e, PipelineEvent::Error(_))));
+        assert!(!pipeline.is_parked());
+        let art = pipeline.store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::Draft);
     }
 
     #[test]
     fn tick_idles_when_no_work() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
-        // No artifacts registered
-        let kernel = BaselineKernel::new();
-        let output = pipeline.tick(&kernel);
-
+        let mut pipeline = fresh_pipeline();
+        let output = pipeline.tick(&BaselineKernel::new());
         assert!(output
             .events
             .iter()
@@ -656,54 +1084,45 @@ mod tests {
 
     #[test]
     fn tick_idles_when_paused() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
+        let mut pipeline = fresh_pipeline();
         pipeline.store.register(Kind::Code, "test-art", "marvin");
-
         pipeline
             .state
             .transition(onsager_spine::factory_event::ForgeProcessState::Paused)
             .unwrap();
 
-        let kernel = BaselineKernel::new();
-        let output = pipeline.tick(&kernel);
-
+        let output = pipeline.tick(&BaselineKernel::new());
         assert!(output
             .events
             .iter()
             .any(|e| matches!(e, PipelineEvent::IdleTick)));
+        assert!(!pipeline.is_parked(), "paused tick must not park anything");
     }
 
-    #[test]
-    fn full_lifecycle_three_ticks() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
-        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
+    /// Drive a single decision end-to-end with Allow on both gates and a
+    /// Completed shaping result. Helper for the seal tests below.
+    fn drive_to_completion(
+        pipeline: &mut ForgePipeline,
+        pending_verdicts: &PendingVerdicts,
+        pending_shapings: &PendingShapings,
+        kernel: &dyn SchedulingKernel,
+    ) {
+        let out = pipeline.tick(kernel);
+        let gate_id = pre_dispatch_gate_id(&out);
+        pending_verdicts.insert(&gate_id, GateVerdict::Allow);
 
-        let kernel = BaselineKernel::new();
+        let out = pipeline.tick(kernel);
+        let req_id = shaping_request_id(&out);
+        pending_shapings.insert(&req_id, shaping_completed(&req_id));
 
-        // Tick 1: Draft -> InProgress
-        pipeline.tick(&kernel);
-        assert_eq!(
-            pipeline.store.get(&id).unwrap().state,
-            ArtifactState::InProgress
-        );
+        let out = pipeline.tick(kernel);
+        let trans = transition_gate_id(&out);
+        pending_verdicts.insert(&trans, GateVerdict::Allow);
 
-        // Tick 2: InProgress -> UnderReview
-        pipeline.tick(&kernel);
-        assert_eq!(
-            pipeline.store.get(&id).unwrap().state,
-            ArtifactState::UnderReview
-        );
-
-        // Tick 3: UnderReview is not schedulable, so idle
-        let output = pipeline.tick(&kernel);
-        assert!(output
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+        pipeline.tick(kernel);
     }
 
-    /// Mock SealSink: returns a deterministic bundle id per artifact, tracks
-    /// how many seals were requested.
+    /// Mock SealSink: returns a deterministic bundle id per artifact.
     struct MockSeal {
         counter: std::sync::atomic::AtomicU32,
     }
@@ -731,9 +1150,8 @@ mod tests {
         }
     }
 
-    /// Kernel that always targets `Released` for any artifact currently in
-    /// `UnderReview`. Used to exercise the seal path without building a full
-    /// factory loop.
+    /// Kernel that always targets `Released` for any artifact in
+    /// `UnderReview`.
     struct ReleaseKernel;
     impl SchedulingKernel for ReleaseKernel {
         fn decide(&self, world: &WorldState) -> Option<ShapingDecision> {
@@ -752,28 +1170,51 @@ mod tests {
                 priority: 100,
             })
         }
-
         fn observe(&mut self, _event: &onsager_spine::factory_event::FactoryEvent) {}
     }
 
     #[test]
     fn seal_emits_bundle_sealed_on_release() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow)
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone())
             .with_warehouse(Box::new(MockSeal::new()));
         let id = pipeline.store.register(Kind::Code, "svc", "marvin");
 
-        // Drive to UnderReview via the baseline kernel.
+        // Drive to UnderReview with the baseline kernel (two decisions).
         let baseline = BaselineKernel::new();
-        pipeline.tick(&baseline); // Draft -> InProgress
-        pipeline.tick(&baseline); // InProgress -> UnderReview
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
+        );
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
+        );
         assert_eq!(
             pipeline.store.get(&id).unwrap().state,
             ArtifactState::UnderReview
         );
 
-        // Now push to Released and seal.
-        let output = pipeline.tick(&ReleaseKernel);
-        let sealed_event = output.events.iter().find_map(|e| match e {
+        // Now push to Released and seal — the final tick of
+        // `drive_to_completion` produces the BundleSealed event.
+        let release = ReleaseKernel;
+        let out1 = pipeline.tick(&release);
+        let g = pre_dispatch_gate_id(&out1);
+        pending_verdicts.insert(&g, GateVerdict::Allow);
+        let out2 = pipeline.tick(&release);
+        let r = shaping_request_id(&out2);
+        pending_shapings.insert(&r, shaping_completed(&r));
+        let out3 = pipeline.tick(&release);
+        let t = transition_gate_id(&out3);
+        pending_verdicts.insert(&t, GateVerdict::Allow);
+        let out4 = pipeline.tick(&release);
+
+        let sealed_event = out4.events.iter().find_map(|e| match e {
             PipelineEvent::BundleSealed {
                 artifact_id,
                 bundle_id,
@@ -807,23 +1248,46 @@ mod tests {
 
     #[test]
     fn seal_failure_blocks_release_transition() {
-        // warehouse-and-delivery-v0.1 §5.1: Released implies a sealed bundle.
-        // If sealing fails, the artifact must not advance to Released.
-        let mut pipeline =
-            ForgePipeline::new(MockStiglab, MockSynodicAllow).with_warehouse(Box::new(FailingSeal));
+        // warehouse-and-delivery-v0.1 §5.1: Released implies a sealed
+        // bundle. If sealing fails, the artifact must not advance.
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone())
+            .with_warehouse(Box::new(FailingSeal));
         let id = pipeline.store.register(Kind::Code, "svc", "marvin");
 
+        // Two complete cycles with the baseline kernel walk through
+        // Draft → InProgress → UnderReview.
         let baseline = BaselineKernel::new();
-        pipeline.tick(&baseline);
-        pipeline.tick(&baseline);
-        assert_eq!(
-            pipeline.store.get(&id).unwrap().state,
-            ArtifactState::UnderReview
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
+        );
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
         );
 
-        let output = pipeline.tick(&ReleaseKernel);
-        // No advance, no sealed event.
-        let has_advance = output.events.iter().any(|e| {
+        // Attempt the release. The transition gate Allow path tries to
+        // seal, fails, and emits an error event — no advance, no
+        // BundleSealed.
+        let release = ReleaseKernel;
+        let out1 = pipeline.tick(&release);
+        let g = pre_dispatch_gate_id(&out1);
+        pending_verdicts.insert(&g, GateVerdict::Allow);
+        let out2 = pipeline.tick(&release);
+        let r = shaping_request_id(&out2);
+        pending_shapings.insert(&r, shaping_completed(&r));
+        let out3 = pipeline.tick(&release);
+        let t = transition_gate_id(&out3);
+        pending_verdicts.insert(&t, GateVerdict::Allow);
+        let out = pipeline.tick(&release);
+
+        let has_advance = out.events.iter().any(|e| {
             matches!(
                 e,
                 PipelineEvent::ArtifactAdvanced {
@@ -836,73 +1300,12 @@ mod tests {
             !has_advance,
             "sealing failure must abort the release transition"
         );
-        let has_sealed = output
+        assert!(!out
             .events
             .iter()
-            .any(|e| matches!(e, PipelineEvent::BundleSealed { .. }));
-        assert!(!has_sealed);
-
+            .any(|e| matches!(e, PipelineEvent::BundleSealed { .. })));
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::UnderReview);
         assert!(art.current_version_id.is_none());
-    }
-
-    #[test]
-    fn no_seal_when_warehouse_absent() {
-        let mut pipeline = ForgePipeline::new(MockStiglab, MockSynodicAllow);
-        let id = pipeline.store.register(Kind::Code, "svc", "marvin");
-
-        let baseline = BaselineKernel::new();
-        pipeline.tick(&baseline);
-        pipeline.tick(&baseline);
-
-        let output = pipeline.tick(&ReleaseKernel);
-        let has_sealed = output
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::BundleSealed { .. }));
-        assert!(
-            !has_sealed,
-            "pipeline without SealSink must not emit BundleSealed"
-        );
-
-        let art = pipeline.store.get(&id).unwrap();
-        assert_eq!(art.state, ArtifactState::Released);
-        assert!(art.current_version_id.is_none());
-    }
-
-    #[test]
-    fn tick_does_not_advance_on_failed_shaping() {
-        /// Mock Stiglab that always fails.
-        struct MockStiglabFail;
-        impl StiglabDispatcher for MockStiglabFail {
-            fn dispatch(&self, req: &ShapingRequest) -> ShapingResult {
-                ShapingResult {
-                    request_id: req.request_id.clone(),
-                    outcome: ShapingOutcome::Failed,
-                    content_ref: None,
-                    change_summary: "shaping failed".into(),
-                    quality_signals: vec![],
-                    session_id: "mock_session".into(),
-                    duration_ms: 100,
-                    error: Some(onsager_spine::protocol::ErrorDetail {
-                        code: "test_failure".into(),
-                        message: "mock failure".into(),
-                        retriable: Some(true),
-                    }),
-                }
-            }
-        }
-
-        let mut pipeline = ForgePipeline::new(MockStiglabFail, MockSynodicAllow);
-        let id = pipeline.store.register(Kind::Code, "test-art", "marvin");
-
-        let kernel = BaselineKernel::new();
-        pipeline.tick(&kernel);
-
-        // Artifact should remain in Draft — not advanced
-        let art = pipeline.store.get(&id).unwrap();
-        assert_eq!(art.state, ArtifactState::Draft);
-        assert_eq!(art.current_version, 0);
     }
 }

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -221,19 +221,26 @@ impl<W: Warehouse + 'static> SealSink for WarehouseSealSink<W> {
 /// pipeline parks one of these per tick when it emits a request event;
 /// the next tick consults the parking maps and advances the stage.
 ///
-/// Process-private and lost on restart. Phase 6 (#148 follow-up) moves
-/// this into a forge-private `pending_pipeline_decisions` table with
-/// replay on boot so a mid-tick crash doesn't drop in-flight decisions.
+/// Process-private and lost on restart. Phase 6 (#186) moves this into
+/// a forge-private `pending_pipeline_decisions` table with replay on
+/// boot so a mid-tick crash doesn't drop in-flight decisions.
+///
+/// `pub(crate)` (not `pub`): the parking lifecycle is an internal
+/// detail of the pipeline state machine — the public surface is the
+/// observable `PipelineEvent` stream + `is_parked()`. Keeping these
+/// types crate-private leaves the parking shape free to evolve
+/// (per-artifact concurrency, persistence) without breaking external
+/// callers.
 #[derive(Debug, Clone)]
-pub struct ParkedDecision {
-    pub decision: ShapingDecision,
+pub(crate) struct ParkedDecision {
+    pub(crate) decision: ShapingDecision,
     /// Snapshot of the artifact at the moment the decision was made.
     /// Held so the pipeline can build follow-up gate requests with the
     /// same `current_state` / `artifact_kind` it used initially —
     /// reading the live store mid-decision could surface a state
     /// changed by an out-of-band write.
-    pub artifact_snapshot: Artifact,
-    pub stage: ParkStage,
+    pub(crate) artifact_snapshot: Artifact,
+    pub(crate) stage: ParkStage,
 }
 
 /// Where a parked decision is in the lifecycle. Each variant carries
@@ -241,8 +248,14 @@ pub struct ParkedDecision {
 /// response from the parking maps. The `result` payload on the
 /// transition variant is `Box`ed so the enum's stack footprint stays
 /// small (the other variants are short strings).
+///
+/// `pub(crate)` for the same reason as [`ParkedDecision`]. The
+/// `Awaiting*` shared prefix mirrors the lifecycle vocabulary used in
+/// the module-level docstring and the resume helpers; `clippy`'s
+/// uniform-prefix lint is not worth the legibility cost here.
 #[derive(Debug, Clone)]
-pub enum ParkStage {
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum ParkStage {
     AwaitingPreDispatchVerdict {
         gate_id: String,
     },
@@ -294,10 +307,12 @@ impl ForgePipeline {
         }
     }
 
-    /// Whether the pipeline is currently parked on a decision. Used by
-    /// tests to assert the state machine reached the expected park
-    /// without poking at private fields.
-    pub fn is_parked(&self) -> bool {
+    /// Whether the pipeline is currently parked on a decision. Test
+    /// helper: gated on `cfg(test)` because no production code reads
+    /// it today. If a future dashboard endpoint wants to surface
+    /// "in-flight" state, lift the gate to `pub(crate)`.
+    #[cfg(test)]
+    fn is_parked(&self) -> bool {
         self.parked.is_some()
     }
 
@@ -564,32 +579,39 @@ impl ForgePipeline {
     }
 
     /// Apply a state-transition verdict — the terminal stage of a
-    /// successful pipeline run.
+    /// successful pipeline run. Destructures `parked` so the boxed
+    /// `ShapingResult` can move out by value (no clone of a payload
+    /// the box was put there to keep small).
     fn advance_after_transition(
         &mut self,
         parked: ParkedDecision,
         verdict: GateVerdict,
         output: &mut TickOutput,
     ) {
-        let result = match parked.stage {
-            ParkStage::AwaitingTransitionVerdict { ref result, .. } => (**result).clone(),
+        let ParkedDecision {
+            decision,
+            artifact_snapshot,
+            stage,
+        } = parked;
+        let result = match stage {
+            ParkStage::AwaitingTransitionVerdict { result, .. } => *result,
             _ => unreachable!("advance_after_transition called from non-transition stage"),
         };
 
         output.events.push(PipelineEvent::GateVerdictReceived {
-            artifact_id: parked.decision.artifact_id.to_string(),
+            artifact_id: decision.artifact_id.to_string(),
             gate_point: GatePoint::StateTransition,
             verdict: summarize(&verdict),
         });
 
         match verdict {
             GateVerdict::Allow | GateVerdict::Modify { .. } => {
-                self.apply_transition(parked, result, output);
+                self.apply_transition(decision, artifact_snapshot, result, output);
             }
             GateVerdict::Deny { reason } => {
                 output.events.push(PipelineEvent::Error(format!(
                     "state transition gate denied for {}: {}",
-                    parked.decision.artifact_id, reason
+                    decision.artifact_id, reason
                 )));
             }
             GateVerdict::Escalate { .. } => {
@@ -599,15 +621,18 @@ impl ForgePipeline {
     }
 
     /// Seal-if-Released and advance the artifact. Called only from
-    /// the Allow/Modify branch of [`Self::advance_after_transition`].
+    /// the Allow/Modify branch of [`Self::advance_after_transition`],
+    /// which destructures the parked decision so the boxed
+    /// `ShapingResult` can flow through by value (no clone).
     fn apply_transition(
         &mut self,
-        parked: ParkedDecision,
+        decision: ShapingDecision,
+        artifact_snapshot: Artifact,
         result: ShapingResult,
         output: &mut TickOutput,
     ) {
-        let from_state = parked.artifact_snapshot.state;
-        let target_state = parked.decision.target_state;
+        let from_state = artifact_snapshot.state;
+        let target_state = decision.target_state;
 
         // warehouse-and-delivery-v0.1 §5.1: Released implies a sealed
         // bundle. Seal before advancing — if it fails the transition
@@ -617,18 +642,16 @@ impl ForgePipeline {
             target_state == ArtifactState::Released && result.outcome == ShapingOutcome::Completed;
         let sealed = if sealing_release {
             match &self.warehouse {
-                Some(warehouse) => {
-                    match warehouse.seal_release(&parked.decision.artifact_id, &result) {
-                        Ok(s) => Some(s),
-                        Err(e) => {
-                            output.events.push(PipelineEvent::Error(format!(
-                                "warehouse seal failed for {}: {}",
-                                parked.decision.artifact_id, e
-                            )));
-                            return;
-                        }
+                Some(warehouse) => match warehouse.seal_release(&decision.artifact_id, &result) {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        output.events.push(PipelineEvent::Error(format!(
+                            "warehouse seal failed for {}: {}",
+                            decision.artifact_id, e
+                        )));
+                        return;
                     }
-                }
+                },
                 None => None,
             }
         } else {
@@ -637,20 +660,20 @@ impl ForgePipeline {
 
         match self
             .store
-            .advance(&parked.decision.artifact_id, target_state, &result)
+            .advance(&decision.artifact_id, target_state, &result)
         {
             Ok(()) => {
                 output.events.push(PipelineEvent::ArtifactAdvanced {
-                    artifact_id: parked.decision.artifact_id.to_string(),
+                    artifact_id: decision.artifact_id.to_string(),
                     from_state,
                     to_state: target_state,
                 });
 
                 if let Some(sealed) = sealed {
                     self.store
-                        .record_version(&parked.decision.artifact_id, sealed.bundle_id.clone());
+                        .record_version(&decision.artifact_id, sealed.bundle_id.clone());
                     output.events.push(PipelineEvent::BundleSealed {
-                        artifact_id: parked.decision.artifact_id.to_string(),
+                        artifact_id: decision.artifact_id.to_string(),
                         bundle_id: sealed.bundle_id,
                         version: sealed.version,
                     });
@@ -659,7 +682,7 @@ impl ForgePipeline {
             Err(e) => {
                 output.events.push(PipelineEvent::Error(format!(
                     "failed to advance {}: {}",
-                    parked.decision.artifact_id, e
+                    decision.artifact_id, e
                 )));
             }
         }
@@ -1306,6 +1329,72 @@ mod tests {
             .any(|e| matches!(e, PipelineEvent::BundleSealed { .. })));
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::UnderReview);
+        assert!(art.current_version_id.is_none());
+    }
+
+    #[test]
+    fn release_transition_advances_without_bundle_sealed_when_warehouse_absent() {
+        // Pipelines that don't attach a SealSink (legacy deployments)
+        // still advance to Released — they just don't emit a
+        // BundleSealed event. Regression coverage for the Allow branch
+        // of advance_after_transition when self.warehouse is None.
+        let pending_verdicts = PendingVerdicts::new();
+        let pending_shapings = PendingShapings::new();
+        let mut pipeline = ForgePipeline::new(pending_verdicts.clone(), pending_shapings.clone());
+        let id = pipeline.store.register(Kind::Code, "svc", "marvin");
+
+        // Walk through Draft → InProgress → UnderReview with the
+        // baseline kernel, then push to Released with the warehouse
+        // absent.
+        let baseline = BaselineKernel::new();
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
+        );
+        drive_to_completion(
+            &mut pipeline,
+            &pending_verdicts,
+            &pending_shapings,
+            &baseline,
+        );
+        assert_eq!(
+            pipeline.store.get(&id).unwrap().state,
+            ArtifactState::UnderReview
+        );
+
+        let release = ReleaseKernel;
+        let out1 = pipeline.tick(&release);
+        let g = pre_dispatch_gate_id(&out1);
+        pending_verdicts.insert(&g, GateVerdict::Allow);
+        let out2 = pipeline.tick(&release);
+        let r = shaping_request_id(&out2);
+        pending_shapings.insert(&r, shaping_completed(&r));
+        let out3 = pipeline.tick(&release);
+        let t = transition_gate_id(&out3);
+        pending_verdicts.insert(&t, GateVerdict::Allow);
+        let out = pipeline.tick(&release);
+
+        // Released, no BundleSealed event.
+        assert!(out.events.iter().any(|e| {
+            matches!(
+                e,
+                PipelineEvent::ArtifactAdvanced {
+                    to_state: ArtifactState::Released,
+                    ..
+                }
+            )
+        }));
+        assert!(
+            !out.events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::BundleSealed { .. })),
+            "pipeline without SealSink must not emit BundleSealed"
+        );
+
+        let art = pipeline.store.get(&id).unwrap();
+        assert_eq!(art.state, ArtifactState::Released);
         assert!(art.current_version_id.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 of Lever C (spec #131 / ADR 0004 — see #148). Replaces
`ForgePipeline`'s synchronous tick loop with a parked state machine
that emits spine events and resumes when the matching listener-
populated entry lands in `PendingVerdicts` / `PendingShapings`.

**Stacked on #182.** Base of this PR is `claude/onsager-migration-workflow-phase3`;
once #182 merges I'll re-target this PR to `main`.

The main pipeline path no longer calls `self.synodic.evaluate()` or
`self.stiglab.dispatch()` — those traits stay alive only for
`LiveGateEvaluator` (the workflow stage runner gate path), which
**phase 5 converts and then deletes**.

### Pipeline shape
- `ForgePipeline` drops the `<S, G>` generics; it now takes
  `PendingVerdicts` + `PendingShapings` on `new()`.
- New `ParkedDecision { decision, artifact_snapshot, stage }` and
  `ParkStage { AwaitingPreDispatchVerdict | AwaitingShapingResult |
  AwaitingTransitionVerdict { result: Box<ShapingResult> } }`. Result
  boxed to keep `ParkStage`'s stack footprint flat (clippy
  `large-enum-variant`).
- `tick()` either drains a parked decision via `resume_parked()` or
  asks the kernel for a fresh decision and parks it via
  `start_decision()`. Empty resumes emit `IdleTick` so callers can
  distinguish "waiting" from "decided but did nothing".
- Resume helpers: `advance_after_pre_dispatch`, `kick_off_shaping`,
  `advance_after_shaping`, `advance_after_transition`,
  `apply_transition`. **Escalate** at any gate clears the park
  (forge invariant #5 — let the kernel re-propose; the escalation
  sits on the spine for a delegate).
- `artifact_snapshot` is held alongside the decision so follow-up
  `GateRequest`s carry the same `current_state` / `artifact_kind`
  seen at decision time, even if a concurrent write changes the live
  store between resumes.
- Free helpers: `build_pre_dispatch_gate`, `build_transition_gate`,
  `summarize`.

### `cmd/serve.rs`
- Pipeline construction: `ForgePipeline::new(pending_verdicts.clone(),
  pending_shapings.clone())` — the HTTP types are no longer threaded
  in.
- `HttpStiglabDispatcher` / `HttpSynodicGate` are kept but
  instantiated only for the workflow-stage-runner gate evaluator
  (`evaluator_stiglab` / `evaluator_synodic`). Phase 5 deletes them.
- `ForgeSharedState.pipeline` drops its `<S, G>` type params.
- The pending maps move from "spawn site → `ForgeSharedState`" to a
  shared clone the pipeline owns directly; `ForgeSharedState` retains
  its clones for HTTP introspection.

### Tests rewritten around the event flow
- New helper `drive_to_completion` + extractors for the
  pre-dispatch `gate_id`, transition `gate_id`, and shaping
  `request_id` from a tick output.
- Each lifecycle test walks Allow / Deny / Escalate / Failed-shaping
  / sealing-failure paths through the explicit park stages,
  asserting the exact event sequence and store transitions instead
  of relying on a synchronous one-tick advance.

### Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p forge --lib` — 122 passed
- [x] `cargo test -p forge` — 4 integration tests passed
- [x] `cargo run -p xtask -- gen-event-docs --check` — up to date
- [x] `cargo run -p xtask -- lint-seams` — clean; 7 exemptions
      unchanged from phase 3 (the four forge entries get deleted in
      phase 5)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Part of #148

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLiAAvfpHXMaQ9BkmAACfp)_