### PR TITLE
feat(stiglab): per-workspace API surface and credentials

### DIFF
--- a/crates/stiglab/migrations/002_workspace_scoped_credentials.sql
+++ b/crates/stiglab/migrations/002_workspace_scoped_credentials.sql
@@ -1,0 +1,95 @@
+-- 002_workspace_scoped_credentials.sql (issue #164, child C of #161)
+--
+-- Per-workspace credential isolation, workspace-scoped sessions, and a
+-- belt-and-suspenders UNIQUE on github_app_installations.install_id.
+--
+-- After this migration:
+--   * Credentials are scoped to (user_id, workspace_id, name) — a user has
+--     a separate `CLAUDE_CODE_OAUTH_TOKEN` per workspace, not a global one.
+--   * Sessions carry `workspace_id` so the agent runner can fetch the
+--     workspace's credentials at dispatch time.
+--   * `github_app_installations.install_id` is enforced UNIQUE so the
+--     webhook ingress can resolve `install_id → workspace_id` deterministically.
+--     Per the parent spec (#161 open question, decided in #164):
+--     install_id ↔ workspace_id is a 1:1 invariant.
+--
+-- This file is the canonical documentation; the actual DDL is executed at
+-- startup by `crates/stiglab/src/server/db.rs`'s `run_migrations` because
+-- stiglab still uses an inlined-SQL migration runner (no sqlx-migrate).
+
+-- ── user_credentials.workspace_id ──
+--
+-- Backfill rule:
+--   1. Add the column nullable.
+--   2. Backfill each row to the credential owner's first workspace
+--      membership (lowest joined_at, ties broken by workspace_id).
+--   3. Drop rows whose owner has no membership at all — those credentials
+--      were unreachable anyway under the new per-workspace contract.
+--   4. Tighten the column to NOT NULL.
+--   5. Replace the unique index with a per-(workspace, user, name) one so
+--      the same credential name can exist in multiple workspaces for the
+--      same user.
+
+ALTER TABLE user_credentials
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+
+UPDATE user_credentials
+SET workspace_id = (
+    SELECT m.workspace_id
+    FROM workspace_members m
+    WHERE m.user_id = user_credentials.user_id
+    ORDER BY m.joined_at ASC, m.workspace_id ASC
+    LIMIT 1
+)
+WHERE workspace_id IS NULL;
+
+DELETE FROM user_credentials WHERE workspace_id IS NULL;
+
+ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL;
+
+-- The legacy `UNIQUE(user_id, name)` predates per-workspace scoping and
+-- would now block a user from holding the same credential name in two
+-- workspaces. Drop it; rely on the new index below.
+DROP INDEX IF EXISTS user_credentials_user_id_name_key;
+DROP INDEX IF EXISTS idx_user_credentials_user_name;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_workspace_user_name
+    ON user_credentials (workspace_id, user_id, name);
+
+CREATE INDEX IF NOT EXISTS idx_user_credentials_workspace
+    ON user_credentials (workspace_id);
+
+-- ── sessions.workspace_id ──
+--
+-- Sessions are routed at dispatch time using the dispatcher's workspace
+-- context (project's workspace_id, or the caller's workspace for direct
+-- task POSTs). Backfill existing rows from the joined project; rows
+-- without a project remain NULL — they are pre-#164 personal sessions
+-- and will not appear under any `?workspace=` filter (matching the
+-- spec's "no merged worldview" intent).
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+
+UPDATE sessions
+SET workspace_id = (
+    SELECT p.workspace_id FROM projects p WHERE p.id = sessions.project_id
+)
+WHERE workspace_id IS NULL AND project_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id
+    ON sessions (workspace_id);
+
+-- ── github_app_installations.install_id UNIQUE ──
+--
+-- The CREATE TABLE above already declares `install_id BIGINT NOT NULL UNIQUE`,
+-- but legacy databases created before that declaration carry the column
+-- without the constraint. Add a unique index defensively so webhook
+-- resolution can rely on the 1:1 invariant.
+--
+-- Pre-existing duplicates would need manual cleanup before this index can
+-- build; if such a database exists in production, this CREATE INDEX will
+-- fail and the operator must reconcile the duplicates first.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_github_app_installations_install_id_unique
+    ON github_app_installations (install_id);

--- a/crates/stiglab/src/core/task.rs
+++ b/crates/stiglab/src/core/task.rs
@@ -30,4 +30,14 @@ pub struct TaskRequest {
     /// omitted for personal sessions.
     #[serde(default)]
     pub project_id: Option<String>,
+    /// Optional explicit workspace scope (#164). When set without
+    /// `project_id`, the session is filed under this workspace and
+    /// shows up in `/api/sessions?workspace=` listings + receives the
+    /// workspace's credential bundle at dispatch. When `project_id`
+    /// is set, that wins (the project owns its workspace context); a
+    /// disagreement between the two surfaces as a 400. Omitting both
+    /// preserves the legacy "personal session" path that doesn't
+    /// surface in any workspace listing.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
 }

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -148,15 +148,19 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // Per-workspace credential isolation lands in the 002 block below.
+    // Fresh databases get the new schema directly; legacy databases pick
+    // up the column + constraints via the ALTER chain in the 002 section.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS user_credentials (
             id TEXT PRIMARY KEY,
             user_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
             name TEXT NOT NULL,
             encrypted_value TEXT NOT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
-            UNIQUE(user_id, name)
+            UNIQUE(workspace_id, user_id, name)
         )",
     )
     .execute(pool)
@@ -502,6 +506,91 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_workspace_workflow_stages_workflow_id \
          ON workspace_workflow_stages (workflow_id, seq)",
+    )
+    .execute(pool)
+    .await?;
+
+    // ── 002_workspace_scoped_credentials (issue #164) ────────────────
+    //
+    // Per-workspace credential isolation, workspace-scoped sessions, and a
+    // belt-and-suspenders UNIQUE on github_app_installations.install_id.
+    // See `migrations/002_workspace_scoped_credentials.sql` for the
+    // canonical SQL and rationale.
+
+    let _ = sqlx::query("ALTER TABLE user_credentials ADD COLUMN workspace_id TEXT")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "UPDATE user_credentials \
+         SET workspace_id = ( \
+             SELECT m.workspace_id FROM workspace_members m \
+             WHERE m.user_id = user_credentials.user_id \
+             ORDER BY m.joined_at ASC, m.workspace_id ASC \
+             LIMIT 1 \
+         ) \
+         WHERE workspace_id IS NULL",
+    )
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM user_credentials WHERE workspace_id IS NULL")
+        .execute(pool)
+        .await;
+    // Postgres-only `SET NOT NULL`; SQLite tests rebuild the schema each
+    // run so the contract is enforced via the new unique index instead.
+    let _ = sqlx::query("ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL")
+        .execute(pool)
+        .await;
+    // Drop the legacy `(user_id, name)` unique constraint — its modern
+    // equivalent is `(workspace_id, user_id, name)`. Both names cover the
+    // index/constraint forms Postgres might have created.
+    let _ = sqlx::query("DROP INDEX IF EXISTS user_credentials_user_id_name_key")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DROP INDEX IF EXISTS idx_user_credentials_user_name")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "ALTER TABLE user_credentials DROP CONSTRAINT IF EXISTS user_credentials_user_id_name_key",
+    )
+    .execute(pool)
+    .await;
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_workspace_user_name \
+         ON user_credentials (workspace_id, user_id, name)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_user_credentials_workspace \
+         ON user_credentials (workspace_id)",
+    )
+    .execute(pool)
+    .await?;
+
+    // sessions.workspace_id — backfill from project; rows without a
+    // project remain NULL (legacy personal sessions).
+    let _ = sqlx::query("ALTER TABLE sessions ADD COLUMN workspace_id TEXT")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "UPDATE sessions \
+         SET workspace_id = ( \
+             SELECT p.workspace_id FROM projects p WHERE p.id = sessions.project_id \
+         ) \
+         WHERE workspace_id IS NULL AND project_id IS NOT NULL",
+    )
+    .execute(pool)
+    .await;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions (workspace_id)")
+        .execute(pool)
+        .await?;
+
+    // Belt-and-suspenders UNIQUE(install_id) for legacy databases created
+    // before the constraint was added to CREATE TABLE. Webhook resolution
+    // depends on the 1:1 install_id ↔ workspace_id invariant.
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_github_app_installations_install_id_unique \
+         ON github_app_installations (install_id)",
     )
     .execute(pool)
     .await?;
@@ -1062,6 +1151,7 @@ pub struct UserCredential {
 
 pub async fn set_user_credential(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
     name: &str,
     encrypted_value: &str,
@@ -1069,12 +1159,13 @@ pub async fn set_user_credential(
     let id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO user_credentials (id, user_id, name, encrypted_value, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $5)
-         ON CONFLICT(user_id, name) DO UPDATE SET encrypted_value = $4, updated_at = $5",
+        "INSERT INTO user_credentials (id, user_id, workspace_id, name, encrypted_value, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $6)
+         ON CONFLICT(workspace_id, user_id, name) DO UPDATE SET encrypted_value = $5, updated_at = $6",
     )
     .bind(&id)
     .bind(user_id)
+    .bind(workspace_id)
     .bind(name)
     .bind(encrypted_value)
     .bind(&now)
@@ -1085,11 +1176,14 @@ pub async fn set_user_credential(
 
 pub async fn get_user_credentials(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
 ) -> anyhow::Result<Vec<UserCredential>> {
     let rows = sqlx::query_as::<_, UserCredentialRow>(
-        "SELECT name, created_at, updated_at FROM user_credentials WHERE user_id = $1 ORDER BY name",
+        "SELECT name, created_at, updated_at FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 ORDER BY name",
     )
+    .bind(workspace_id)
     .bind(user_id)
     .fetch_all(pool)
     .await?;
@@ -1105,12 +1199,15 @@ pub async fn get_user_credentials(
 
 pub async fn get_user_credential_value(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
     name: &str,
 ) -> anyhow::Result<Option<String>> {
     let row = sqlx::query_scalar::<_, String>(
-        "SELECT encrypted_value FROM user_credentials WHERE user_id = $1 AND name = $2",
+        "SELECT encrypted_value FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 AND name = $3",
     )
+    .bind(workspace_id)
     .bind(user_id)
     .bind(name)
     .fetch_optional(pool)
@@ -1118,13 +1215,22 @@ pub async fn get_user_credential_value(
     Ok(row)
 }
 
+/// Read every credential row for `(workspace_id, user_id)` as
+/// `(name, encrypted_value)` pairs. Used by the session-launch path to
+/// build the env-var map handed to the agent process. Sessions resolve
+/// `workspace_id` from `sessions.workspace_id`; legacy NULL-workspace
+/// sessions get an empty map (no credentials → loud failure via
+/// `stiglab.session_failed`, never the wrong-workspace token).
 pub async fn get_all_user_credential_values(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let rows = sqlx::query_as::<_, CredentialKvRow>(
-        "SELECT name, encrypted_value FROM user_credentials WHERE user_id = $1",
+        "SELECT name, encrypted_value FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2",
     )
+    .bind(workspace_id)
     .bind(user_id)
     .fetch_all(pool)
     .await?;
@@ -1136,25 +1242,33 @@ pub async fn get_all_user_credential_values(
 
 pub async fn delete_user_credential(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
     name: &str,
 ) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM user_credentials WHERE user_id = $1 AND name = $2")
-        .bind(user_id)
-        .bind(name)
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "DELETE FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 AND name = $3",
+    )
+    .bind(workspace_id)
+    .bind(user_id)
+    .bind(name)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
 pub async fn user_credential_exists(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
     name: &str,
 ) -> anyhow::Result<bool> {
     let row = sqlx::query_scalar::<_, String>(
-        "SELECT name FROM user_credentials WHERE user_id = $1 AND name = $2",
+        "SELECT name FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 AND name = $3",
     )
+    .bind(workspace_id)
     .bind(user_id)
     .bind(name)
     .fetch_optional(pool)
@@ -1162,11 +1276,11 @@ pub async fn user_credential_exists(
     Ok(row.is_some())
 }
 
-/// True if the user has at least one credential row matching one of
-/// `names`. Used by the workflow-activate gate (issue #156) to refuse
-/// activation when the owner has no Claude auth credential — without
-/// this check, the workflow would be active but every session would
-/// fail with "stdout closed without result event".
+/// True if the user has at least one credential row in `workspace_id`
+/// matching one of `names`. Used by the workflow-activate gate (issue
+/// #156) to refuse activation when the owner has no Claude auth
+/// credential — without this check, the workflow would be active but
+/// every session would fail with "stdout closed without result event".
 ///
 /// Checks by exact name match because the Claude CLI keys on specific
 /// env var names (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`).
@@ -1174,21 +1288,25 @@ pub async fn user_credential_exists(
 /// into a doomed workflow without the name filter.
 pub async fn user_has_credential_in(
     pool: &AnyPool,
+    workspace_id: &str,
     user_id: &str,
     names: &[&str],
 ) -> anyhow::Result<bool> {
     if names.is_empty() {
         return Ok(false);
     }
-    // Build `name IN ($2, $3, ...)` with placeholders matched to the
+    // Build `name IN ($3, $4, ...)` with placeholders matched to the
     // sqlx binding count — sqlx-AnyPool doesn't speak Postgres array
     // params portably across SQLite.
-    let placeholders: Vec<String> = (2..=names.len() + 1).map(|i| format!("${i}")).collect();
+    let placeholders: Vec<String> = (3..=names.len() + 2).map(|i| format!("${i}")).collect();
     let sql = format!(
-        "SELECT name FROM user_credentials WHERE user_id = $1 AND name IN ({}) LIMIT 1",
+        "SELECT name FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 AND name IN ({}) LIMIT 1",
         placeholders.join(", ")
     );
-    let mut q = sqlx::query_scalar::<_, String>(&sql).bind(user_id);
+    let mut q = sqlx::query_scalar::<_, String>(&sql)
+        .bind(workspace_id)
+        .bind(user_id);
     for n in names {
         q = q.bind(*n);
     }
@@ -1396,23 +1514,38 @@ pub async fn insert_session_with_user(
     session: &Session,
     user_id: Option<&str>,
 ) -> anyhow::Result<()> {
-    insert_session_with_user_and_project(pool, session, user_id, None).await
+    insert_session_with_user_project_workspace(pool, session, user_id, None, None).await
 }
 
-/// Variant that also binds a `project_id` when the session is scoped to a
-/// workspace-owned project (issue #59). Pre-existing sessions with a null
-/// `project_id` remain personal sessions forever.
+/// Insert a session with workspace + project context.
+///
+/// `workspace_id` is what the runner reads back at dispatch to fetch
+/// per-workspace credentials (#164). `project_id` is the existing
+/// workspace-owned project link from #59. A session can have a
+/// workspace without a project (direct task POST), but never a project
+/// without a workspace — callers resolve the workspace from the project
+/// before this call.
 pub async fn insert_session_with_user_and_project(
     pool: &AnyPool,
     session: &Session,
     user_id: Option<&str>,
     project_id: Option<&str>,
 ) -> anyhow::Result<()> {
+    insert_session_with_user_project_workspace(pool, session, user_id, project_id, None).await
+}
+
+pub async fn insert_session_with_user_project_workspace(
+    pool: &AnyPool,
+    session: &Session,
+    user_id: Option<&str>,
+    project_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO sessions (id, task_id, node_id, state, prompt, output, working_dir, \
-                               user_id, project_id, artifact_id, artifact_version, \
+                               user_id, project_id, workspace_id, artifact_id, artifact_version, \
                                created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
     )
     .bind(&session.id)
     .bind(&session.task_id)
@@ -1423,6 +1556,7 @@ pub async fn insert_session_with_user_and_project(
     .bind(&session.working_dir)
     .bind(user_id)
     .bind(project_id)
+    .bind(workspace_id)
     .bind(&session.artifact_id)
     .bind(session.artifact_version)
     .bind(session.created_at.to_rfc3339())
@@ -1432,13 +1566,42 @@ pub async fn insert_session_with_user_and_project(
     Ok(())
 }
 
-pub async fn list_sessions_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Result<Vec<Session>> {
+/// List sessions owned by `user_id` and scoped to `workspace_id`.
+///
+/// Pre-#164 sessions with a NULL `workspace_id` (personal direct-task
+/// POSTs that predate the column) never appear here — the spec's
+/// "no merged worldview" intent is enforced by the filter, not the read.
+pub async fn list_sessions_for_user_in_workspace(
+    pool: &AnyPool,
+    user_id: &str,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<Session>> {
     let rows = sqlx::query_as::<_, SessionRow>(
         "SELECT id, task_id, node_id, state, prompt, output, working_dir, \
                 artifact_id, artifact_version, created_at, updated_at \
-         FROM sessions WHERE user_id = $1 ORDER BY created_at DESC",
+         FROM sessions WHERE user_id = $1 AND workspace_id = $2 \
+         ORDER BY created_at DESC",
     )
     .bind(user_id)
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+/// List every session in `workspace_id` regardless of owner. Used in the
+/// `auth_enabled = false` branch where the synthetic anonymous user has
+/// no membership rows to filter against.
+pub async fn list_sessions_in_workspace(
+    pool: &AnyPool,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<Session>> {
+    let rows = sqlx::query_as::<_, SessionRow>(
+        "SELECT id, task_id, node_id, state, prompt, output, working_dir, \
+                artifact_id, artifact_version, created_at, updated_at \
+         FROM sessions WHERE workspace_id = $1 ORDER BY created_at DESC",
+    )
+    .bind(workspace_id)
     .fetch_all(pool)
     .await?;
     rows.into_iter().map(|r| r.try_into()).collect()
@@ -1452,6 +1615,21 @@ pub async fn get_session_owner(pool: &AnyPool, session_id: &str) -> anyhow::Resu
     .fetch_optional(pool)
     .await?;
     Ok(row)
+}
+
+/// Workspace context for a session, used by the detail/log endpoints to
+/// 404 callers that aren't members of the owning workspace, and by the
+/// session-launch path to fetch the right credential set.
+pub async fn get_session_workspace(
+    pool: &AnyPool,
+    session_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let row =
+        sqlx::query_scalar::<_, Option<String>>("SELECT workspace_id FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.flatten())
 }
 
 // ── Row types for sqlx ──

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -99,13 +99,15 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         //   OAuth app directly.
         .route("/api/auth/sso/redeem", post(routes::auth::sso_redeem))
         .route("/api/auth/sso/finish", get(routes::auth::sso_finish))
-        // Credential routes
+        // Credential routes — per-workspace post-#164.  Each workspace
+        // carries its own secret store; sessions launched in W1 will
+        // never reach for a token registered in W2.
         .route(
-            "/api/credentials",
+            "/api/workspaces/{workspace_id}/credentials",
             get(routes::credentials::list_credentials),
         )
         .route(
-            "/api/credentials/{name}",
+            "/api/workspaces/{workspace_id}/credentials/{name}",
             put(routes::credentials::set_credential).delete(routes::credentials::delete_credential),
         )
         // Personal Access Tokens (issue #143)

--- a/crates/stiglab/src/server/routes/credentials.rs
+++ b/crates/stiglab/src/server/routes/credentials.rs
@@ -1,6 +1,14 @@
+//! Per-workspace credential CRUD (issue #164, child C of #161).
+//!
+//! Credentials live under `/api/workspaces/:workspace/credentials` so a
+//! user holding two workspaces gets two independent secret stores —
+//! launching a session in W1 will never reach for a token registered in
+//! W2. Every route funnels through `require_workspace_access` for the
+//! 404-not-403 membership check + PAT scope guardrail.
+
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::Deserialize;
 
@@ -8,12 +16,12 @@ use crate::server::auth::{encrypt_credential, AuthUser, RequestPrincipal};
 use crate::server::db;
 use crate::server::state::AppState;
 
+use super::require_workspace_access;
+
 /// Standard 403 body for the PAT destructive-credential guardrail (issue
 /// #143). PATs may read and create credentials, but deleting an existing
-/// credential or overwriting one requires a real browser session — those
-/// actions take a refresh of the secret out of the user's hands and into
-/// any system that holds the token, which is the explicit non-goal here.
-fn pat_destructive_blocked() -> axum::response::Response {
+/// credential or overwriting one requires a real browser session.
+fn pat_destructive_blocked() -> Response {
     (
         StatusCode::FORBIDDEN,
         Json(serde_json::json!({
@@ -29,12 +37,17 @@ pub struct SetCredentialBody {
     pub value: String,
 }
 
-/// GET /api/credentials — List credential names for the current user (no values).
+/// GET /api/workspaces/:workspace/credentials — list credential names for
+/// the current user in this workspace (no values).
 pub async fn list_credentials(
     State(state): State<AppState>,
     auth_user: AuthUser,
-) -> impl IntoResponse {
-    match db::get_user_credentials(&state.db, &auth_user.user_id).await {
+    Path(workspace_id): Path<String>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
+    match db::get_user_credentials(&state.db, &workspace_id, &auth_user.user_id).await {
         Ok(creds) => {
             let items: Vec<_> = creds
                 .into_iter()
@@ -55,18 +68,23 @@ pub async fn list_credentials(
     }
 }
 
-/// PUT /api/credentials/{name} — Set or update a credential.
+/// PUT /api/workspaces/:workspace/credentials/{name} — set or update a credential.
 pub async fn set_credential(
     State(state): State<AppState>,
     auth_user: AuthUser,
-    Path(name): Path<String>,
+    Path((workspace_id, name)): Path<(String, String)>,
     Json(body): Json<SetCredentialBody>,
-) -> impl IntoResponse {
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
+
     // PAT principals can create new credentials but not overwrite existing
     // ones — silently rotating a secret over the API while the dashboard
     // still shows the old one would be confusing and a footgun.
     if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
-        match db::user_credential_exists(&state.db, &auth_user.user_id, &name).await {
+        match db::user_credential_exists(&state.db, &workspace_id, &auth_user.user_id, &name).await
+        {
             Ok(true) => return pat_destructive_blocked(),
             Ok(false) => {}
             Err(e) => {
@@ -92,7 +110,15 @@ pub async fn set_credential(
         }
     };
 
-    match db::set_user_credential(&state.db, &auth_user.user_id, &name, &encrypted).await {
+    match db::set_user_credential(
+        &state.db,
+        &workspace_id,
+        &auth_user.user_id,
+        &name,
+        &encrypted,
+    )
+    .await
+    {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => {
             tracing::error!("failed to set credential: {e}");
@@ -101,18 +127,21 @@ pub async fn set_credential(
     }
 }
 
-/// DELETE /api/credentials/{name} — Delete a credential.
+/// DELETE /api/workspaces/:workspace/credentials/{name} — delete a credential.
 pub async fn delete_credential(
     State(state): State<AppState>,
     auth_user: AuthUser,
-    Path(name): Path<String>,
-) -> impl IntoResponse {
+    Path((workspace_id, name)): Path<(String, String)>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
     // The destructive guard is unconditional for PATs — deletion is always
     // a session-only operation regardless of whether the credential exists.
     if matches!(auth_user.principal, RequestPrincipal::Pat { .. }) {
         return pat_destructive_blocked();
     }
-    match db::delete_user_credential(&state.db, &auth_user.user_id, &name).await {
+    match db::delete_user_credential(&state.db, &workspace_id, &auth_user.user_id, &name).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => {
             tracing::error!("failed to delete credential: {e}");

--- a/crates/stiglab/src/server/routes/nodes.rs
+++ b/crates/stiglab/src/server/routes/nodes.rs
@@ -14,10 +14,11 @@ use super::require_workspace_access;
 ///
 /// Nodes are global infrastructure (one set of physical agents serves
 /// every workspace), but the list endpoint still requires `?workspace=`
-/// so the API surface follows one filter pattern (#164). The
-/// membership check 404s callers that aren't members of the requested
-/// workspace, so node IDs don't leak across workspaces even though the
-/// underlying registry is shared.
+/// so the API surface follows one filter pattern (#164). The membership
+/// check 404s non-members of the requested workspace, preventing them
+/// from accessing the nodes listing even though the underlying registry
+/// is shared. Members of any one workspace can still see every node;
+/// per-workspace node scoping is a separate concern (no spec yet).
 pub async fn list_nodes(
     State(state): State<AppState>,
     auth_user: AuthUser,

--- a/crates/stiglab/src/server/routes/nodes.rs
+++ b/crates/stiglab/src/server/routes/nodes.rs
@@ -1,13 +1,37 @@
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 
 use crate::server::auth::AuthUser;
 use crate::server::db;
+use crate::server::routes::sessions::WorkspaceQuery;
 use crate::server::state::AppState;
 
-pub async fn list_nodes(State(state): State<AppState>, _auth_user: AuthUser) -> impl IntoResponse {
+use super::require_workspace_access;
+
+/// GET /api/nodes?workspace=W — list connected agent nodes.
+///
+/// Nodes are global infrastructure (one set of physical agents serves
+/// every workspace), but the list endpoint still requires `?workspace=`
+/// so the API surface follows one filter pattern (#164). The
+/// membership check 404s callers that aren't members of the requested
+/// workspace, so node IDs don't leak across workspaces even though the
+/// underlying registry is shared.
+pub async fn list_nodes(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Query(q): Query<WorkspaceQuery>,
+) -> Response {
+    let workspace_id = q.workspace.trim();
+    if workspace_id.is_empty() {
+        return crate::server::routes::sessions::missing_workspace();
+    }
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+            return r;
+        }
+    }
     match db::list_nodes(&state.db).await {
         Ok(nodes) => Json(serde_json::json!({ "nodes": nodes })).into_response(),
         Err(e) => {

--- a/crates/stiglab/src/server/routes/sessions.rs
+++ b/crates/stiglab/src/server/routes/sessions.rs
@@ -1,9 +1,10 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures_util::stream;
+use serde::Deserialize;
 use std::convert::Infallible;
 use std::time::Duration;
 
@@ -11,14 +12,67 @@ use crate::server::auth::AuthUser;
 use crate::server::db;
 use crate::server::state::AppState;
 
+use super::require_workspace_access;
+
+/// Required `?workspace=` filter for every workspace-scoped list endpoint
+/// (issue #164). A missing param returns 400 — explicit is better than
+/// implicit, and a default-to-everything would hide cross-workspace
+/// leaks behind a default value.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceQuery {
+    pub workspace: String,
+}
+
+#[allow(clippy::result_large_err)]
+fn require_workspace_param(q: &WorkspaceQuery) -> Result<&str, Response> {
+    let ws = q.workspace.trim();
+    if ws.is_empty() {
+        Err(missing_workspace())
+    } else {
+        Ok(ws)
+    }
+}
+
+pub(super) fn missing_workspace() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "workspace query parameter is required",
+            "detail": "every workspace-scoped list endpoint requires ?workspace=<id>",
+        })),
+    )
+        .into_response()
+}
+
+pub(super) fn not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": "session not found" })),
+    )
+        .into_response()
+}
+
 pub async fn list_sessions(
     State(state): State<AppState>,
     auth_user: AuthUser,
-) -> impl IntoResponse {
+    Query(q): Query<WorkspaceQuery>,
+) -> Response {
+    let workspace_id = match require_workspace_param(&q) {
+        Ok(w) => w.to_string(),
+        Err(r) => return r,
+    };
+
+    // The synthetic anonymous principal has no membership rows, so the
+    // membership-check helper would 404 every request in
+    // auth_enabled = false mode. Skip the check there but still scope
+    // the query to the requested workspace.
     let result = if auth_user.user_id == "anonymous" {
-        db::list_sessions(&state.db).await
+        db::list_sessions_in_workspace(&state.db, &workspace_id).await
     } else {
-        db::list_sessions_for_user(&state.db, &auth_user.user_id).await
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            return r;
+        }
+        db::list_sessions_for_user_in_workspace(&state.db, &auth_user.user_id, &workspace_id).await
     };
 
     match result {
@@ -30,27 +84,68 @@ pub async fn list_sessions(
     }
 }
 
+/// Verify the caller may read `session_id`. Returns the session's
+/// resolved workspace_id on success (Some when the session is
+/// workspace-scoped, None for legacy personal sessions). Per the spec,
+/// non-members get a flat 404 — leaking 403 would let callers enumerate
+/// session IDs across workspaces.
+#[allow(clippy::result_large_err)]
+async fn authorize_session_read(
+    state: &AppState,
+    auth_user: &AuthUser,
+    session_id: &str,
+) -> Result<Option<String>, Response> {
+    if auth_user.user_id == "anonymous" {
+        return Ok(None);
+    }
+
+    let workspace_id = match db::get_session_workspace(&state.db, session_id).await {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!("failed to look up session workspace: {e}");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
+        }
+    };
+
+    if let Some(ref ws) = workspace_id {
+        // 404 (not 403) on workspace mismatch — see require_workspace_access.
+        require_workspace_access(&state.db, auth_user, ws)
+            .await
+            .map_err(rewrite_workspace_404_to_session)?;
+        return Ok(Some(ws.clone()));
+    }
+
+    // Legacy personal session (pre-#164, no workspace_id). Fall back to
+    // the original owner check so the same user keeps access.
+    match db::get_session_owner(&state.db, session_id).await {
+        Ok(Some(owner)) if owner != auth_user.user_id => Err(not_found()),
+        Ok(_) => Ok(None),
+        Err(e) => {
+            tracing::error!("failed to verify session ownership: {e}");
+            Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())
+        }
+    }
+}
+
+/// `require_workspace_access` returns "workspace not found" on a 404. For
+/// session detail/log endpoints the caller is asking after a session, so
+/// rewrite the body to the session's not-found shape — a reader peeking
+/// at the body shouldn't be able to tell whether the workspace or the
+/// session was the missing piece.
+fn rewrite_workspace_404_to_session(resp: Response) -> Response {
+    if resp.status() == StatusCode::NOT_FOUND {
+        return not_found();
+    }
+    resp
+}
+
 pub async fn get_session(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(session_id): Path<String>,
-) -> impl IntoResponse {
-    // Verify ownership if auth is enabled
-    if auth_user.user_id != "anonymous" {
-        match db::get_session_owner(&state.db, &session_id).await {
-            Ok(Some(owner)) if owner != auth_user.user_id => {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "error": "access denied" })),
-                )
-                    .into_response();
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("failed to verify session ownership: {e}");
-                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-            }
-        }
+) -> Response {
+    if let Err(r) = authorize_session_read(&state, &auth_user, &session_id).await {
+        return r;
     }
 
     match db::get_session(&state.db, &session_id).await {
@@ -81,11 +176,7 @@ pub async fn get_session(
             }))
             .into_response()
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "session not found" })),
-        )
-            .into_response(),
+        Ok(None) => not_found(),
         Err(e) => {
             tracing::error!("failed to get session: {e}");
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
@@ -98,24 +189,8 @@ pub async fn session_logs(
     auth_user: AuthUser,
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
-    // Verify ownership if auth is enabled
-    if auth_user.user_id != "anonymous" {
-        match db::get_session_owner(&state.db, &session_id).await {
-            Ok(Some(owner)) if owner != auth_user.user_id => {
-                return Err((
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "error": "access denied" })),
-                ));
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("failed to verify session ownership: {e}");
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": e.to_string() })),
-                ));
-            }
-        }
+    if let Err(r) = authorize_session_read(&state, &auth_user, &session_id).await {
+        return Err((r.status(), Json(serde_json::json!({ "error": "see body" }))));
     }
 
     // Verify session exists

--- a/crates/stiglab/src/server/routes/sessions.rs
+++ b/crates/stiglab/src/server/routes/sessions.rs
@@ -188,24 +188,26 @@ pub async fn session_logs(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(session_id): Path<String>,
-) -> impl IntoResponse {
+) -> Response {
     if let Err(r) = authorize_session_read(&state, &auth_user, &session_id).await {
-        return Err((r.status(), Json(serde_json::json!({ "error": "see body" }))));
+        // Forward the helper's response verbatim — it already carries the
+        // 404-rewrite for workspace mismatch and the 403 PAT-scope body
+        // (`pat_workspace_scope_mismatch`); replacing it with a generic
+        // shape would hide both.
+        return r;
     }
 
     // Verify session exists
     match db::get_session(&state.db, &session_id).await {
         Ok(None) => {
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "session not found" })),
-            ));
+            return not_found();
         }
         Err(e) => {
-            return Err((
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({ "error": e.to_string() })),
-            ));
+            )
+                .into_response();
         }
         Ok(Some(_)) => {}
     }
@@ -256,5 +258,7 @@ pub async fn session_logs(
         ))
     });
 
-    Ok(Sse::new(sse_stream).keep_alive(KeepAlive::default()))
+    Sse::new(sse_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -104,6 +104,14 @@ pub async fn dispatch_shaping_inner(
         None => return Ok(DispatchOutcome::NoAvailableNode),
     };
 
+    // Resolve the workspace this dispatch targets from the spine
+    // artifact row (#164).  The session's workspace pins which
+    // credential set the agent runner reaches for and which `?workspace=`
+    // listing surfaces it. Falls back to None when the spine isn't wired
+    // (dev / tests without spine), in which case credentials are skipped
+    // — same loud-fail behaviour as the no-`created_by` path.
+    let workspace_id = resolve_workspace_for_artifact(state, req.artifact_id.as_str()).await;
+
     let mut session = Session {
         id: Uuid::new_v4().to_string(),
         task_id: task.id.clone(),
@@ -119,9 +127,24 @@ pub async fn dispatch_shaping_inner(
     };
 
     if idempotency_key.is_empty() {
-        db::insert_session(&state.db, &session).await?;
+        db::insert_session_with_user_project_workspace(
+            &state.db,
+            &session,
+            req.created_by.as_deref(),
+            None,
+            workspace_id.as_deref(),
+        )
+        .await?;
     } else {
-        match db::insert_session_with_idempotency_key(&state.db, &session, idempotency_key).await? {
+        match insert_session_with_idempotency_and_workspace(
+            &state.db,
+            &session,
+            req.created_by.as_deref(),
+            workspace_id.as_deref(),
+            idempotency_key,
+        )
+        .await?
+        {
             true => { /* new session inserted */ }
             false => {
                 // Concurrent insert with the same key won the race; load
@@ -138,13 +161,14 @@ pub async fn dispatch_shaping_inner(
         }
     }
 
-    // Fetch user credentials when the request carries `created_by`. Direct
-    // callers that don't set it keep the legacy `None` behavior — the
-    // resulting session_failed event surfaces the broken state via
-    // forge's signal listener.
-    let credentials = match req.created_by.as_deref() {
-        Some(uid) => super::tasks::fetch_user_credentials(state, uid).await,
-        None => None,
+    // Fetch credentials scoped to the session's workspace (#164). A
+    // request without both `created_by` and a resolvable workspace gets
+    // `None` — the resulting session_failed event surfaces the broken
+    // state via forge's signal listener rather than dispatching with the
+    // wrong workspace's secrets.
+    let credentials = match (req.created_by.as_deref(), workspace_id.as_deref()) {
+        (Some(uid), Some(ws)) => super::tasks::fetch_workspace_credentials(state, ws, uid).await,
+        _ => None,
     };
 
     // Dispatch to the agent over WebSocket.
@@ -339,6 +363,60 @@ async fn terminal_response(session: &Session) -> axum::response::Response {
 
 fn is_terminal(state: SessionState) -> bool {
     matches!(state, SessionState::Done | SessionState::Failed)
+}
+
+/// Resolve the workspace an artifact belongs to by querying the spine
+/// `artifacts.workspace_id` column added in #162. Returns `None` when
+/// the spine isn't connected, the artifact row is missing, or the
+/// query fails — every failure mode degrades gracefully and the
+/// caller treats a missing workspace as "no credentials, dispatch and
+/// fail loudly".
+async fn resolve_workspace_for_artifact(state: &AppState, artifact_id: &str) -> Option<String> {
+    let spine = state.spine.as_ref()?;
+    sqlx::query_scalar::<_, String>("SELECT workspace_id FROM artifacts WHERE artifact_id = $1")
+        .bind(artifact_id)
+        .fetch_optional(spine.pool())
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Insert a session bound to an idempotency key with full workspace +
+/// user context. Mirrors `db::insert_session_with_idempotency_key` but
+/// also writes `user_id` and `workspace_id` so the session row has the
+/// full provenance the new list/credential paths need (#164).
+async fn insert_session_with_idempotency_and_workspace(
+    pool: &sqlx::AnyPool,
+    session: &Session,
+    user_id: Option<&str>,
+    workspace_id: Option<&str>,
+    idempotency_key: &str,
+) -> anyhow::Result<bool> {
+    let affected = sqlx::query(
+        "INSERT INTO sessions (id, task_id, node_id, state, prompt, output, working_dir, \
+                               user_id, workspace_id, artifact_id, artifact_version, \
+                               idempotency_key, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) \
+         ON CONFLICT (idempotency_key) DO NOTHING",
+    )
+    .bind(&session.id)
+    .bind(&session.task_id)
+    .bind(&session.node_id)
+    .bind(session.state.to_string())
+    .bind(&session.prompt)
+    .bind(&session.output)
+    .bind(&session.working_dir)
+    .bind(user_id)
+    .bind(workspace_id)
+    .bind(&session.artifact_id)
+    .bind(session.artifact_version)
+    .bind(idempotency_key)
+    .bind(session.created_at.to_rfc3339())
+    .bind(session.updated_at.to_rfc3339())
+    .execute(pool)
+    .await?
+    .rows_affected();
+    Ok(affected > 0)
 }
 
 /// Parse `"30s"`, `"1500ms"`, or a bare seconds integer like `"15"`. Returns

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -6,15 +6,20 @@
 
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+use crate::server::auth::AuthUser;
 use crate::server::state::AppState;
+
+use super::require_workspace_access;
 
 #[derive(Debug, Deserialize)]
 pub struct EventsQuery {
+    /// Required workspace scope (#164). Missing → 400.
+    pub workspace: String,
     pub stream_type: Option<String>,
     pub event_type: Option<String>,
     /// Exact-match filter on `stream_id`. Used by per-artifact and
@@ -86,6 +91,10 @@ pub struct HorizontalLineageRow {
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterArtifactRequest {
+    /// Workspace the new artifact belongs to (#164). Caller must be a
+    /// member; the value is written into `artifacts.workspace_id` so
+    /// later list/detail queries scope it correctly.
+    pub workspace_id: String,
     pub kind: String,
     pub name: String,
     pub owner: String,
@@ -134,11 +143,25 @@ pub struct OverrideGateRequest {
     pub actor: Option<String>,
 }
 
-/// GET /api/spine/events — query the events_ext table.
+/// GET /api/spine/events?workspace=W — query the events_ext table.
+///
+/// Filters event rows whose payload references the requested workspace
+/// (matched on `data->>'workspace_id'`). The `?workspace=` query param
+/// is required (#164) — a missing value returns 400 so a caller can't
+/// silently scan every workspace's stream.
 pub async fn list_events(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Query(params): Query<EventsQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let workspace_id = params.workspace.trim();
+    if workspace_id.is_empty() {
+        return missing_workspace();
+    }
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
+
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -156,22 +179,24 @@ pub async fn list_events(
     // `events_ext` stores the partition key in `namespace` and the actor inside
     // `metadata`. The API surfaces them as `stream_type` / `actor` for clients,
     // so we alias on the way out.
+    //
+    // Workspace scope is matched on `data->>'workspace_id'`; events that
+    // don't carry the field (legacy, infrastructure-level) are excluded
+    // so a workspace listing never includes another workspace's rows.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
                 COALESCE(metadata->>'actor', '') AS actor, created_at \
-         FROM events_ext",
+         FROM events_ext WHERE data->>'workspace_id' = ",
     );
-    let mut sep = " WHERE ";
+    qb.push_bind(workspace_id.to_string());
     if let Some(st) = params.stream_type.as_deref() {
-        qb.push(sep).push("namespace = ").push_bind(st.to_string());
-        sep = " AND ";
+        qb.push(" AND namespace = ").push_bind(st.to_string());
     }
     if let Some(et) = params.event_type.as_deref() {
-        qb.push(sep).push("event_type = ").push_bind(et.to_string());
-        sep = " AND ";
+        qb.push(" AND event_type = ").push_bind(et.to_string());
     }
     if let Some(sid) = params.stream_id.as_deref() {
-        qb.push(sep).push("stream_id = ").push_bind(sid.to_string());
+        qb.push(" AND stream_id = ").push_bind(sid.to_string());
     }
     qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
     let result = qb.build_query_as::<SpineEvent>().fetch_all(pool).await;
@@ -189,9 +214,26 @@ pub async fn list_events(
     }
 }
 
-/// Filters for `GET /api/spine/artifacts`. All optional.
+/// Standard 400 body for the `?workspace=` requirement on every
+/// workspace-scoped list endpoint (#164). Mirrors the helper in
+/// `routes/sessions.rs` — kept duplicated to avoid a fragile module
+/// dependency.
+fn missing_workspace() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "workspace query parameter is required",
+            "detail": "every workspace-scoped list endpoint requires ?workspace=<id>",
+        })),
+    )
+        .into_response()
+}
+
+/// Filters for `GET /api/spine/artifacts`.
 #[derive(Debug, Deserialize)]
 pub struct ListArtifactsQuery {
+    /// Required workspace scope (#164). Missing → 400.
+    pub workspace: String,
     /// Filter by `kind` discriminator (e.g. `pull_request`, `github_issue`).
     pub kind: Option<String>,
     /// Filter by `metadata->>'project_id'`. Used by the dashboard `/issues`
@@ -199,15 +241,23 @@ pub struct ListArtifactsQuery {
     pub project_id: Option<String>,
 }
 
-/// GET /api/spine/artifacts — list artifacts from the spine.
+/// GET /api/spine/artifacts?workspace=W — list artifacts from the spine.
 ///
-/// Supports `?kind=` and `?project_id=` filters so the dashboard's per-page
-/// queries (Factory PRs, Issues inbox) can target a single discriminated
-/// slice without scanning the whole table client-side.
+/// Filters by `workspace_id` (required). Optional `?kind=` and
+/// `?project_id=` further narrow the listing.
 pub async fn list_artifacts(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Query(filters): Query<ListArtifactsQuery>,
-) -> impl IntoResponse {
+) -> Response {
+    let workspace_id = filters.workspace.trim();
+    if workspace_id.is_empty() {
+        return missing_workspace();
+    }
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
+
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -221,47 +271,25 @@ pub async fn list_artifacts(
 
     let pool = spine.pool();
 
-    // Build the query with optional WHERE clauses. sqlx::Postgres binds use
-    // `$N` positional placeholders; we keep this simple by branching on the
-    // (kind, project_id) combinations rather than building a string.
-    let base = "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
+    // The base query always filters by workspace_id (#162 added the
+    // column on the spine `artifacts` table).  Optional kind/project
+    // filters tack onto the same WHERE clause via QueryBuilder so a
+    // mis-set bind index can't shift between branches.
+    let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
                 consumers, external_ref, created_at, updated_at, last_observed_at \
-                FROM artifacts";
-    let result = match (filters.kind.as_deref(), filters.project_id.as_deref()) {
-        (Some(kind), Some(project_id)) => {
-            sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE kind = $1 AND metadata->>'project_id' = $2 \
-                 ORDER BY updated_at DESC LIMIT 100"
-            ))
-            .bind(kind)
-            .bind(project_id)
-            .fetch_all(pool)
-            .await
-        }
-        (Some(kind), None) => {
-            sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE kind = $1 ORDER BY updated_at DESC LIMIT 100"
-            ))
-            .bind(kind)
-            .fetch_all(pool)
-            .await
-        }
-        (None, Some(project_id)) => {
-            sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} WHERE metadata->>'project_id' = $1 ORDER BY updated_at DESC LIMIT 100"
-            ))
-            .bind(project_id)
-            .fetch_all(pool)
-            .await
-        }
-        (None, None) => {
-            sqlx::query_as::<_, SpineArtifact>(&format!(
-                "{base} ORDER BY updated_at DESC LIMIT 100"
-            ))
-            .fetch_all(pool)
-            .await
-        }
-    };
+         FROM artifacts WHERE workspace_id = ",
+    );
+    qb.push_bind(workspace_id.to_string());
+    if let Some(kind) = filters.kind.as_deref() {
+        qb.push(" AND kind = ").push_bind(kind.to_string());
+    }
+    if let Some(project_id) = filters.project_id.as_deref() {
+        qb.push(" AND metadata->>'project_id' = ")
+            .push_bind(project_id.to_string());
+    }
+    qb.push(" ORDER BY updated_at DESC LIMIT 100");
+    let result = qb.build_query_as::<SpineArtifact>().fetch_all(pool).await;
 
     match result {
         Ok(artifacts) => Json(serde_json::json!({ "artifacts": artifacts })).into_response(),
@@ -279,8 +307,21 @@ pub async fn list_artifacts(
 /// POST /api/spine/artifacts — register a new artifact in Draft state.
 pub async fn register_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Json(req): Json<RegisterArtifactRequest>,
-) -> impl IntoResponse {
+) -> Response {
+    let workspace_id = req.workspace_id.trim();
+    if workspace_id.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "workspace_id is required" })),
+        )
+            .into_response();
+    }
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+        return r;
+    }
+
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -296,14 +337,15 @@ pub async fn register_artifact(
     let artifact_id = format!("art_{}", ulid::Ulid::new());
 
     let result = sqlx::query(
-        "INSERT INTO artifacts (artifact_id, kind, name, owner, created_by, state, current_version) \
-         VALUES ($1, $2, $3, $4, $5, 'draft', 0)",
+        "INSERT INTO artifacts (artifact_id, kind, name, owner, created_by, state, current_version, workspace_id) \
+         VALUES ($1, $2, $3, $4, $5, 'draft', 0, $6)",
     )
     .bind(&artifact_id)
     .bind(&req.kind)
     .bind(&req.name)
     .bind(&req.owner)
     .bind("dashboard") // created_by
+    .bind(workspace_id)
     .execute(pool)
     .await;
 
@@ -370,11 +412,14 @@ pub async fn register_artifact(
     }
 }
 
-/// GET /api/spine/artifacts/:id — single artifact detail with versions and lineage.
+/// GET /api/spine/artifacts/:id — single artifact detail with versions
+/// and lineage. 404s callers who aren't members of the artifact's
+/// workspace (#164) so artifact IDs can't be enumerated cross-workspace.
 pub async fn get_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
-) -> impl IntoResponse {
+) -> Response {
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -387,6 +432,48 @@ pub async fn get_artifact(
     };
 
     let pool = spine.pool();
+
+    // Resolve the artifact's workspace first so the membership check
+    // 404s before any further data is read; the artifact body itself
+    // is fetched separately to keep the row type a clean SpineArtifact.
+    let workspace_id: String = match sqlx::query_scalar::<_, String>(
+        "SELECT workspace_id FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(Some(w)) => w,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("spine artifact workspace lookup failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to query artifact" })),
+            )
+                .into_response();
+        }
+    };
+
+    // 404 (not 403) on workspace mismatch via the shared helper —
+    // rewrite the body to "artifact not found" so artifact IDs don't
+    // leak via the workspace-not-found body.
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        return r;
+    }
 
     let artifact = sqlx::query_as::<_, SpineArtifact>(
         "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, \
@@ -546,9 +633,10 @@ async fn fetch_related_events(
 /// POST /api/spine/artifacts/:id/retry
 pub async fn retry_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<RetryRequest>,
-) -> impl IntoResponse {
+) -> Response {
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -562,21 +650,44 @@ pub async fn retry_artifact(
 
     let pool = spine.pool();
 
-    // Confirm the artifact exists and is not archived.
-    let current_state: Option<String> =
-        sqlx::query_scalar("SELECT state FROM artifacts WHERE artifact_id = $1")
-            .bind(&id)
-            .fetch_optional(pool)
-            .await
-            .unwrap_or(None);
-
-    let Some(state_str) = current_state else {
+    // Resolve workspace + state in one round-trip; the membership check
+    // comes before any mutation so a non-member can't probe artifact
+    // state via the side-effect.
+    let row: Option<(String, String)> = match sqlx::query_as::<_, (String, String)>(
+        "SELECT workspace_id, state FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(opt) => opt,
+        Err(e) => {
+            tracing::error!("artifact lookup failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load artifact" })),
+            )
+                .into_response();
+        }
+    };
+    let Some((workspace_id, state_str)) = row else {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "artifact not found" })),
         )
             .into_response();
     };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        return r;
+    }
+    let _ = workspace_id;
 
     if state_str == "archived" || state_str == "released" {
         return (
@@ -620,9 +731,10 @@ pub async fn retry_artifact(
 /// POST /api/spine/artifacts/:id/abort
 pub async fn abort_artifact(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<AbortRequest>,
-) -> impl IntoResponse {
+) -> Response {
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -636,20 +748,40 @@ pub async fn abort_artifact(
 
     let pool = spine.pool();
 
-    let previous_state: Option<String> =
-        sqlx::query_scalar("SELECT state FROM artifacts WHERE artifact_id = $1")
-            .bind(&id)
-            .fetch_optional(pool)
-            .await
-            .unwrap_or(None);
-
-    let Some(previous_state) = previous_state else {
+    let row: Option<(String, String)> = match sqlx::query_as::<_, (String, String)>(
+        "SELECT workspace_id, state FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(opt) => opt,
+        Err(e) => {
+            tracing::error!("artifact lookup failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load artifact" })),
+            )
+                .into_response();
+        }
+    };
+    let Some((workspace_id, previous_state)) = row else {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "artifact not found" })),
         )
             .into_response();
     };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        return r;
+    }
 
     if previous_state == "archived" {
         return (
@@ -713,9 +845,10 @@ pub async fn abort_artifact(
 /// POST /api/spine/artifacts/:id/override-gate
 pub async fn override_gate(
     State(state): State<AppState>,
+    auth_user: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<OverrideGateRequest>,
-) -> impl IntoResponse {
+) -> Response {
     let spine = match &state.spine {
         Some(s) => s,
         None => {
@@ -729,19 +862,39 @@ pub async fn override_gate(
 
     let pool = spine.pool();
 
-    let exists: Option<String> =
-        sqlx::query_scalar("SELECT artifact_id FROM artifacts WHERE artifact_id = $1")
-            .bind(&id)
-            .fetch_optional(pool)
-            .await
-            .unwrap_or(None);
-
-    if exists.is_none() {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "artifact not found" })),
-        )
-            .into_response();
+    let workspace_id: String = match sqlx::query_scalar::<_, String>(
+        "SELECT workspace_id FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(Some(w)) => w,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("artifact lookup failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load artifact" })),
+            )
+                .into_response();
+        }
+    };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
+        }
+        return r;
     }
 
     let verdict = req.verdict.as_deref().unwrap_or("allow").to_lowercase();

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -158,8 +158,14 @@ pub async fn list_events(
     if workspace_id.is_empty() {
         return missing_workspace();
     }
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-        return r;
+    // Skip the membership check for the synthetic anonymous principal
+    // so auth-disabled dev mode keeps these endpoints usable. The
+    // `?workspace=` requirement still applies and the SQL still filters
+    // by it — anonymous just means no per-user gate.
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+            return r;
+        }
     }
 
     let spine = match &state.spine {
@@ -254,8 +260,14 @@ pub async fn list_artifacts(
     if workspace_id.is_empty() {
         return missing_workspace();
     }
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-        return r;
+    // Skip the membership check for the synthetic anonymous principal
+    // so auth-disabled dev mode keeps these endpoints usable. The
+    // `?workspace=` requirement still applies and the SQL still filters
+    // by it — anonymous just means no per-user gate.
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+            return r;
+        }
     }
 
     let spine = match &state.spine {
@@ -318,8 +330,14 @@ pub async fn register_artifact(
         )
             .into_response();
     }
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-        return r;
+    // Skip the membership check for the synthetic anonymous principal
+    // so auth-disabled dev mode keeps these endpoints usable. The
+    // `?workspace=` requirement still applies and the SQL still filters
+    // by it — anonymous just means no per-user gate.
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
+            return r;
+        }
     }
 
     let spine = match &state.spine {
@@ -464,15 +482,17 @@ pub async fn get_artifact(
     // 404 (not 403) on workspace mismatch via the shared helper —
     // rewrite the body to "artifact not found" so artifact IDs don't
     // leak via the workspace-not-found body.
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        if r.status() == StatusCode::NOT_FOUND {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "artifact not found" })),
-            )
-                .into_response();
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            if r.status() == StatusCode::NOT_FOUND {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "artifact not found" })),
+                )
+                    .into_response();
+            }
+            return r;
         }
-        return r;
     }
 
     let artifact = sqlx::query_as::<_, SpineArtifact>(
@@ -677,15 +697,17 @@ pub async fn retry_artifact(
         )
             .into_response();
     };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        if r.status() == StatusCode::NOT_FOUND {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "artifact not found" })),
-            )
-                .into_response();
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            if r.status() == StatusCode::NOT_FOUND {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "artifact not found" })),
+                )
+                    .into_response();
+            }
+            return r;
         }
-        return r;
     }
     let _ = workspace_id;
 
@@ -772,15 +794,17 @@ pub async fn abort_artifact(
         )
             .into_response();
     };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        if r.status() == StatusCode::NOT_FOUND {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "artifact not found" })),
-            )
-                .into_response();
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            if r.status() == StatusCode::NOT_FOUND {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "artifact not found" })),
+                )
+                    .into_response();
+            }
+            return r;
         }
-        return r;
     }
 
     if previous_state == "archived" {
@@ -886,15 +910,17 @@ pub async fn override_gate(
                 .into_response();
         }
     };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        if r.status() == StatusCode::NOT_FOUND {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "artifact not found" })),
-            )
-                .into_response();
+    if auth_user.user_id != "anonymous" {
+        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+            if r.status() == StatusCode::NOT_FOUND {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({ "error": "artifact not found" })),
+                )
+                    .into_response();
+            }
+            return r;
         }
-        return r;
     }
 
     let verdict = req.verdict.as_deref().unwrap_or("allow").to_lowercase();

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -105,7 +105,10 @@ pub async fn create_task(
     // Validate project membership if the caller scoped the session to a
     // workspace-owned project (issue #59). Non-members get 404 via
     // `assert_workspace_member` so project IDs can't be enumerated.
-    if let Some(ref project_id) = request.project_id {
+    // The project also resolves the workspace the session is launched
+    // into — credentials, listing, and detail-access checks all key on
+    // that workspace_id (issue #164).
+    let workspace_id: Option<String> = if let Some(ref project_id) = request.project_id {
         if user_id.is_none() {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -138,13 +141,17 @@ pub async fn create_task(
         {
             return r;
         }
-    }
+        Some(project.workspace_id)
+    } else {
+        None
+    };
 
-    if let Err(e) = db::insert_session_with_user_and_project(
+    if let Err(e) = db::insert_session_with_user_project_workspace(
         &state.db,
         &session,
         user_id,
         request.project_id.as_deref(),
+        workspace_id.as_deref(),
     )
     .await
     {
@@ -152,11 +159,13 @@ pub async fn create_task(
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
 
-    // Fetch user credentials to pass to the agent
-    let credentials = if let Some(uid) = user_id {
-        fetch_user_credentials(&state, uid).await
-    } else {
-        None
+    // Fetch user credentials scoped to the session's workspace. Personal
+    // sessions (no project, no workspace) get no credentials — the resulting
+    // session_failed event surfaces the broken state via forge's listener
+    // rather than silently launching an unauthenticated agent.
+    let credentials = match (user_id, workspace_id.as_deref()) {
+        (Some(uid), Some(ws)) => fetch_workspace_credentials(&state, ws, uid).await,
+        _ => None,
     };
 
     // Dispatch to agent via WebSocket
@@ -193,18 +202,22 @@ pub async fn create_task(
         .into_response()
 }
 
-/// Fetch all user credentials, decrypt them, and return as a HashMap.
+/// Fetch the credentials a user holds in a specific workspace, decrypt
+/// them, and return as a HashMap of env-var name → plaintext value.
 ///
-/// Used by both `POST /api/tasks` (direct user-triggered sessions) and
-/// `POST /api/shaping` (forge-dispatched workflow sessions, see issue
-/// #156). Visible to sibling route modules; not part of the public API.
-pub(super) async fn fetch_user_credentials(
+/// Used by both `POST /api/tasks` and the spine-dispatched
+/// `forge.shaping_dispatched` listener (`crate::server::shaping_listener`).
+/// The workspace argument is mandatory post-#164 — credentials are
+/// per-workspace and a session in W1 must never be launched with a
+/// W2 token.
+pub(super) async fn fetch_workspace_credentials(
     state: &AppState,
+    workspace_id: &str,
     user_id: &str,
 ) -> Option<HashMap<String, String>> {
     let key = state.config.credential_key.as_deref()?;
 
-    let encrypted_creds = db::get_all_user_credential_values(&state.db, user_id)
+    let encrypted_creds = db::get_all_user_credential_values(&state.db, workspace_id, user_id)
         .await
         .ok()?;
 

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -108,6 +108,15 @@ pub async fn create_task(
     // The project also resolves the workspace the session is launched
     // into — credentials, listing, and detail-access checks all key on
     // that workspace_id (issue #164).
+    //
+    // Resolution order for the session's workspace:
+    //   1. project_id  → use that project's workspace (project owns scope)
+    //   2. workspace_id explicit → use it after a membership check
+    //   3. neither     → personal session, NULL workspace_id (legacy path)
+    //
+    // When both are supplied and disagree, 400 — the dashboard should
+    // pick one rather than the server silently preferring one over the
+    // other.
     let workspace_id: Option<String> = if let Some(ref project_id) = request.project_id {
         if user_id.is_none() {
             return (
@@ -132,6 +141,17 @@ pub async fn create_task(
                 return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
             }
         };
+        if let Some(ref explicit) = request.workspace_id {
+            if explicit != &project.workspace_id {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "workspace_id does not match the project's workspace",
+                    })),
+                )
+                    .into_response();
+            }
+        }
         if let Err(r) = crate::server::routes::workspaces::assert_workspace_member(
             &state.db,
             &auth_user,
@@ -142,6 +162,25 @@ pub async fn create_task(
             return r;
         }
         Some(project.workspace_id)
+    } else if let Some(ref explicit) = request.workspace_id {
+        if user_id.is_none() {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "authentication required to scope a session to a workspace"
+                })),
+            )
+                .into_response();
+        }
+        // 404 (not 403) on non-membership via the shared helper —
+        // matches every other workspace-scoped surface so a caller
+        // can't enumerate workspaces by probing this endpoint.
+        if let Err(r) =
+            crate::server::routes::require_workspace_access(&state.db, &auth_user, explicit).await
+        {
+            return r;
+        }
+        Some(explicit.clone())
     } else {
         None
     };

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -162,7 +162,21 @@ pub async fn handle(State(state): State<AppState>, headers: HeaderMap, body: Byt
     }
 
     let events = route_event(&state, &event, &parsed).await;
-    emit_events(&state, events).await;
+    // Resolve the install → workspace mapping once. The mapping is 1:1
+    // by the migration's UNIQUE(install_id) (#164); we look it up here
+    // so every emitted event carries `workspace_id` regardless of which
+    // typed FactoryEventKind variant it lives in.
+    let workspace_id = match state.db.acquire().await {
+        Ok(_) => {
+            crate::server::db::get_github_app_installation_by_install_id(&state.db, install_id)
+                .await
+                .ok()
+                .flatten()
+                .map(|i| i.workspace_id)
+        }
+        Err(_) => None,
+    };
+    emit_events(&state, events, workspace_id.as_deref()).await;
 
     (
         StatusCode::ACCEPTED,
@@ -223,7 +237,7 @@ async fn route_event(state: &AppState, event: &str, payload: &Value) -> Vec<Rout
     }
 }
 
-async fn emit_events(state: &AppState, events: Vec<RoutedEvent>) {
+async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: Option<&str>) {
     let Some(spine) = state.spine.as_ref() else {
         if !events.is_empty() {
             tracing::warn!("spine not configured; dropping {} events", events.len());
@@ -231,13 +245,23 @@ async fn emit_events(state: &AppState, events: Vec<RoutedEvent>) {
         return;
     };
     for ev in events {
-        let data = match serde_json::to_value(&ev.kind) {
+        let mut data = match serde_json::to_value(&ev.kind) {
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("failed to serialize spine event: {e}");
                 continue;
             }
         };
+        // Stamp workspace_id (#164) so downstream consumers — including
+        // the workspace-scoped `/api/spine/events` listing — can filter
+        // by workspace without re-resolving the install. The
+        // `TriggerFired` payload already includes its workflow's
+        // workspace; we don't overwrite it (a missing entry is the
+        // common case for `gate.*` events from check / PR webhooks).
+        if let (Some(ws), Some(obj)) = (workspace_id, data.as_object_mut()) {
+            obj.entry("workspace_id".to_string())
+                .or_insert(serde_json::Value::String(ws.to_string()));
+        }
         let namespace = spine_namespace(&ev.kind);
         if let Err(e) = spine
             .emit_raw(

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -166,17 +166,31 @@ pub async fn handle(State(state): State<AppState>, headers: HeaderMap, body: Byt
     // by the migration's UNIQUE(install_id) (#164); we look it up here
     // so every emitted event carries `workspace_id` regardless of which
     // typed FactoryEventKind variant it lives in.
-    let workspace_id = match state.db.acquire().await {
-        Ok(_) => {
-            crate::server::db::get_github_app_installation_by_install_id(&state.db, install_id)
-                .await
-                .ok()
-                .flatten()
-                .map(|i| i.workspace_id)
+    //
+    // Fail closed: the secret-cipher lookup above already proved the
+    // install exists, so a missing workspace mapping or a query error
+    // here would be a real schema/database problem — not something we
+    // want to paper over by emitting unscoped events that vanish from
+    // workspace-filtered listings.
+    let workspace_id = match crate::server::db::get_github_app_installation_by_install_id(
+        &state.db, install_id,
+    )
+    .await
+    {
+        Ok(Some(installation)) => installation.workspace_id,
+        Ok(None) => {
+            tracing::error!(
+                install_id,
+                "installation passed secret lookup but workspace mapping is missing"
+            );
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
-        Err(_) => None,
+        Err(e) => {
+            tracing::error!(install_id, error = %e, "failed to resolve workspace_id for installation");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
     };
-    emit_events(&state, events, workspace_id.as_deref()).await;
+    emit_events(&state, events, &workspace_id).await;
 
     (
         StatusCode::ACCEPTED,
@@ -237,7 +251,7 @@ async fn route_event(state: &AppState, event: &str, payload: &Value) -> Vec<Rout
     }
 }
 
-async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: Option<&str>) {
+async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: &str) {
     let Some(spine) = state.spine.as_ref() else {
         if !events.is_empty() {
             tracing::warn!("spine not configured; dropping {} events", events.len());
@@ -258,9 +272,9 @@ async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: O
         // `TriggerFired` payload already includes its workflow's
         // workspace; we don't overwrite it (a missing entry is the
         // common case for `gate.*` events from check / PR webhooks).
-        if let (Some(ws), Some(obj)) = (workspace_id, data.as_object_mut()) {
+        if let Some(obj) = data.as_object_mut() {
             obj.entry("workspace_id".to_string())
-                .or_insert(serde_json::Value::String(ws.to_string()));
+                .or_insert(serde_json::Value::String(workspace_id.to_string()));
         }
         let namespace = spine_namespace(&ev.kind);
         if let Err(e) = spine

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -92,18 +92,28 @@ fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
     }
 }
 
-/// Issue #156: ensure the workflow's owner has at least one Claude
-/// auth credential before activating. Returns a 4xx response when
-/// missing so the dashboard can surface a "connect Claude credentials"
-/// CTA.
+/// Issue #156 (workspace-scoped post-#164): ensure the workflow's owner
+/// has at least one Claude auth credential **in the workflow's
+/// workspace** before activating. Returns a 4xx response when missing so
+/// the dashboard can surface a "connect Claude credentials" CTA.
 ///
 /// Checks by exact credential name (not "any credential row") because
 /// the Claude CLI only honors specific env vars; a user with only
 /// custom-named secrets would silently activate into a workflow whose
 /// every session fails with "stdout closed without result event".
 #[allow(clippy::result_large_err)]
-async fn require_owner_credentials(state: &AppState, owner_user_id: &str) -> Result<(), Response> {
-    match db::user_has_credential_in(&state.db, owner_user_id, CLAUDE_AUTH_CREDENTIAL_NAMES).await
+async fn require_owner_credentials(
+    state: &AppState,
+    workspace_id: &str,
+    owner_user_id: &str,
+) -> Result<(), Response> {
+    match db::user_has_credential_in(
+        &state.db,
+        workspace_id,
+        owner_user_id,
+        CLAUDE_AUTH_CREDENTIAL_NAMES,
+    )
+    .await
     {
         Ok(true) => Ok(()),
         Ok(false) => Err((
@@ -111,11 +121,12 @@ async fn require_owner_credentials(state: &AppState, owner_user_id: &str) -> Res
             Json(serde_json::json!({
                 "error": "no_credentials_for_workflow",
                 "message": format!(
-                    "Workflow owner has no Claude credentials. Connect one of {:?} in Settings before activating.",
+                    "Workflow owner has no Claude credentials in this workspace. Connect one of {:?} in Settings before activating.",
                     CLAUDE_AUTH_CREDENTIAL_NAMES
                 ),
                 "required_one_of": CLAUDE_AUTH_CREDENTIAL_NAMES,
                 "owner_user_id": owner_user_id,
+                "workspace_id": workspace_id,
             })),
         )
             .into_response()),
@@ -299,11 +310,14 @@ pub async fn create_workflow(
     // stays `active=false` and the caller sees the activation error.
     if body.active {
         // Issue #156: same activation gate as patch_workflow — refuse to
-        // activate if the owner has no credentials. Here `created_by` is
-        // the caller themselves (just set above), so this in practice
-        // surfaces the case where a user creates+activates without ever
-        // having connected Claude credentials.
-        if let Err(r) = require_owner_credentials(&state, &workflow.created_by).await {
+        // activate if the owner has no credentials in the workflow's
+        // workspace (post-#164). Here `created_by` is the caller themselves
+        // (just set above), so this in practice surfaces the case where a
+        // user creates+activates without ever having connected Claude
+        // credentials in this workspace.
+        if let Err(r) =
+            require_owner_credentials(&state, &workflow.workspace_id, &workflow.created_by).await
+        {
             return r;
         }
         if let Err(r) = activate_workflow(&state, &workflow.id, &headers).await {
@@ -579,15 +593,18 @@ pub async fn patch_workflow(
     }
 
     if desired_active {
-        // Issue #156: refuse activation when the workflow's owner has no
-        // credentials. Without this guard the workflow would be active
+        // Issue #156 (workspace-scoped post-#164): refuse activation when
+        // the workflow's owner has no credentials in the workflow's
+        // workspace. Without this guard the workflow would be active
         // but every shaping dispatch would spawn an agent without
         // CLAUDE_CODE_OAUTH_TOKEN and immediately fail with "stdout
         // closed without result event". Failing fast at activation
         // surfaces the broken state in the UX layer (a 4xx the dashboard
         // can render as "connect Claude credentials") instead of in the
         // spine event stream where users won't see it.
-        if let Err(r) = require_owner_credentials(&state, &workflow.created_by).await {
+        if let Err(r) =
+            require_owner_credentials(&state, &workflow.workspace_id, &workflow.created_by).await
+        {
             return r;
         }
         if let Err(r) = activate_workflow(&state, &workflow_id, &headers).await {

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -694,15 +694,21 @@ async fn delete_pat_revokes_so_subsequent_use_401s() {
 async fn pat_can_create_credential_but_not_overwrite() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
-    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "creds").await;
+    // Workspace-scoped PAT (#164) — credentials live under
+    // /api/workspaces/:workspace/credentials, so the PAT must address
+    // that workspace.
+    let (_, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     let state = AppState::new(pool, auth_enabled_config(), None);
     let app_ = app(state);
+
+    let url = format!("/api/workspaces/{}/credentials/CI_TOKEN", workspace.id);
 
     // PUT to a brand-new credential name succeeds.
     let create = bearer(
         Request::builder()
             .method("PUT")
-            .uri("/api/credentials/CI_TOKEN")
+            .uri(&url)
             .header(header::CONTENT_TYPE, "application/json"),
         &token,
     )
@@ -717,7 +723,7 @@ async fn pat_can_create_credential_but_not_overwrite() {
     let overwrite = bearer(
         Request::builder()
             .method("PUT")
-            .uri("/api/credentials/CI_TOKEN")
+            .uri(&url)
             .header(header::CONTENT_TYPE, "application/json"),
         &token,
     )
@@ -735,26 +741,23 @@ async fn pat_can_create_credential_but_not_overwrite() {
 async fn pat_cannot_delete_credential() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "creds-del").await;
     // Pre-create a credential via the DB so the DELETE actually has
     // something to refer to.
     let key = stiglab::server::auth::generate_credential_key();
     let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
-    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+    db::set_user_credential(&pool, &workspace.id, &user.id, "CI_TOKEN", &enc)
         .await
         .unwrap();
-    let (_, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     let state = AppState::new(pool, auth_enabled_config(), None);
 
+    let url = format!("/api/workspaces/{}/credentials/CI_TOKEN", workspace.id);
     let resp = app(state)
         .oneshot(
-            bearer(
-                Request::builder()
-                    .method("DELETE")
-                    .uri("/api/credentials/CI_TOKEN"),
-                &token,
-            )
-            .body(Body::empty())
-            .unwrap(),
+            bearer(Request::builder().method("DELETE").uri(&url), &token)
+                .body(Body::empty())
+                .unwrap(),
         )
         .await
         .unwrap();
@@ -768,9 +771,10 @@ async fn session_can_still_delete_credential_after_guardrail_added() {
     // Regression guard: the destructive guardrail must only fire for PATs.
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "creds-sess").await;
     let key = stiglab::server::auth::generate_credential_key();
     let enc = stiglab::server::auth::encrypt_credential(&key, "abc").unwrap();
-    db::set_user_credential(&pool, &user.id, "CI_TOKEN", &enc)
+    db::set_user_credential(&pool, &workspace.id, &user.id, "CI_TOKEN", &enc)
         .await
         .unwrap();
     let session_token = stiglab::server::auth::generate_session_token();
@@ -784,11 +788,12 @@ async fn session_can_still_delete_credential_after_guardrail_added() {
     .unwrap();
     let state = AppState::new(pool, auth_enabled_config(), None);
 
+    let url = format!("/api/workspaces/{}/credentials/CI_TOKEN", workspace.id);
     let resp = app(state)
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri("/api/credentials/CI_TOKEN")
+                .uri(&url)
                 .header(header::COOKIE, format!("stiglab_session={session_token}"))
                 .body(Body::empty())
                 .unwrap(),

--- a/crates/stiglab/tests/workspace_scoping.rs
+++ b/crates/stiglab/tests/workspace_scoping.rs
@@ -460,3 +460,166 @@ async fn github_app_install_id_is_unique() {
         "duplicate install_id must violate the UNIQUE index"
     );
 }
+
+// ── session_logs forwards the auth helper's response verbatim ──
+
+#[tokio::test]
+async fn session_logs_for_other_workspace_returns_404_not_generic_body() {
+    // Regression for the Copilot review on PR #189: the previous
+    // implementation replaced the auth helper's response with a
+    // generic `{ "error": "see body" }` body, hiding both the
+    // `pat_workspace_scope_mismatch` 403 and the rewritten "session
+    // not found" 404. The forwarded response should pass through.
+    let pool = test_pool().await;
+    let owner_w1 = seed_user(&pool, "wonly1", 1).await;
+    let owner_w2 = seed_user(&pool, "wonly2", 2).await;
+    let _w1 = seed_workspace(&pool, &owner_w1.id, "w1").await;
+    let w2 = seed_workspace(&pool, &owner_w2.id, "w2").await;
+    let s_w2 = seed_session_in_workspace(&pool, &owner_w2.id, &w2.id).await;
+
+    let session_token = seed_session_cookie(&pool, &owner_w1.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}/logs", s_w2.id))
+                .header(header::COOKIE, cookie(&session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = read_json(resp).await;
+    assert_eq!(body["error"], "session not found");
+}
+
+// ── POST /api/tasks honours an explicit workspace_id ──
+
+#[tokio::test]
+async fn create_task_with_explicit_workspace_id_files_under_that_workspace() {
+    // Regression for the Copilot review on PR #189: post-#164 a session
+    // created with no project_id used to land with `workspace_id =
+    // NULL`, making it invisible to every `?workspace=` listing. The
+    // new path lets callers pass `workspace_id` directly so the
+    // session is discoverable + correctly credentialed.
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w = seed_workspace(&pool, &user.id, "w-tasks").await;
+
+    // Seed a node so the task dispatch can pick a target.
+    sqlx::query(
+        "INSERT INTO nodes (id, name, hostname, status, max_sessions, \
+                            active_sessions, last_heartbeat, registered_at) \
+         VALUES ($1, $2, $3, 'online', 4, 0, $4, $4)",
+    )
+    .bind("n1")
+    .bind("n1")
+    .bind("local")
+    .bind(Utc::now().to_rfc3339())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool.clone(), auth_enabled_config(), None);
+
+    let body = serde_json::json!({
+        "prompt": "hi",
+        "workspace_id": w.id,
+    });
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tasks")
+                .header(header::COOKIE, cookie(&session_token))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // The session row carries the workspace, so it shows up under
+    // the W-scoped listing.
+    let listed = db::list_sessions_for_user_in_workspace(&pool, &user.id, &w.id)
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1, "session should appear under W's listing");
+}
+
+#[tokio::test]
+async fn create_task_rejects_conflicting_project_and_workspace_ids() {
+    // When both project_id and workspace_id are set and disagree, the
+    // server 400s rather than silently preferring one — the dashboard
+    // should pick which scope is authoritative.
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w_a = seed_workspace(&pool, &user.id, "w-a").await;
+    let w_b = seed_workspace(&pool, &user.id, "w-b").await;
+
+    // The node lookup runs before the workspace validation in
+    // `create_task`; without a node it 503s and we never reach the
+    // conflict check.
+    sqlx::query(
+        "INSERT INTO nodes (id, name, hostname, status, max_sessions, \
+                            active_sessions, last_heartbeat, registered_at) \
+         VALUES ($1, $2, $3, 'online', 4, 0, $4, $4)",
+    )
+    .bind("n1")
+    .bind("n1")
+    .bind("local")
+    .bind(Utc::now().to_rfc3339())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Seed an installation + project owned by w_a.
+    let install = stiglab::core::GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: w_a.id.clone(),
+        install_id: 1234,
+        account_login: "acme".into(),
+        account_type: stiglab::core::GitHubAccountType::Organization,
+        created_at: Utc::now(),
+    };
+    db::insert_github_app_installation(&pool, &install, None)
+        .await
+        .unwrap();
+    let project = stiglab::core::Project {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: w_a.id.clone(),
+        github_app_installation_id: install.id.clone(),
+        repo_owner: "acme".into(),
+        repo_name: "widgets".into(),
+        default_branch: "main".into(),
+        created_at: Utc::now(),
+    };
+    db::insert_project(&pool, &project).await.unwrap();
+
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let body = serde_json::json!({
+        "prompt": "hi",
+        "project_id": project.id,
+        // Disagrees with project.workspace_id (= w_a.id).
+        "workspace_id": w_b.id,
+    });
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tasks")
+                .header(header::COOKIE, cookie(&session_token))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/stiglab/tests/workspace_scoping.rs
+++ b/crates/stiglab/tests/workspace_scoping.rs
@@ -1,0 +1,462 @@
+//! Integration tests for issue #164: per-workspace API surface.
+//!
+//! Mirrors the contract test items in the spec:
+//!   * `?workspace=` is required on every workspace-scoped list endpoint
+//!     (400 on miss).
+//!   * Sessions filtered by workspace don't leak across workspaces.
+//!   * Detail endpoints return 404 (not 403) when the caller isn't a
+//!     member of the owning workspace — matches the `require_workspace_access`
+//!     contract documented in `routes/mod.rs`.
+//!   * PATs pinned to W1 cannot list `?workspace=W2` (the principal-level
+//!     guardrail returns 403 with `pat_workspace_scope_mismatch`).
+//!   * Per-workspace credentials store and retrieve under the new path.
+//!
+//! Reuses the SQLite-in-memory + `build_router` pattern from
+//! `tests/pats.rs` and `tests/workflow_webhook.rs`.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::Utc;
+use sqlx::pool::PoolOptions;
+use sqlx::AnyPool;
+use stiglab::core::{Session, SessionState, User, Workspace, WorkspaceMember};
+use stiglab::server::auth::{generate_credential_key, generate_pat_token};
+use stiglab::server::config::ServerConfig;
+use stiglab::server::db;
+use stiglab::server::state::AppState;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+async fn test_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = PoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite connect");
+    db::run_migrations(&pool).await.expect("migrations");
+    pool
+}
+
+fn auth_enabled_config() -> ServerConfig {
+    ServerConfig {
+        host: "0.0.0.0".into(),
+        port: 3000,
+        database_url: "sqlite::memory:".into(),
+        static_dir: None,
+        cors_origin: None,
+        github_client_id: Some("client-id".into()),
+        github_client_secret: Some("client-secret".into()),
+        credential_key: Some(generate_credential_key()),
+        public_url: None,
+        github_app_webhook_secret: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
+        internal_dispatch_token: None,
+    }
+}
+
+async fn seed_user(pool: &AnyPool, login: &str, github_id: i64) -> User {
+    let user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id,
+        github_login: login.into(),
+        github_name: None,
+        github_avatar_url: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(pool, &user).await.unwrap();
+    user
+}
+
+async fn seed_workspace(pool: &AnyPool, user_id: &str, slug: &str) -> Workspace {
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: Uuid::new_v4().to_string(),
+        slug: slug.into(),
+        name: slug.into(),
+        created_by: user_id.into(),
+        created_at: now,
+    };
+    let member = WorkspaceMember {
+        workspace_id: workspace.id.clone(),
+        user_id: user_id.into(),
+        joined_at: now,
+    };
+    db::insert_workspace_with_creator(pool, &workspace, &member)
+        .await
+        .unwrap();
+    workspace
+}
+
+async fn seed_session_in_workspace(pool: &AnyPool, user_id: &str, workspace_id: &str) -> Session {
+    let session = Session {
+        id: Uuid::new_v4().to_string(),
+        task_id: Uuid::new_v4().to_string(),
+        node_id: "n1".into(),
+        state: SessionState::Pending,
+        prompt: "p".into(),
+        output: None,
+        working_dir: None,
+        artifact_id: None,
+        artifact_version: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::insert_session_with_user_project_workspace(
+        pool,
+        &session,
+        Some(user_id),
+        None,
+        Some(workspace_id),
+    )
+    .await
+    .unwrap();
+    session
+}
+
+async fn mint_pat(pool: &AnyPool, user_id: &str, workspace_id: &str) -> String {
+    let generated = generate_pat_token();
+    let id = Uuid::new_v4().to_string();
+    db::insert_user_pat(
+        pool,
+        &id,
+        user_id,
+        workspace_id,
+        "ci",
+        &generated.prefix,
+        &generated.hash,
+        None,
+    )
+    .await
+    .unwrap();
+    generated.token
+}
+
+fn app(state: AppState) -> axum::Router {
+    stiglab::server::build_router(state.clone(), &state.config)
+}
+
+fn cookie(token: &str) -> String {
+    format!("stiglab_session={token}")
+}
+
+async fn seed_session_cookie(pool: &AnyPool, user_id: &str) -> String {
+    let token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        pool,
+        &token,
+        user_id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    token
+}
+
+async fn read_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+// ── ?workspace= is required on list endpoints ──
+
+#[tokio::test]
+async fn list_sessions_without_workspace_returns_400() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let _ws = seed_workspace(&pool, &user.id, "w1").await;
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .header(header::COOKIE, cookie(&session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_nodes_without_workspace_returns_400() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let _ws = seed_workspace(&pool, &user.id, "w1").await;
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/nodes")
+                .header(header::COOKIE, cookie(&session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── parent contract test: cross-workspace session listing must not leak ──
+
+#[tokio::test]
+async fn list_sessions_filters_by_workspace_no_cross_leak() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w1 = seed_workspace(&pool, &user.id, "w1").await;
+    let w2 = seed_workspace(&pool, &user.id, "w2").await;
+    let s_w1 = seed_session_in_workspace(&pool, &user.id, &w1.id).await;
+    let _s_w2 = seed_session_in_workspace(&pool, &user.id, &w2.id).await;
+
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions?workspace={}", w1.id))
+                .header(header::COOKIE, cookie(&session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    let sessions = body["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1, "only the W1 session should appear");
+    assert_eq!(sessions[0]["id"], s_w1.id);
+}
+
+// ── 404 (not 403) on cross-workspace detail access ──
+
+#[tokio::test]
+async fn get_session_in_other_workspace_returns_404_not_403() {
+    let pool = test_pool().await;
+    // owner_w1 only belongs to W1. owner_w2 owns the session in W2.
+    let owner_w1 = seed_user(&pool, "wonly1", 1).await;
+    let owner_w2 = seed_user(&pool, "wonly2", 2).await;
+    let _w1 = seed_workspace(&pool, &owner_w1.id, "w1").await;
+    let w2 = seed_workspace(&pool, &owner_w2.id, "w2").await;
+    let s_w2 = seed_session_in_workspace(&pool, &owner_w2.id, &w2.id).await;
+
+    // owner_w1 logs in and asks for s_w2 — must 404.
+    let session_token = seed_session_cookie(&pool, &owner_w1.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}", s_w2.id))
+                .header(header::COOKIE, cookie(&session_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "cross-workspace detail must 404, not 403"
+    );
+}
+
+// ── PAT pinned to W1 cannot list ?workspace=W2 ──
+
+#[tokio::test]
+async fn pat_pinned_to_w1_cannot_list_w2_sessions() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w1 = seed_workspace(&pool, &user.id, "w1").await;
+    let w2 = seed_workspace(&pool, &user.id, "w2").await;
+    let _s_w2 = seed_session_in_workspace(&pool, &user.id, &w2.id).await;
+
+    let token = mint_pat(&pool, &user.id, &w1.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions?workspace={}", w2.id))
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = read_json(resp).await;
+    assert_eq!(body["error"], "pat_workspace_scope_mismatch");
+}
+
+// ── per-workspace credentials live under /api/workspaces/:workspace/credentials ──
+
+#[tokio::test]
+async fn credentials_are_scoped_per_workspace() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w1 = seed_workspace(&pool, &user.id, "w1").await;
+    let w2 = seed_workspace(&pool, &user.id, "w2").await;
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let app_ = app(state);
+
+    // PUT a credential in W1.
+    let put = Request::builder()
+        .method("PUT")
+        .uri(format!(
+            "/api/workspaces/{}/credentials/CLAUDE_CODE_OAUTH_TOKEN",
+            w1.id
+        ))
+        .header(header::COOKIE, cookie(&session_token))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({ "value": "w1-secret" }).to_string(),
+        ))
+        .unwrap();
+    let resp = app_.clone().oneshot(put).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // GET in W1 sees it.
+    let list_w1 = Request::builder()
+        .uri(format!("/api/workspaces/{}/credentials", w1.id))
+        .header(header::COOKIE, cookie(&session_token))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app_.clone().oneshot(list_w1).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    let names: Vec<&str> = body["credentials"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["CLAUDE_CODE_OAUTH_TOKEN"]);
+
+    // GET in W2 — same user, different workspace — sees nothing.
+    let list_w2 = Request::builder()
+        .uri(format!("/api/workspaces/{}/credentials", w2.id))
+        .header(header::COOKIE, cookie(&session_token))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app_.oneshot(list_w2).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    assert!(body["credentials"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn credentials_in_other_workspace_404_for_non_member() {
+    let pool = test_pool().await;
+    let owner = seed_user(&pool, "owner", 1).await;
+    let outsider = seed_user(&pool, "outsider", 2).await;
+    let w1 = seed_workspace(&pool, &owner.id, "w1").await;
+    // outsider has no membership in w1.
+    let outsider_token = seed_session_cookie(&pool, &outsider.id).await;
+    let state = AppState::new(pool, auth_enabled_config(), None);
+
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/workspaces/{}/credentials", w1.id))
+                .header(header::COOKIE, cookie(&outsider_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Outsider must see workspace-not-found, not the credential surface.
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ── credential lookup at session-launch time ──
+
+#[tokio::test]
+async fn workspace_scoped_credential_lookup_returns_only_the_workspace_value() {
+    // Direct DB-level check that the per-workspace lookup honours the
+    // partition: a user with two workspaces holding the same credential
+    // name in each gets the W1 value when asked about W1, never the W2
+    // value (and vice versa). This is the contract the session-launch
+    // path relies on to send the right token to the agent runner.
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w1 = seed_workspace(&pool, &user.id, "w1").await;
+    let w2 = seed_workspace(&pool, &user.id, "w2").await;
+    let key = stiglab::server::auth::generate_credential_key();
+
+    let enc_w1 = stiglab::server::auth::encrypt_credential(&key, "w1-token").unwrap();
+    let enc_w2 = stiglab::server::auth::encrypt_credential(&key, "w2-token").unwrap();
+    db::set_user_credential(&pool, &w1.id, &user.id, "CLAUDE_CODE_OAUTH_TOKEN", &enc_w1)
+        .await
+        .unwrap();
+    db::set_user_credential(&pool, &w2.id, &user.id, "CLAUDE_CODE_OAUTH_TOKEN", &enc_w2)
+        .await
+        .unwrap();
+
+    let creds_w1 = db::get_all_user_credential_values(&pool, &w1.id, &user.id)
+        .await
+        .unwrap();
+    assert_eq!(creds_w1.len(), 1);
+    let plaintext_w1 = stiglab::server::auth::decrypt_credential(&key, &creds_w1[0].1).unwrap();
+    assert_eq!(plaintext_w1, "w1-token");
+
+    let creds_w2 = db::get_all_user_credential_values(&pool, &w2.id, &user.id)
+        .await
+        .unwrap();
+    assert_eq!(creds_w2.len(), 1);
+    let plaintext_w2 = stiglab::server::auth::decrypt_credential(&key, &creds_w2[0].1).unwrap();
+    assert_eq!(plaintext_w2, "w2-token");
+}
+
+// ── github_app_installations.install_id is UNIQUE ──
+
+#[tokio::test]
+async fn github_app_install_id_is_unique() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "u", 1).await;
+    let w1 = seed_workspace(&pool, &user.id, "w1").await;
+    let w2 = seed_workspace(&pool, &user.id, "w2").await;
+
+    let install_a = stiglab::core::GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: w1.id.clone(),
+        install_id: 42,
+        account_login: "acme".into(),
+        account_type: stiglab::core::GitHubAccountType::Organization,
+        created_at: Utc::now(),
+    };
+    db::insert_github_app_installation(&pool, &install_a, None)
+        .await
+        .unwrap();
+
+    // Re-using the same numeric install_id under a different workspace
+    // must fail — the unique index documented in
+    // `migrations/002_workspace_scoped_credentials.sql` enforces the
+    // 1:1 install_id ↔ workspace_id invariant the webhook handler
+    // depends on.
+    let install_b = stiglab::core::GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: w2.id.clone(),
+        install_id: 42,
+        account_login: "globex".into(),
+        account_type: stiglab::core::GitHubAccountType::Organization,
+        created_at: Utc::now(),
+    };
+    let result = db::insert_github_app_installation(&pool, &install_b, None).await;
+    assert!(
+        result.is_err(),
+        "duplicate install_id must violate the UNIQUE index"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #164 (Child C of #161). After Children A (#162, spine `workspace_id` columns) and B (#163, stiglab `tenant_id` → `workspace_id` rename) landed, this child wires the workspace column into the API surface so the parent's contract test passes:

- **List endpoints** (`/api/sessions`, `/api/nodes`, `/api/spine/{events,artifacts}`) require `?workspace=<id>` — missing → 400, non-member → 404.
- **Detail endpoints** (`/api/sessions/:id`, `/api/spine/artifacts/:id`, retry/abort/override-gate) load the row's `workspace_id` and 404 (not 403) on mismatch via the existing `require_workspace_access` helper.
- **Credentials** moved from global `/api/credentials` to per-workspace `/api/workspaces/:workspace/credentials`. The migration adds `workspace_id NOT NULL` to `user_credentials`, backfills from the user's first membership, drops unreachable rows, and replaces the `(user_id, name)` unique with `(workspace_id, user_id, name)`.
- **Session launch** resolves the artifact's workspace from the spine (`artifacts.workspace_id` from #162) and fetches the credential bundle for `(workspace_id, owner_user_id)`. Direct task POSTs scoped to a project inherit that project's workspace.
- **Webhook ingress** resolves `install_id → workspace_id` once and stamps the workspace onto every emitted spine event regardless of the typed `FactoryEventKind` variant. A new `UNIQUE(install_id)` index enforces the 1:1 invariant the spec calls out.

## Delivers

- [x] `require_workspace_access` helper (already existed; routes funnel through it)
- [x] List endpoints filter by `?workspace=`, reject missing as 400
- [x] Detail endpoints validate workspace; 404 on mismatch
- [x] Credentials migration + per-workspace route surface; old `/api/credentials` removed
- [x] Session launch passes workspace-scoped credentials
- [x] Webhook handlers resolve workspace from install record
- [x] `UNIQUE(install_id)` on `github_app_installations`
- [x] Integration tests for the spec's six contract items

Forge dropped from scope: the open question in the spec resolved to "forge has no user-facing list endpoints" — its `/api/{health,status,artifacts}` are operational/admin only.

## Test plan

- [x] `cargo test --workspace --lib` clean (with `RUSTFLAGS="-D warnings"`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo run -p xtask -- lint-seams` clean
- [x] New `tests/workspace_scoping.rs` covers: missing `?workspace=` → 400 (sessions, nodes); cross-workspace listing leak; 404 vs 403 on detail mismatch; PAT-pinned-W1 → W2 returns 403 with `pat_workspace_scope_mismatch`; per-workspace credential isolation; `install_id` UNIQUE.
- [x] Existing `tests/pats.rs` updated to the new `/api/workspaces/:workspace/credentials/...` paths and 5-arg `set_user_credential` signature.
- [ ] Manual: run a session in W1 with W1-only `CLAUDE_CODE_OAUTH_TOKEN` and confirm it dispatches with that token (requires Postgres + agent connection — not exercised in CI).

https://claude.ai/code/session_01KpzbGQNiBuigPGsJK3W8hH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpzbGQNiBuigPGsJK3W8hH)_