### PR TITLE
docs(adr-0004): sync lever status with what's landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,23 +45,28 @@ This is the rule. ADR 0001 set it; [ADR 0004](docs/adr/0004-tighten-the-seams.md
 captures the decision to make it machine-checkable and the six-lever
 execution plan that spec #131 tracks (A–F: persisted rule →
 mechanical guardrails → finish ADR 0001 migration → spine as SoT →
-registry-backed event types → API/UI contract enforcement). Until the
-levers all land, the rule is review-time discipline; treat the drift
-patterns below as the working heuristics.
+registry-backed event types → API/UI contract enforcement). Levers B,
+C, and F have landed and are CI-enforced via `lint_seams` and
+`lint_api_contract` (see status below); D and E remain open and are
+still review-time discipline — treat the drift patterns below as the
+working heuristics for the open levers.
 
 Lever status (canonical: ADR 0004's adoption checklist). As of
 2026-04-30: A, B, C, F have landed; D and E are open.
 
 - **A** (PR #144): rule persisted in `CLAUDE.md` + skills.
-- **B**: `xtask/src/lint_seams.rs` enforces arch-deps, sibling-
-  subsystem HTTP, `serde(alias)`, `*_mirror.rs`, and legacy type
-  aliases. New code must not reintroduce sibling-subsystem HTTP
-  calls — the lint hard-fails.
+- **B**: `xtask/src/lint_seams.rs` enforces arch-deps, references
+  that indicate sibling-subsystem HTTP (sibling `*_URL` / `*_PORT`
+  env vars, `localhost:<well-known-port>` literals), `serde(alias)`,
+  `*_mirror.rs`, and legacy type aliases. New code must not
+  reintroduce references that indicate sibling-subsystem HTTP — the
+  lint hard-fails.
 - **C** (#148): `HttpStiglabDispatcher` / `HttpSynodicGate` and
   `POST /api/shaping` / `POST /api/gate` are gone. Forge ↔
   stiglab/synodic flows through the spine only —
   `forge.gate_requested` / `synodic.gate_verdict` and
-  `forge.shaping_dispatched` / `stiglab.shaping_result_ready`.
+  `forge.shaping_dispatched` / `stiglab.session_completed` (with
+  `stiglab.shaping_result_ready` emitted alongside it).
 - **D** (open): `crates/stiglab/src/server/workflow_spine_mirror.rs`
   and the `BundleId` → `ArtifactVersionId` alias still in tree.
 - **E** (#150, open): producer-without-consumer is a reminder in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,15 +49,26 @@ registry-backed event types → API/UI contract enforcement). Until the
 levers all land, the rule is review-time discipline; treat the drift
 patterns below as the working heuristics.
 
-Lever C status (#148): seam rule passing. The legacy
-`HttpStiglabDispatcher` / `HttpSynodicGate` HTTP RPCs in
-`crates/forge/src/cmd/serve.rs` are gone (phase 5), as are the
-`POST /api/shaping` and `POST /api/gate` endpoints they called.
-Forge ↔ stiglab/synodic coordination flows through the spine only —
-`forge.gate_requested` / `synodic.gate_verdict` and
-`forge.shaping_dispatched` / `stiglab.shaping_result_ready`. New code
-must not reintroduce sibling-subsystem HTTP calls; the seam-rule lint
-in `xtask` enforces this.
+Lever status (canonical: ADR 0004's adoption checklist). As of
+2026-04-30: A, B, C, F have landed; D and E are open.
+
+- **A** (PR #144): rule persisted in `CLAUDE.md` + skills.
+- **B**: `xtask/src/lint_seams.rs` enforces arch-deps, sibling-
+  subsystem HTTP, `serde(alias)`, `*_mirror.rs`, and legacy type
+  aliases. New code must not reintroduce sibling-subsystem HTTP
+  calls — the lint hard-fails.
+- **C** (#148): `HttpStiglabDispatcher` / `HttpSynodicGate` and
+  `POST /api/shaping` / `POST /api/gate` are gone. Forge ↔
+  stiglab/synodic flows through the spine only —
+  `forge.gate_requested` / `synodic.gate_verdict` and
+  `forge.shaping_dispatched` / `stiglab.shaping_result_ready`.
+- **D** (open): `crates/stiglab/src/server/workflow_spine_mirror.rs`
+  and the `BundleId` → `ArtifactVersionId` alias still in tree.
+- **E** (#150, open): producer-without-consumer is a reminder in
+  `lint_seams` pending the registry manifest.
+- **F** (PR #207): `xtask/src/lint_api_contract.rs` asserts every
+  backend route has a dashboard caller (or an allowlisted external-
+  only reason) and every dashboard call lands on a backend route.
 
 ## Internal aesthetic
 

--- a/docs/adr/0004-tighten-the-seams.md
+++ b/docs/adr/0004-tighten-the-seams.md
@@ -217,18 +217,31 @@ registry entry that CI validates.
 ## Adoption checklist
 
 Execution lives in the child specs of #131. Each lever's checklist
-is in its sub-issue:
+is in its sub-issue. Status as of 2026-04-30:
 
 - [x] **Lever A** — persist the rule in `CLAUDE.md` + skills.
       _Landed: PR #144._
-- [ ] **Lever B** — mechanical guardrails (no-escape-hatch CI lint).
-- [ ] **Lever C** — complete the ADR 0001 migration; delete
-      `onsager-protocol`.
+- [x] **Lever B** — mechanical guardrails (no-escape-hatch CI lint).
+      _Landed: `xtask/src/lint_seams.rs` enforces arch-deps, sibling-
+      subsystem HTTP, `serde(alias)`, `*_mirror.rs`, and legacy type
+      aliases; producer-without-consumer is gated on Lever E._
+- [x] **Lever C** — complete the ADR 0001 migration; delete
+      `onsager-protocol`. _Landed: closed by PR #148. The
+      `HttpStiglabDispatcher` / `HttpSynodicGate` RPCs are gone;
+      coordination flows through `forge.gate_requested` /
+      `synodic.gate_verdict` and `forge.shaping_dispatched` /
+      `stiglab.shaping_result_ready`._
 - [ ] **Lever D** — spine as SoT for workflows; remove
       `workflow_spine_mirror.rs` and the `BundleId` alias.
+      _Open: mirror module and alias still in tree._
 - [ ] **Lever E** — registry-backed event types + capability
-      advertisement.
-- [ ] **Lever F** — API/UI contract enforcement.
+      advertisement (#150). _Open: `lint_seams` carries the producer-
+      without-consumer reminder pending the registry manifest._
+- [x] **Lever F** — API/UI contract enforcement.
+      _Landed: `xtask/src/lint_api_contract.rs` (closed by PR #207)
+      asserts every backend route has a dashboard caller (or an
+      allowlisted external-only reason) and every dashboard call
+      lands on a backend route._
 
 ## Out of scope
 

--- a/docs/adr/0004-tighten-the-seams.md
+++ b/docs/adr/0004-tighten-the-seams.md
@@ -230,7 +230,8 @@ is in its sub-issue. Status as of 2026-04-30:
       `HttpStiglabDispatcher` / `HttpSynodicGate` RPCs are gone;
       coordination flows through `forge.gate_requested` /
       `synodic.gate_verdict` and `forge.shaping_dispatched` /
-      `stiglab.shaping_result_ready`._
+      `stiglab.session_completed` (with
+      `stiglab.shaping_result_ready` emitted alongside it)._
 - [ ] **Lever D** — spine as SoT for workflows; remove
       `workflow_spine_mirror.rs` and the `BundleId` alias.
       _Open: mirror module and alias still in tree._


### PR DESCRIPTION
## Summary

Tech-debt audit (2026-04-30) flagged that ADR 0004's adoption checklist is out of sync with reality:

- Lever B is enforced by `xtask/src/lint_seams.rs` (in tree).
- Lever C closed by PR #148.
- Lever F closed by PR #207 (`xtask/src/lint_api_contract.rs`).

…but all three were still listed as unchecked, and the root `CLAUDE.md` lever-status callout only mentioned Lever C. This drift makes contributors more likely to re-spec landed work or assume the seam rule is still purely review-time.

This PR:

- Marks Lever B, C, F as landed in `docs/adr/0004-tighten-the-seams.md` with one-line provenance for each.
- Replaces the "Lever C status" paragraph in `CLAUDE.md` with a per-lever status block (A–F), pointing at ADR 0004 as the canonical source.
- Leaves Lever D (`workflow_spine_mirror.rs` + `BundleId` alias still in tree) and Lever E (#150 registry manifest) explicitly open.

Docs-only — no code or behavior changes.

## Audit follow-ups not in this PR

The audit also recommended (each warrants its own spec, not bundled here):

- Bridge-debt metadata + expiry lint (xtask + comment normalization).
- Producer-without-consumer lint backfill — already gated on Lever E (#150).
- Tenant→workspace terminology sweep in residual comments/docs.
- Template TODO hardening for synodic orchestration scaffolding.

## Test plan

- [ ] CI passes (docs-only; lint targets unchanged).
- [ ] Render the ADR and CLAUDE.md changes on GitHub and verify the checklist + bullets read cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvxrigPiE65cpv3xUYahud)_