### PR TITLE
feat(dashboard,stiglab): per-row debug actions on Issues page

### DIFF
--- a/apps/dashboard/src/components/IssueActionsMenu.tsx
+++ b/apps/dashboard/src/components/IssueActionsMenu.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  ExternalLink,
+  MoreHorizontal,
+  PlayCircle,
+  RefreshCw,
+} from "lucide-react"
+import { api, type ReplayMatch } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+// Per-row debug actions for the Issues page (spec #203). Workflow
+// triggers in production are passive (real GitHub `issues.labeled`
+// webhook → `workflow.trigger_fired`); this menu adds the active
+// counterpart so a developer can manually drive a single issue
+// through the same path while debugging.
+//
+// Three actions:
+// - Refresh: client-side React Query invalidation only.
+// - Replay trigger: opens a confirm dialog that previews the
+//   matched workflows (server-side dry run) and, on confirm, fires
+//   one `workflow.trigger_fired` per match with `source=manual_replay`.
+// - Open in GitHub: external link, kept here so the row stays clean.
+//
+// Skeleton-only rows (no live data) hide the menu — replay needs the
+// issue's current labels.
+export interface IssueActionsMenuProps {
+  projectId: string | null
+  issueNumber: number | null
+  htmlUrl: string | null
+  /// Stable React Query key for the issue list this row belongs to,
+  /// used when "Refresh this issue" invalidates the cache.
+  listQueryKey: readonly unknown[]
+}
+
+export function IssueActionsMenu({
+  projectId,
+  issueNumber,
+  htmlUrl,
+  listQueryKey,
+}: IssueActionsMenuProps) {
+  const queryClient = useQueryClient()
+  const [confirming, setConfirming] = useState(false)
+  const replayable = projectId != null && issueNumber != null
+
+  const preview = useMutation({
+    mutationFn: () =>
+      api.replayIssueTrigger(projectId!, issueNumber!, { dry_run: true }),
+  })
+
+  const fire = useMutation({
+    mutationFn: () =>
+      api.replayIssueTrigger(projectId!, issueNumber!, { dry_run: false }),
+  })
+
+  function openReplay() {
+    if (!replayable) return
+    preview.reset()
+    fire.reset()
+    setConfirming(true)
+    preview.mutate()
+  }
+
+  function refresh() {
+    void queryClient.invalidateQueries({ queryKey: listQueryKey })
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label="Issue actions"
+            />
+          }
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem onClick={refresh}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh this issue
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={!replayable} onClick={openReplay}>
+            <PlayCircle className="mr-2 h-4 w-4" />
+            Replay trigger…
+          </DropdownMenuItem>
+          {htmlUrl ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                render={
+                  <a href={htmlUrl} target="_blank" rel="noreferrer" />
+                }
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Open in GitHub
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={confirming} onOpenChange={setConfirming}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Replay workflow trigger?</DialogTitle>
+            <DialogDescription>
+              Re-fires <code>workflow.trigger_fired</code> for issue #
+              {issueNumber} as if a matching label had just been applied.
+              Marked <code>source=manual_replay</code>; downstream stages
+              run as they would for the real webhook.
+            </DialogDescription>
+          </DialogHeader>
+
+          <ReplayPreview
+            isLoading={preview.isPending}
+            error={
+              preview.error instanceof Error ? preview.error.message : null
+            }
+            matches={preview.data?.matches ?? null}
+            fired={fire.data ?? null}
+            fireError={
+              fire.error instanceof Error ? fire.error.message : null
+            }
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirming(false)}
+              disabled={fire.isPending}
+            >
+              {fire.data ? "Close" : "Cancel"}
+            </Button>
+            {fire.data == null ? (
+              <Button
+                type="button"
+                onClick={() => fire.mutate()}
+                disabled={
+                  fire.isPending ||
+                  preview.isPending ||
+                  (preview.data?.matches.length ?? 0) === 0
+                }
+              >
+                {fire.isPending ? "Firing…" : "Fire trigger"}
+              </Button>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+interface ReplayPreviewProps {
+  isLoading: boolean
+  error: string | null
+  matches: ReplayMatch[] | null
+  fired: { event_ids: number[]; matches: ReplayMatch[] } | null
+  fireError: string | null
+}
+
+function ReplayPreview({
+  isLoading,
+  error,
+  matches,
+  fired,
+  fireError,
+}: ReplayPreviewProps) {
+  if (fired) {
+    return (
+      <div className="space-y-2 text-sm">
+        <p className="font-medium text-foreground">
+          Fired {fired.event_ids.length}{" "}
+          {fired.event_ids.length === 1 ? "workflow" : "workflows"}.
+        </p>
+        <MatchesList matches={fired.matches} />
+        <p className="text-xs text-muted-foreground">
+          Spine event IDs: {fired.event_ids.join(", ") || "—"}
+        </p>
+      </div>
+    )
+  }
+  if (fireError) {
+    return <p className="text-sm text-destructive">{fireError}</p>
+  }
+  if (isLoading) {
+    return (
+      <p className="text-sm text-muted-foreground">Looking up matches…</p>
+    )
+  }
+  if (error) {
+    return <p className="text-sm text-destructive">{error}</p>
+  }
+  if (!matches) return null
+  if (matches.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No active workflows match this issue&apos;s current labels. Add
+        the trigger label on GitHub or activate a workflow with a matching
+        label, then try again.
+      </p>
+    )
+  }
+  return (
+    <div className="space-y-2 text-sm">
+      <p>
+        Will fire {matches.length}{" "}
+        {matches.length === 1 ? "workflow" : "workflows"}:
+      </p>
+      <MatchesList matches={matches} />
+    </div>
+  )
+}
+
+function MatchesList({ matches }: { matches: ReplayMatch[] }) {
+  return (
+    <ul className="space-y-1 text-sm">
+      {matches.map((m) => (
+        <li key={`${m.workflow_id}:${m.label}`} className="flex gap-2">
+          <span className="font-medium">{m.workflow_name}</span>
+          <span className="text-muted-foreground">
+            on label <code>{m.label}</code>
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/dashboard/src/components/IssueActionsMenu.tsx
+++ b/apps/dashboard/src/components/IssueActionsMenu.tsx
@@ -37,8 +37,11 @@ import {
 //   one `workflow.trigger_fired` per match with `source=manual_replay`.
 // - Open in GitHub: external link, kept here so the row stays clean.
 //
-// Skeleton-only rows (no live data) hide the menu — replay needs the
-// issue's current labels.
+// Skeleton-only rows (no live data) keep the kebab so Refresh stays
+// reachable — Refresh re-runs the list query, which is exactly what's
+// needed when a row is missing live data. Replay is disabled instead
+// of hidden because it needs the issue's current labels, and the
+// "Open in GitHub" entry only renders when an `htmlUrl` is known.
 export interface IssueActionsMenuProps {
   projectId: string | null
   issueNumber: number | null
@@ -110,7 +113,11 @@ export function IssueActionsMenu({
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 render={
-                  <a href={htmlUrl} target="_blank" rel="noreferrer" />
+                  <a
+                    href={htmlUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
                 }
               >
                 <ExternalLink className="mr-2 h-4 w-4" />

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -302,6 +302,32 @@ export interface BackfillRequestBody {
   state?: 'open' | 'closed' | 'all';
 }
 
+/// Manual replay of a `workflow.trigger_fired` event for one issue
+/// (spec #203). Active counterpart to the passive
+/// `issues.labeled` webhook path — used for debugging when no e2e
+/// workflow run has fired yet.
+export interface ReplayIssueTriggerRequest {
+  /// `true` (default on the server) returns the matched workflow list
+  /// without emitting; `false` emits one event per match.
+  dry_run?: boolean;
+}
+
+export interface ReplayMatch {
+  workflow_id: string;
+  workflow_name: string;
+  label: string;
+}
+
+export interface ReplayIssueTriggerResponse {
+  project_id: string;
+  issue_number: number;
+  dry_run: boolean;
+  matches: ReplayMatch[];
+  /// Spine event IDs for the emitted events. Empty in dry-run mode and
+  /// when there were zero matches.
+  event_ids: number[];
+}
+
 export interface BackfillReport {
   project_id: string;
   repo: string;
@@ -969,4 +995,16 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+  replayIssueTrigger: (
+    projectId: string,
+    issueNumber: number,
+    body: ReplayIssueTriggerRequest = {},
+  ) =>
+    request<ReplayIssueTriggerResponse>(
+      `/projects/${encodeURIComponent(projectId)}/issues/${issueNumber}/replay-trigger`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    ),
 };

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ExternalLink, Inbox, RefreshCw } from "lucide-react"
+import { Inbox, RefreshCw } from "lucide-react"
 import { Link, useSearchParams } from "react-router-dom"
 
 import {
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/table"
 import { usePageHeader } from "@/components/layout/PageHeader"
 import { BackfillDialog } from "@/components/BackfillDialog"
+import { IssueActionsMenu } from "@/components/IssueActionsMenu"
 import { useActiveWorkspace } from "@/lib/workspace"
 
 type StateFilter = "open" | "closed" | "all"
@@ -289,7 +290,16 @@ export function IssuesPage() {
             <>
               <div className="flex flex-col gap-2 md:hidden">
                 {rows.map((r) => (
-                  <IssueCard key={rowKey(r)} row={r} />
+                  <IssueCard
+                    key={rowKey(r)}
+                    row={r}
+                    projectId={selectedProjectId}
+                    listQueryKey={[
+                      "project-issues",
+                      selectedProjectId,
+                      stateFilter,
+                    ]}
+                  />
                 ))}
               </div>
               <div className="hidden md:block">
@@ -334,22 +344,16 @@ export function IssuesPage() {
                             {display.updatedAt}
                           </TableCell>
                           <TableCell>
-                            {display.htmlUrl ? (
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                render={
-                                  <a
-                                    href={display.htmlUrl}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  />
-                                }
-                              >
-                                <ExternalLink className="h-3.5 w-3.5" />
-                                <span className="sr-only">Open in GitHub</span>
-                              </Button>
-                            ) : null}
+                            <IssueActionsMenu
+                              projectId={selectedProjectId}
+                              issueNumber={r.issue?.number ?? null}
+                              htmlUrl={display.htmlUrl}
+                              listQueryKey={[
+                                "project-issues",
+                                selectedProjectId,
+                                stateFilter,
+                              ]}
+                            />
                           </TableCell>
                         </TableRow>
                       )
@@ -432,20 +436,33 @@ function describeRow(row: HydratedIssueRow): RowDisplay {
   }
 }
 
-function IssueCard({ row }: { row: HydratedIssueRow }) {
+function IssueCard({
+  row,
+  projectId,
+  listQueryKey,
+}: {
+  row: HydratedIssueRow
+  projectId: string | null
+  listQueryKey: readonly unknown[]
+}) {
   const display = describeRow(row)
   const cardClass =
     "flex flex-col gap-1.5 rounded-lg border p-3 transition-colors active:bg-accent"
-  const inner = (
-    <>
+  return (
+    <div className={cardClass}>
       <div className="flex items-start justify-between gap-2">
         <span className="line-clamp-2 text-sm font-medium">{display.title}</span>
-        <Badge
-          variant={display.openState ? "default" : "secondary"}
-          className="shrink-0"
-        >
-          {display.stateLabel}
-        </Badge>
+        <div className="flex shrink-0 items-center gap-1">
+          <Badge variant={display.openState ? "default" : "secondary"}>
+            {display.stateLabel}
+          </Badge>
+          <IssueActionsMenu
+            projectId={projectId}
+            issueNumber={row.issue?.number ?? null}
+            htmlUrl={display.htmlUrl}
+            listQueryKey={listQueryKey}
+          />
+        </div>
       </div>
       <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <span>{display.subtitle}</span>
@@ -455,21 +472,8 @@ function IssueCard({ row }: { row: HydratedIssueRow }) {
       {display.labels.length > 0 ? (
         <LabelChips labels={display.labels} />
       ) : null}
-    </>
+    </div>
   )
-  if (display.htmlUrl) {
-    return (
-      <a
-        href={display.htmlUrl}
-        target="_blank"
-        rel="noreferrer"
-        className={cardClass}
-      >
-        {inner}
-      </a>
-    )
-  }
-  return <div className={cardClass}>{inner}</div>
 }
 
 function LabelChips({ labels }: { labels: string[] }) {

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -446,8 +446,10 @@ function IssueCard({
   listQueryKey: readonly unknown[]
 }) {
   const display = describeRow(row)
-  const cardClass =
-    "flex flex-col gap-1.5 rounded-lg border p-3 transition-colors active:bg-accent"
+  // No interactive cursor / press state on the card itself — the row
+  // is no longer a single clickable surface; per-row navigation lives
+  // in the kebab menu's "Open in GitHub" item.
+  const cardClass = "flex flex-col gap-1.5 rounded-lg border p-3"
   return (
     <div className={cardClass}>
       <div className="flex items-start justify-between gap-2">

--- a/apps/dashboard/tests/smoke/issue-actions-menu.test.tsx
+++ b/apps/dashboard/tests/smoke/issue-actions-menu.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { IssueActionsMenu } from "@/components/IssueActionsMenu";
+import { api } from "@/lib/api";
+
+function renderWith(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    ),
+  };
+}
+
+describe("IssueActionsMenu", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the kebab and shows the three actions for a hydrated row", async () => {
+    const user = userEvent.setup();
+    renderWith(
+      <IssueActionsMenu
+        projectId="proj_1"
+        issueNumber={42}
+        htmlUrl="https://github.com/acme/widgets/issues/42"
+        listQueryKey={["project-issues", "proj_1", "open"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Issue actions" }));
+
+    expect(
+      await screen.findByText("Refresh this issue"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Replay trigger…")).toBeInTheDocument();
+    expect(screen.getByText("Open in GitHub")).toBeInTheDocument();
+  });
+
+  it("disables Replay when there is no project context", async () => {
+    const user = userEvent.setup();
+    renderWith(
+      <IssueActionsMenu
+        projectId={null}
+        issueNumber={null}
+        htmlUrl={null}
+        listQueryKey={["project-issues", null, "open"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Issue actions" }));
+    const item = await screen.findByText("Replay trigger…");
+    expect(item.closest('[role="menuitem"]')).toHaveAttribute("aria-disabled");
+  });
+
+  it("Refresh invalidates the issue list query", async () => {
+    const user = userEvent.setup();
+    const { queryClient } = renderWith(
+      <IssueActionsMenu
+        projectId="proj_1"
+        issueNumber={42}
+        htmlUrl={null}
+        listQueryKey={["project-issues", "proj_1", "open"]}
+      />,
+    );
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await user.click(screen.getByRole("button", { name: "Issue actions" }));
+    await user.click(await screen.findByText("Refresh this issue"));
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["project-issues", "proj_1", "open"],
+    });
+  });
+
+  it("Replay shows the dry-run preview before firing", async () => {
+    const user = userEvent.setup();
+    const previewSpy = vi
+      .spyOn(api, "replayIssueTrigger")
+      .mockResolvedValueOnce({
+        project_id: "proj_1",
+        issue_number: 42,
+        dry_run: true,
+        matches: [
+          {
+            workflow_id: "wf_1",
+            workflow_name: "sdd",
+            label: "spec",
+          },
+        ],
+        event_ids: [],
+      });
+
+    renderWith(
+      <IssueActionsMenu
+        projectId="proj_1"
+        issueNumber={42}
+        htmlUrl={null}
+        listQueryKey={["project-issues", "proj_1", "open"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Issue actions" }));
+    await user.click(await screen.findByText("Replay trigger…"));
+
+    // Server is called with dry_run=true first.
+    await waitFor(() => {
+      expect(previewSpy).toHaveBeenCalledWith("proj_1", 42, { dry_run: true });
+    });
+    expect(await screen.findByText(/Will fire 1 workflow/)).toBeInTheDocument();
+    expect(screen.getByText("sdd")).toBeInTheDocument();
+  });
+
+  it("Replay reports zero matches without enabling Fire", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "replayIssueTrigger").mockResolvedValueOnce({
+      project_id: "proj_1",
+      issue_number: 42,
+      dry_run: true,
+      matches: [],
+      event_ids: [],
+    });
+
+    renderWith(
+      <IssueActionsMenu
+        projectId="proj_1"
+        issueNumber={42}
+        htmlUrl={null}
+        listQueryKey={["project-issues", "proj_1", "open"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Issue actions" }));
+    await user.click(await screen.findByText("Replay trigger…"));
+
+    expect(
+      await screen.findByText(/No active workflows match/),
+    ).toBeInTheDocument();
+    const fireButton = screen.getByRole("button", { name: "Fire trigger" });
+    expect(fireButton).toBeDisabled();
+  });
+});

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -188,6 +188,14 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/projects/{id}/backfill",
             post(routes::projects::backfill_project),
         )
+        // Manual replay of `workflow.trigger_fired` for a single issue —
+        // active counterpart to the passive `issues.labeled` webhook
+        // path (#203). Useful when debugging an end-to-end workflow run
+        // that didn't fire.
+        .route(
+            "/api/projects/{id}/issues/{number}/replay-trigger",
+            post(routes::projects::replay_issue_trigger),
+        )
         // Legacy `/api/tenants/*` paths — return 308 Permanent Redirect to
         // the new `/api/workspaces/*` surface so existing clients (CLI,
         // PATs, dashboards on older deploys) keep working for one release.

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -38,12 +38,12 @@ use sqlx::{AnyPool, PgPool};
 use crate::server::auth::AuthUser;
 use crate::server::db;
 use crate::server::github_app;
+use crate::server::routes::webhooks::spine_namespace;
 use crate::server::state::AppState;
 use crate::server::webhook_router::{
     build_trigger_fired_events, trigger_source, IssueTriggerContext, RoutedEvent,
 };
 use crate::server::workflow_db;
-use onsager_spine::factory_event::FactoryEventKind;
 
 const HARD_CAP: usize = 200;
 const DEFAULT_CAP: usize = 100;
@@ -939,34 +939,39 @@ pub async fn replay_issue_trigger(
         Err(r) => return r,
     };
 
+    // One DB round-trip for every `(repo, label)` an issue carries gets
+    // expensive when an issue has many labels. Pull every active
+    // workflow on `(workspace, repo)` once and partition by label
+    // in-memory.
+    let candidates = match workflow_db::find_active_github_workflows_for_workspace_repo(
+        &state.db,
+        &project.workspace_id,
+        &project.repo_owner,
+        &project.repo_name,
+    )
+    .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(
+                workspace_id = %project.workspace_id,
+                error = %e,
+                "failed to look up active workflows for replay-trigger"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "workflow lookup failed" })),
+            )
+                .into_response();
+        }
+    };
+    let label_set: std::collections::HashSet<&str> =
+        issue.labels.iter().map(|l| l.name.as_str()).collect();
     let mut matches: Vec<(crate::core::workflow::Workflow, String)> = Vec::new();
-    for label in &issue.labels {
-        let hits = match workflow_db::find_active_github_workflows_for_label_in_workspace(
-            &state.db,
-            &project.workspace_id,
-            &project.repo_owner,
-            &project.repo_name,
-            &label.name,
-        )
-        .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::error!(
-                    workspace_id = %project.workspace_id,
-                    label = %label.name,
-                    error = %e,
-                    "failed to look up active workflows for replay-trigger"
-                );
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": "workflow lookup failed" })),
-                )
-                    .into_response();
-            }
-        };
-        for wf in hits {
-            matches.push((wf, label.name.clone()));
+    for wf in candidates {
+        if label_set.contains(wf.trigger_label.as_str()) {
+            let label = wf.trigger_label.clone();
+            matches.push((wf, label));
         }
     }
 
@@ -983,7 +988,11 @@ pub async fn replay_issue_trigger(
         return Json(serde_json::json!(ReplayResponse {
             project_id: project.id,
             issue_number,
-            dry_run: true,
+            // Echo the requested mode rather than coercing to dry-run on
+            // an empty match set — the client distinguishes "I asked to
+            // fire but nothing matched" (`dry_run=false, event_ids=[]`)
+            // from "I asked to preview" (`dry_run=true`).
+            dry_run,
             matches: preview,
             event_ids: Vec::new(),
         }))
@@ -1039,7 +1048,7 @@ pub async fn replay_issue_trigger(
             match spine
                 .emit_raw(
                     &ev.kind.stream_id(),
-                    spine_namespace_for(&ev.kind),
+                    spine_namespace(&ev.kind),
                     "stiglab",
                     ev.kind.event_type(),
                     &data,
@@ -1067,16 +1076,6 @@ pub async fn replay_issue_trigger(
         event_ids,
     }))
     .into_response()
-}
-
-fn spine_namespace_for(kind: &FactoryEventKind) -> &'static str {
-    // Keep aligned with `webhooks::spine_namespace` — replays must land
-    // in the same partition as live webhook events so listeners see one
-    // unified stream.
-    match kind {
-        FactoryEventKind::TriggerFired { .. } => "workflow",
-        _ => "stiglab",
-    }
 }
 
 #[allow(clippy::result_large_err)]

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -39,6 +39,11 @@ use crate::server::auth::AuthUser;
 use crate::server::db;
 use crate::server::github_app;
 use crate::server::state::AppState;
+use crate::server::webhook_router::{
+    build_trigger_fired_events, trigger_source, IssueTriggerContext, RoutedEvent,
+};
+use crate::server::workflow_db;
+use onsager_spine::factory_event::FactoryEventKind;
 
 const HARD_CAP: usize = 200;
 const DEFAULT_CAP: usize = 100;
@@ -853,4 +858,276 @@ async fn upsert_pr_skeleton(
     .await?;
     tx.commit().await?;
     Ok(true)
+}
+
+// ── POST /api/projects/:id/issues/:number/replay-trigger ─────────────────
+//
+// Active-mode debug counterpart to the passive `issues.labeled` webhook
+// path. Reads the issue's *current* labels live from GitHub, finds active
+// workflows in the project's workspace whose `(repo, label)` matches, and
+// either previews (`dry_run=true`, default) or emits one
+// `workflow.trigger_fired` per match identical to the webhook path —
+// distinguishable only by `payload.source = "manual_replay"` plus
+// `payload.replayed_by = <user_id>`.
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ReplayTriggerBody {
+    /// `true` (default) returns the matched-workflow list without
+    /// emitting; `false` emits one `workflow.trigger_fired` per match.
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReplayMatch {
+    workflow_id: String,
+    workflow_name: String,
+    label: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReplayResponse {
+    project_id: String,
+    issue_number: u64,
+    dry_run: bool,
+    matches: Vec<ReplayMatch>,
+    /// Spine event IDs for the emitted `workflow.trigger_fired` events.
+    /// Empty in dry-run mode and when there were zero matches.
+    event_ids: Vec<i64>,
+}
+
+pub async fn replay_issue_trigger(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((project_id, issue_number)): Path<(String, u64)>,
+    Json(body): Json<ReplayTriggerBody>,
+) -> Response {
+    let project = match require_project_for_user(&state.db, &auth_user, &project_id).await {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    let dry_run = body.dry_run.unwrap_or(true);
+
+    let token = match mint_token(&state.db, &project.github_app_installation_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "GitHub App not configured" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("mint_token failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub auth failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let issue = match fetch_single_issue(
+        &token.token,
+        &project.repo_owner,
+        &project.repo_name,
+        issue_number,
+    )
+    .await
+    {
+        Ok(i) => i,
+        Err(r) => return r,
+    };
+
+    let mut matches: Vec<(crate::core::workflow::Workflow, String)> = Vec::new();
+    for label in &issue.labels {
+        let hits = match workflow_db::find_active_github_workflows_for_label_in_workspace(
+            &state.db,
+            &project.workspace_id,
+            &project.repo_owner,
+            &project.repo_name,
+            &label.name,
+        )
+        .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::error!(
+                    workspace_id = %project.workspace_id,
+                    label = %label.name,
+                    error = %e,
+                    "failed to look up active workflows for replay-trigger"
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": "workflow lookup failed" })),
+                )
+                    .into_response();
+            }
+        };
+        for wf in hits {
+            matches.push((wf, label.name.clone()));
+        }
+    }
+
+    let preview: Vec<ReplayMatch> = matches
+        .iter()
+        .map(|(w, label)| ReplayMatch {
+            workflow_id: w.id.clone(),
+            workflow_name: w.name.clone(),
+            label: label.clone(),
+        })
+        .collect();
+
+    if dry_run || matches.is_empty() {
+        return Json(serde_json::json!(ReplayResponse {
+            project_id: project.id,
+            issue_number,
+            dry_run: true,
+            matches: preview,
+            event_ids: Vec::new(),
+        }))
+        .into_response();
+    }
+
+    let Some(spine) = state.spine.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "spine not connected" })),
+        )
+            .into_response();
+    };
+
+    // Group matches by label so each `build_trigger_fired_events` call
+    // produces one event per workflow for that label — matching the
+    // webhook path which fires once per `(label, workflow)` pair.
+    let mut event_ids = Vec::new();
+    let mut by_label: std::collections::BTreeMap<String, Vec<crate::core::workflow::Workflow>> =
+        std::collections::BTreeMap::new();
+    for (wf, label) in matches {
+        by_label.entry(label).or_default().push(wf);
+    }
+    for (label, wfs) in by_label {
+        let events: Vec<RoutedEvent> = build_trigger_fired_events(
+            &IssueTriggerContext {
+                repo_owner: &project.repo_owner,
+                repo_name: &project.repo_name,
+                issue_number,
+                title: &issue.title,
+                label: &label,
+                source: trigger_source::MANUAL_REPLAY,
+                replayed_by: Some(&auth_user.user_id),
+            },
+            &wfs,
+        );
+        for ev in events {
+            let mut data = match serde_json::to_value(&ev.kind) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!("failed to serialize replay-trigger event: {e}");
+                    continue;
+                }
+            };
+            // Match the webhook path's workspace_id stamping. `TriggerFired`
+            // carries the workflow's workspace inside `payload`, so the
+            // top-level field is informational redundancy for the
+            // workspace-scoped event listings.
+            if let Some(obj) = data.as_object_mut() {
+                obj.entry("workspace_id".to_string())
+                    .or_insert(serde_json::Value::String(project.workspace_id.clone()));
+            }
+            match spine
+                .emit_raw(
+                    &ev.kind.stream_id(),
+                    spine_namespace_for(&ev.kind),
+                    "stiglab",
+                    ev.kind.event_type(),
+                    &data,
+                )
+                .await
+            {
+                Ok(id) => event_ids.push(id),
+                Err(e) => {
+                    tracing::error!("failed to emit replay-trigger event: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({ "error": "failed to emit event" })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    }
+
+    Json(serde_json::json!(ReplayResponse {
+        project_id: project.id,
+        issue_number,
+        dry_run: false,
+        matches: preview,
+        event_ids,
+    }))
+    .into_response()
+}
+
+fn spine_namespace_for(kind: &FactoryEventKind) -> &'static str {
+    // Keep aligned with `webhooks::spine_namespace` — replays must land
+    // in the same partition as live webhook events so listeners see one
+    // unified stream.
+    match kind {
+        FactoryEventKind::TriggerFired { .. } => "workflow",
+        _ => "stiglab",
+    }
+}
+
+#[allow(clippy::result_large_err)]
+async fn fetch_single_issue(
+    token: &str,
+    repo_owner: &str,
+    repo_name: &str,
+    issue_number: u64,
+) -> Result<LiveIssue, Response> {
+    let url =
+        format!("https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}");
+    let resp = match gh_client()
+        .get(&url)
+        .bearer_auth(token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("github single-issue fetch failed: {e}");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github fetch failed" })),
+            )
+                .into_response());
+        }
+    };
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(not_found("issue not found"));
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let snippet = resp.text().await.unwrap_or_default();
+        tracing::warn!(%status, "github single-issue fetch non-2xx: {snippet}");
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({ "error": "github API error" })),
+        )
+            .into_response());
+    }
+    let parsed: LiveIssue = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("github single-issue parse failed: {e}");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github response parse failed" })),
+            )
+                .into_response());
+        }
+    };
+    Ok(parsed)
 }

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -292,7 +292,11 @@ async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: &
     }
 }
 
-fn spine_namespace(kind: &FactoryEventKind) -> &'static str {
+/// Namespace partition for webhook-sourced spine events. Public so the
+/// manual-replay route in `routes::projects` can route replayed events
+/// into the same partition as live ones — keeping consumer streams
+/// unified.
+pub fn spine_namespace(kind: &FactoryEventKind) -> &'static str {
     match kind {
         FactoryEventKind::TriggerFired { .. } => "workflow",
         FactoryEventKind::GateCheckUpdated { .. }

--- a/crates/stiglab/src/server/webhook_router.rs
+++ b/crates/stiglab/src/server/webhook_router.rs
@@ -27,6 +27,63 @@ pub struct RoutedEvent {
     pub kind: FactoryEventKind,
 }
 
+/// Source tag stamped into every `workflow.trigger_fired` payload so
+/// downstream consumers (and audit views) can tell a real GitHub-webhook
+/// fire apart from a manual replay invoked from the dashboard.
+pub mod trigger_source {
+    pub const WEBHOOK: &str = "github_webhook";
+    pub const MANUAL_REPLAY: &str = "manual_replay";
+}
+
+/// Already-resolved fields for one `issues.labeled`-shaped trigger event.
+/// The webhook path extracts these from the GitHub payload; the manual
+/// replay route builds them from the project + the live issue.
+pub struct IssueTriggerContext<'a> {
+    pub repo_owner: &'a str,
+    pub repo_name: &'a str,
+    pub issue_number: u64,
+    pub title: &'a str,
+    pub label: &'a str,
+    pub source: &'a str,
+    pub replayed_by: Option<&'a str>,
+}
+
+/// Build one `TriggerFired` event per matching workflow from an
+/// already-resolved context. Shared by the live webhook path and the
+/// manual replay route so both produce identical payload shapes — the
+/// only difference is the `source` field (and an optional `replayed_by`).
+pub fn build_trigger_fired_events(
+    ctx: &IssueTriggerContext<'_>,
+    matched: &[Workflow],
+) -> Vec<RoutedEvent> {
+    matched
+        .iter()
+        .map(|w| {
+            let mut payload = serde_json::json!({
+                "repo_owner": ctx.repo_owner,
+                "repo_name": ctx.repo_name,
+                "issue_number": ctx.issue_number,
+                "title": ctx.title,
+                "label": ctx.label,
+                "workspace_id": w.workspace_id,
+                "source": ctx.source,
+            });
+            if let Some(uid) = ctx.replayed_by {
+                if let Some(obj) = payload.as_object_mut() {
+                    obj.insert("replayed_by".into(), Value::String(uid.to_string()));
+                }
+            }
+            RoutedEvent {
+                kind: FactoryEventKind::TriggerFired {
+                    workflow_id: w.id.clone(),
+                    trigger_kind: w.trigger_kind.to_string(),
+                    payload,
+                },
+            }
+        })
+        .collect()
+}
+
 /// Inspect an `issues` payload; if action is `labeled`, return one
 /// `TriggerFired` per matching workflow.
 ///
@@ -48,42 +105,27 @@ pub fn route_issues_labeled(payload: &Value, matched: &[Workflow]) -> Vec<Routed
     let repo_owner = repo
         .pointer("/owner/login")
         .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let repo_name = repo
-        .get("name")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
+        .unwrap_or_default();
+    let repo_name = repo.get("name").and_then(Value::as_str).unwrap_or_default();
     let issue_number = issue.get("number").and_then(Value::as_u64).unwrap_or(0);
-    let title = issue
-        .get("title")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
+    let title = issue.get("title").and_then(Value::as_str).unwrap_or("");
     let label_name = payload
         .pointer("/label/name")
         .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
+        .unwrap_or("");
 
-    matched
-        .iter()
-        .map(|w| RoutedEvent {
-            kind: FactoryEventKind::TriggerFired {
-                workflow_id: w.id.clone(),
-                trigger_kind: w.trigger_kind.to_string(),
-                payload: serde_json::json!({
-                    "repo_owner": repo_owner,
-                    "repo_name": repo_name,
-                    "issue_number": issue_number,
-                    "title": title,
-                    "label": label_name,
-                    "workspace_id": w.workspace_id,
-                }),
-            },
-        })
-        .collect()
+    build_trigger_fired_events(
+        &IssueTriggerContext {
+            repo_owner,
+            repo_name,
+            issue_number,
+            title,
+            label: label_name,
+            source: trigger_source::WEBHOOK,
+            replayed_by: None,
+        },
+        matched,
+    )
 }
 
 /// Inspect a `check_suite`, `check_run`, or `status` payload and produce a
@@ -245,10 +287,67 @@ mod tests {
                         Some(123)
                     );
                     assert_eq!(payload.get("label").and_then(Value::as_str), Some("spec"));
+                    assert_eq!(
+                        payload.get("source").and_then(Value::as_str),
+                        Some(trigger_source::WEBHOOK)
+                    );
+                    assert!(payload.get("replayed_by").is_none());
                 }
                 _ => panic!("wrong event kind"),
             }
         }
+    }
+
+    #[test]
+    fn manual_replay_matches_webhook_payload_except_source() {
+        let payload = json!({
+            "action": "labeled",
+            "issue": {"number": 123, "title": "fix the bug"},
+            "label": {"name": "spec"},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![sample_workflow("spec")];
+        let from_webhook = route_issues_labeled(&payload, &workflows);
+        let from_replay = build_trigger_fired_events(
+            &IssueTriggerContext {
+                repo_owner: "acme",
+                repo_name: "widgets",
+                issue_number: 123,
+                title: "fix the bug",
+                label: "spec",
+                source: trigger_source::MANUAL_REPLAY,
+                replayed_by: Some("u_abc"),
+            },
+            &workflows,
+        );
+        assert_eq!(from_webhook.len(), 1);
+        assert_eq!(from_replay.len(), 1);
+        let (
+            FactoryEventKind::TriggerFired { payload: w, .. },
+            FactoryEventKind::TriggerFired { payload: r, .. },
+        ) = (&from_webhook[0].kind, &from_replay[0].kind)
+        else {
+            panic!("wrong event kind");
+        };
+        for key in [
+            "repo_owner",
+            "repo_name",
+            "issue_number",
+            "title",
+            "label",
+            "workspace_id",
+        ] {
+            assert_eq!(w.get(key), r.get(key), "mismatch on {key}");
+        }
+        assert_eq!(
+            w.get("source").and_then(Value::as_str),
+            Some(trigger_source::WEBHOOK)
+        );
+        assert_eq!(
+            r.get("source").and_then(Value::as_str),
+            Some(trigger_source::MANUAL_REPLAY)
+        );
+        assert_eq!(r.get("replayed_by").and_then(Value::as_str), Some("u_abc"));
     }
 
     #[test]

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -239,6 +239,36 @@ pub async fn find_active_github_workflows_for_label(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// Find every **active** workflow whose `github-issue-webhook` trigger
+/// targets this repo + label, scoped to a single workspace. Used by the
+/// dashboard's manual-replay route so the matched set respects the
+/// caller's workspace boundary even when the same `(repo_owner, repo_name)`
+/// is connected to multiple workspaces.
+pub async fn find_active_github_workflows_for_label_in_workspace(
+    pool: &AnyPool,
+    workspace_id: &str,
+    repo_owner: &str,
+    repo_name: &str,
+    label: &str,
+) -> anyhow::Result<Vec<Workflow>> {
+    let trigger_kind = TriggerKind::GithubIssueWebhook.to_string();
+    let rows = sqlx::query_as::<_, WorkflowRow>(
+        "SELECT id, workspace_id, name, trigger_kind, repo_owner, repo_name, trigger_label, \
+                install_id, preset_id, active, created_by, created_at, updated_at \
+         FROM workspace_workflows \
+         WHERE active = 1 AND workspace_id = $1 AND trigger_kind = $2 \
+           AND repo_owner = $3 AND repo_name = $4 AND trigger_label = $5",
+    )
+    .bind(workspace_id)
+    .bind(&trigger_kind)
+    .bind(repo_owner)
+    .bind(repo_name)
+    .bind(label)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 /// Whether any other active workflow on `(repo_owner, repo_name)` still
 /// needs webhook delivery. Used by the deactivation hook to decide if it
 /// can deregister the repo-level webhook.
@@ -388,6 +418,25 @@ mod tests {
         let hits = find_active_github_workflows_for_label(&pool, "acme", "widgets", "spec")
             .await
             .unwrap();
+        let ids: Vec<_> = hits.iter().map(|w| w.id.as_str()).collect();
+        assert_eq!(ids, vec![wf_a.id.as_str()]);
+    }
+
+    #[tokio::test]
+    async fn workspace_scoped_lookup_excludes_other_workspaces() {
+        let pool = pool().await;
+        let wf_a = sample_workflow("w1", "widgets", "spec", true);
+        let wf_b = sample_workflow("w2", "widgets", "spec", true);
+        for wf in [&wf_a, &wf_b] {
+            insert_workflow_with_stages(&pool, wf, std::slice::from_ref(&agent_stage(&wf.id)))
+                .await
+                .unwrap();
+        }
+        let hits = find_active_github_workflows_for_label_in_workspace(
+            &pool, "w1", "acme", "widgets", "spec",
+        )
+        .await
+        .unwrap();
         let ids: Vec<_> = hits.iter().map(|w| w.id.as_str()).collect();
         assert_eq!(ids, vec![wf_a.id.as_str()]);
     }

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -269,6 +269,32 @@ pub async fn find_active_github_workflows_for_label_in_workspace(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
+/// All active `github-issue-webhook` workflows for `(workspace, repo)` —
+/// returned without label filtering so callers iterating over many
+/// candidate labels can do one round-trip and partition in-memory.
+pub async fn find_active_github_workflows_for_workspace_repo(
+    pool: &AnyPool,
+    workspace_id: &str,
+    repo_owner: &str,
+    repo_name: &str,
+) -> anyhow::Result<Vec<Workflow>> {
+    let trigger_kind = TriggerKind::GithubIssueWebhook.to_string();
+    let rows = sqlx::query_as::<_, WorkflowRow>(
+        "SELECT id, workspace_id, name, trigger_kind, repo_owner, repo_name, trigger_label, \
+                install_id, preset_id, active, created_by, created_at, updated_at \
+         FROM workspace_workflows \
+         WHERE active = 1 AND workspace_id = $1 AND trigger_kind = $2 \
+           AND repo_owner = $3 AND repo_name = $4",
+    )
+    .bind(workspace_id)
+    .bind(&trigger_kind)
+    .bind(repo_owner)
+    .bind(repo_name)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
 /// Whether any other active workflow on `(repo_owner, repo_name)` still
 /// needs webhook delivery. Used by the deactivation hook to decide if it
 /// can deregister the repo-level webhook.

--- a/crates/stiglab/tests/replay_trigger.rs
+++ b/crates/stiglab/tests/replay_trigger.rs
@@ -1,0 +1,210 @@
+//! Integration tests for the `/api/projects/:id/issues/:number/replay-trigger`
+//! route (spec #203). The handler reaches out to GitHub for live label data
+//! when access is granted, so these tests focus on the paths that short-
+//! circuit before that fetch — `require_project_for_user`'s 404 contract
+//! and the cross-workspace boundary.
+//!
+//! End-to-end coverage of the dry-run match resolution + spine emission
+//! requires a GitHub stub and is left to manual testing on the preview
+//! deploy. The unit tests in `server::webhook_router` already pin the
+//! payload shape produced by `build_trigger_fired_events`.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::Utc;
+use sqlx::pool::PoolOptions;
+use sqlx::AnyPool;
+use stiglab::core::{
+    GitHubAccountType, GitHubAppInstallation, Project, User, Workspace, WorkspaceMember,
+};
+use stiglab::server::auth::generate_credential_key;
+use stiglab::server::config::ServerConfig;
+use stiglab::server::db;
+use stiglab::server::state::AppState;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+async fn test_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = PoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite connect");
+    db::run_migrations(&pool).await.expect("migrations");
+    pool
+}
+
+fn auth_enabled_config() -> ServerConfig {
+    ServerConfig {
+        host: "0.0.0.0".into(),
+        port: 3000,
+        database_url: "sqlite::memory:".into(),
+        static_dir: None,
+        cors_origin: None,
+        github_client_id: Some("client-id".into()),
+        github_client_secret: Some("client-secret".into()),
+        credential_key: Some(generate_credential_key()),
+        public_url: None,
+        github_app_webhook_secret: None,
+        sso_state_secret: None,
+        sso_exchange_secret: None,
+        sso_return_host_allowlist: Vec::new(),
+        sso_auth_domain: None,
+        internal_dispatch_token: None,
+    }
+}
+
+async fn seed_user(pool: &AnyPool, login: &str, github_id: i64) -> User {
+    let user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id,
+        github_login: login.into(),
+        github_name: None,
+        github_avatar_url: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    db::upsert_user(pool, &user).await.unwrap();
+    user
+}
+
+async fn seed_workspace(pool: &AnyPool, user_id: &str, slug: &str) -> Workspace {
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: Uuid::new_v4().to_string(),
+        slug: slug.into(),
+        name: slug.into(),
+        created_by: user_id.into(),
+        created_at: now,
+    };
+    let member = WorkspaceMember {
+        workspace_id: workspace.id.clone(),
+        user_id: user_id.into(),
+        joined_at: now,
+    };
+    db::insert_workspace_with_creator(pool, &workspace, &member)
+        .await
+        .unwrap();
+    workspace
+}
+
+async fn seed_project(pool: &AnyPool, workspace_id: &str) -> Project {
+    let install = GitHubAppInstallation {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.into(),
+        install_id: 1234,
+        account_login: "acme".into(),
+        account_type: GitHubAccountType::Organization,
+        created_at: Utc::now(),
+    };
+    db::insert_github_app_installation(pool, &install, None)
+        .await
+        .unwrap();
+    let project = Project {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.into(),
+        github_app_installation_id: install.id.clone(),
+        repo_owner: "acme".into(),
+        repo_name: "widgets".into(),
+        default_branch: "main".into(),
+        created_at: Utc::now(),
+    };
+    db::insert_project(pool, &project).await.unwrap();
+    project
+}
+
+async fn seed_session_cookie(pool: &AnyPool, user_id: &str) -> String {
+    let token = stiglab::server::auth::generate_session_token();
+    db::create_auth_session(
+        pool,
+        &token,
+        user_id,
+        Utc::now() + chrono::Duration::days(1),
+    )
+    .await
+    .unwrap();
+    token
+}
+
+fn cookie(token: &str) -> String {
+    format!("stiglab_session={token}")
+}
+
+fn app(state: AppState) -> axum::Router {
+    stiglab::server::build_router(state.clone(), &state.config)
+}
+
+fn replay_request(project_id: &str, issue_number: u64, session_token: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(format!(
+            "/api/projects/{project_id}/issues/{issue_number}/replay-trigger"
+        ))
+        .header(header::COOKIE, cookie(session_token))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"dry_run":true}"#))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn replay_trigger_unknown_project_is_404() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "alice", 1).await;
+    let _workspace = seed_workspace(&pool, &user.id, "w-a").await;
+    let session_token = seed_session_cookie(&pool, &user.id).await;
+
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let resp = app(state)
+        .oneshot(replay_request("does-not-exist", 1, &session_token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn replay_trigger_cross_workspace_is_404() {
+    // alice owns w_a, bob owns w_b. bob's project is invisible to alice;
+    // a hit against it must 404 (not 403) to avoid leaking workspace
+    // membership — same contract as the rest of the project-scoped routes.
+    let pool = test_pool().await;
+    let alice = seed_user(&pool, "alice", 1).await;
+    let bob = seed_user(&pool, "bob", 2).await;
+    let _w_a = seed_workspace(&pool, &alice.id, "w-a").await;
+    let w_b = seed_workspace(&pool, &bob.id, "w-b").await;
+    let bob_project = seed_project(&pool, &w_b.id).await;
+
+    let alice_token = seed_session_cookie(&pool, &alice.id).await;
+
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let resp = app(state)
+        .oneshot(replay_request(&bob_project.id, 1, &alice_token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn replay_trigger_unauthenticated_is_401() {
+    let pool = test_pool().await;
+    let user = seed_user(&pool, "alice", 1).await;
+    let workspace = seed_workspace(&pool, &user.id, "w-a").await;
+    let project = seed_project(&pool, &workspace.id).await;
+
+    let state = AppState::new(pool, auth_enabled_config(), None);
+    let resp = app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/projects/{}/issues/1/replay-trigger",
+                    project.id
+                ))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"dry_run":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary

Adds a per-row kebab menu to the Issues page so a developer can manually drive a workflow trigger against an issue while debugging — the active counterpart to the passive `issues.labeled` webhook path.

- **Refresh this issue** — client-side React Query invalidation; catches stale-hydration bugs.
- **Replay trigger…** — opens a confirm dialog showing the matched workflows (server-side dry-run), then on confirm fires one `workflow.trigger_fired` per match identical to the webhook path. Distinguishable only by `payload.source = "manual_replay"` and `payload.replayed_by = <user_id>`.
- **Open in GitHub** — moved from a standalone button into the menu so the row stays clean.

New backend route `POST /api/projects/:id/issues/:number/replay-trigger` reads the issue's current labels live from GitHub, finds active workflows in the project's workspace whose `(repo, label)` matches, and either previews (`dry_run=true`, default) or emits events. Reuses a shared `build_trigger_fired_events` helper so the replay path produces the exact same payload shape the webhook path produces — only `source` differs.

Closes #203

## Test plan

- [x] `cargo test -p stiglab --lib` — 162 pass, including `manual_replay_matches_webhook_payload_except_source` and `workspace_scoped_lookup_excludes_other_workspaces`
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo run -p xtask -- lint-seams` — clean (no new exemptions)
- [x] `pnpm test` — 103 pass, including 5 new tests for `IssueActionsMenu`
- [x] `pnpm lint` / `pnpm build` — clean
- [ ] Manual: with at least one active workflow whose `trigger_label` matches a label on a real issue, click **Replay trigger…** → dialog shows the workflow → click **Fire trigger** → spine shows `workflow.trigger_fired` with `source=manual_replay`, downstream stages advance.
- [ ] Manual (mobile viewport): kebab is reachable on `IssueCard`; the dialog is usable on a 375px-wide screen.

https://claude.ai/code/session_01JywpEonJvFAoqimqg9eAuL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JywpEonJvFAoqimqg9eAuL)_