### PR TITLE
refactor: delete three half-wired HTTP routes (#209, #210, #211)

### DIFF
--- a/crates/stiglab/src/runner.rs
+++ b/crates/stiglab/src/runner.rs
@@ -134,17 +134,9 @@ pub async fn start_built_in_runner(
     // Task: process outbound messages from SessionManager using the shared handler
     let event_pool = pool.clone();
     let runner_spine = state.spine.clone();
-    let runner_completion_tx = state.session_completion_tx.clone();
     tokio::spawn(async move {
         while let Some(msg) = outbound_rx.recv().await {
-            handler::handle_agent_message(
-                &event_pool,
-                &node_id,
-                msg,
-                runner_spine.as_ref(),
-                Some(&runner_completion_tx),
-            )
-            .await;
+            handler::handle_agent_message(&event_pool, &node_id, msg, runner_spine.as_ref()).await;
         }
     });
 

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -3,34 +3,18 @@
 
 use crate::core::{adapter, AgentMessage, SessionState};
 use sqlx::AnyPool;
-use tokio::sync::broadcast;
 
 use crate::server::db;
 use crate::server::spine::SpineEmitter;
 
-/// Notify in-process waiters that a session reached a terminal state.
-///
-/// `tx` is `None` for the runner code path that doesn't carry an `AppState`
-/// — those callers don't have HTTP `wait` clients to notify, so the no-op
-/// is safe.
-fn notify_terminal(tx: Option<&broadcast::Sender<String>>, session_id: &str) {
-    if let Some(tx) = tx {
-        // Errors are expected when there are zero subscribers; ignore.
-        let _ = tx.send(session_id.to_string());
-    }
-}
-
 /// Process an `AgentMessage` by applying the corresponding DB mutations.
 /// `node_id` identifies the agent node (used only for heartbeat updates).
 /// If `spine` is provided, factory events are emitted on session transitions.
-/// If `completion_tx` is provided, in-process waiters subscribed to it are
-/// notified when a session reaches Done or Failed (issue #31).
 pub async fn handle_agent_message(
     pool: &AnyPool,
     node_id: &str,
     msg: AgentMessage,
     spine: Option<&SpineEmitter>,
-    completion_tx: Option<&broadcast::Sender<String>>,
 ) {
     match msg {
         AgentMessage::Heartbeat { active_sessions } => {
@@ -47,13 +31,9 @@ pub async fn handle_agent_message(
             session_id,
             ref state,
         } => {
-            let persisted = match db::update_session_state(pool, &session_id, *state).await {
-                Ok(()) => true,
-                Err(e) => {
-                    tracing::error!("failed to update session state: {e}");
-                    false
-                }
-            };
+            if let Err(e) = db::update_session_state(pool, &session_id, *state).await {
+                tracing::error!("failed to update session state: {e}");
+            }
             // Emit spine event when session transitions to Running
             if *state == SessionState::Running {
                 if let Some(spine) = spine {
@@ -62,9 +42,6 @@ pub async fn handle_agent_message(
                         tracing::warn!("failed to emit session_started spine event: {e}");
                     }
                 }
-            }
-            if persisted && matches!(*state, SessionState::Done | SessionState::Failed) {
-                notify_terminal(completion_tx, &session_id);
             }
         }
         AgentMessage::SessionOutput {
@@ -83,16 +60,8 @@ pub async fn handle_agent_message(
             }
         }
         AgentMessage::SessionCompleted { session_id, output } => {
-            let persisted =
-                match db::update_session_state(pool, &session_id, SessionState::Done).await {
-                    Ok(()) => true,
-                    Err(e) => {
-                        tracing::error!("failed to update session state to done: {e}");
-                        false
-                    }
-                };
-            if persisted {
-                notify_terminal(completion_tx, &session_id);
+            if let Err(e) = db::update_session_state(pool, &session_id, SessionState::Done).await {
+                tracing::error!("failed to update session state to done: {e}");
             }
             // Only persist the final output as a fallback when no chunks were
             // already streamed, to avoid duplicating the entire response.
@@ -168,16 +137,9 @@ pub async fn handle_agent_message(
             }
         }
         AgentMessage::SessionFailed { session_id, error } => {
-            let persisted =
-                match db::update_session_state(pool, &session_id, SessionState::Failed).await {
-                    Ok(()) => true,
-                    Err(e) => {
-                        tracing::error!("failed to update session state to failed: {e}");
-                        false
-                    }
-                };
-            if persisted {
-                notify_terminal(completion_tx, &session_id);
+            if let Err(e) = db::update_session_state(pool, &session_id, SessionState::Failed).await
+            {
+                tracing::error!("failed to update session state to failed: {e}");
             }
             if let Err(e) = db::append_session_log(pool, &session_id, &error, "stderr").await {
                 tracing::error!("failed to append session log: {e}");

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -65,15 +65,12 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         .route("/api/health", get(routes::health::health))
         .route("/api/nodes", get(routes::nodes::list_nodes))
         .route("/api/tasks", post(routes::tasks::create_task))
-        // POST /api/shaping was the legacy forge → stiglab dispatch
-        // entrypoint; deleted in Lever C phase 5 (#148). Forge now
-        // emits `forge.shaping_dispatched` directly onto the spine
-        // and `shaping_listener` consumes it. The GET status endpoint
-        // stays for the dashboard's session view.
-        .route(
-            "/api/shaping/{session_id}",
-            get(routes::shaping::get_shaping_status),
-        )
+        // The legacy `POST /api/shaping` (forge → stiglab dispatch)
+        // and the `GET /api/shaping/{session_id}` long-poll status
+        // endpoint are both gone. Forge dispatch flows through the
+        // spine via `forge.shaping_dispatched` (consumed by
+        // `shaping_listener`); the dashboard reads session state via
+        // `GET /api/sessions/{id}` and the spine event feed.
         .route("/api/sessions", get(routes::sessions::list_sessions))
         .route("/api/sessions/{id}", get(routes::sessions::get_session))
         .route(

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -1,29 +1,14 @@
-//! Shaping HTTP endpoints (the dashboard's read side).
+//! Shaping dispatch core — used by `shaping_listener` to spawn an
+//! agent session in response to `forge.shaping_dispatched`.
 //!
 //! Phase 5 of Lever C (#148) deleted the legacy `POST /api/shaping`
-//! entrypoint that forge used; spawn-side dispatch now flows through
-//! the spine via `crates/stiglab/src/server/shaping_listener.rs`,
-//! which calls [`dispatch_shaping_inner`] (still defined here so the
-//! HTTP and listener paths share one dispatch core if a future use
-//! case re-introduces an HTTP wrapper).
-//!
-//! What remains:
-//!
-//! - `GET  /api/shaping/{id}`      → 200 with `ShapingResult` if terminal, else 202 with current state
-//! - `GET  /api/shaping/{id}?wait=Ns` → same, but blocks up to N seconds waiting for terminal state
-//!
-//! `wait` is capped at [`MAX_WAIT_SECS`] so individual HTTP roundtrips stay
-//! friendly to load balancers, proxies and mobile networks.
+//! entrypoint, and #209 deleted the dashboard-facing
+//! `GET /api/shaping/{session_id}` long-poll status endpoint
+//! (the dashboard reads session state via `GET /api/sessions/{id}`
+//! and the spine event feed). What's left here is the shared
+//! dispatch core called by the spine listener.
 
-use std::time::Duration;
-
-use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::Json;
 use chrono::Utc;
-use serde::Deserialize;
-use tokio::sync::broadcast::error::RecvError;
 use uuid::Uuid;
 
 use crate::core::adapter;
@@ -31,17 +16,6 @@ use crate::core::{ServerMessage, Session, SessionState};
 
 use crate::server::db;
 use crate::server::state::AppState;
-
-/// Hard cap on the per-request `wait` window. The full shaping deadline can
-/// still be longer; the caller is expected to loop.
-const MAX_WAIT_SECS: u64 = 30;
-
-#[derive(Debug, Deserialize)]
-pub struct StatusQuery {
-    /// e.g. "20s" or "1500ms" or a bare seconds integer.
-    #[serde(default)]
-    pub wait: Option<String>,
-}
 
 /// Outcome of [`dispatch_shaping_inner`] — distinguishes a freshly created
 /// session from one returned via the idempotency-key fast path.
@@ -205,166 +179,6 @@ pub async fn dispatch_shaping_inner(
     Ok(DispatchOutcome::Created(session))
 }
 
-/// `GET /api/shaping/{session_id}?wait=Ns` — return the current shaping
-/// status. With `wait`, blocks up to N seconds (capped at [`MAX_WAIT_SECS`])
-/// for a terminal transition, using an in-process broadcast channel so the
-/// database is queried at most once per call.
-pub async fn get_shaping_status(
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-    Query(query): Query<StatusQuery>,
-) -> impl IntoResponse {
-    let session = match db::get_session(&state.db, &session_id).await {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "session not found" })),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            tracing::error!("failed to load session: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            )
-                .into_response();
-        }
-    };
-
-    if is_terminal(session.state) {
-        return terminal_response(&session).await;
-    }
-
-    let Some(wait_str) = query.wait.as_deref() else {
-        return pending_response(&session);
-    };
-
-    let Some(wait) = parse_wait(wait_str) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "wait must be a duration like '20s', '1500ms', or a bare seconds integer"
-            })),
-        )
-            .into_response();
-    };
-
-    // Subscribe before re-checking the DB to avoid a race where the session
-    // becomes terminal between the check above and the subscription below.
-    let mut rx = state.session_completion_tx.subscribe();
-    if let Ok(Some(s)) = db::get_session(&state.db, &session_id).await {
-        if is_terminal(s.state) {
-            return terminal_response(&s).await;
-        }
-    }
-
-    let target = session_id.clone();
-    let signaled = tokio::time::timeout(wait, async move {
-        loop {
-            match rx.recv().await {
-                Ok(id) if id == target => return true,
-                Ok(_) => continue,
-                Err(RecvError::Lagged(_)) => continue,
-                Err(RecvError::Closed) => return false,
-            }
-        }
-    })
-    .await
-    .unwrap_or(false);
-
-    if !signaled {
-        // Timed out — return current pending state without re-querying twice.
-        match db::get_session(&state.db, &session_id).await {
-            Ok(Some(s)) if is_terminal(s.state) => terminal_response(&s).await,
-            Ok(Some(s)) => pending_response(&s),
-            Ok(None) => (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "session not found" })),
-            )
-                .into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            )
-                .into_response(),
-        }
-    } else {
-        // A broadcast fired for this session_id; re-read the DB to get the
-        // authoritative state. The notifier only fires on a successful state
-        // update so this should be terminal, but verify before returning
-        // 200 (a spurious broadcast must not promote a non-terminal session
-        // to a terminal response).
-        match db::get_session(&state.db, &session_id).await {
-            Ok(Some(s)) if is_terminal(s.state) => terminal_response(&s).await,
-            Ok(Some(s)) => pending_response(&s),
-            Ok(None) => (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": "session not found" })),
-            )
-                .into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            )
-                .into_response(),
-        }
-    }
-}
-
-fn pending_response(session: &Session) -> axum::response::Response {
-    (
-        StatusCode::ACCEPTED,
-        Json(serde_json::json!({
-            "session_id": session.id,
-            "state": session.state.to_string(),
-            "status_url": format!("/api/shaping/{}", session.id),
-        })),
-    )
-        .into_response()
-}
-
-async fn terminal_response(session: &Session) -> axum::response::Response {
-    // Reconstruct a ShapingRequest-shaped envelope from the session's stored
-    // artifact link so the adapter can build a ShapingResult identical to
-    // what the legacy long-poll endpoint used to return.
-    //
-    // This handler does NOT emit spine events — the agent message handler
-    // (`crate::server::handler::handle_agent_message`) is the single source
-    // of terminal transition events. Emitting from GET as well would make
-    // the status endpoint non-idempotent and spam duplicates for every
-    // poll after a session terminates.
-    let artifact_id_str = session.artifact_id.clone().unwrap_or_default();
-    let synthesized_req = onsager_spine::protocol::ShapingRequest {
-        request_id: session.task_id.clone(),
-        artifact_id: onsager_artifact::ArtifactId::new(&artifact_id_str),
-        target_version: session.artifact_version.unwrap_or(0).max(0) as u32,
-        shaping_intent: serde_json::json!({}),
-        inputs: vec![],
-        constraints: vec![],
-        deadline: None,
-        // Synthesised for adapter shape-matching only; not dispatched
-        // anywhere. Owner identity isn't part of the persisted session
-        // row, and the adapter doesn't read this field anyway.
-        created_by: None,
-    };
-
-    let duration_ms = session
-        .updated_at
-        .signed_duration_since(session.created_at)
-        .num_milliseconds()
-        .max(0) as u64;
-
-    let result = adapter::session_to_shaping_result(&synthesized_req, session, duration_ms);
-
-    (StatusCode::OK, Json(result)).into_response()
-}
-
-fn is_terminal(state: SessionState) -> bool {
-    matches!(state, SessionState::Done | SessionState::Failed)
-}
-
 /// Resolve the workspace an artifact belongs to by querying the spine
 /// `artifacts.workspace_id` column added in #162. Returns `None` when
 /// the spine isn't connected, the artifact row is missing, or the
@@ -417,73 +231,4 @@ async fn insert_session_with_idempotency_and_workspace(
     .await?
     .rows_affected();
     Ok(affected > 0)
-}
-
-/// Parse `"30s"`, `"1500ms"`, or a bare seconds integer like `"15"`. Returns
-/// `None` on parse failure. The result is clamped to [`MAX_WAIT_SECS`].
-fn parse_wait(raw: &str) -> Option<Duration> {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return None;
-    }
-    let dur = if let Some(ms_str) = raw.strip_suffix("ms") {
-        let ms: u64 = ms_str.trim().parse().ok()?;
-        Duration::from_millis(ms)
-    } else if let Some(s_str) = raw.strip_suffix('s') {
-        let s: u64 = s_str.trim().parse().ok()?;
-        Duration::from_secs(s)
-    } else {
-        let s: u64 = raw.parse().ok()?;
-        Duration::from_secs(s)
-    };
-    Some(dur.min(Duration::from_secs(MAX_WAIT_SECS)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_wait_accepts_seconds_with_suffix() {
-        assert_eq!(parse_wait("20s"), Some(Duration::from_secs(20)));
-        assert_eq!(parse_wait("0s"), Some(Duration::from_secs(0)));
-    }
-
-    #[test]
-    fn parse_wait_accepts_milliseconds() {
-        assert_eq!(parse_wait("500ms"), Some(Duration::from_millis(500)));
-    }
-
-    #[test]
-    fn parse_wait_accepts_bare_seconds_integer() {
-        assert_eq!(parse_wait("15"), Some(Duration::from_secs(15)));
-    }
-
-    #[test]
-    fn parse_wait_caps_at_max_wait() {
-        assert_eq!(
-            parse_wait("3600s"),
-            Some(Duration::from_secs(MAX_WAIT_SECS))
-        );
-        assert_eq!(
-            parse_wait("999999"),
-            Some(Duration::from_secs(MAX_WAIT_SECS))
-        );
-    }
-
-    #[test]
-    fn parse_wait_rejects_garbage() {
-        assert!(parse_wait("abc").is_none());
-        assert!(parse_wait("").is_none());
-        assert!(parse_wait("  ").is_none());
-    }
-
-    #[test]
-    fn is_terminal_matches_done_and_failed() {
-        assert!(is_terminal(SessionState::Done));
-        assert!(is_terminal(SessionState::Failed));
-        assert!(!is_terminal(SessionState::Running));
-        assert!(!is_terminal(SessionState::Pending));
-        assert!(!is_terminal(SessionState::Dispatched));
-    }
 }

--- a/crates/stiglab/src/server/state.rs
+++ b/crates/stiglab/src/server/state.rs
@@ -3,21 +3,13 @@ use std::sync::Arc;
 
 use axum::extract::ws::Message;
 use sqlx::AnyPool;
-use tokio::sync::{broadcast, mpsc, RwLock};
+use tokio::sync::{mpsc, RwLock};
 
 use crate::server::config::ServerConfig;
 use crate::server::proxy_cache::ProxyCache;
 use crate::server::spine::SpineEmitter;
 
 pub type WsSender = mpsc::UnboundedSender<Message>;
-
-/// Capacity of the per-process session-completion broadcast channel.
-///
-/// `tokio::sync::broadcast` overwrites the oldest message on overflow; the
-/// `wait` endpoint treats `Lagged` as a no-op (it just falls through to the
-/// next iteration / DB read). Sized for many concurrent waiters per terminal
-/// transition without dropping useful events under normal load.
-const SESSION_COMPLETION_CHANNEL_CAPACITY: usize = 1024;
 
 #[derive(Debug)]
 pub struct AgentConnection {
@@ -32,10 +24,6 @@ pub struct AppState {
     pub agents: Arc<RwLock<HashMap<String, AgentConnection>>>,
     pub config: ServerConfig,
     pub spine: Option<SpineEmitter>,
-    /// Broadcasts `session_id` whenever a session reaches a terminal state
-    /// (Done or Failed). Powers `GET /api/shaping/{id}?wait=Ns` so the
-    /// status endpoint doesn't need to poll the database (issue #31).
-    pub session_completion_tx: broadcast::Sender<String>,
     /// Short-TTL cache for `/api/projects/:id/{issues,pulls}` live-hydration
     /// reads (#170). Reference-only artifact rows don't carry GitHub-authored
     /// fields; the proxy fetches them on demand and this cache deduplicates
@@ -45,13 +33,11 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(db: AnyPool, config: ServerConfig, spine: Option<SpineEmitter>) -> Self {
-        let (session_completion_tx, _) = broadcast::channel(SESSION_COMPLETION_CHANNEL_CAPACITY);
         AppState {
             db,
             agents: Arc::new(RwLock::new(HashMap::new())),
             config,
             spine,
-            session_completion_tx,
             proxy_cache: Arc::new(ProxyCache::from_env()),
         }
     }

--- a/crates/stiglab/src/server/ws/agent.rs
+++ b/crates/stiglab/src/server/ws/agent.rs
@@ -106,14 +106,8 @@ async fn handle_agent_connection(socket: WebSocket, state: AppState) {
 
             other => {
                 if let Some(ref nid) = node_id {
-                    handler::handle_agent_message(
-                        &state.db,
-                        nid,
-                        other,
-                        state.spine.as_ref(),
-                        Some(&state.session_completion_tx),
-                    )
-                    .await;
+                    handler::handle_agent_message(&state.db, nid, other, state.spine.as_ref())
+                        .await;
                 }
             }
         }

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use axum::extract::{FromRef, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{get, patch, post};
+use axum::routing::{get, patch};
 use axum::{Json, Router};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -129,7 +129,6 @@ impl ServeCmd {
         let api = Router::new()
             .route("/health", get(health))
             .route("/events", get(list_events).post(create_event))
-            .route("/events/{id}", get(get_event))
             .route("/events/{id}/resolve", patch(resolve_event))
             .route("/stats", get(get_stats))
             .route("/rules", get(list_rules))
@@ -138,12 +137,7 @@ impl ServeCmd {
             // `synodic.gate_verdict`) instead of HTTP.
             // Rule proposal queue (issue #36 Step 2)
             .route("/rule-proposals", get(list_rule_proposals))
-            .route("/rule-proposals/{id}/resolve", patch(resolve_rule_proposal))
-            // Escalation resolution proposals (issue #37)
-            .route(
-                "/escalations/{id}/propose-resolution",
-                post(propose_escalation_resolution),
-            );
+            .route("/rule-proposals/{id}/resolve", patch(resolve_rule_proposal));
 
         // Spawn the ising.rule_proposed listener on the shared spine
         // handle (issue #36 Step 2). A missing spine handle is non-fatal —
@@ -250,17 +244,6 @@ async fn list_events(
     };
     let events = store.get_governance_events(filters).await?;
     Ok(Json(events))
-}
-
-async fn get_event(
-    State(store): State<Arc<dyn Storage>>,
-    Path(id): Path<String>,
-) -> Result<Json<GovernanceEvent>, AppError> {
-    let event = store
-        .get_governance_event(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("event not found".into()))?;
-    Ok(Json(event))
 }
 
 async fn create_event(
@@ -426,79 +409,12 @@ fn classify_resolve_error(err: anyhow::Error) -> AppError {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Escalation resolution proposals (issue #37)
-// ---------------------------------------------------------------------------
-
-#[derive(Deserialize)]
-struct ProposeResolutionBody {
-    artifact_id: String,
-    /// Identity of the proposer: `"supervisor"`, `"human:<id>"`, or any
-    /// free-form string representing the delegate.
-    proposer: String,
-    /// One of `"allow" | "deny" | "modify" | "escalate"`.
-    proposed_verdict: String,
-    rationale: String,
-}
-
-/// POST `/api/escalations/{id}/propose-resolution` — record a delegate's
-/// proposed resolution on the spine as `synodic.gate_resolution_proposed`.
-/// The proposal is not applied; Forge/Synodic wiring converts accepted
-/// proposals into a final verdict on a separate path.
-///
-/// The spine handle is pulled from `AppState` so we reuse one `PgPool`
-/// across all requests instead of building a fresh pool per call.
-async fn propose_escalation_resolution(
-    State(spine): State<Option<Arc<onsager_spine::EventStore>>>,
-    Path(escalation_id): Path<String>,
-    Json(body): Json<ProposeResolutionBody>,
-) -> Result<StatusCode, AppError> {
-    let verdict = match body.proposed_verdict.to_ascii_lowercase().as_str() {
-        "allow" => onsager_spine::factory_event::VerdictSummary::Allow,
-        "deny" => onsager_spine::factory_event::VerdictSummary::Deny,
-        "modify" => onsager_spine::factory_event::VerdictSummary::Modify,
-        "escalate" => onsager_spine::factory_event::VerdictSummary::Escalate,
-        other => {
-            return Err(AppError::BadRequest(format!(
-                "proposed_verdict must be allow|deny|modify|escalate, got {other}"
-            )));
-        }
-    };
-
-    let Some(spine) = spine else {
-        return Err(AppError::ServiceUnavailable(
-            "spine not attached; Synodic must be run with a postgres DATABASE_URL \
-             to emit gate_resolution_proposed events"
-                .into(),
-        ));
-    };
-
-    let event = onsager_spine::factory_event::FactoryEventKind::SynodicGateResolutionProposed {
-        escalation_id: escalation_id.clone(),
-        artifact_id: onsager_artifact::ArtifactId::new(&body.artifact_id),
-        proposer: body.proposer,
-        proposed_verdict: verdict,
-        rationale: body.rationale,
-    };
-    let data = serde_json::to_value(&event).expect("FactoryEventKind must serialize");
-    let metadata = onsager_spine::EventMetadata {
-        actor: "synodic".into(),
-        ..Default::default()
-    };
-    spine
-        .append_ext(
-            &escalation_id,
-            "synodic",
-            event.event_type(),
-            data,
-            &metadata,
-            None,
-        )
-        .await
-        .map_err(|e| AppError::Internal(anyhow::anyhow!("append_ext: {e}")))?;
-
-    Ok(StatusCode::ACCEPTED)
-}
+// `POST /api/escalations/{id}/propose-resolution` was the HTTP entry
+// point for issue #37's escalation-resolution-proposals flow; deleted
+// in #211 (no caller in-tree, and the
+// `synodic.gate_resolution_proposed` event it emitted has no consumer).
+// The spine event type itself is left in place pending a separate
+// decision.
 
 // `POST /api/gate` was the legacy forge → synodic gate evaluation
 // entrypoint; deleted in Lever C phase 5 (#148). Forge now emits
@@ -516,7 +432,6 @@ enum AppError {
     NotFound(String),
     BadRequest(String),
     Conflict(String),
-    ServiceUnavailable(String),
 }
 
 impl From<anyhow::Error> for AppError {
@@ -548,11 +463,6 @@ impl IntoResponse for AppError {
                 .into_response(),
             Self::Conflict(msg) => (
                 StatusCode::CONFLICT,
-                Json(serde_json::json!({ "error": msg })),
-            )
-                .into_response(),
-            Self::ServiceUnavailable(msg) => (
-                StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": msg })),
             )
                 .into_response(),

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -447,24 +447,6 @@ pub const EXTERNAL_ONLY_ROUTES: &[(&str, &str)] = &[
         "/health",
         "synodic internal health endpoint — ops-only, not a dashboard surface",
     ),
-    // Pre-existing half-wires found by Lever F at land time. These are real
-    // "no caller" debt; allowlisting documents them so the lint stays green
-    // while each is wired (or deleted) on its own follow-up issue.
-    (
-        "/api/shaping/{session_id}",
-        "kept for the dashboard session view (per #148 phase 5 comment); \
-         caller not yet wired — tracked in #209",
-    ),
-    (
-        "/events/{id}",
-        "synodic governance event detail — caller not yet wired in dashboard; \
-         tracked in #210",
-    ),
-    (
-        "/escalations/{id}/propose-resolution",
-        "synodic escalation resolution proposal (per #37) — caller not yet \
-         wired in dashboard; tracked in #211",
-    ),
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the three follow-up issues PR #207 filed at land time for the half-wires the Lever F api-contract lint surfaced. All three were "no caller in-tree, no UI surface, no consumer" — dead HTTP surface, not pending wiring — so this PR removes them and drops the matching `EXTERNAL_ONLY_ROUTES` allowlist entries.

Closes #209
Closes #210
Closes #211
Part of #151 (Lever F)

## Decisions (per-issue)

The full rationale is documented as comments on each issue:
- [#209](https://github.com/onsager-ai/onsager/issues/209#issuecomment-4342779822) — delete `/api/shaping/{session_id}` (stiglab)
- [#210](https://github.com/onsager-ai/onsager/issues/210#issuecomment-4342780808) — delete `/events/{id}` (synodic)
- [#211](https://github.com/onsager-ai/onsager/issues/211#issuecomment-4342782492) — delete `/escalations/{id}/propose-resolution` (synodic)

TL;DR — the dashboard already gets equivalent state from `getSession(id)` + the spine event feed (`forge.shaping_dispatched` / `stiglab.shaping_result_ready`); the governance list endpoint already returns the full `GovernanceEvent` shape with no detail-only field; the propose-resolution handler was a thin HTTP wrapper around a spine event that has zero consumers.

## Changes

**stiglab — #209:**
- `crates/stiglab/src/server/mod.rs`: drop `/api/shaping/{session_id}` route registration.
- `crates/stiglab/src/server/routes/shaping.rs`: drop `get_shaping_status`, `pending_response`, `terminal_response`, `is_terminal`, `parse_wait`, `MAX_WAIT_SECS`, `StatusQuery`, and the parse-wait test module. Keeps `dispatch_shaping_inner` + `DispatchOutcome` + the workspace/idempotency helpers used by `shaping_listener` consuming `forge.shaping_dispatched`.
- `crates/stiglab/src/server/state.rs`, `handler.rs`, `runner.rs`, `ws/agent.rs`: drop the `session_completion_tx` broadcast channel — the only consumer was `get_shaping_status`. Leaving the producer wired to no consumer would be the exact drift pattern CLAUDE.md flags.

**synodic — #210, #211:**
- `crates/synodic/src/cmd/serve.rs`: drop the `/events/{id}` route + `get_event` handler; drop the `/escalations/{id}/propose-resolution` route + `propose_escalation_resolution` handler + `ProposeResolutionBody` struct. Drop `axum::routing::post` import (no longer used) and `AppError::ServiceUnavailable` (only constructed by the deleted handler). `Storage::get_governance_event` stays — `resolve_event` uses it for an existence check.
- The `SynodicGateResolutionProposed` spine event type is intentionally left in place; removing it touches more code (factory_event, registry, tests) and wants its own decision.

**xtask:**
- `xtask/src/lint_api_contract.rs`: drop the three `EXTERNAL_ONLY_ROUTES` entries.

## Test plan

- [x] `cargo build --workspace` clean (also tested with `RUSTFLAGS="-D warnings"`).
- [x] `cargo clippy -p stiglab -p synodic -p xtask --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run -p xtask -- check-api-contract` clean (now `59 backend routes, 58 dashboard calls, 13 allowed exemption(s)` — was 60/56/16 before).
- [x] `cargo run -p xtask -- lint-seams` clean.
- [x] `cargo test -p xtask` (52 passed, including the `analyse_real_codebase_is_clean` canary).
- [x] `cargo test -p stiglab` (156 passed) and `cargo test -p synodic` (114 passed).
- [x] `cargo test --workspace` green.
- [x] `pnpm --dir apps/dashboard test` green (106 passed).
- [ ] CI green on `rust.yml` (the new step from #207 included).

## Note on base branch

This PR is rebased on top of `claude/tech-debt-overhaul-VAKrz` (#207) because the allowlist entries we're dropping live in the file #207 introduces. Once #207 merges, this PR's base should be retargeted to `main`.

https://claude.ai/code/session_01TEATnnxiFYxCYWJrGtrVd9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEATnnxiFYxCYWJrGtrVd9)_