### PR TITLE
Document repo merge policy: squash to main, rebase from main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,18 @@ cargo fmt --all -- --check
 - Unit tests co-located in `#[cfg(test)]` modules
 - All internal deps use `path = "../..."` -- no git deps, no crates.io
 
+## Merge policy
+
+- **PR → main: squash only.** Merge commits and rebase-merges are
+  disabled at the repo level; the GitHub merge button only offers
+  squash. One PR = one commit on `main`.
+- **main → PR: rebase, not merge.** When updating a PR branch with
+  `main` (locally or via the "Update branch" button), use rebase.
+  This keeps PR history linear and avoids merge commits inside
+  feature branches that would then be squashed away anyway.
+- Local equivalent: `git pull --rebase origin main` (or set
+  `git config --global pull.rebase true` once).
+
 ## Environment variables
 
 Subsystem-specific env vars worth calling out:


### PR DESCRIPTION
## Summary
- Adds a short **Merge policy** section to `CLAUDE.md` so the convention is on-record for humans and agents.
- Policy: PR → main is **squash only**; updating a PR branch with main uses **rebase**, not merge.
- Includes the local `git pull --rebase` equivalent.

## Why
The actual enforcement of squash-only on the merge button is a GitHub repo-level setting (`allow_squash_merge=true`, `allow_merge_commit=false`, `allow_rebase_merge=false`) and is being flipped in repo Settings outside this PR. The "Update branch" rebase default is also a repo-setting toggle. This PR records the policy in `CLAUDE.md` so:
- Agents updating branches default to `git pull --rebase` instead of producing merge commits inside feature branches.
- New contributors don't have to discover the rule from a failed merge attempt.

No code changes — docs only, hence the `trivial` label.

## Test plan
- [x] `CLAUDE.md` renders correctly (heading nests under `##`, fits the existing Conventions → Environment variables flow).
- [ ] Repo Settings → General → Pull Requests reflects squash-only + rebase-as-update-default (manual, owner action).

https://claude.ai/code/session_014FDALnLSEKc5Jp98dUQWZd

---
_Generated by [Claude Code](https://claude.ai/code/session_014FDALnLSEKc5Jp98dUQWZd)_