### PR TITLE
docs(claude): prefer Edit over Write to avoid timeouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,9 @@ Subsystem-specific env vars worth calling out:
 ## File editing (Claude Code tools)
 
 Prefer the `Edit` tool over `Write` for any change to an existing file. Full
-rewrites with `Write` stream-idle-timeout on files larger than ~150 lines and
-there is no automatic retry — a stalled `Write` silently leaves the file in
-its previous state or, worse, half-written. If a rewrite is genuinely
+rewrites with `Write` can hit a stream idle timeout on files larger than ~150
+lines and there is no automatic retry — a stalled `Write` silently leaves the
+file in its previous state or, worse, half-written. If a rewrite is genuinely
 necessary, split it: write a smaller initial version, then extend with
 follow-up `Edit` calls.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,15 @@ Subsystem-specific env vars worth calling out:
   parse errors always deny regardless of policy — those are protocol bugs
   that should surface loudly.
 
+## File editing (Claude Code tools)
+
+Prefer the `Edit` tool over `Write` for any change to an existing file. Full
+rewrites with `Write` stream-idle-timeout on files larger than ~150 lines and
+there is no automatic retry — a stalled `Write` silently leaves the file in
+its previous state or, worse, half-written. If a rewrite is genuinely
+necessary, split it: write a smaller initial version, then extend with
+follow-up `Edit` calls.
+
 ## Session defaults (Claude Code cloud)
 
 If the current branch name starts with `claude/` (the prefix cloud sessions


### PR DESCRIPTION
## Summary

- Adds a short "File editing (Claude Code tools)" section to `CLAUDE.md` telling future sessions to prefer `Edit` over `Write` and to chunk any genuine rewrite, because `Write` stream-idle-timeouts on files >~150 lines with no automatic retry.

This is a one-paragraph doc-only change — no code, no behavior. Labeling `trivial` per the spec-vs-trivial gate.

## Test plan

- [x] `git diff` reviewed — only `CLAUDE.md` changed, +9/-0.

https://claude.ai/code/session_01W8GmW6eZDm2x6mThcf7tQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8GmW6eZDm2x6mThcf7tQM)_