### PR TITLE
feat(stiglab,dashboard): drop anonymous mode, add dev-login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,11 @@ ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # STIGLAB_MAX_SESSIONS=4
 # STIGLAB_AGENT_COMMAND=claude
 # STIGLAB_NODE_NAME=main
-# GitHub OAuth (optional — auth disabled when unset)
+# GitHub OAuth — required for real users (issue #193).
+# Unset is OK in local dev: debug builds expose a "Dev Login as
+# ${USER}@local" button on the LoginPage that mints a session for a
+# seeded local user (cargo build --release strips this entirely). To
+# log in as your real GitHub identity locally, set both vars below.
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
 # STIGLAB_CREDENTIAL_KEY=          # 32-byte hex key for AES-256-GCM credential encryption

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ just dev                   # Postgres, migrations, and all services
 just smoke-test            # verify everything works (in another terminal)
 ```
 
+Open the dashboard at http://localhost:5173 and click **Dev Login** —
+debug builds (the default `cargo build` / `just dev` profile) seed a
+`${USER}@local` user plus a default workspace and expose a one-click
+login button on the LoginPage. A persistent banner reminds you you're
+in dev mode. Release builds (`cargo build --release`) strip the
+seeder + the `/api/auth/dev-login` route entirely; production deploys
+must use real GitHub OAuth.
+
+To use your real GitHub identity locally instead, set
+`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in `.env` and click
+**Sign in with GitHub** on the LoginPage.
+
 To run agent sessions, add your `CLAUDE_CODE_OAUTH_TOKEN` via
 **Dashboard → Settings → Credentials** (encrypted at rest, passed to agents
 as env vars).

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import { PageSkeleton } from "@/components/layout/PageSkeleton"
 import { LoginPage } from "@/pages/LoginPage"
 import { api } from "@/lib/api"
 import { readLastUsedWorkspace, WorkspaceScope } from "@/lib/workspace"
+import { DevModeBanner } from "@/components/layout/DevModeBanner"
 import type { ReactNode } from "react"
 
 const FactoryOverviewPage = lazy(() =>
@@ -76,18 +77,15 @@ const queryClient = new QueryClient({
 })
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
-  const { user, loading, authEnabled } = useAuth()
+  const { user, loading } = useAuth()
 
   if (loading) {
     return <AppShellSkeleton />
   }
 
-  // If auth is not enabled, allow access
-  if (!authEnabled) {
-    return <>{children}</>
-  }
-
-  // If auth is enabled but no user, redirect to login
+  // Auth is always-on as of #193 — anonymous mode is gone. Either the
+  // user has a real session (GitHub OAuth or dev-login in debug builds)
+  // or they bounce to /login.
   if (!user) {
     return <Navigate to="/login" replace />
   }
@@ -115,16 +113,13 @@ function LazyRoute({
 const ONBOARDING_SEEN_KEY = "onsager.onboarding_seen"
 
 function OnboardingGate({ children }: { children: ReactNode }) {
-  const { user, authEnabled } = useAuth()
   const location = useLocation()
-  // Only run the onboarding redirect for authenticated users — anonymous
-  // mode (auth disabled or no session) has no workspace concept to gate.
-  const gateEnabled = authEnabled && !!user
+  // ProtectedRoute already enforces an authenticated user, so the query
+  // can fire unconditionally — there's no anonymous branch to skip.
   const { data, isLoading } = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
     staleTime: 30_000,
-    enabled: gateEnabled,
   })
   const workspaces = data?.workspaces ?? []
   const seen =
@@ -141,13 +136,7 @@ function OnboardingGate({ children }: { children: ReactNode }) {
     }
   }, [onWorkspaces])
 
-  if (
-    gateEnabled &&
-    !isLoading &&
-    workspaces.length === 0 &&
-    !seen &&
-    !onWorkspaces
-  ) {
+  if (!isLoading && workspaces.length === 0 && !seen && !onWorkspaces) {
     return <Navigate to="/workspaces?welcome=1" replace />
   }
 
@@ -157,31 +146,17 @@ function OnboardingGate({ children }: { children: ReactNode }) {
 // Bare-path redirect: `/` → `/workspaces/<active>` if the user has a
 // workspace, otherwise let `OnboardingGate` send them to the picker.
 // "Active" is last-used (localStorage) when valid, else memberships[0].
-// Anonymous mode (auth disabled or no user) keeps the legacy bare path
-// rendering FactoryOverview directly so the existing demo flow still works.
 function BarePathRedirect() {
-  const { user, authEnabled, loading } = useAuth()
-  const gateEnabled = authEnabled && !!user
+  const { loading } = useAuth()
   const { data, isLoading } = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
     staleTime: 30_000,
-    enabled: gateEnabled,
   })
   const workspaces = data?.workspaces ?? []
 
-  if (loading || (gateEnabled && isLoading)) {
+  if (loading || isLoading) {
     return <AppShellSkeleton />
-  }
-
-  if (!gateEnabled) {
-    // Anonymous / auth-disabled: render the global Factory overview at
-    // `/`, same as before. There's no workspace to scope to.
-    return (
-      <LazyRoute>
-        <FactoryOverviewPage />
-      </LazyRoute>
-    )
   }
 
   if (workspaces.length === 0) {
@@ -195,60 +170,6 @@ function BarePathRedirect() {
   return <Navigate to={`/workspaces/${active.slug}`} replace />
 }
 
-// Per-resource legacy redirect: `/sessions` → `/workspaces/<active>/sessions`.
-// One release of compat per spec #166; tracked by bridge-debt follow-up issue
-// at land time.
-//
-// Anonymous mode (`authEnabled=false` or signed out) has no workspace concept;
-// the post-#166 list pages require WorkspaceContext (they call
-// `useActiveWorkspace()`), so anonymous-mode users can't render those pages
-// directly anymore. We bounce them to `/` (the FactoryOverview, which works
-// without a workspace) instead of pretending the legacy path renders. Once
-// #164 lands and `workspace_id` becomes mandatory at the API, this branch
-// goes away with the legacy redirect itself.
-function LegacyRedirect({ to }: { to: string }) {
-  const { user, authEnabled } = useAuth()
-  const gateEnabled = authEnabled && !!user
-  const { data, isLoading } = useQuery({
-    queryKey: ["workspaces"],
-    queryFn: api.listWorkspaces,
-    staleTime: 30_000,
-    enabled: gateEnabled,
-  })
-  const workspaces = data?.workspaces ?? []
-  const location = useLocation()
-
-  if (gateEnabled && isLoading) return <AppShellSkeleton />
-
-  if (!gateEnabled) {
-    // Anonymous / auth-disabled: send to the overview at `/`. Pages here
-    // require WorkspaceContext, which doesn't exist without auth.
-    return <Navigate to="/" replace />
-  }
-
-  if (workspaces.length === 0) {
-    // Authed but zero memberships — OnboardingGate ultimately runs the
-    // welcome flow; bouncing to the picker keeps the screen non-empty
-    // until that fires.
-    return <Navigate to="/workspaces" replace />
-  }
-
-  const lastUsed = readLastUsedWorkspace()
-  const active = workspaces.find((w) => w.slug === lastUsed) ?? workspaces[0]
-  const search = location.search ?? ""
-  return (
-    <Navigate to={`/workspaces/${active.slug}/${to}${search}`} replace />
-  )
-}
-
-// Trailing-segment redirect for `/sessions/:id`, `/artifacts/:id`,
-// `/workflows/:id`. Reads the dynamic param and tacks it on.
-function LegacyDetailRedirect({ resource }: { resource: string }) {
-  const params = useParams()
-  const id = params.id ?? ""
-  return <LegacyRedirect to={`${resource}/${id}`} />
-}
-
 // Issue #82 first-run redirect: when an authed user with ≥1 workspace has
 // zero workflows and lands on a workspace overview, bounce them to that
 // workspace's workflows page once so the stepped hero can pitch the
@@ -257,10 +178,8 @@ function LegacyDetailRedirect({ resource }: { resource: string }) {
 const WORKFLOWS_ONBOARDING_SEEN_KEY = "onsager.workflows_onboarding_seen"
 
 function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
-  const { user, authEnabled } = useAuth()
   const location = useLocation()
   const params = useParams<{ workspace?: string }>()
-  const gateEnabled = authEnabled && !!user
   const slug = params.workspace ?? ""
 
   // Fire both queries in parallel — the old code chained `workflows` on
@@ -271,7 +190,6 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
     staleTime: 30_000,
-    enabled: gateEnabled,
   })
   const hasWorkspace = (workspacesData?.workspaces?.length ?? 0) > 0
 
@@ -279,7 +197,6 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
     queryKey: ["workflows", "user"],
     queryFn: () => api.listWorkflowsForUser(),
     staleTime: 30_000,
-    enabled: gateEnabled,
   })
   const workflowsCount = workflowsData?.workflows?.length ?? 0
 
@@ -298,7 +215,6 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
   }, [onWorkflows])
 
   if (
-    gateEnabled &&
     hasWorkspace &&
     !workflowsLoading &&
     workflowsCount === 0 &&
@@ -312,7 +228,7 @@ function WorkflowsFirstRunGate({ children }: { children: ReactNode }) {
 }
 
 function AppRoutes() {
-  const { user, loading, authEnabled } = useAuth()
+  const { user, loading } = useAuth()
 
   if (loading) {
     return <AppShellSkeleton />
@@ -322,20 +238,18 @@ function AppRoutes() {
     <Routes>
       <Route
         path="/login"
-        element={
-          // If already logged in or auth disabled, redirect to dashboard
-          !authEnabled || user ? <Navigate to="/" replace /> : <LoginPage />
-        }
+        element={user ? <Navigate to="/" replace /> : <LoginPage />}
       />
       <Route
         path="/*"
         element={
           <ProtectedRoute>
+            <DevModeBanner />
             <AppLayout>
               <OnboardingGate>
                 <Routes>
-                  {/* Bare path: redirect to last-used workspace (or render
-                      Factory overview in anonymous mode). */}
+                  {/* Bare path: redirect to last-used workspace. With auth
+                      always-on (#193), every user has a membership context. */}
                   <Route path="/" element={<BarePathRedirect />} />
 
                   {/* Workspace picker / list. Stays unscoped — the user
@@ -423,38 +337,6 @@ function AppRoutes() {
                         </WorkflowsFirstRunGate>
                       </WorkspaceScope>
                     }
-                  />
-
-                  {/* Legacy redirects: one release of compat per spec
-                      #166. Tracked by a bridge-debt follow-up issue. */}
-                  <Route path="/sessions" element={<LegacyRedirect to="sessions" />} />
-                  <Route
-                    path="/sessions/:id"
-                    element={<LegacyDetailRedirect resource="sessions" />}
-                  />
-                  <Route path="/nodes" element={<LegacyRedirect to="nodes" />} />
-                  <Route path="/artifacts" element={<LegacyRedirect to="artifacts" />} />
-                  <Route
-                    path="/artifacts/:id"
-                    element={<LegacyDetailRedirect resource="artifacts" />}
-                  />
-                  <Route path="/issues" element={<LegacyRedirect to="issues" />} />
-                  <Route path="/spine" element={<LegacyRedirect to="spine" />} />
-                  <Route
-                    path="/governance"
-                    element={<LegacyRedirect to="governance" />}
-                  />
-                  <Route
-                    path="/workflows"
-                    element={<LegacyRedirect to="workflows" />}
-                  />
-                  <Route
-                    path="/workflows/start"
-                    element={<LegacyRedirect to="workflows/start" />}
-                  />
-                  <Route
-                    path="/workflows/:id"
-                    element={<LegacyDetailRedirect resource="workflows" />}
                   />
                 </Routes>
               </OnboardingGate>

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -15,7 +15,6 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar"
-import { useAuth } from "@/lib/auth"
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
 import { SetupChecklist } from "@/components/workspaces/SetupChecklist"
 import { useSetupProgress } from "@/hooks/useSetupProgress"
@@ -72,46 +71,43 @@ const SCOPED_SECTIONS: NavSection[] = [
 
 export function AppSidebar() {
   const location = useLocation()
-  const { user, authEnabled } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
   // Call the progress hook once at the sidebar root and thread the result
   // down — avoids a second observer/render path when SetupChecklist mounts.
   const setupProgress = useSetupProgress()
   const { hasWorkspace, workspacesLoading } = setupProgress
   const activeWorkspace = useOptionalActiveWorkspace()
-  const authed = authEnabled && !!user
 
-  // Anonymous mode (auth disabled or signed out) has no workspace concept,
-  // so legacy paths render at the root and the resource nav points at
-  // them directly. The progressive nav from #72 also lands here for
-  // authed-but-zero-workspace users — they only see the workspace-picker
-  // entry until they create one.
+  // Auth is always-on as of #193. Pages outside a scoped route (the
+  // workspace picker, account settings) leave `activeWorkspace` null
+  // and route nav back to `/workspaces` so the user picks one.
   const linkBase = activeWorkspace
     ? `/workspaces/${activeWorkspace.slug}`
-    : ""
-  const overviewPath = linkBase || "/"
+    : null
+  const overviewPath = linkBase ?? "/workspaces"
 
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false)
   }
 
-  // Progressive disclosure: authenticated users with zero workspaces only
-  // see the System group + the switcher (which handles "create workspace").
+  // Progressive disclosure: users with zero workspaces only see the
+  // System group + the switcher (which handles "create workspace").
   // Once the first workspace lands the full nav unlocks. Gate on
   // workspacesLoading only (not the aggregate `loading`) so the nav
   // decision doesn't wait for the slower projects/installs queries.
-  const gateNav = authed && !workspacesLoading && !hasWorkspace
+  const gateNav = !workspacesLoading && !hasWorkspace
   const visibleSections = SCOPED_SECTIONS.filter((s) => {
     if (gateNav && s.label !== "System") return false
     return true
   })
 
-  // Prefix every nav item's path with the active workspace's root, or
-  // — in anonymous / no-workspace mode — render the legacy bare path so
-  // the link still resolves through the App.tsx legacy redirects.
+  // Prefix every nav item's path with the active workspace's root.
+  // Outside a scoped route (e.g. while the picker is mounted) we point
+  // the suffix-less Overview row at the picker so the user lands
+  // somewhere they can pick a workspace.
   const resolvePath = (suffix: string): string => {
     if (suffix === "") return overviewPath
-    return linkBase ? `${linkBase}/${suffix}` : `/${suffix}`
+    return linkBase ? `${linkBase}/${suffix}` : "/workspaces"
   }
 
   return (
@@ -123,7 +119,7 @@ export function AppSidebar() {
         </Link>
       </SidebarHeader>
       <SidebarContent>
-        {authed && <WorkspaceSwitcher />}
+        <WorkspaceSwitcher />
         {visibleSections.map((section) => (
           <SidebarGroup key={section.label}>
             <SidebarGroupLabel>{section.label}</SidebarGroupLabel>

--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/components/ui/command"
 import { CreateSessionSheet } from "@/components/sessions/CreateSessionSheet"
 import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
-import { useAuth } from "@/lib/auth"
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
 
 // Single global "do something" surface — create a primitive or jump to
@@ -105,8 +104,6 @@ export function CommandPaletteTrigger() {
 function CommandPaletteDialog() {
   const { open, setOpen } = usePalette()
   const navigate = useNavigate()
-  const { user, authEnabled } = useAuth()
-  const canAuth = authEnabled && !!user
   const activeWorkspace = useOptionalActiveWorkspace()
 
   const [sessionOpen, setSessionOpen] = useState(false)
@@ -117,14 +114,17 @@ function CommandPaletteDialog() {
     action()
   }
   const go = (path: string) => run(() => navigate(path))
-  // Scope deep-links to the active workspace when there is one. Falls
-  // back to the legacy bare path for anonymous mode (the App.tsx route
-  // table redirects to the picker for authed users without a workspace).
+  // Scope deep-links to the active workspace when there is one;
+  // otherwise route to the workspace picker so the user lands on a
+  // surface that can resolve the missing context (auth is always-on
+  // post-#193, so the picker is always reachable).
   const scoped = (suffix: string) =>
-    activeWorkspace ? `/workspaces/${activeWorkspace.slug}/${suffix}` : `/${suffix}`
+    activeWorkspace
+      ? `/workspaces/${activeWorkspace.slug}/${suffix}`
+      : "/workspaces"
   const overview = activeWorkspace
     ? `/workspaces/${activeWorkspace.slug}`
-    : "/"
+    : "/workspaces"
 
   return (
     <>
@@ -146,24 +146,20 @@ function CommandPaletteDialog() {
                 <Zap className="mr-2 h-4 w-4" />
                 New workflow
               </CommandItem>
-              {canAuth && (
-                <CommandItem
-                  keywords={["new"]}
-                  onSelect={() => run(() => setSessionOpen(true))}
-                >
-                  <Terminal className="mr-2 h-4 w-4" />
-                  New session
-                </CommandItem>
-              )}
-              {canAuth && (
-                <CommandItem
-                  keywords={["new", "tenant"]}
-                  onSelect={() => run(() => setWorkspaceOpen(true))}
-                >
-                  <Building2 className="mr-2 h-4 w-4" />
-                  New workspace
-                </CommandItem>
-              )}
+              <CommandItem
+                keywords={["new"]}
+                onSelect={() => run(() => setSessionOpen(true))}
+              >
+                <Terminal className="mr-2 h-4 w-4" />
+                New session
+              </CommandItem>
+              <CommandItem
+                keywords={["new", "tenant"]}
+                onSelect={() => run(() => setWorkspaceOpen(true))}
+              >
+                <Building2 className="mr-2 h-4 w-4" />
+                New workspace
+              </CommandItem>
             </CommandGroup>
 
             <CommandSeparator />
@@ -173,12 +169,10 @@ function CommandPaletteDialog() {
                 <Factory className="mr-2 h-4 w-4" />
                 Factory overview
               </CommandItem>
-              {canAuth && (
-                <CommandItem onSelect={() => go("/workspaces")}>
-                  <Building2 className="mr-2 h-4 w-4" />
-                  Workspaces
-                </CommandItem>
-              )}
+              <CommandItem onSelect={() => go("/workspaces")}>
+                <Building2 className="mr-2 h-4 w-4" />
+                Workspaces
+              </CommandItem>
               <CommandItem onSelect={() => go(scoped("workflows"))}>
                 <GitBranch className="mr-2 h-4 w-4" />
                 Workflows
@@ -215,12 +209,10 @@ function CommandPaletteDialog() {
       {sessionOpen && (
         <CreateSessionSheet open={sessionOpen} onOpenChange={setSessionOpen} />
       )}
-      {canAuth && (
-        <NewWorkspaceDialog
-          open={workspaceOpen}
-          onOpenChange={setWorkspaceOpen}
-        />
-      )}
+      <NewWorkspaceDialog
+        open={workspaceOpen}
+        onOpenChange={setWorkspaceOpen}
+      />
     </>
   )
 }

--- a/apps/dashboard/src/components/layout/DevModeBanner.tsx
+++ b/apps/dashboard/src/components/layout/DevModeBanner.tsx
@@ -1,0 +1,33 @@
+import { TerminalSquare } from "lucide-react"
+import { useAuth } from "@/lib/auth"
+
+/**
+ * Persistent banner shown only when the active session was minted via
+ * dev-login (issue #193). It's the discoverability surface for an
+ * otherwise-invisible primitive — without it, a returning user can land
+ * on the dashboard already authenticated as `${USER}@local` with no
+ * idea why their account looks the way it does.
+ *
+ * The banner is mounted unconditionally near the top of the app shell
+ * and self-hides when `session_kind` is anything other than `"dev"`. We
+ * keep it inside `<ProtectedRoute>` so it never paints on `/login`.
+ */
+export function DevModeBanner() {
+  const { user, sessionKind } = useAuth()
+  if (sessionKind !== "dev" || !user) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 border-b border-amber-300 bg-amber-50 px-4 py-1.5 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/60 dark:text-amber-100"
+    >
+      <TerminalSquare className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">
+        Dev mode — signed in as{" "}
+        <span className="font-mono font-medium">{user.github_login}</span>.
+        Build with <span className="font-mono">--release</span> to disable.
+      </span>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/layout/UserMenu.tsx
+++ b/apps/dashboard/src/components/layout/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronsUpDown, LogOut, Monitor, Moon, Settings, Sun, User as UserIcon } from "lucide-react"
+import { ChevronsUpDown, LogOut, Monitor, Moon, Settings, Sun } from "lucide-react"
 import { Link } from "react-router-dom"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
@@ -22,21 +22,22 @@ export interface UserMenuProps {
 }
 
 export function UserMenu({ variant = "icon" }: UserMenuProps) {
-  const { user, authEnabled, logout } = useAuth()
+  const { user, logout } = useAuth()
   const { setTheme } = useTheme()
 
+  // Auth is always-on as of #193 — `user` is non-null here for any
+  // mounted UserMenu (it lives behind ProtectedRoute).
   const initial = user?.github_name?.[0] ?? user?.github_login?.[0] ?? "?"
   const label = user?.github_name ?? user?.github_login ?? "Account"
-  const sublabel = authEnabled && user?.github_login ? `@${user.github_login}` : undefined
+  const sublabel = user?.github_login ? `@${user.github_login}` : undefined
 
-  const avatar =
-    authEnabled && user?.github_avatar_url ? (
-      <img src={user.github_avatar_url} alt={label} className="h-7 w-7 shrink-0 rounded-full" />
-    ) : (
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium uppercase text-muted-foreground">
-        {authEnabled ? initial : <UserIcon className="h-4 w-4" />}
-      </div>
-    )
+  const avatar = user?.github_avatar_url ? (
+    <img src={user.github_avatar_url} alt={label} className="h-7 w-7 shrink-0 rounded-full" />
+  ) : (
+    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium uppercase text-muted-foreground">
+      {initial}
+    </div>
+  )
 
   const trigger =
     variant === "row" ? (
@@ -73,7 +74,7 @@ export function UserMenu({ variant = "icon" }: UserMenuProps) {
         side={variant === "row" ? "top" : "bottom"}
         className="w-56"
       >
-        {authEnabled && user ? (
+        {user && (
           <>
             <DropdownMenuLabel className="flex flex-col gap-0.5 px-2 py-1.5">
               <span className="truncate text-sm font-medium text-foreground">
@@ -87,7 +88,7 @@ export function UserMenu({ variant = "icon" }: UserMenuProps) {
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
           </>
-        ) : null}
+        )}
         <DropdownMenuItem render={<Link to="/settings" />}>
           <Settings className="mr-2 h-4 w-4" />
           Settings
@@ -106,15 +107,11 @@ export function UserMenu({ variant = "icon" }: UserMenuProps) {
           <Monitor className="mr-2 h-4 w-4" />
           System
         </DropdownMenuItem>
-        {authEnabled && user && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onClick={logout}>
-              <LogOut className="mr-2 h-4 w-4" />
-              Sign out
-            </DropdownMenuItem>
-          </>
-        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={logout}>
+          <LogOut className="mr-2 h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/dashboard/src/hooks/useNodes.ts
+++ b/apps/dashboard/src/hooks/useNodes.ts
@@ -4,17 +4,17 @@ import { useAuth } from '@/lib/auth';
 import { useOptionalActiveWorkspace } from '@/lib/workspace';
 
 export function useNodes() {
-  // When auth is enabled, `/api/nodes` returns 401 for anonymous requests;
-  // firing the poll pre-login floods the console and the browser's network
-  // tab with 401s. Gate on resolved auth state so the query only runs once
-  // we know the user is logged in (or auth is disabled entirely).
-  const { user, loading, authEnabled } = useAuth();
+  // Wait for the AuthProvider's `/me` round-trip so the query doesn't
+  // fire before the session cookie is confirmed (firing pre-login
+  // floods the network tab with 401s). With auth always-on (#193) the
+  // gate is just `!loading && user`.
+  const { user, loading } = useAuth();
   const workspace = useOptionalActiveWorkspace();
   // CreateSessionSheet renders this hook from outside the scoped layout
   // (e.g. command palette before a workspace is picked). Skip the fetch
   // there — listing global nodes is meaningless once `/api/nodes`
   // requires `workspace_id` (#164).
-  const enabled = !loading && (!authEnabled || !!user) && !!workspace;
+  const enabled = !loading && !!user && !!workspace;
 
   return useQuery({
     queryKey: ['nodes', workspace?.id ?? ''],

--- a/apps/dashboard/src/hooks/useSetupProgress.ts
+++ b/apps/dashboard/src/hooks/useSetupProgress.ts
@@ -28,8 +28,11 @@ export interface SetupProgress {
  * and avoids double-fetching across callers.
  */
 export function useSetupProgress(): SetupProgress {
-  const { user, authEnabled } = useAuth()
-  const authed = Boolean(authEnabled && user)
+  const { user } = useAuth()
+  // Auth is always-on as of #193; `user` is non-null behind ProtectedRoute.
+  // The flag stays for any consumer that wants to know whether `/me`
+  // resolved (vs. still loading) before reacting to query results.
+  const authed = Boolean(user)
 
   const { data: wsData, isLoading: wsLoading } = useQuery({
     queryKey: ["workspaces"],

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -64,6 +64,13 @@ export interface User {
   github_avatar_url: string | null;
 }
 
+/**
+ * How the active session was minted (issue #193). `"github"` for a real
+ * OAuth session; `"dev"` for a `${USER}@local` session minted by the
+ * `/api/auth/dev-login` flow available only in debug builds.
+ */
+export type SessionKind = 'github' | 'dev';
+
 export interface Credential {
   name: string;
   created_at: string;
@@ -629,11 +636,22 @@ export const api = {
   getHealth: () => request<{ status: string; version: string }>('/health'),
   // Auth
   getMe: () =>
-    request<{ user: User; auth_enabled: boolean; via?: 'session' | 'pat' }>(
+    request<{ user: User; session_kind: SessionKind; via?: 'session' | 'pat' }>(
       '/auth/me',
     ),
   logout: () =>
     request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
+  /**
+   * Mint a session for the seeded `${USER}@local` dev user (issue #193).
+   * 404s in release builds — the route is `cfg(debug_assertions)`-gated
+   * server-side. The LoginPage probes for that 404 to decide whether to
+   * render the "Dev Login" button.
+   */
+  devLogin: () =>
+    request<{ ok: boolean; session_kind: SessionKind; user: User }>(
+      '/auth/dev-login',
+      { method: 'POST' },
+    ),
   // Personal Access Tokens (issue #143)
   listPats: () => request<{ pats: Pat[] }>('/pats'),
   createPat: (body: {

--- a/apps/dashboard/src/lib/auth.tsx
+++ b/apps/dashboard/src/lib/auth.tsx
@@ -1,17 +1,22 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react"
-import { api, ApiError, type User } from "./api"
+import { api, type SessionKind, type User } from "./api"
 
 interface AuthContextValue {
   user: User | null
   loading: boolean
-  authEnabled: boolean
+  /**
+   * How the session was minted, surfaced by `/api/auth/me`. `"github"` for
+   * a real OAuth session, `"dev"` for a debug-build dev-login session.
+   * `null` while loading or when the user is signed out (issue #193).
+   */
+  sessionKind: SessionKind | null
   logout: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   loading: true,
-  authEnabled: false,
+  sessionKind: null,
   logout: async () => {},
 })
 
@@ -22,25 +27,19 @@ export function useAuth() {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
+  const [sessionKind, setSessionKind] = useState<SessionKind | null>(null)
   const [loading, setLoading] = useState(true)
-  const [authEnabled, setAuthEnabled] = useState(false)
 
   useEffect(() => {
     api
       .getMe()
       .then((data) => {
         setUser(data.user)
-        setAuthEnabled(data.auth_enabled)
+        setSessionKind(data.session_kind)
       })
-      .catch((err) => {
+      .catch(() => {
         setUser(null)
-        // Only treat as "auth enabled" if the backend explicitly returned 401.
-        // Network errors or 404s (e.g. no backend running) mean auth is not available.
-        if (err instanceof ApiError && err.status === 401) {
-          setAuthEnabled(true)
-        } else {
-          setAuthEnabled(false)
-        }
+        setSessionKind(null)
       })
       .finally(() => setLoading(false))
   }, [])
@@ -50,12 +49,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await api.logout()
     } finally {
       setUser(null)
+      setSessionKind(null)
       window.location.href = "/login"
     }
   }, [])
 
   return (
-    <AuthContext.Provider value={{ user, loading, authEnabled, logout }}>
+    <AuthContext.Provider value={{ user, loading, sessionKind, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/apps/dashboard/src/lib/workspace.tsx
+++ b/apps/dashboard/src/lib/workspace.tsx
@@ -8,7 +8,6 @@ import {
 import { Navigate, useLocation, useParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { api, type Workspace } from "@/lib/api"
-import { useAuth } from "@/lib/auth"
 
 // Per spec #166: the active workspace is whatever lives at `:workspace`
 // in the URL. This provider validates the slug against the user's
@@ -46,16 +45,15 @@ export function readLastUsedWorkspace(): string | null {
   }
 }
 
-/** Fetch the user's workspaces. Disabled when auth is off + no user. */
+/** Fetch the user's workspaces. Auth is always-on as of #193 — the
+ * caller is behind ProtectedRoute so the query can fire unconditionally.
+ */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useWorkspacesQuery() {
-  const { user, authEnabled } = useAuth()
-  const enabled = !authEnabled || !!user
   return useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
     staleTime: 30_000,
-    enabled,
   })
 }
 

--- a/apps/dashboard/src/pages/FactoryOverviewPage.tsx
+++ b/apps/dashboard/src/pages/FactoryOverviewPage.tsx
@@ -99,14 +99,13 @@ export function FactoryOverviewPage() {
   // stats, spine events, nodes, session spend, user workflows). The
   // dedicated `useNodes()` hook applies this gate too — see its
   // comment for the original motivation.
-  const { user, loading: authLoading, authEnabled } = useAuth()
+  const { loading: authLoading } = useAuth()
   const workspace = useOptionalActiveWorkspace()
-  const enabled = !authLoading && (!authEnabled || !!user)
-  // The page renders both scoped (`/workspaces/:slug`) and bare-path
-  // (anonymous mode at `/`) — outside a scoped route, the workspace id
-  // is empty and the backend treats the call as global. Once #164 lands
-  // and `workspace_id` becomes mandatory, the bare-path render will
-  // migrate to a no-workspace empty state instead.
+  const enabled = !authLoading
+  // The page renders inside a scoped (`/workspaces/:slug/*`) route, but
+  // it can also mount briefly on the bare-path redirect render before
+  // the navigate fires. `workspace?.id ?? ""` keeps the queries safe
+  // either way; the empty workspace id is filtered out by the API.
   const wsId = workspace?.id ?? ""
 
   const { data: artifactsData } = useQuery({

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -9,7 +9,6 @@ import {
   type ProjectIssueRow,
   type SpineArtifact,
 } from "@/lib/api"
-import { useAuth } from "@/lib/auth"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -48,9 +47,7 @@ type StateFilter = "open" | "closed" | "all"
  * connect a project before there's anything to render.
  */
 export function IssuesPage() {
-  const { authEnabled, user } = useAuth()
   const workspace = useActiveWorkspace()
-  const authed = !authEnabled || !!user
 
   // `?project=<id>` selects the active project on first render. Subsequent
   // user picks via the dropdown override into local state, so deep-links
@@ -63,7 +60,6 @@ export function IssuesPage() {
   const projectsQuery = useQuery({
     queryKey: ["projects-for-user"],
     queryFn: api.listAllProjects,
-    enabled: authed,
   })
   const projects: Project[] = useMemo(() => {
     const all = projectsQuery.data?.projects ?? []
@@ -93,7 +89,7 @@ export function IssuesPage() {
         kind: "github_issue",
         project_id: selectedProjectId ?? undefined,
       }),
-    enabled: authed && !!selectedProjectId,
+    enabled: !!selectedProjectId,
     refetchInterval: 15_000,
   })
 
@@ -106,7 +102,7 @@ export function IssuesPage() {
   const liveQuery = useQuery({
     queryKey: ["project-issues", selectedProjectId, stateFilter],
     queryFn: () => api.listProjectIssues(selectedProjectId!, stateFilter),
-    enabled: authed && !!selectedProjectId,
+    enabled: !!selectedProjectId,
     refetchInterval: 60_000,
   })
 
@@ -191,16 +187,6 @@ export function IssuesPage() {
         />
       ) : null,
   })
-
-  if (!authed) {
-    return (
-      <div className="space-y-4">
-        <p className="text-muted-foreground">
-          Sign in to see your project's GitHub issues.
-        </p>
-      </div>
-    )
-  }
 
   if (projectsQuery.isLoading) {
     return <p className="py-8 text-center text-muted-foreground">Loading…</p>

--- a/apps/dashboard/src/pages/LoginPage.tsx
+++ b/apps/dashboard/src/pages/LoginPage.tsx
@@ -1,8 +1,61 @@
+import { useEffect, useState } from "react"
+import { TerminalSquare } from "lucide-react"
 import { OnsagerLogo } from "@/components/layout/OnsagerLogo"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { api, ApiError } from "@/lib/api"
 
+/**
+ * Login screen.
+ *
+ * Renders the GitHub OAuth entry-point unconditionally. The "Dev Login"
+ * button is conditional: we probe `/api/auth/dev-login` with a HEAD-style
+ * request and only render the button when the route exists, which is the
+ * case in `cargo build` (debug) but not `cargo build --release`. Issue
+ * #193 — anonymous mode was deleted; dev-login replaces it as the
+ * SSO-free path for local development.
+ */
 export function LoginPage() {
+  const [devAvailable, setDevAvailable] = useState(false)
+  const [devLoggingIn, setDevLoggingIn] = useState(false)
+  const [devError, setDevError] = useState<string | null>(null)
+
+  // Detect whether the server has the dev-login route. A bare GET is
+  // enough — debug builds reply 405 (route registered, wrong method);
+  // release builds reply 404 (route absent). Any non-404 means present.
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/auth/dev-login", { method: "GET" })
+      .then((r) => {
+        if (!cancelled) setDevAvailable(r.status !== 404)
+      })
+      .catch(() => {
+        // Network failure — leave the button hidden rather than
+        // letting a backend outage suggest dev-login is available.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function handleDevLogin() {
+    setDevLoggingIn(true)
+    setDevError(null)
+    try {
+      await api.devLogin()
+      // Cookie is now set; reload so AuthProvider re-fetches /me and the
+      // app shell renders behind the new session.
+      window.location.href = "/"
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? `dev-login failed (${err.status})`
+          : "dev-login failed"
+      setDevError(msg)
+      setDevLoggingIn(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-sm">
@@ -15,7 +68,7 @@ export function LoginPage() {
             Sign in to manage your distributed agent sessions.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
           <a
             href="/api/auth/github"
             className={buttonVariants({ size: "lg", className: "w-full" })}
@@ -25,6 +78,37 @@ export function LoginPage() {
             </svg>
             Sign in with GitHub
           </a>
+          {devAvailable && (
+            <>
+              <div className="relative my-1 flex items-center">
+                <div className="flex-1 border-t border-border" />
+                <span className="px-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  Local dev only
+                </span>
+                <div className="flex-1 border-t border-border" />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                className="w-full"
+                disabled={devLoggingIn}
+                onClick={handleDevLogin}
+              >
+                <TerminalSquare className="mr-2 h-5 w-5" />
+                {devLoggingIn ? "Signing in…" : "Dev Login"}
+              </Button>
+              {devError && (
+                <p className="text-center text-xs text-destructive">
+                  {devError}
+                </p>
+              )}
+              <p className="text-center text-[11px] text-muted-foreground">
+                Available in debug builds only. Build with{" "}
+                <span className="font-mono">--release</span> to disable.
+              </p>
+            </>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
+++ b/apps/dashboard/src/pages/PersonalAccessTokensPage.tsx
@@ -7,11 +7,9 @@ import {
   Copy,
   KeyRound,
   Plus,
-  ShieldAlert,
   Trash2,
 } from "lucide-react"
 
-import { useAuth } from "@/lib/auth"
 import { api, type Pat } from "@/lib/api"
 import { usePageHeader } from "@/components/layout/PageHeader"
 import { Button } from "@/components/ui/button"
@@ -386,22 +384,16 @@ function PatRow({ pat, workspaceName, onRevoke, isRevoking }: PatRowProps) {
 
 export function PersonalAccessTokensPage() {
   usePageHeader({ title: "Tokens", backTo: "/settings" })
-  const { user, authEnabled } = useAuth()
   const queryClient = useQueryClient()
   const [createOpen, setCreateOpen] = useState(false)
 
   const patsQuery = useQuery({
     queryKey: ["pats"],
     queryFn: api.listPats,
-    // PATs only make sense for an authenticated user — anonymous mode
-    // renders the "unavailable" stub below, so don't fire a doomed
-    // request that would just 401 and clutter logs.
-    enabled: authEnabled && !!user,
   })
   const workspacesQuery = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
-    enabled: authEnabled && !!user,
   })
 
   const revoke = useMutation({
@@ -417,30 +409,6 @@ export function PersonalAccessTokensPage() {
     const byId = new Map(workspaces.map((w) => [w.id, w.name]))
     return (id: string) => byId.get(id) ?? id
   }, [workspaces])
-
-  // Anonymous mode (auth disabled or no session) has no concept of a user
-  // to mint a PAT against — render a stub instead of a 401.
-  if (authEnabled && !user) {
-    return null
-  }
-  if (!authEnabled) {
-    return (
-      <div className="space-y-4">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShieldAlert className="h-4 w-4" />
-              Tokens unavailable
-            </CardTitle>
-            <CardDescription>
-              Personal access tokens require authentication. Configure GitHub
-              OAuth on this server to enable them.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
-    )
-  }
 
   const pats = patsQuery.data?.pats ?? []
 

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -13,7 +13,7 @@ import { usePageHeader } from "@/components/layout/PageHeader"
  */
 export function SettingsPage() {
   usePageHeader({ title: "Settings" })
-  const { user, authEnabled } = useAuth()
+  const { user } = useAuth()
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -24,8 +24,7 @@ export function SettingsPage() {
         </p>
       </div>
 
-      {/* Profile — only show when auth is enabled (not anonymous) */}
-      {authEnabled && user && (
+      {user && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base md:text-lg">
@@ -70,28 +69,24 @@ export function SettingsPage() {
         </CardContent>
       </Card>
 
-      {/* Personal Access Tokens link-out. Hidden in anonymous mode (no
-          user to mint a token against). */}
-      {authEnabled && user && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-              <KeyRound className="h-4 w-4" />
-              Personal access tokens
-            </CardTitle>
-            <CardDescription>
-              Bearer tokens for calling the Onsager API from CLIs, agents, and
-              scheduled jobs.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button render={<Link to="/settings/tokens" />} variant="outline">
-              Manage tokens
-              <ArrowRight className="ml-1 h-4 w-4" />
-            </Button>
-          </CardContent>
-        </Card>
-      )}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+            <KeyRound className="h-4 w-4" />
+            Personal access tokens
+          </CardTitle>
+          <CardDescription>
+            Bearer tokens for calling the Onsager API from CLIs, agents, and
+            scheduled jobs.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button render={<Link to="/settings/tokens" />} variant="outline">
+            Manage tokens
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/apps/dashboard/src/pages/WorkflowsPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowsPage.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { GitBranch, Plus } from "lucide-react"
 import { api } from "@/lib/api"
-import { useAuth } from "@/lib/auth"
 import { useActiveWorkspace } from "@/lib/workspace"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -13,15 +12,12 @@ import { usePageHeader } from "@/components/layout/PageHeader"
 
 export function WorkflowsPage() {
   usePageHeader({ title: "Workflows" })
-  const { user, authEnabled } = useAuth()
   const workspace = useActiveWorkspace()
-  const authed = authEnabled ? !!user : true
   const [creating, setCreating] = useState(false)
 
   const { data, isLoading } = useQuery({
     queryKey: ["workflows", workspace.id],
     queryFn: () => api.listWorkflows(workspace.id),
-    enabled: authed,
   })
   const workflows = data?.workflows ?? []
 

--- a/apps/dashboard/src/pages/WorkspacesPage.tsx
+++ b/apps/dashboard/src/pages/WorkspacesPage.tsx
@@ -2,9 +2,7 @@ import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useSearchParams } from "react-router-dom"
 import { api } from "@/lib/api"
-import { useAuth } from "@/lib/auth"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Plus } from "lucide-react"
 import { WorkspaceCard } from "@/components/workspaces/WorkspaceCard"
@@ -18,12 +16,9 @@ import { usePageHeader } from "@/components/layout/PageHeader"
  */
 export function WorkspacesPage() {
   usePageHeader({ title: "Workspaces" })
-  const { user, authEnabled } = useAuth()
-  const canLoadWorkspaces = Boolean(authEnabled && user)
   const { data, isLoading } = useQuery({
     queryKey: ["workspaces"],
     queryFn: api.listWorkspaces,
-    enabled: canLoadWorkspaces,
   })
   const workspaces = useMemo(() => data?.workspaces ?? [], [data])
   const [createOpen, setCreateOpen] = useState(false)
@@ -37,8 +32,7 @@ export function WorkspacesPage() {
     setSearchParams(next, { replace: true })
   }
 
-  const showOnboarding =
-    canLoadWorkspaces && !isLoading && (workspaces.length === 0 || welcome)
+  const showOnboarding = !isLoading && (workspaces.length === 0 || welcome)
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -53,7 +47,7 @@ export function WorkspacesPage() {
             auto-mirror repos — projects are opt-in per repo.
           </p>
         </div>
-        {canLoadWorkspaces && workspaces.length > 0 && (
+        {workspaces.length > 0 && (
           <Button
             onClick={() => {
               setCreateOpen(true)
@@ -66,16 +60,7 @@ export function WorkspacesPage() {
         )}
       </div>
 
-      {!canLoadWorkspaces && (
-        <Card>
-          <CardContent className="p-6 text-sm text-muted-foreground">
-            Workspaces require authentication. Sign in to create one and
-            manage GitHub installations, projects, and members.
-          </CardContent>
-        </Card>
-      )}
-
-      {canLoadWorkspaces && isLoading && (
+      {isLoading && (
         <div className="space-y-3">
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
@@ -91,8 +76,7 @@ export function WorkspacesPage() {
         />
       )}
 
-      {canLoadWorkspaces &&
-        !isLoading &&
+      {!isLoading &&
         workspaces.map((ws) => <WorkspaceCard key={ws.id} workspace={ws} />)}
 
       <NewWorkspaceDialog

--- a/crates/stiglab/src/main.rs
+++ b/crates/stiglab/src/main.rs
@@ -100,6 +100,16 @@ async fn run_server(
     let pool = db::init_pool(&config.database_url).await?;
     tracing::info!("database connected");
 
+    // Dev-login seeding (issue #193). Debug builds always materialize a
+    // `${USER}@local` user + `dev` workspace + membership, idempotently,
+    // so the LoginPage's "Dev Login" button always has a real user to
+    // mint a session for. Release builds skip this entirely — the
+    // symbol is `cfg(debug_assertions)`-gated, not just no-op'd.
+    #[cfg(debug_assertions)]
+    if let Err(e) = stiglab::server::dev_auth::seed_dev_user_and_workspace(&pool).await {
+        tracing::warn!("dev-login: seeder failed (non-fatal): {e}");
+    }
+
     // Connect to Onsager event spine if configured
     let spine = if let Ok(url) = std::env::var("ONSAGER_DATABASE_URL") {
         tracing::info!("connecting to onsager event spine...");

--- a/crates/stiglab/src/server/auth.rs
+++ b/crates/stiglab/src/server/auth.rs
@@ -282,8 +282,7 @@ pub async fn verify_pat(
 /// gate behavior on the principal kind.
 #[derive(Debug, Clone)]
 pub enum RequestPrincipal {
-    /// Cookie-based session (the existing `stiglab_session` flow), or the
-    /// synthetic anonymous principal when auth is disabled.
+    /// Cookie-based session (the `stiglab_session` flow).
     Session,
     /// PAT-authenticated request.  `pat_id` identifies the issuing token row;
     /// `workspace_id` pins the request to that workspace — every PAT is
@@ -309,8 +308,32 @@ impl RequestPrincipal {
     }
 }
 
+/// How the user behind a request was minted. The dashboard renders a
+/// persistent dev-mode banner when this is `Dev` (issue #193).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionKind {
+    /// Real GitHub OAuth user.
+    Github,
+    /// Local-only dev user seeded by `seed_dev_user_and_workspace` and
+    /// minted via `/api/auth/dev-login`. Only reachable in debug builds.
+    Dev,
+}
+
+/// Negative `github_id` is the type-level signal for a dev-seeded user
+/// (real GitHub user IDs are always positive). Centralized here so the
+/// seeder, the auth extractor, and `/api/auth/me` agree on the rule.
+pub fn session_kind_for_github_id(github_id: i64) -> SessionKind {
+    if github_id < 0 {
+        SessionKind::Dev
+    } else {
+        SessionKind::Github
+    }
+}
+
 /// Authenticated user extracted from request cookies or a PAT Bearer token.
-/// When auth is disabled (no GitHub config), returns a synthetic anonymous user.
+/// Auth is always-on as of issue #193 — every request must resolve to a
+/// real `users` row. There is no synthetic principal.
 #[derive(Debug, Clone)]
 pub struct AuthUser {
     pub user_id: String,
@@ -318,18 +341,7 @@ pub struct AuthUser {
     pub github_name: Option<String>,
     pub github_avatar_url: Option<String>,
     pub principal: RequestPrincipal,
-}
-
-impl AuthUser {
-    fn anonymous() -> Self {
-        AuthUser {
-            user_id: "anonymous".to_string(),
-            github_login: "anonymous".to_string(),
-            github_name: None,
-            github_avatar_url: None,
-            principal: RequestPrincipal::Session,
-        }
-    }
+    pub session_kind: SessionKind,
 }
 
 /// Pull the bearer token (if any) out of the `Authorization` header.
@@ -365,11 +377,6 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // If auth is not enabled, return anonymous user
-        if !state.config.auth_enabled() {
-            return Ok(AuthUser::anonymous());
-        }
-
         // 1) Try PAT Bearer token first. A valid PAT wins over any cookie
         //    on the same request — cookie + Bearer normally doesn't happen
         //    in practice, but a CLI smoke test of the dashboard shouldn't
@@ -417,6 +424,7 @@ impl FromRequestParts<AppState> for AuthUser {
                             }
                         });
 
+                        let session_kind = session_kind_for_github_id(user.github_id);
                         return Ok(AuthUser {
                             user_id: user.id,
                             github_login: user.github_login,
@@ -426,6 +434,7 @@ impl FromRequestParts<AppState> for AuthUser {
                                 pat_id: pat.id,
                                 workspace_id: pat.workspace_id,
                             },
+                            session_kind,
                         });
                     }
                     Ok(PatVerifyOutcome::Unknown)
@@ -458,13 +467,17 @@ impl FromRequestParts<AppState> for AuthUser {
 
         // Look up session in DB
         match db::get_auth_session(&state.db, &session_id).await {
-            Ok(Some(auth_session)) => Ok(AuthUser {
-                user_id: auth_session.user_id,
-                github_login: auth_session.user.github_login,
-                github_name: auth_session.user.github_name,
-                github_avatar_url: auth_session.user.github_avatar_url,
-                principal: RequestPrincipal::Session,
-            }),
+            Ok(Some(auth_session)) => {
+                let session_kind = session_kind_for_github_id(auth_session.user.github_id);
+                Ok(AuthUser {
+                    user_id: auth_session.user_id,
+                    github_login: auth_session.user.github_login,
+                    github_name: auth_session.user.github_name,
+                    github_avatar_url: auth_session.user.github_avatar_url,
+                    principal: RequestPrincipal::Session,
+                    session_kind,
+                })
+            }
             Ok(None) => Err((StatusCode::UNAUTHORIZED, "session expired").into_response()),
             Err(e) => {
                 tracing::error!("failed to look up auth session: {e}");
@@ -596,12 +609,25 @@ mod tests {
     }
 
     #[test]
-    fn test_auth_user_anonymous() {
-        let user = AuthUser::anonymous();
-        assert_eq!(user.user_id, "anonymous");
-        assert_eq!(user.github_login, "anonymous");
-        assert!(user.github_name.is_none());
-        assert!(matches!(user.principal, RequestPrincipal::Session));
+    fn session_kind_negative_github_id_is_dev() {
+        // Real GitHub IDs are always positive; the seeder uses negative IDs
+        // for dev-only users so the type is recoverable from the user row
+        // alone (no extra column on `auth_sessions`).
+        assert_eq!(session_kind_for_github_id(-1), SessionKind::Dev);
+        assert_eq!(session_kind_for_github_id(-9999), SessionKind::Dev);
+        assert_eq!(session_kind_for_github_id(0), SessionKind::Github);
+        assert_eq!(session_kind_for_github_id(123_456), SessionKind::Github);
+    }
+
+    #[test]
+    fn session_kind_serializes_lowercase() {
+        // The dashboard reads `session_kind: "github" | "dev"` from
+        // `/api/auth/me`; lock the wire shape down here.
+        assert_eq!(
+            serde_json::to_string(&SessionKind::Github).unwrap(),
+            "\"github\""
+        );
+        assert_eq!(serde_json::to_string(&SessionKind::Dev).unwrap(), "\"dev\"");
     }
 
     #[test]

--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -101,13 +101,10 @@ impl ServerConfig {
         config
     }
 
-    /// Returns true if GitHub OAuth is configured (both client ID and secret are set).
-    pub fn auth_enabled(&self) -> bool {
-        !matches!(self.sso_mode(), SsoMode::Disabled)
-    }
-
-    /// Classify the process's role in the SSO flow.
-    pub fn sso_mode(&self) -> SsoMode {
+    /// Classify the process's role in the SSO flow. `None` means no GitHub
+    /// OAuth is configured — the only path to authentication is dev-login
+    /// (debug builds only).
+    pub fn sso_mode(&self) -> Option<SsoMode> {
         let has_github = self.github_client_id.is_some() && self.github_client_secret.is_some();
         let has_owner_secrets =
             self.sso_state_secret.is_some() && self.sso_exchange_secret.is_some();
@@ -116,11 +113,11 @@ impl ServerConfig {
 
         if has_github {
             let delegate_enabled = has_owner_secrets && !self.sso_return_host_allowlist.is_empty();
-            SsoMode::Owner { delegate_enabled }
+            Some(SsoMode::Owner { delegate_enabled })
         } else if has_relying {
-            SsoMode::Relying
+            Some(SsoMode::Relying)
         } else {
-            SsoMode::Disabled
+            None
         }
     }
 
@@ -192,27 +189,15 @@ mod tests {
     }
 
     #[test]
-    fn auth_enabled_when_both_set() {
-        let config = make_config(Some("id"), Some("secret"));
-        assert!(config.auth_enabled());
-    }
-
-    #[test]
-    fn auth_disabled_when_id_missing() {
-        let config = make_config(None, Some("secret"));
-        assert!(!config.auth_enabled());
-    }
-
-    #[test]
-    fn auth_disabled_when_secret_missing() {
-        let config = make_config(Some("id"), None);
-        assert!(!config.auth_enabled());
-    }
-
-    #[test]
-    fn auth_disabled_when_both_missing() {
+    fn sso_mode_none_when_no_github_or_relying() {
+        // No OAuth env, no relying-side env — `sso_mode()` is `None` and
+        // dev-login is the only authentication path (debug builds only).
         let config = make_config(None, None);
-        assert!(!config.auth_enabled());
+        assert!(config.sso_mode().is_none());
+        let config = make_config(None, Some("secret"));
+        assert!(config.sso_mode().is_none());
+        let config = make_config(Some("id"), None);
+        assert!(config.sso_mode().is_none());
     }
 
     #[test]
@@ -220,9 +205,9 @@ mod tests {
         let c = make_config(Some("id"), Some("secret"));
         assert_eq!(
             c.sso_mode(),
-            SsoMode::Owner {
+            Some(SsoMode::Owner {
                 delegate_enabled: false
-            }
+            })
         );
     }
 
@@ -238,9 +223,9 @@ mod tests {
         };
         assert_eq!(
             c.sso_mode(),
-            SsoMode::Owner {
+            Some(SsoMode::Owner {
                 delegate_enabled: true
-            }
+            })
         );
     }
 
@@ -256,9 +241,9 @@ mod tests {
         };
         assert_eq!(
             c.sso_mode(),
-            SsoMode::Owner {
+            Some(SsoMode::Owner {
                 delegate_enabled: false
-            }
+            })
         );
     }
 
@@ -269,7 +254,7 @@ mod tests {
             sso_exchange_secret: Some("exchange-secret".into()),
             ..base_config()
         };
-        assert_eq!(c.sso_mode(), SsoMode::Relying);
+        assert_eq!(c.sso_mode(), Some(SsoMode::Relying));
     }
 
     #[test]

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -1589,24 +1589,6 @@ pub async fn list_sessions_for_user_in_workspace(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
-/// List every session in `workspace_id` regardless of owner. Used in the
-/// `auth_enabled = false` branch where the synthetic anonymous user has
-/// no membership rows to filter against.
-pub async fn list_sessions_in_workspace(
-    pool: &AnyPool,
-    workspace_id: &str,
-) -> anyhow::Result<Vec<Session>> {
-    let rows = sqlx::query_as::<_, SessionRow>(
-        "SELECT id, task_id, node_id, state, prompt, output, working_dir, \
-                artifact_id, artifact_version, created_at, updated_at \
-         FROM sessions WHERE workspace_id = $1 ORDER BY created_at DESC",
-    )
-    .bind(workspace_id)
-    .fetch_all(pool)
-    .await?;
-    rows.into_iter().map(|r| r.try_into()).collect()
-}
-
 pub async fn get_session_owner(pool: &AnyPool, session_id: &str) -> anyhow::Result<Option<String>> {
     let row = sqlx::query_scalar::<_, String>(
         "SELECT user_id FROM sessions WHERE id = $1 AND user_id IS NOT NULL",
@@ -1820,6 +1802,19 @@ pub async fn get_workspace(
         "SELECT id, slug, name, created_by, created_at FROM workspaces WHERE id = $1",
     )
     .bind(workspace_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn get_workspace_by_slug(
+    pool: &AnyPool,
+    slug: &str,
+) -> anyhow::Result<Option<Workspace>> {
+    let row = sqlx::query_as::<_, WorkspaceRow>(
+        "SELECT id, slug, name, created_by, created_at FROM workspaces WHERE slug = $1",
+    )
+    .bind(slug)
     .fetch_optional(pool)
     .await?;
     row.map(|r| r.try_into()).transpose()

--- a/crates/stiglab/src/server/dev_auth.rs
+++ b/crates/stiglab/src/server/dev_auth.rs
@@ -1,0 +1,234 @@
+//! Dev-login mode (issue #193). Local-dev-only replacement for the
+//! removed anonymous-mode branch.
+//!
+//! The whole module is `#[cfg(debug_assertions)]`-gated. Release builds
+//! (`cargo build --release`) physically do not contain the seeder or the
+//! `/api/auth/dev-login` route, so a misconfigured production deploy
+//! cannot serve dev-login regardless of env-var manipulation.
+//!
+//! Two pieces:
+//! - [`seed_dev_user_and_workspace`] is called once at server boot. It
+//!   idempotently materializes a per-developer `${USER}@local` user, a
+//!   default workspace, and the membership linking them. Re-running on a
+//!   warm DB produces no duplicate rows.
+//! - [`dev_login`] handles `POST /api/auth/dev-login` — clicking the
+//!   "Dev Login as ${USER}@local" button on `LoginPage` mints a real
+//!   session cookie for the seeded user.
+//!
+//! Why a negative `github_id`? Real GitHub user IDs are always positive,
+//! so the negative range is a free namespace for synthetic users. The
+//! auth extractor reads `user.github_id < 0` to decide
+//! `session_kind: dev`, which is what drives the dashboard's persistent
+//! dev-mode banner. No extra column on `auth_sessions` required.
+
+#![cfg(debug_assertions)]
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::core::{User, Workspace, WorkspaceMember};
+use crate::server::auth::{generate_session_token, SessionKind};
+use crate::server::db;
+use crate::server::state::AppState;
+
+/// Fixed `github_id` for the seeded dev user. Single value (not derived
+/// from `$USER`) keeps the seed idempotent across `$USER` changes — the
+/// row is always upserted on the same primary key.
+///
+/// Negative is the type-level `SessionKind::Dev` marker (see
+/// `auth::session_kind_for_github_id`).
+pub const DEV_GITHUB_ID: i64 = -1;
+
+/// Slug of the workspace the seeder creates.  Stable across boots so
+/// localhost links never break between restarts.
+pub const DEV_WORKSPACE_SLUG: &str = "dev";
+
+/// Resolve the username we'll seed.  `$USER` from the boot env, falling
+/// back to `dev` so the build works in CI and rootless containers where
+/// `$USER` may be unset.
+pub fn dev_username() -> String {
+    std::env::var("USER")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "dev".to_string())
+}
+
+/// `${USER}@local` — what shows up on the LoginPage button and the
+/// banner.
+pub fn dev_login_label(username: &str) -> String {
+    format!("{username}@local")
+}
+
+/// Idempotently materialize the dev user, the dev workspace, and the
+/// membership linking them.  Called once at server boot from `main.rs`.
+///
+/// Re-running on a warm DB does not duplicate rows: the user is upserted
+/// on `github_id = DEV_GITHUB_ID`; the workspace is fetched by slug
+/// before insert; the membership insert is `OR IGNORE`-style guarded.
+pub async fn seed_dev_user_and_workspace(pool: &sqlx::AnyPool) -> anyhow::Result<()> {
+    let username = dev_username();
+    let login = dev_login_label(&username);
+    let now = Utc::now();
+
+    // Resolve-or-create the user row.  `upsert_user` keys on `github_id`
+    // (UNIQUE) so the same negative ID survives across reboots.
+    let user_id = match db::get_user_by_github_id(pool, DEV_GITHUB_ID).await? {
+        Some(existing) => existing.id,
+        None => Uuid::new_v4().to_string(),
+    };
+    let user = User {
+        id: user_id.clone(),
+        github_id: DEV_GITHUB_ID,
+        github_login: login.clone(),
+        github_name: Some(format!("Dev ({username})")),
+        github_avatar_url: None,
+        created_at: now,
+        updated_at: now,
+    };
+    db::upsert_user(pool, &user).await?;
+
+    // Resolve-or-create the workspace.  Slug is the natural key here; a
+    // collision on a fresh DB is impossible because no real user can
+    // legally claim `dev` as a workspace slug before the seeder runs.
+    let existing_ws = db::get_workspace_by_slug(pool, DEV_WORKSPACE_SLUG).await?;
+    let workspace_id = match existing_ws {
+        Some(ref ws) => ws.id.clone(),
+        None => {
+            let ws = Workspace {
+                id: Uuid::new_v4().to_string(),
+                slug: DEV_WORKSPACE_SLUG.to_string(),
+                name: "Dev workspace".to_string(),
+                created_by: user_id.clone(),
+                created_at: now,
+            };
+            let member = WorkspaceMember {
+                workspace_id: ws.id.clone(),
+                user_id: user_id.clone(),
+                joined_at: now,
+            };
+            db::insert_workspace_with_creator(pool, &ws, &member).await?;
+            ws.id
+        }
+    };
+
+    // Membership might be missing on a workspace that pre-dated the
+    // seeder (or was created by an earlier `$USER`).  Backfill it.
+    if !db::is_workspace_member(pool, &workspace_id, &user_id).await? {
+        let member = WorkspaceMember {
+            workspace_id: workspace_id.clone(),
+            user_id: user_id.clone(),
+            joined_at: now,
+        };
+        db::insert_workspace_member(pool, &member).await?;
+    }
+
+    tracing::info!(
+        user_id = %user_id,
+        login = %login,
+        workspace = %DEV_WORKSPACE_SLUG,
+        "dev-login: seeded user + workspace (debug build)"
+    );
+    Ok(())
+}
+
+/// `POST /api/auth/dev-login` — mint a session cookie for the seeded dev
+/// user.  Debug-only: the route is not registered in release builds.
+pub async fn dev_login(State(state): State<AppState>) -> Response {
+    let user = match db::get_user_by_github_id(&state.db, DEV_GITHUB_ID).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            // Should never happen — `seed_dev_user_and_workspace` runs at
+            // boot.  Surface as 500 so the failure is loud rather than
+            // silently re-seeding here (which would mask boot bugs).
+            tracing::error!("dev-login: dev user missing; boot seeder didn't run?");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "dev user not seeded" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("dev-login: failed to load dev user: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+    };
+
+    let session_token = generate_session_token();
+    let expires_at = Utc::now() + chrono::Duration::days(30);
+    if let Err(e) = db::create_auth_session(&state.db, &session_token, &user.id, expires_at).await {
+        tracing::error!("dev-login: failed to create auth session: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+    }
+
+    tracing::info!(
+        user_id = %user.id,
+        login = %user.github_login,
+        "dev-login: minted session"
+    );
+
+    let secure = state
+        .config
+        .public_url
+        .as_deref()
+        .is_some_and(|u| u.starts_with("https://"));
+    let secure_attr = if secure { "; Secure" } else { "" };
+    let cookie = format!(
+        "stiglab_session={session_token}; Path=/; HttpOnly; SameSite=Lax; \
+         Max-Age=2592000{secure_attr}"
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::SET_COOKIE, cookie)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "ok": true,
+                "session_kind": SessionKind::Dev,
+                "user": {
+                    "id": user.id,
+                    "github_login": user.github_login,
+                    "github_name": user.github_name,
+                },
+            }))
+            .expect("dev-login response serializes"),
+        ))
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_username_falls_back_to_dev() {
+        // SAFETY: tests run single-threaded by default; we restore the
+        // env var below to keep cross-test ordering stable.
+        let prev = std::env::var("USER").ok();
+        std::env::remove_var("USER");
+        assert_eq!(dev_username(), "dev");
+        if let Some(v) = prev {
+            std::env::set_var("USER", v);
+        }
+    }
+
+    #[test]
+    fn dev_login_label_appends_at_local() {
+        assert_eq!(dev_login_label("alice"), "alice@local");
+        assert_eq!(dev_login_label("dev"), "dev@local");
+    }
+
+    #[test]
+    fn dev_github_id_is_negative_and_marks_dev() {
+        // Spec: dev users are recognized by negative github_id.
+        const _: () = assert!(DEV_GITHUB_ID < 0);
+        assert_eq!(
+            crate::server::auth::session_kind_for_github_id(DEV_GITHUB_ID),
+            SessionKind::Dev
+        );
+    }
+}

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -1,6 +1,8 @@
 pub mod auth;
 pub mod config;
 pub mod db;
+#[cfg(debug_assertions)]
+pub mod dev_auth;
 pub mod github_app;
 pub mod handler;
 pub mod proxy_cache;
@@ -266,6 +268,16 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/spine/artifacts/{id}/override-gate",
             post(routes::spine::override_gate),
         );
+
+    // Dev-login (issue #193). The route is only registered in debug
+    // builds — `cargo build --release` strips the symbol, so a release
+    // deploy physically cannot serve `/api/auth/dev-login` regardless of
+    // env-var configuration.
+    #[cfg(debug_assertions)]
+    let api_routes = api_routes.route(
+        "/api/auth/dev-login",
+        post(crate::server::dev_auth::dev_login),
+    );
 
     // Configure CORS
     let cors = if let Some(ref origin) = config.cors_origin {

--- a/crates/stiglab/src/server/routes/auth.rs
+++ b/crates/stiglab/src/server/routes/auth.rs
@@ -47,8 +47,8 @@ pub async fn github_login(
     let config = &state.config;
 
     match config.sso_mode() {
-        SsoMode::Disabled => (StatusCode::NOT_FOUND, "auth not configured").into_response(),
-        SsoMode::Relying => {
+        None => (StatusCode::NOT_FOUND, "auth not configured").into_response(),
+        Some(SsoMode::Relying) => {
             // Previews never talk to GitHub directly — bounce through prod.
             let auth_domain = config
                 .sso_auth_domain
@@ -75,7 +75,7 @@ pub async fn github_login(
             };
             Redirect::temporary(&target).into_response()
         }
-        SsoMode::Owner { delegate_enabled } => {
+        Some(SsoMode::Owner { delegate_enabled }) => {
             let Some(client_id) = config.github_client_id.as_deref() else {
                 return (StatusCode::NOT_FOUND, "auth not configured").into_response();
             };
@@ -148,7 +148,7 @@ pub async fn github_callback(
 ) -> impl IntoResponse {
     let config = &state.config;
 
-    let SsoMode::Owner { delegate_enabled } = config.sso_mode() else {
+    let Some(SsoMode::Owner { delegate_enabled }) = config.sso_mode() else {
         return (StatusCode::NOT_FOUND, "auth not configured").into_response();
     };
 
@@ -346,9 +346,9 @@ pub async fn sso_redeem(
 ) -> impl IntoResponse {
     let config = &state.config;
 
-    let SsoMode::Owner {
+    let Some(SsoMode::Owner {
         delegate_enabled: true,
-    } = config.sso_mode()
+    }) = config.sso_mode()
     else {
         return (StatusCode::NOT_FOUND, "not found").into_response();
     };
@@ -417,7 +417,7 @@ pub async fn sso_finish(
 ) -> impl IntoResponse {
     let config = &state.config;
 
-    if config.sso_mode() != SsoMode::Relying {
+    if config.sso_mode() != Some(SsoMode::Relying) {
         return (StatusCode::NOT_FOUND, "not found").into_response();
     }
 
@@ -537,8 +537,13 @@ pub async fn sso_finish(
 
 // ── /api/auth/me + logout (unchanged behavior) ──
 
-/// GET /api/auth/me — Return current authenticated user
-pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl IntoResponse {
+/// GET /api/auth/me — Return current authenticated user.
+///
+/// `session_kind` ("github" | "dev") replaces the legacy `auth_enabled`
+/// flag (issue #193). Auth is always-on, so a successful response means
+/// the caller is authenticated; the field signals which path minted the
+/// session, which drives the dashboard's persistent dev-mode banner.
+pub async fn me(State(_state): State<AppState>, auth_user: AuthUser) -> impl IntoResponse {
     let via = match auth_user.principal {
         RequestPrincipal::Pat { .. } => "pat",
         RequestPrincipal::Session => "session",
@@ -550,7 +555,7 @@ pub async fn me(State(state): State<AppState>, auth_user: AuthUser) -> impl Into
             "github_name": auth_user.github_name,
             "github_avatar_url": auth_user.github_avatar_url,
         },
-        "auth_enabled": state.config.auth_enabled(),
+        "session_kind": auth_user.session_kind,
         "via": via,
     }))
 }

--- a/crates/stiglab/src/server/routes/pats.rs
+++ b/crates/stiglab/src/server/routes/pats.rs
@@ -31,15 +31,9 @@ pub struct CreatePatBody {
 
 #[allow(clippy::result_large_err)]
 fn require_authenticated(auth_user: &AuthUser) -> Result<&str, Response> {
-    if auth_user.user_id == "anonymous" {
-        Err((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": "authentication required" })),
-        )
-            .into_response())
-    } else {
-        Ok(auth_user.user_id.as_str())
-    }
+    // Auth is always-on as of #193; the `AuthUser` extractor 401s
+    // unauthenticated requests before they reach this helper.
+    Ok(auth_user.user_id.as_str())
 }
 
 fn pat_summary(pat: &db::UserPat) -> serde_json::Value {

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -47,15 +47,9 @@ const DEFAULT_CAP: usize = 100;
 
 #[allow(clippy::result_large_err)]
 fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
-    if auth_user.user_id == "anonymous" {
-        Err((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": "authentication required" })),
-        )
-            .into_response())
-    } else {
-        Ok(auth_user.user_id.as_str())
-    }
+    // Auth is always-on as of #193; the `AuthUser` extractor 401s
+    // unauthenticated requests before they reach this helper.
+    Ok(auth_user.user_id.as_str())
 }
 
 /// Look up the project + assert the user is a member of its workspace. 404s

--- a/crates/stiglab/src/server/routes/sessions.rs
+++ b/crates/stiglab/src/server/routes/sessions.rs
@@ -62,20 +62,13 @@ pub async fn list_sessions(
         Err(r) => return r,
     };
 
-    // The synthetic anonymous principal has no membership rows, so the
-    // membership-check helper would 404 every request in
-    // auth_enabled = false mode. Skip the check there but still scope
-    // the query to the requested workspace.
-    let result = if auth_user.user_id == "anonymous" {
-        db::list_sessions_in_workspace(&state.db, &workspace_id).await
-    } else {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            return r;
-        }
-        db::list_sessions_for_user_in_workspace(&state.db, &auth_user.user_id, &workspace_id).await
-    };
+    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
+        return r;
+    }
 
-    match result {
+    match db::list_sessions_for_user_in_workspace(&state.db, &auth_user.user_id, &workspace_id)
+        .await
+    {
         Ok(sessions) => Json(serde_json::json!({ "sessions": sessions })).into_response(),
         Err(e) => {
             tracing::error!("failed to list sessions: {e}");
@@ -95,10 +88,6 @@ async fn authorize_session_read(
     auth_user: &AuthUser,
     session_id: &str,
 ) -> Result<Option<String>, Response> {
-    if auth_user.user_id == "anonymous" {
-        return Ok(None);
-    }
-
     let workspace_id = match db::get_session_workspace(&state.db, session_id).await {
         Ok(w) => w,
         Err(e) => {

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -96,11 +96,8 @@ pub async fn create_task(
         updated_at: Utc::now(),
     };
 
-    let user_id = if auth_user.user_id == "anonymous" {
-        None
-    } else {
-        Some(auth_user.user_id.as_str())
-    };
+    // Auth is always-on as of #193 — every request carries a real user.
+    let user_id: &str = auth_user.user_id.as_str();
 
     // Validate project membership if the caller scoped the session to a
     // workspace-owned project (issue #59). Non-members get 404 via
@@ -118,15 +115,6 @@ pub async fn create_task(
     // pick one rather than the server silently preferring one over the
     // other.
     let workspace_id: Option<String> = if let Some(ref project_id) = request.project_id {
-        if user_id.is_none() {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": "authentication required to scope a session to a project"
-                })),
-            )
-                .into_response();
-        };
         let project = match db::get_project(&state.db, project_id).await {
             Ok(Some(p)) => p,
             Ok(None) => {
@@ -163,15 +151,6 @@ pub async fn create_task(
         }
         Some(project.workspace_id)
     } else if let Some(ref explicit) = request.workspace_id {
-        if user_id.is_none() {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": "authentication required to scope a session to a workspace"
-                })),
-            )
-                .into_response();
-        }
         // 404 (not 403) on non-membership via the shared helper —
         // matches every other workspace-scoped surface so a caller
         // can't enumerate workspaces by probing this endpoint.
@@ -188,7 +167,7 @@ pub async fn create_task(
     if let Err(e) = db::insert_session_with_user_project_workspace(
         &state.db,
         &session,
-        user_id,
+        Some(user_id),
         request.project_id.as_deref(),
         workspace_id.as_deref(),
     )
@@ -202,9 +181,9 @@ pub async fn create_task(
     // sessions (no project, no workspace) get no credentials — the resulting
     // session_failed event surfaces the broken state via forge's listener
     // rather than silently launching an unauthenticated agent.
-    let credentials = match (user_id, workspace_id.as_deref()) {
-        (Some(uid), Some(ws)) => fetch_workspace_credentials(&state, ws, uid).await,
-        _ => None,
+    let credentials = match workspace_id.as_deref() {
+        Some(ws) => fetch_workspace_credentials(&state, ws, user_id).await,
+        None => None,
     };
 
     // Dispatch to agent via WebSocket

--- a/crates/stiglab/src/server/routes/workflows.rs
+++ b/crates/stiglab/src/server/routes/workflows.rs
@@ -81,15 +81,9 @@ fn bad_request(msg: impl Into<String>) -> Response {
 
 #[allow(clippy::result_large_err)]
 fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
-    if auth_user.user_id == "anonymous" {
-        Err((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": "authentication required" })),
-        )
-            .into_response())
-    } else {
-        Ok(auth_user.user_id.as_str())
-    }
+    // Auth is always-on as of #193; the `AuthUser` extractor 401s
+    // unauthenticated requests before they reach this helper.
+    Ok(auth_user.user_id.as_str())
 }
 
 /// Issue #156 (workspace-scoped post-#164): ensure the workflow's owner

--- a/crates/stiglab/src/server/routes/workspaces.rs
+++ b/crates/stiglab/src/server/routes/workspaces.rs
@@ -44,15 +44,13 @@ fn not_found(msg: &str) -> Response {
 
 #[allow(clippy::result_large_err)]
 fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
-    if auth_user.user_id == "anonymous" {
-        Err((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": "authentication required" })),
-        )
-            .into_response())
-    } else {
-        Ok(auth_user.user_id.as_str())
-    }
+    // Auth is always-on as of #193; the `AuthUser` extractor 401s
+    // unauthenticated requests before they reach this helper. The
+    // wrapper stays as the canonical place to return the user-id —
+    // callers don't have to thread `auth_user.user_id.as_str()`
+    // by hand and the helper signature is stable for any future
+    // checks (suspension, etc.) that need to short-circuit here.
+    Ok(auth_user.user_id.as_str())
 }
 
 // ── Workspace CRUD ──

--- a/crates/stiglab/src/server/sso.rs
+++ b/crates/stiglab/src/server/sso.rs
@@ -19,10 +19,13 @@ use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
 
 /// How this process relates to the GitHub OAuth app.
+///
+/// `Owner` and `Relying` are the two GitHub-OAuth shapes; the absence of
+/// either is represented as `None` from `ServerConfig::sso_mode()` (never
+/// a separate variant), since a process with no GitHub OAuth configured
+/// has no SSO state to classify.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SsoMode {
-    /// No auth configured — anonymous user.
-    Disabled,
     /// Owns the GitHub OAuth app; handles callbacks directly.
     /// `delegate_enabled` is true when the owner-side secrets for serving
     /// preview environments are also set.

--- a/crates/stiglab/tests/dev_auth.rs
+++ b/crates/stiglab/tests/dev_auth.rs
@@ -1,0 +1,243 @@
+//! Integration tests for dev-login (issue #193).
+//!
+//! Covers:
+//! - Seeder is idempotent across boots — the second call must not
+//!   duplicate user, workspace, or membership rows.
+//! - `from_request_parts` rejects unauthenticated requests with 401
+//!   (no synthetic anonymous fallback).
+//! - `POST /api/auth/dev-login` mints a session cookie for the seeded
+//!   user, and `GET /api/auth/me` reports `session_kind: "dev"`.
+//! - Real GitHub OAuth login (mocked at the user-row level, since GitHub
+//!   itself is never called) still resolves to `session_kind: "github"`.
+//!
+//! Compile-time absence in release builds is enforced by the
+//! `#[cfg(debug_assertions)]` gates around `dev_auth::*` and the
+//! `/api/auth/dev-login` route registration in `server::build_router`.
+//! The whole `dev_auth` module is invisible to release `cargo build`,
+//! so any new code that referenced it would fail to compile under
+//! `cargo build --release`.
+
+#![cfg(debug_assertions)]
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::Utc;
+use sqlx::pool::PoolOptions;
+use sqlx::AnyPool;
+use stiglab::core::User;
+use stiglab::server::config::ServerConfig;
+use stiglab::server::db;
+use stiglab::server::dev_auth;
+use stiglab::server::state::AppState;
+use tower::ServiceExt;
+
+async fn test_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = PoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite connect");
+    db::run_migrations(&pool).await.expect("migrations");
+    pool
+}
+
+fn base_config() -> ServerConfig {
+    ServerConfig {
+        host: "0.0.0.0".into(),
+        port: 3000,
+        database_url: "sqlite::memory:".into(),
+        static_dir: None,
+        cors_origin: None,
+        github_client_id: None,
+        github_client_secret: None,
+        credential_key: None,
+        public_url: None,
+        github_app_webhook_secret: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
+        internal_dispatch_token: None,
+    }
+}
+
+fn app(state: AppState) -> axum::Router {
+    stiglab::server::build_router(state.clone(), &state.config)
+}
+
+fn parse_session_cookie(resp_headers: &axum::http::HeaderMap) -> Option<String> {
+    for v in resp_headers.get_all(header::SET_COOKIE).iter() {
+        let s = v.to_str().ok()?;
+        if let Some(rest) = s.strip_prefix("stiglab_session=") {
+            let token = rest.split(';').next()?.trim();
+            if !token.is_empty() {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn seeder_is_idempotent_across_boots() {
+    let pool = test_pool().await;
+
+    // First boot.
+    dev_auth::seed_dev_user_and_workspace(&pool).await.unwrap();
+    let user_after_first = db::get_user_by_github_id(&pool, dev_auth::DEV_GITHUB_ID)
+        .await
+        .unwrap()
+        .expect("seeded user present");
+    let ws_after_first = db::get_workspace_by_slug(&pool, dev_auth::DEV_WORKSPACE_SLUG)
+        .await
+        .unwrap()
+        .expect("seeded workspace present");
+    assert!(
+        db::is_workspace_member(&pool, &ws_after_first.id, &user_after_first.id)
+            .await
+            .unwrap(),
+        "membership row landed on first boot"
+    );
+
+    // Second boot — should be a no-op apart from refreshing `updated_at`.
+    dev_auth::seed_dev_user_and_workspace(&pool).await.unwrap();
+    let user_after_second = db::get_user_by_github_id(&pool, dev_auth::DEV_GITHUB_ID)
+        .await
+        .unwrap()
+        .expect("user still present");
+    let ws_after_second = db::get_workspace_by_slug(&pool, dev_auth::DEV_WORKSPACE_SLUG)
+        .await
+        .unwrap()
+        .expect("workspace still present");
+
+    // Same primary keys after the second seed — no orphan duplicates.
+    assert_eq!(user_after_first.id, user_after_second.id);
+    assert_eq!(ws_after_first.id, ws_after_second.id);
+
+    // The workspace list scoped to the dev user has exactly one entry.
+    let memberships = db::list_workspaces_for_user(&pool, &user_after_second.id)
+        .await
+        .unwrap();
+    assert_eq!(memberships.len(), 1);
+    assert_eq!(memberships[0].slug, dev_auth::DEV_WORKSPACE_SLUG);
+}
+
+#[tokio::test]
+async fn me_returns_401_for_unauthenticated_request() {
+    let pool = test_pool().await;
+    let state = AppState::new(pool, base_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/auth/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // No anonymous fallback (#193): a request without a session
+    // cookie or PAT must 401, not return a synthetic user.
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn dev_login_mints_session_and_me_reports_dev_kind() {
+    let pool = test_pool().await;
+    dev_auth::seed_dev_user_and_workspace(&pool).await.unwrap();
+    let state = AppState::new(pool, base_config(), None);
+    let router = app(state);
+
+    // Mint a session cookie.
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/dev-login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let token = parse_session_cookie(resp.headers()).expect("session cookie set");
+
+    // Use the cookie to hit /me.
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/auth/me")
+                .header(header::COOKIE, format!("stiglab_session={token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["session_kind"], "dev");
+    // No `auth_enabled` field — drop it from the wire shape (#193).
+    assert!(json.get("auth_enabled").is_none());
+    let login = json["user"]["github_login"]
+        .as_str()
+        .expect("github_login present");
+    assert!(
+        login.ends_with("@local"),
+        "dev user login ends with @local: {login}"
+    );
+}
+
+#[tokio::test]
+async fn me_reports_github_kind_for_real_user() {
+    // Stand in for the OAuth callback path — we insert a real user
+    // (positive github_id) + auth_session directly, since the full
+    // OAuth dance would require mocking GitHub. The branch under test
+    // is `session_kind_for_github_id`, which is the only thing the
+    // wire shape depends on.
+    let pool = test_pool().await;
+    let user = User {
+        id: "user-real".into(),
+        github_id: 12345,
+        github_login: "octocat".into(),
+        github_name: None,
+        github_avatar_url: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(&pool, &user).await.unwrap();
+    let session_token = "test-session-token-real";
+    db::create_auth_session(
+        &pool,
+        session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+
+    let state = AppState::new(pool, base_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/auth/me")
+                .header(header::COOKIE, format!("stiglab_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["session_kind"], "github");
+}


### PR DESCRIPTION
## Summary

Auth becomes always-on. Stiglab now requires every request to resolve to a real `users` row — there is no synthetic principal. The `auth_enabled` config concept is removed entirely. Local dev keeps working via a new **dev-login** mode, gated on `cfg(debug_assertions)`: release builds physically do not contain the seeder or the `/api/auth/dev-login` route.

Closes #193

## Delivers

- [x] Remove `SsoMode::Disabled`; remove `auth_enabled()` from `ServerConfig`; remove the anonymous branch in `from_request_parts`. `sso_mode()` now returns `Option<SsoMode>` (`None` = no GitHub OAuth configured).
- [x] Delete `AuthUser::anonymous()` + `test_auth_user_anonymous`. Add `session_kind: SessionKind` (`Github | Dev`) on `AuthUser`, derived from `user.github_id < 0`.
- [x] New `stiglab::server::dev_auth` module (`#[cfg(debug_assertions)]`): idempotent `seed_dev_user_and_workspace` (uses `$USER`, defaults to `dev`) + `/api/auth/dev-login` route handler.
- [x] `/api/auth/me` drops `auth_enabled`, adds `session_kind`. `apps/dashboard/src/lib/auth.tsx` reads `session_kind` instead.
- [x] Remove every `authEnabled` check across the dashboard (App.tsx, AppSidebar, CommandPalette, UserMenu, WorkflowsPage, SettingsPage, WorkspacesPage, PersonalAccessTokensPage, IssuesPage, FactoryOverviewPage, useNodes, useSetupProgress, lib/workspace.tsx).
- [x] Drop the `linkBase = ""` fallback in `AppSidebar.tsx`; nav always prefixes `/workspaces/<slug>/`, falling back to `/workspaces` (picker) outside a scoped route.
- [x] LoginPage probes `/api/auth/dev-login` (404 in release, ≠404 in debug) and renders the "Dev Login" button when the route exists.
- [x] New `DevModeBanner` component, mounted inside `ProtectedRoute`, shown only when `session_kind === "dev"` — discovery surface for the otherwise-invisible primitive.
- [x] Remove legacy bare-path redirects (`/sessions`, `/nodes`, `/artifacts`, `/issues`, `/spine`, `/governance`, `/workflows{,/start,/:id}`) immediately, per the resolved decision in #193 (no bridge-debt follow-up).
- [x] Update `.env.example` and `README.md` with the dev-login flow.

## Wire shape

`/api/auth/me` (debug build, dev-logged-in):
```json
{
  "user": { "id": "...", "github_login": "${USER}@local", ... },
  "session_kind": "dev",
  "via": "session"
}
```

Real OAuth user reports `"session_kind": "github"`. The legacy `auth_enabled` field is gone from the wire shape.

## Test plan

- [x] Unit: `from_request_parts` with no session and no PAT → 401 (no anonymous fallback).
- [x] Unit: `seed_dev_user_and_workspace` is idempotent — second boot does not duplicate user/workspace/membership rows.
- [x] Unit: `SessionKind` serializes as `"github" | "dev"` (locks the wire shape).
- [x] Integration: dev-login mints a session cookie; `/me` then returns `session_kind: "dev"` with a `${USER}@local` login.
- [x] Integration: a real GitHub-shaped session (positive `github_id`) reports `session_kind: "github"`.
- [x] Integration: `/me` 401s without a session — no anonymous fallback.
- [x] Compile-time: `dev_auth` module + `/api/auth/dev-login` route are `#[cfg(debug_assertions)]`-gated. Release-mode `cargo check -p stiglab --release` confirms the symbols are absent (any release-only reference would fail to compile).
- [x] Dashboard: `pnpm lint` clean, `pnpm test` green (95 tests), `pnpm build` succeeds.
- [x] Workspace: `RUSTFLAGS="-D warnings" cargo build --workspace`, `cargo test --workspace --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean.
- [x] `cargo run -p xtask --quiet -- lint-seams` clean (no new exemptions).
- [ ] Manual: `just dev` from a clean DB → LoginPage shows Dev Login button → click → dashboard loads with switcher and dev banner visible.
- [ ] L2 web-testing pass per `web-testing` skill (desktop + mobile).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NuX9wSc1JxBiadFvGNK5Bs)_