### PR TITLE
fix(dev-infra): apply all spine migrations, not just 001-004

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,11 @@ services:
       PGPASSWORD: onsager
     entrypoint: >
       sh -c "
-        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/001_initial.sql &&
-        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/002_artifacts.sql &&
-        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/003_artifacts_git_context.sql &&
-        psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f /migrations/004_artifact_pipeline.sql
+        set -e;
+        for f in /migrations/*.sql; do
+          echo \"==> applying $$f\";
+          psql -X -v ON_ERROR_STOP=1 -h db -U onsager -d onsager -f \"$$f\";
+        done
       "
 
 volumes:

--- a/justfile
+++ b/justfile
@@ -115,10 +115,12 @@ dev-synodic port="3001":
 
 # ── DB ───────────────────────────────────────────────────────────────
 db-migrate:
-    psql "$DATABASE_URL" -f crates/onsager-spine/migrations/001_initial.sql
-    psql "$DATABASE_URL" -f crates/onsager-spine/migrations/002_artifacts.sql
-    psql "$DATABASE_URL" -f crates/onsager-spine/migrations/003_artifacts_git_context.sql
-    psql "$DATABASE_URL" -f crates/onsager-spine/migrations/004_artifact_pipeline.sql
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for f in crates/onsager-spine/migrations/*.sql; do
+        echo "==> applying $f"
+        psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f "$f"
+    done
 
 # ── Test (with spine integration) ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- The migrate compose service and the `just db-migrate` recipe both hardcoded migrations 001–004, so a fresh `just dev-infra` left the DB seven migrations behind (no `workflows` table, no `current_version_id`, no workspace_id columns).
- Forge surfaced this on startup as a per-second `relation "workflows" does not exist` / `column "current_version_id" does not exist` log loop; reproducing required noticing the loop and applying 005–011 by hand.
- Both call sites now glob `*.sql` and apply in sorted order (the 3-digit prefix gives the correct sequence), so the schema stays current as new migrations land.

## Test plan
- [x] `docker compose run --rm migrate` against an existing DB applies all 11 migrations idempotently — verified locally, no errors.
- [x] `docker compose config` resolves `$$f` correctly (compose escapes to `$f` for the shell).
- [ ] CI pipeline passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)