### PR TITLE
feat(dashboard,stiglab): issue detail page

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -23,6 +23,9 @@ const ArtifactsPage = lazy(() =>
 const IssuesPage = lazy(() =>
   import("@/pages/IssuesPage").then((m) => ({ default: m.IssuesPage })),
 )
+const IssueDetailPage = lazy(() =>
+  import("@/pages/IssueDetailPage").then((m) => ({ default: m.IssueDetailPage })),
+)
 const ArtifactDetailPage = lazy(() =>
   import("@/pages/ArtifactDetailPage").then((m) => ({ default: m.ArtifactDetailPage })),
 )
@@ -296,6 +299,10 @@ function AppRoutes() {
                             <Route
                               path="issues"
                               element={<LazyRoute variant="list"><IssuesPage /></LazyRoute>}
+                            />
+                            <Route
+                              path="issues/:projectId/:number"
+                              element={<LazyRoute variant="detail"><IssueDetailPage /></LazyRoute>}
                             />
                             <Route
                               path="spine"

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -276,6 +276,33 @@ export interface ProjectIssueRow {
   updated_at: string;
 }
 
+/// Detail-shape counterpart to `ProjectIssueRow` (#205). Adds the
+/// fields the list endpoint omits — body, assignees, milestone, and
+/// the created/closed timestamps. Hits the same proxy cache as the
+/// list endpoint and uses the same fail-open envelope: `issue` is
+/// null and `error` is set when the upstream is rate-limited or
+/// unreachable.
+export interface ProjectIssueDetail {
+  number: number;
+  title: string;
+  state: string;
+  html_url: string;
+  author: string | null;
+  labels: string[];
+  assignees: string[];
+  comments: number;
+  body: string | null;
+  milestone: { title: string; state: string } | null;
+  created_at: string | null;
+  updated_at: string;
+  closed_at: string | null;
+}
+
+export interface ProjectIssueDetailResponse {
+  issue: ProjectIssueDetail | null;
+  error?: string;
+}
+
 export interface ProjectPullRow {
   number: number;
   title: string;
@@ -984,6 +1011,10 @@ export const api = {
       `/projects/${encodeURIComponent(projectId)}/issues${qs}`,
     );
   },
+  getProjectIssue: (projectId: string, number: number) =>
+    request<ProjectIssueDetailResponse>(
+      `/projects/${encodeURIComponent(projectId)}/issues/${number}`,
+    ),
   listProjectPulls: (projectId: string, state?: 'open' | 'closed' | 'all') => {
     const qs = state ? `?state=${state}` : '';
     return request<ProjectLiveListResponse<ProjectPullRow>>(

--- a/apps/dashboard/src/pages/IssueDetailPage.tsx
+++ b/apps/dashboard/src/pages/IssueDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 
 import {
   api,
+  ApiError,
   type ProjectIssueDetail,
   type SpineArtifact,
 } from "@/lib/api"
@@ -31,11 +32,15 @@ export function IssueDetailPage() {
     projectId: string
     number: string
   }>()
-  const issueNumber = Number.parseInt(numberParam, 10)
-  const numberValid = Number.isFinite(issueNumber) && issueNumber > 0
+  // Strict digit-only check before parseInt — a malformed segment like
+  // "42abc" would otherwise parse to 42 and silently link to the wrong
+  // issue. queryKey uses the raw string so an invalid input never
+  // serializes NaN into the cache key.
+  const numberValid = /^\d+$/.test(numberParam)
+  const issueNumber = numberValid ? Number.parseInt(numberParam, 10) : 0
 
   const liveQuery = useQuery({
-    queryKey: ["project-issue", projectId, issueNumber],
+    queryKey: ["project-issue", projectId, numberParam],
     queryFn: () => api.getProjectIssue(projectId, issueNumber),
     enabled: !!projectId && numberValid,
     refetchInterval: 60_000,
@@ -51,7 +56,7 @@ export function IssueDetailPage() {
         kind: "github_issue",
         project_id: projectId,
       }),
-    enabled: !!projectId,
+    enabled: !!projectId && numberValid,
     refetchInterval: 30_000,
   })
 
@@ -66,7 +71,13 @@ export function IssueDetailPage() {
   }, [skeletonsQuery.data, projectId, issueNumber, numberValid])
 
   const issue: ProjectIssueDetail | null = liveQuery.data?.issue ?? null
+  // The proxy fail-open envelope (`{ issue: null, error: ... }`) carries
+  // `rate_limited` / `github_unreachable`. A network/HTTP error throws
+  // an `ApiError`; we render those as a not-found / error state below
+  // rather than degraded mode.
   const proxyError = liveQuery.data?.error ?? null
+  const liveErrored = liveQuery.error instanceof ApiError ? liveQuery.error : null
+  const liveNotFound = liveErrored?.status === 404
 
   const inboxBackTo = `/workspaces/${workspace.slug}/issues${
     projectId ? `?project=${encodeURIComponent(projectId)}` : ""
@@ -74,17 +85,21 @@ export function IssueDetailPage() {
 
   // Mobile chrome — title is `#N` so it stays short; the full issue
   // title renders below in the page body. The kebab reuses the same
-  // replay/external-link actions as the inbox row.
+  // replay/external-link actions as the inbox row. `Replay trigger`
+  // needs the issue's *current* labels, so we only enable it (by
+  // passing the number) when live data is present — degraded modes
+  // (proxy fail-open or live HTTP error) get the disabled state.
+  const replayIssueNumber = issue && numberValid ? issueNumber : null
   const headerActions = useMemo(
     () => (
       <IssueActionsMenu
         projectId={projectId || null}
-        issueNumber={numberValid ? issueNumber : null}
+        issueNumber={replayIssueNumber}
         htmlUrl={issue?.html_url ?? null}
-        listQueryKey={["project-issue", projectId, issueNumber]}
+        listQueryKey={["project-issue", projectId, numberParam]}
       />
     ),
-    [projectId, issueNumber, numberValid, issue?.html_url],
+    [projectId, replayIssueNumber, numberParam, issue?.html_url],
   )
   usePageHeader({
     title: numberValid ? `#${issueNumber}` : "Issue",
@@ -104,6 +119,18 @@ export function IssueDetailPage() {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
         <p className="text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+
+  // 404 from the backend means the issue genuinely doesn't exist —
+  // surface that explicitly even if a stale skeleton happens to match.
+  // Other live errors fall through to the error banner below; the
+  // skeleton (if present) still anchors the page.
+  if (liveNotFound) {
+    return (
+      <div className="space-y-4">
+        <p className="text-destructive">Issue not found.</p>
       </div>
     )
   }
@@ -155,6 +182,14 @@ export function IssueDetailPage() {
         </Card>
       ) : null}
 
+      {liveErrored && !liveNotFound ? (
+        <Card>
+          <CardContent className="py-3 text-sm text-destructive">
+            Couldn&apos;t load this issue: {liveErrored.message}
+          </CardContent>
+        </Card>
+      ) : null}
+
       {/* Desktop: external link as inline button. Mobile uses the
           overflow menu in the global top bar. */}
       {issue?.html_url ? (
@@ -182,7 +217,7 @@ export function IssueDetailPage() {
         <MetaCard label="Updated" value={display.updatedLabel} />
         <MetaCard
           label="Lifecycle"
-          value={skeleton ? skeleton.state.replace("_", " ") : "—"}
+          value={skeleton ? skeleton.state.replaceAll("_", " ") : "—"}
         />
       </div>
 
@@ -321,10 +356,13 @@ function describe(
     }
   }
   // Skeleton-only fallback — same shape the inbox uses on a degraded
-  // proxy. Lifecycle `draft` ↔ open, `archived` ↔ closed.
+  // proxy. Lifecycle `draft` ↔ open, `archived` ↔ closed. The title
+  // falls back to `Issue #N` rather than the artifact id (which is an
+  // internal identifier already shown under "Onsager metadata" and is
+  // not user-meaningful).
   const open = skeleton?.state === "draft"
   return {
-    title: skeleton?.id ?? `Issue #${number}`,
+    title: `Issue #${number}`,
     openState: open,
     stateLabel: open ? "open" : "closed",
     author: "—",

--- a/apps/dashboard/src/pages/IssueDetailPage.tsx
+++ b/apps/dashboard/src/pages/IssueDetailPage.tsx
@@ -1,0 +1,338 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Link, useParams } from "react-router-dom"
+import { ArrowLeft, ExternalLink } from "lucide-react"
+
+import {
+  api,
+  type ProjectIssueDetail,
+  type SpineArtifact,
+} from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { IssueActionsMenu } from "@/components/IssueActionsMenu"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { useActiveWorkspace } from "@/lib/workspace"
+
+/**
+ * Issue detail page (#205).
+ *
+ * Joins the live-hydrated GitHub issue (`GET /api/projects/:id/issues/:n`)
+ * with the matching reference-only `SpineArtifact` skeleton (kind=
+ * `github_issue`, looked up by `external_ref`). The proxy is fail-open
+ * per #170: if GitHub is rate-limited or unreachable, the live response
+ * carries `{ issue: null, error: "..." }` and we render the skeleton
+ * alone with the same banner copy as the inbox.
+ */
+export function IssueDetailPage() {
+  const workspace = useActiveWorkspace()
+  const { projectId = "", number: numberParam = "" } = useParams<{
+    projectId: string
+    number: string
+  }>()
+  const issueNumber = Number.parseInt(numberParam, 10)
+  const numberValid = Number.isFinite(issueNumber) && issueNumber > 0
+
+  const liveQuery = useQuery({
+    queryKey: ["project-issue", projectId, issueNumber],
+    queryFn: () => api.getProjectIssue(projectId, issueNumber),
+    enabled: !!projectId && numberValid,
+    refetchInterval: 60_000,
+  })
+
+  // Skeleton lookup: filter the workspace's `github_issue` artifacts by
+  // project, then match the row whose `external_ref` matches this issue.
+  // Same join key the inbox uses.
+  const skeletonsQuery = useQuery({
+    queryKey: ["artifacts", workspace.id, "github_issue", projectId],
+    queryFn: () =>
+      api.getArtifacts(workspace.id, {
+        kind: "github_issue",
+        project_id: projectId,
+      }),
+    enabled: !!projectId,
+    refetchInterval: 30_000,
+  })
+
+  const skeleton: SpineArtifact | null = useMemo(() => {
+    if (!projectId || !numberValid) return null
+    const externalRef = `github:project:${projectId}:issue:${issueNumber}`
+    return (
+      skeletonsQuery.data?.artifacts.find(
+        (a) => a.external_ref === externalRef,
+      ) ?? null
+    )
+  }, [skeletonsQuery.data, projectId, issueNumber, numberValid])
+
+  const issue: ProjectIssueDetail | null = liveQuery.data?.issue ?? null
+  const proxyError = liveQuery.data?.error ?? null
+
+  const inboxBackTo = `/workspaces/${workspace.slug}/issues${
+    projectId ? `?project=${encodeURIComponent(projectId)}` : ""
+  }`
+
+  // Mobile chrome — title is `#N` so it stays short; the full issue
+  // title renders below in the page body. The kebab reuses the same
+  // replay/external-link actions as the inbox row.
+  const headerActions = useMemo(
+    () => (
+      <IssueActionsMenu
+        projectId={projectId || null}
+        issueNumber={numberValid ? issueNumber : null}
+        htmlUrl={issue?.html_url ?? null}
+        listQueryKey={["project-issue", projectId, issueNumber]}
+      />
+    ),
+    [projectId, issueNumber, numberValid, issue?.html_url],
+  )
+  usePageHeader({
+    title: numberValid ? `#${issueNumber}` : "Issue",
+    backTo: inboxBackTo,
+    actions: headerActions,
+  })
+
+  if (!projectId || !numberValid) {
+    return (
+      <div className="space-y-4">
+        <p className="text-destructive">Invalid issue URL.</p>
+      </div>
+    )
+  }
+
+  if (liveQuery.isLoading && skeletonsQuery.isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+
+  if (!issue && !skeleton && !liveQuery.isLoading) {
+    return (
+      <div className="space-y-4">
+        <p className="text-destructive">Issue not found.</p>
+      </div>
+    )
+  }
+
+  const display = describe(issue, skeleton, issueNumber)
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {/* Desktop header — back link. Mobile uses the global top bar. */}
+      <Link
+        to={inboxBackTo}
+        className="hidden items-center gap-1 text-sm text-muted-foreground hover:text-foreground md:inline-flex"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to Issues
+      </Link>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="hidden truncate text-2xl font-bold tracking-tight md:block">
+            {display.title}
+          </h1>
+          <p className="text-sm text-muted-foreground font-mono">
+            #{issueNumber}
+          </p>
+        </div>
+        <Badge
+          variant={display.openState ? "default" : "secondary"}
+          className="text-sm"
+        >
+          {display.stateLabel}
+        </Badge>
+      </div>
+
+      {proxyError ? (
+        <Card>
+          <CardContent className="py-3 text-sm text-muted-foreground">
+            {proxyError === "rate_limited"
+              ? "GitHub rate limit reached. Showing the last-known artifact; details will return in about a minute."
+              : "Couldn't reach GitHub. Showing the last-known artifact; details will refresh once the connection recovers."}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {/* Desktop: external link as inline button. Mobile uses the
+          overflow menu in the global top bar. */}
+      {issue?.html_url ? (
+        <div className="hidden flex-wrap gap-2 md:flex">
+          <Button
+            variant="outline"
+            size="sm"
+            render={
+              <a
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            }
+          >
+            <ExternalLink className="mr-1 h-3.5 w-3.5" />
+            Open in GitHub
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <MetaCard label="Author" value={display.author} />
+        <MetaCard label="Comments" value={display.commentsLabel} />
+        <MetaCard label="Updated" value={display.updatedLabel} />
+        <MetaCard
+          label="Lifecycle"
+          value={skeleton ? skeleton.state.replace("_", " ") : "—"}
+        />
+      </div>
+
+      {display.labels.length > 0 ? (
+        <Card>
+          <CardHeader className="px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Labels</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2 px-4 md:px-6">
+            {display.labels.map((l) => (
+              <Badge key={l} variant="outline">
+                {l}
+              </Badge>
+            ))}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {display.assignees.length > 0 ? (
+        <Card>
+          <CardHeader className="px-4 md:px-6">
+            <CardTitle className="text-base md:text-lg">Assignees</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2 px-4 md:px-6">
+            {display.assignees.map((a) => (
+              <Badge key={a} variant="secondary">
+                {a}
+              </Badge>
+            ))}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-lg">Description</CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          {issue?.body && issue.body.trim().length > 0 ? (
+            // No markdown lib in deps yet — render as preformatted text so
+            // line breaks survive. A follow-up will add proper rendering.
+            <pre className="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-foreground">
+              {issue.body}
+            </pre>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {proxyError
+                ? "Description unavailable while GitHub is degraded."
+                : "No description."}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-lg">
+            Onsager metadata
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 gap-3 px-4 md:grid-cols-3 md:px-6">
+          <MetaCard
+            label="Artifact ID"
+            value={skeleton?.id ?? "—"}
+            mono
+          />
+          <MetaCard
+            label="Version"
+            value={skeleton ? `v${skeleton.current_version}` : "—"}
+            mono
+          />
+          <MetaCard
+            label="Last observed"
+            value={
+              skeleton?.last_observed_at
+                ? new Date(skeleton.last_observed_at).toLocaleString()
+                : "—"
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function MetaCard({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <Card>
+      <CardContent className="px-3 py-3">
+        <div className="text-xs text-muted-foreground">{label}</div>
+        <div
+          className={`truncate font-medium ${mono ? "font-mono text-sm" : ""}`}
+          title={value}
+        >
+          {value}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface IssueDisplay {
+  title: string
+  openState: boolean
+  stateLabel: string
+  author: string
+  commentsLabel: string
+  updatedLabel: string
+  labels: string[]
+  assignees: string[]
+}
+
+function describe(
+  issue: ProjectIssueDetail | null,
+  skeleton: SpineArtifact | null,
+  number: number,
+): IssueDisplay {
+  if (issue) {
+    return {
+      title: issue.title,
+      openState: issue.state === "open",
+      stateLabel: issue.state,
+      author: issue.author ?? "—",
+      commentsLabel: String(issue.comments),
+      updatedLabel: new Date(issue.updated_at).toLocaleString(),
+      labels: issue.labels,
+      assignees: issue.assignees,
+    }
+  }
+  // Skeleton-only fallback — same shape the inbox uses on a degraded
+  // proxy. Lifecycle `draft` ↔ open, `archived` ↔ closed.
+  const open = skeleton?.state === "draft"
+  return {
+    title: skeleton?.id ?? `Issue #${number}`,
+    openState: open,
+    stateLabel: open ? "open" : "closed",
+    author: "—",
+    commentsLabel: "—",
+    updatedLabel: skeleton?.last_observed_at
+      ? `last seen ${new Date(skeleton.last_observed_at).toLocaleString()}`
+      : "—",
+    labels: [],
+    assignees: [],
+  }
+}

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -294,6 +294,7 @@ export function IssuesPage() {
                     key={rowKey(r)}
                     row={r}
                     projectId={selectedProjectId}
+                    workspaceSlug={workspace.slug}
                     listQueryKey={[
                       "project-issues",
                       selectedProjectId,
@@ -317,12 +318,26 @@ export function IssuesPage() {
                   <TableBody>
                     {rows.map((r) => {
                       const display = describeRow(r)
+                      const detailNumber = detailIssueNumber(r)
+                      const detailHref =
+                        selectedProjectId && detailNumber != null
+                          ? `/workspaces/${workspace.slug}/issues/${selectedProjectId}/${detailNumber}`
+                          : null
                       return (
                         <TableRow key={rowKey(r)}>
                           <TableCell className="max-w-md">
-                            <div className="truncate font-medium">
-                              {display.title}
-                            </div>
+                            {detailHref ? (
+                              <Link
+                                to={detailHref}
+                                className="block truncate font-medium hover:underline"
+                              >
+                                {display.title}
+                              </Link>
+                            ) : (
+                              <div className="truncate font-medium">
+                                {display.title}
+                              </div>
+                            )}
                             <div className="text-xs text-muted-foreground">
                               {display.subtitle}
                             </div>
@@ -399,6 +414,18 @@ function rowKey(row: HydratedIssueRow): string {
   return row.skeleton?.id ?? Math.random().toString(36)
 }
 
+/// Extract the issue number for the detail-page link. Prefers the live
+/// row's number; falls back to parsing the skeleton's `external_ref`
+/// tail (`...:issue:42`) so skeleton-only rows can still navigate. Returns
+/// null if neither side has a usable number.
+function detailIssueNumber(row: HydratedIssueRow): number | null {
+  if (row.issue) return row.issue.number
+  const tail = row.skeleton?.external_ref?.split(":issue:").pop()
+  if (!tail) return null
+  const parsed = Number.parseInt(tail, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 /// Project hydrated + skeleton rows down to the values the table/card
 /// renderers display. Skeleton-only rows derive their state from the
 /// artifact's lifecycle column and surface a "—" placeholder for fields
@@ -439,21 +466,38 @@ function describeRow(row: HydratedIssueRow): RowDisplay {
 function IssueCard({
   row,
   projectId,
+  workspaceSlug,
   listQueryKey,
 }: {
   row: HydratedIssueRow
   projectId: string | null
+  workspaceSlug: string
   listQueryKey: readonly unknown[]
 }) {
   const display = describeRow(row)
-  // No interactive cursor / press state on the card itself — the row
-  // is no longer a single clickable surface; per-row navigation lives
-  // in the kebab menu's "Open in GitHub" item.
+  const detailNumber = detailIssueNumber(row)
+  const detailHref =
+    projectId && detailNumber != null
+      ? `/workspaces/${workspaceSlug}/issues/${projectId}/${detailNumber}`
+      : null
+  // The whole card is not a single clickable surface (the kebab needs
+  // its own hit target); the title is the link, the rest is metadata.
   const cardClass = "flex flex-col gap-1.5 rounded-lg border p-3"
   return (
     <div className={cardClass}>
       <div className="flex items-start justify-between gap-2">
-        <span className="line-clamp-2 text-sm font-medium">{display.title}</span>
+        {detailHref ? (
+          <Link
+            to={detailHref}
+            className="line-clamp-2 text-sm font-medium hover:underline"
+          >
+            {display.title}
+          </Link>
+        ) : (
+          <span className="line-clamp-2 text-sm font-medium">
+            {display.title}
+          </span>
+        )}
         <div className="flex shrink-0 items-center gap-1">
           <Badge variant={display.openState ? "default" : "secondary"}>
             {display.stateLabel}

--- a/apps/dashboard/src/pages/IssuesPage.tsx
+++ b/apps/dashboard/src/pages/IssuesPage.tsx
@@ -416,14 +416,15 @@ function rowKey(row: HydratedIssueRow): string {
 
 /// Extract the issue number for the detail-page link. Prefers the live
 /// row's number; falls back to parsing the skeleton's `external_ref`
-/// tail (`...:issue:42`) so skeleton-only rows can still navigate. Returns
-/// null if neither side has a usable number.
+/// tail (`...:issue:42`) so skeleton-only rows can still navigate.
+/// Requires the tail to be all digits — `parseInt` on a partial string
+/// like `"42abc"` would otherwise silently link to the wrong issue.
+/// Returns null if neither side has a usable number.
 function detailIssueNumber(row: HydratedIssueRow): number | null {
   if (row.issue) return row.issue.number
   const tail = row.skeleton?.external_ref?.split(":issue:").pop()
-  if (!tail) return null
-  const parsed = Number.parseInt(tail, 10)
-  return Number.isFinite(parsed) ? parsed : null
+  if (!tail || !/^\d+$/.test(tail)) return null
+  return Number.parseInt(tail, 10)
 }
 
 /// Project hydrated + skeleton rows down to the values the table/card

--- a/apps/dashboard/tests/smoke/issue-detail-page.test.tsx
+++ b/apps/dashboard/tests/smoke/issue-detail-page.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { IssueDetailPage } from "@/pages/IssueDetailPage"
+import { ApiError } from "@/lib/api"
+
+// Smoke coverage for the live + skeleton join, the proxy fail-open
+// banner, and the replay-disabled-when-degraded contract that the page
+// inherits from `IssueActionsMenu` (Copilot review on PR #206).
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  getProjectIssue: vi.fn(),
+  getArtifacts: vi.fn(),
+  replayIssueTrigger: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return { ...actual, api: apiMock }
+})
+
+import { WorkspaceScope } from "@/lib/workspace"
+
+function renderPage(initialPath = "/workspaces/acme/issues/proj_1/42") {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route
+                    path="issues/:projectId/:number"
+                    element={<IssueDetailPage />}
+                  />
+                </Routes>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const workspace = {
+  id: "ws1",
+  slug: "acme",
+  name: "Acme",
+  created_by: "u1",
+  created_at: "2026-01-01",
+}
+
+describe("IssueDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+    apiMock.getArtifacts.mockResolvedValue({ artifacts: [] })
+  })
+
+  it("renders the live title, body, and labels when the proxy succeeds", async () => {
+    apiMock.getProjectIssue.mockResolvedValue({
+      issue: {
+        number: 42,
+        title: "Add issue detail page",
+        state: "open",
+        html_url: "https://github.com/acme/widgets/issues/42",
+        author: "alice",
+        labels: ["spec", "area:dashboard"],
+        assignees: ["bob"],
+        comments: 3,
+        body: "We should have an issue detail page.",
+        milestone: null,
+        created_at: "2026-04-01T00:00:00Z",
+        updated_at: "2026-04-29T00:00:00Z",
+        closed_at: null,
+      },
+    })
+
+    renderPage()
+
+    expect(
+      await screen.findByText("Add issue detail page"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("We should have an issue detail page."),
+    ).toBeInTheDocument()
+    expect(screen.getByText("spec")).toBeInTheDocument()
+    expect(screen.getByText("area:dashboard")).toBeInTheDocument()
+    expect(screen.getByText("bob")).toBeInTheDocument()
+  })
+
+  it("renders the rate-limit banner when the proxy fails open", async () => {
+    apiMock.getProjectIssue.mockResolvedValue({
+      issue: null,
+      error: "rate_limited",
+    })
+    apiMock.getArtifacts.mockResolvedValue({
+      artifacts: [
+        {
+          id: "art_1",
+          kind: "github_issue",
+          name: null,
+          owner: null,
+          state: "draft",
+          current_version: 1,
+          external_ref: "github:project:proj_1:issue:42",
+          created_at: "2026-04-01T00:00:00Z",
+          updated_at: "2026-04-29T00:00:00Z",
+          last_observed_at: "2026-04-29T00:00:00Z",
+        },
+      ],
+    })
+
+    renderPage()
+
+    expect(
+      await screen.findByText(/GitHub rate limit reached/),
+    ).toBeInTheDocument()
+    // Skeleton-only title falls back to `Issue #N`, not the artifact id.
+    // The artifact id still appears under "Onsager metadata" — that's
+    // intentional; what matters is that the page header isn't an opaque
+    // identifier.
+    expect(
+      screen.getByRole("heading", { name: "Issue #42" }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows an explicit not-found state when the backend returns 404", async () => {
+    apiMock.getProjectIssue.mockRejectedValue(
+      new ApiError("issue not found", 404),
+    )
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Issue not found.")).toBeInTheDocument()
+    })
+  })
+})

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -181,6 +181,10 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             get(routes::projects::list_project_issues),
         )
         .route(
+            "/api/projects/{id}/issues/{number}",
+            get(routes::projects::get_project_issue),
+        )
+        .route(
             "/api/projects/{id}/pulls",
             get(routes::projects::list_project_pulls),
         )

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -105,6 +105,18 @@ struct LiveIssue {
     pull_request: Option<serde_json::Value>,
     comments: u32,
     updated_at: String,
+    // Detail-only fields. The list endpoint ignores them; the
+    // single-issue handler surfaces them in `LiveIssueDetailRow`.
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    assignees: Vec<LiveUser>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    closed_at: Option<String>,
+    #[serde(default)]
+    milestone: Option<LiveMilestone>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -115,6 +127,12 @@ struct LiveUser {
 #[derive(Debug, Deserialize)]
 struct LiveLabel {
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LiveMilestone {
+    title: String,
+    state: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -227,6 +245,34 @@ struct LiveIssueRow {
     labels: Vec<String>,
     comments: u32,
     updated_at: String,
+}
+
+/// Single-issue detail payload (#205). Superset of `LiveIssueRow` with
+/// the fields the list endpoint omits — body, assignees, milestone,
+/// created/closed timestamps. Cached the same way as the list response
+/// (per-process LRU+TTL); keyed independently so a `/issues/:n` fetch
+/// doesn't evict a `/issues` page and vice versa.
+#[derive(Debug, Serialize)]
+struct LiveIssueDetailRow {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    author: Option<String>,
+    labels: Vec<String>,
+    assignees: Vec<String>,
+    comments: u32,
+    body: Option<String>,
+    milestone: Option<LiveMilestoneRow>,
+    created_at: Option<String>,
+    updated_at: String,
+    closed_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LiveMilestoneRow {
+    title: String,
+    state: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -360,6 +406,138 @@ pub async fn list_project_issues(
         .collect();
 
     let body = serde_json::json!({ "issues": rows });
+    state.proxy_cache.put(cache_key, body.clone());
+    Json(body).into_response()
+}
+
+// ── GET /api/projects/:id/issues/:number ─────────────────────────────────
+
+/// GET `/api/projects/:project_id/issues/:number` — single hydrated
+/// issue used by the dashboard's issue detail page (#205). Same
+/// proxy-cache + fail-open shape as `list_project_issues`: a
+/// rate-limited or unreachable upstream returns
+/// `{ "issue": null, "error": "rate_limited" | "github_unreachable" }`
+/// so the dashboard can render the skeleton-only fallback rather than
+/// crash. 404 propagates as 404 (the issue genuinely doesn't exist).
+pub async fn get_project_issue(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((project_id, number)): Path<(String, u64)>,
+) -> Response {
+    let project = match require_project_for_user(&state.db, &auth_user, &project_id).await {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+
+    let cache_key = format!("issue:{project_id}:{number}");
+    if let Some(cached) = state.proxy_cache.get(&cache_key) {
+        return Json(cached).into_response();
+    }
+
+    let token = match mint_token(&state.db, &project.github_app_installation_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": "GitHub App not configured" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("mint_token failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "GitHub auth failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let url = format!(
+        "https://api.github.com/repos/{owner}/{repo}/issues/{number}",
+        owner = project.repo_owner,
+        repo = project.repo_name,
+    );
+    let resp = match gh_client()
+        .get(&url)
+        .bearer_auth(&token.token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("github single-issue fetch failed: {e}");
+            return Json(serde_json::json!({
+                "issue": serde_json::Value::Null,
+                "error": "github_unreachable",
+            }))
+            .into_response();
+        }
+    };
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return not_found("issue not found");
+    }
+    if resp.status() == reqwest::StatusCode::FORBIDDEN
+        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        return Json(serde_json::json!({
+            "issue": serde_json::Value::Null,
+            "error": "rate_limited",
+        }))
+        .into_response();
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let snippet = resp.text().await.unwrap_or_default();
+        tracing::warn!(%status, "github single-issue fetch non-2xx: {snippet}");
+        return (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({ "error": "github API error" })),
+        )
+            .into_response();
+    }
+
+    let parsed: LiveIssue = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("github single-issue parse failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": "github response parse failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    // GitHub's issues endpoint will happily return a PR if asked by
+    // number — guard against it so the issue page doesn't render PR
+    // metadata as if it were an issue.
+    if parsed.pull_request.is_some() {
+        return not_found("issue not found");
+    }
+
+    let row = LiveIssueDetailRow {
+        number: parsed.number,
+        title: parsed.title,
+        state: parsed.state,
+        html_url: parsed.html_url,
+        author: parsed.user.map(|u| u.login),
+        labels: parsed.labels.into_iter().map(|l| l.name).collect(),
+        assignees: parsed.assignees.into_iter().map(|u| u.login).collect(),
+        comments: parsed.comments,
+        body: parsed.body,
+        milestone: parsed.milestone.map(|m| LiveMilestoneRow {
+            title: m.title,
+            state: m.state,
+        }),
+        created_at: parsed.created_at,
+        updated_at: parsed.updated_at,
+        closed_at: parsed.closed_at,
+    };
+
+    let body = serde_json::json!({ "issue": row });
     state.proxy_cache.put(cache_key, body.clone());
     Json(body).into_response()
 }


### PR DESCRIPTION
Closes #205

## Summary

Adds a per-issue detail page in the dashboard so the inbox is no
longer "open in GitHub or nothing." Inbox row titles now link to
`/workspaces/:workspace/issues/:projectId/:number`, where the page
joins the live-hydrated GitHub issue with its reference-only spine
artifact (#170 join shape) and renders title, state, labels, author,
body, assignees, plus our derived `state` / `last_observed_at` /
`current_version`. Replay-trigger reuses the existing dialog flow
from `IssueActionsMenu`.

## Delivers

- [x] Add `GET /api/projects/{id}/issues/{number}` handler in
      `crates/stiglab/src/server/routes/projects.rs`, registered in
      `crates/stiglab/src/server/mod.rs`.
- [x] Extend the proxy response shape with `body`, `assignees`,
      `created_at`, `closed_at`, `milestone`; reuse the proxy cache.
- [x] Add `ProjectIssueDetail` type + `api.getProjectIssue(projectId, number)`
      to `apps/dashboard/src/lib/api.ts`.
- [x] Create `apps/dashboard/src/pages/IssueDetailPage.tsx` joining
      live + skeleton, with `usePageHeader` chrome and the replay
      action reusing the existing dialog.
- [x] Register the lazy route `issues/:projectId/:number` in
      `apps/dashboard/src/App.tsx`.
- [x] Wrap inbox row titles in `IssuesPage.tsx` with a `Link` to the
      detail page (both desktop table and mobile card).

## Design notes

- Backend mirrors `list_project_issues` exactly: same `mint_token`
  flow, same proxy cache (key `issue:{project_id}:{number}`), and
  the same fail-open envelope — `{ issue: null, error: "rate_limited" | "github_unreachable" }`
  — so the page can render skeleton-only with the same banner copy
  as the inbox.
- `LiveIssue` gained `body` / `assignees` / `created_at` / `closed_at`
  / `milestone` as optional fields. The list endpoint constructs
  `LiveIssueRow` and ignores them; the detail handler emits
  `LiveIssueDetailRow` which surfaces them.
- GitHub will return PRs from `/issues/:n` if asked by number — the
  handler 404s on `pull_request != null` so the issue page can't
  render PR metadata as if it were an issue.
- Body rendered as preformatted text (no markdown lib in deps yet —
  follow-up).

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- lint-seams` (clean; no new exemptions)
- [x] `pnpm exec tsc -b --noEmit` (dashboard)
- [x] `pnpm exec eslint .` (dashboard)
- [x] `pnpm test` (dashboard, 103/103)
- [ ] Manual: click an inbox row title → detail page loads with body
      and labels.
- [ ] Manual: rate-limited / unreachable upstream renders the
      skeleton-only fallback with the same banner copy as the inbox.
- [ ] Manual mobile (375×812): header is `← #N · ⋯`; body wraps without
      horizontal scroll.

## Out of scope (follow-ups)

- Comments thread fetch + render
- Related spine events / linked workflow runs / sessions on the page
- Markdown rendering of the body (`react-markdown` decision)
- Parallel PR detail page

https://claude.ai/code/session_01PmU1FUySmv2KGPcPvwADnd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmU1FUySmv2KGPcPvwADnd)_