### PR TITLE
fix(dashboard): correct sidebar active-state highlighting

### DIFF
--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -127,15 +127,20 @@ export function AppSidebar() {
               <SidebarMenu>
                 {section.items.map((item) => {
                   const path = resolvePath(item.path)
+                  // Outside a scoped route every non-Overview item shares
+                  // the `/workspaces` picker fallback — none of them is
+                  // really "this page", so don't highlight any.
+                  const isActive =
+                    item.path === ""
+                      ? location.pathname === path
+                      : linkBase != null &&
+                        (location.pathname === path ||
+                          location.pathname.startsWith(`${path}/`))
                   return (
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton
                         render={<Link to={path} onClick={closeMobile} />}
-                        isActive={
-                          item.path === ""
-                            ? location.pathname === path
-                            : location.pathname.startsWith(path)
-                        }
+                        isActive={isActive}
                       >
                         <item.icon className="h-4 w-4" />
                         <span>{item.title}</span>


### PR DESCRIPTION
Closes #197

## Summary

- Two bugs combined to make every sidebar item appear highlighted on routes outside a scoped workspace (e.g. `/workspaces`):
  1. With no active workspace, `resolvePath` returned the same `/workspaces` fallback for every non-Overview item, so every row had the same href.
  2. The active check used `pathname.startsWith(path)` with no segment boundary, so on `/workspaces` it matched every row.
- Skip the active check for non-Overview items when `linkBase == null` (those rows are pointing at the picker fallback, not their real destination), and replace the unbounded prefix with `pathname === path || pathname.startsWith(`${path}/`)`.

## Test plan

- [ ] On `/workspaces` (picker), no nav item is highlighted (Overview may highlight because its href genuinely equals `/workspaces`).
- [ ] Within a scoped route like `/workspaces/foo/sessions/123`, only "Sessions" is highlighted.
- [ ] Navigating between Issues / Workflows / Artifacts / Sessions / Nodes / Settings inside a workspace highlights exactly one row at a time.
- [ ] `pnpm tsc --noEmit` clean (modulo the pre-existing `tsconfig` deprecation warning).

---
_Generated by [Claude Code](https://claude.ai/code/session_018rFaW7vNmtfZovoXyTpuw1)_