### PR TITLE
fix(dashboard): resolve active workspace from URL in sidebar

### DIFF
--- a/apps/dashboard/src/lib/workspace.tsx
+++ b/apps/dashboard/src/lib/workspace.tsx
@@ -126,11 +126,23 @@ export function useActiveWorkspace(): Workspace {
   return ctx.workspace
 }
 
-/** Optional: callers outside scoped routes (sidebar switcher) read this. */
+/** Optional: callers outside scoped routes (sidebar switcher, AppSidebar
+ * nav links) read this. The sidebar lives in `AppLayout`, which mounts
+ * above the `/workspaces/:workspace/*` route, so `WorkspaceContext` is
+ * not in scope there. Fall back to the URL pathname + memberships query
+ * so the sidebar can resolve `/workspaces/<active>/...` links and the
+ * switcher's trigger button shows the active workspace's name.
+ */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useOptionalActiveWorkspace(): Workspace | null {
   const ctx = useContext(WorkspaceContext)
-  return ctx?.workspace ?? null
+  const location = useLocation()
+  const { data } = useWorkspacesQuery()
+  if (ctx) return ctx.workspace
+  const match = location.pathname.match(/^\/workspaces\/([^/]+)/)
+  const slug = match?.[1]
+  if (!slug) return null
+  return data?.workspaces?.find((w) => w.slug === slug) ?? null
 }
 
 /** All workspaces the caller is a member of (memoized list from cache). */

--- a/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
+++ b/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { SidebarProvider } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/components/layout/AppSidebar"
+
+// AppSidebar is mounted in AppLayout, which sits above the
+// `/workspaces/:workspace/*` route — so WorkspaceContext is not in
+// scope. The sidebar must still resolve scoped nav links from the URL
+// itself; otherwise every sidebar item collapses to the `/workspaces`
+// fallback and the active sidebar group never matches the open page.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u1" }, authEnabled: true }),
+}))
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [
+        {
+          id: "w1",
+          slug: "acme",
+          name: "Acme",
+          created_by: "u1",
+          created_at: "2026-01-01",
+        },
+        {
+          id: "w2",
+          slug: "beta",
+          name: "Beta",
+          created_by: "u1",
+          created_at: "2026-01-01",
+        },
+      ],
+    }),
+    listAllProjects: vi.fn().mockResolvedValue({ projects: [] }),
+    listInstallations: vi.fn().mockResolvedValue({ installations: [] }),
+  },
+}))
+
+function renderAppSidebar(initialPath: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <SidebarProvider>
+                <AppSidebar />
+              </SidebarProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("AppSidebar nav link resolution", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("scopes nav links to the workspace in the URL", async () => {
+    renderAppSidebar("/workspaces/acme/sessions")
+
+    await waitFor(() => {
+      const sessions = screen.getByRole("link", { name: /Sessions/i })
+      expect(sessions).toHaveAttribute("href", "/workspaces/acme/sessions")
+    })
+
+    expect(
+      screen.getByRole("link", { name: /^Workflows$/ }),
+    ).toHaveAttribute("href", "/workspaces/acme/workflows")
+    expect(screen.getByRole("link", { name: /Settings/i })).toHaveAttribute(
+      "href",
+      "/workspaces/acme/settings",
+    )
+    // Overview row uses an empty suffix; it should land on the workspace
+    // root rather than the global picker.
+    expect(screen.getByRole("link", { name: /Overview/i })).toHaveAttribute(
+      "href",
+      "/workspaces/acme",
+    )
+  })
+
+  it("falls back to /workspaces when there is no workspace in the URL", async () => {
+    renderAppSidebar("/settings")
+
+    // Wait for the workspaces query to resolve so the system row renders.
+    await waitFor(() => {
+      const settings = screen.getByRole("link", { name: /Settings/i })
+      expect(settings).toHaveAttribute("href", "/workspaces")
+    })
+  })
+})

--- a/apps/dashboard/tests/smoke/workspace-switcher.test.tsx
+++ b/apps/dashboard/tests/smoke/workspace-switcher.test.tsx
@@ -98,4 +98,35 @@ describe("WorkspaceSwitcher", () => {
       )
     },
   )
+
+  // Regression: the AppSidebar (and the switcher inside it) lives in
+  // AppLayout, which mounts above the `/workspaces/:workspace/*` route —
+  // so WorkspaceContext is not available. Without a URL fallback in
+  // useOptionalActiveWorkspace, the switcher shows "Select workspace"
+  // and every sidebar nav link resolves to `/workspaces` regardless of
+  // the active workspace.
+  it("renders the active workspace when mounted outside WorkspaceScope", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={["/workspaces/acme/sessions"]}>
+          <Routes>
+            <Route
+              path="/workspaces/:workspace/*"
+              element={
+                <SidebarProvider>
+                  <WorkspaceSwitcher />
+                  <LocationProbe />
+                </SidebarProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+    expect(await screen.findByText("Acme")).toBeInTheDocument()
+    expect(screen.getByText("acme")).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Closes #200

## Summary

- AppSidebar (and the WorkspaceSwitcher inside it) mount in `AppLayout`, but `<WorkspaceScope>` lives *inside* the `/workspaces/:workspace/*` route element — so the context that supplies the active workspace is never visible to the sidebar.
- Result: switcher trigger always reads "Select workspace" on scoped paths, and `linkBase` collapses to `/workspaces` so every nav item bounces the user to the picker instead of staying under the active workspace.
- Fix: have `useOptionalActiveWorkspace` fall back to `location.pathname` + the memberships query when no `WorkspaceContext` is present. Scoped pages keep using the context (no extra fetch — same query cache).

## Test plan

- [x] `pnpm --filter dashboard test` — 98 tests pass (3 new).
- [x] `pnpm --filter dashboard lint` clean.
- [x] `pnpm --filter dashboard build` clean.
- [x] Playwright probe against the dev server: on `/workspaces/acme/sessions`, the switcher shows "Acme" and the Sessions link href is `/workspaces/acme/sessions`. After switching to Beta the URL becomes `/workspaces/beta/sessions`; clicking Sessions stays scoped, clicking Settings goes to `/workspaces/beta/settings`. On the unscoped `/workspaces` picker, links correctly fall back.
- [ ] Manual: log in, switch workspaces from the sidebar, verify every nav row routes to the picked workspace's resource.

https://claude.ai/code/session_01Du82McPZKjVZ73MSJ74jps

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du82McPZKjVZ73MSJ74jps)_