### PR TITLE
test(dashboard): fix mocked api name in app-sidebar-links suite

### DIFF
--- a/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
+++ b/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
@@ -37,7 +37,9 @@ vi.mock("@/lib/api", () => ({
       ],
     }),
     listAllProjects: vi.fn().mockResolvedValue({ projects: [] }),
-    listInstallations: vi.fn().mockResolvedValue({ installations: [] }),
+    listWorkspaceInstallations: vi
+      .fn()
+      .mockResolvedValue({ installations: [] }),
   },
 }))
 


### PR DESCRIPTION
Trivial follow-up to #201 — addresses Copilot review post-merge.

## Summary

- `useSetupProgress` calls `api.listWorkspaceInstallations(workspaceId)`. The new `app-sidebar-links` smoke suite mocked it as `listInstallations`, so React Query was actually catching a `TypeError: api.listWorkspaceInstallations is not a function` and treating it as a query error.
- The tests still passed because the assertions are about link hrefs (resolved from the URL via `useOptionalActiveWorkspace`) and don't depend on installation state. But the wrong mock name would mask any future regression that relies on the install query firing.

## Test plan

- [x] `pnpm --filter dashboard test -- tests/smoke/app-sidebar-links.test.tsx` passes (2/2).

https://claude.ai/code/session_01Du82McPZKjVZ73MSJ74jps

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du82McPZKjVZ73MSJ74jps)_