### PR TITLE
docs(portal): foundation for promoting portal to edge subsystem

### DIFF
--- a/.claude/skills/issue-spec/references/spec-format.md
+++ b/.claude/skills/issue-spec/references/spec-format.md
@@ -36,6 +36,7 @@ Apply labels when creating the issue:
 - `area:ising` — continuous improvement engine
 - `area:stiglab` — agent session orchestration
 - `area:synodic` — agent governance
+- `area:portal` — edge subsystem (public HTTP, OAuth, webhooks, credentials)
 - `area:dashboard` — React UI under `apps/dashboard`
 - `area:onsager` — the `onsager` dispatcher CLI
 - `area:infra` — CI, migrations, docker-compose, justfile, workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,23 @@ ships with its dev-process counterpart enabled, and every durable
 dev-process pattern is filed as evidence for a future primitive.
 
 ```
-         onsager-spine (event bus lib)
-        /       |        |        \
-   forge    stiglab   synodic    ising    <- do NOT depend on each other
+                onsager-spine (event bus lib)
+         /     /     |        |        \
+   portal  forge  stiglab  synodic   ising
+   (edge)         (factory subsystems — AI-native concerns)
 ```
 
-**Architectural invariant**: subsystems (`forge`, `stiglab`, `synodic`, `ising`)
-must NOT import each other, and must NOT be statically linked into the same
-binary. The `onsager` dispatcher has zero business dependencies -- it discovers
-subsystem binaries on PATH.
+**Architectural invariant**: subsystems (`portal`, `forge`, `stiglab`,
+`synodic`, `ising`) must NOT import each other, and must NOT be statically
+linked into the same binary. The `onsager` dispatcher has zero business
+dependencies -- it discovers subsystem binaries on PATH.
+
+`portal` is the **edge** subsystem — eventually the only one that hosts
+public HTTP routes (dashboard API, GitHub webhooks, OAuth, credential
+CRUD). Factory subsystems (`forge`, `stiglab`, `synodic`, `ising`) live
+behind the seam and coordinate exclusively via the spine. Spec #222
+promotes portal to first-class peer status; while that migration is in
+flight stiglab still owns the bulk of the external HTTP surface.
 
 ## The seam rule (canonical)
 
@@ -36,7 +44,8 @@ subsystem binaries on PATH.
 > - **User-facing endpoints** called by the dashboard.
 > - **Webhooks** called by external services (GitHub, etc.).
 >
-> Subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> The external HTTP boundary is owned by `portal` (the edge subsystem).
+> Factory subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
 > **exclusively** via the spine: events on the bus + reads against
 > shared spine tables. No subsystem makes HTTP calls to another
 > subsystem. No subsystem imports another subsystem's crate.

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -1,0 +1,77 @@
+# Portal
+
+The **edge** subsystem. Portal owns clause 1 of the seam rule —
+external HTTP boundaries — so the factory subsystems (`forge`,
+`stiglab`, `synodic`, `ising`) can stay behind the seam and
+coordinate exclusively via the spine.
+
+## The seam rule (canonical)
+
+> HTTP APIs exist only at external boundaries:
+> - **User-facing endpoints** called by the dashboard.
+> - **Webhooks** called by external services (GitHub, etc.).
+>
+> The external HTTP boundary is owned by `portal` (the edge subsystem).
+> Factory subsystems (`forge`, `stiglab`, `synodic`, `ising`) coordinate
+> **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another
+> subsystem. No subsystem imports another subsystem's crate.
+
+What this means for portal specifically:
+
+- **Allowed HTTP surfaces.** Public dashboard API, OAuth callbacks,
+  webhook receivers. Anything an external client (browser, GitHub,
+  future GitLab/Slack/Linear integrations) calls into.
+- **Forbidden HTTP surfaces.** Routes that exist only to be called by
+  a sibling subsystem. Clause 2 still applies to portal — when portal
+  needs `forge`/`stiglab`/`synodic`/`ising` to do work, it emits a
+  spine intent, not an HTTP request.
+- **Cargo deps.** Portal may depend on `onsager-{artifact, github,
+  spine, registry}`. It must NOT depend on `forge`, `stiglab`,
+  `synodic`, or `ising`.
+- **Spine is the coordination medium.** When a portal route handler
+  needs another subsystem to act, emit a spine event (e.g. portal
+  receives `PATCH /api/workflows/:id active=true`, does the GitHub
+  side-effects it owns, then emits `workflow.activate_requested`
+  for stiglab to consume).
+- **Credentials live in portal.** `user_credentials`,
+  `github_app_installations`, `user_pats`,
+  `portal_webhook_secrets` — anything that decrypts to a
+  `Credential` for `onsager-github` is portal-shaped. Workspace and
+  workspace-membership tables live in the spine (cross-cutting).
+
+See [ADR 0004 — Tighten the seams](../../docs/adr/0004-tighten-the-seams.md)
+(amendment 2026-04-30 names portal as clause-1's owner) and spec
+[#222](https://github.com/onsager-ai/onsager/issues/222) for the
+promotion plan.
+
+## Status (in flight)
+
+Spec #222 promotes portal from a thin webhook+proxy service to a
+first-class edge subsystem. The migration is staged:
+
+- **Foundation (this work).** ADR 0004 amendment, `area:portal`
+  label, root `CLAUDE.md` topology update, this file.
+- **Routes (follow-ups).** Move `/api/webhooks/github`,
+  `/api/workflows/*`, `/api/credentials/*`, `/api/installations/*`,
+  `/api/workspaces/*`, `/auth/github/*`, and the preset registry
+  out of stiglab into portal. Each route group lands atomically
+  (portal handler live + stiglab handler deleted in the same PR).
+- **Schema split (follow-ups).** `workspaces` /
+  `workspace_members` / `projects` move into
+  `crates/onsager-spine/migrations/`; `user_credentials`,
+  `github_app_installations`, `user_pats`,
+  `portal_webhook_secrets` move into
+  `crates/onsager-portal/migrations/`. Atomic per-PR per Lever B.
+
+While the migration is in flight, stiglab still hosts most of the
+external HTTP surface — that is the drift #222 closes, not a pattern
+to extend. New external concerns attach to portal.
+
+## Build & Test
+
+```bash
+cargo build -p onsager-portal
+cargo test  -p onsager-portal --lib
+cargo clippy -p onsager-portal --all-targets -- -D warnings
+```

--- a/docs/adr/0004-tighten-the-seams.md
+++ b/docs/adr/0004-tighten-the-seams.md
@@ -260,3 +260,31 @@ is in its sub-issue. Status as of 2026-04-30:
 - **A retroactive audit of every existing `serde(alias)` and type
   alias in the workspace.** Lever B's lint applies to *new* code;
   pre-existing aliases get triaged as their owning sub-issues land.
+
+## Amendment 2026-04-30 — clause-1 vs clause-2 ownership
+
+Spec #222 (promote `onsager-portal` to a first-class edge subsystem)
+surfaced a structural gap in the rule as originally stated: clause 2
+(subsystems coordinate via the spine, no sibling-subsystem HTTP) is
+machine-checkable and lever-B-enforced, but **clause 1 (the external
+HTTP boundary itself) had no concrete owner**. Stiglab carried it by
+default — every new external concern (OAuth callback, credential CRUD,
+webhook ingest, workflow CRUD, preset registry) landed in stiglab
+because stiglab was the only subsystem with a public HTTP surface, and
+stiglab consequently grew into a kitchen-sink edge.
+
+The amendment names the owner. **Clause 1 is owned by `portal`.**
+Portal becomes a peer of `forge` / `stiglab` / `synodic` / `ising`,
+governed by the same seam-rule discipline (clause 2 still applies — it
+coordinates with the factory subsystems exclusively via the spine, and
+must not import their crates). The distinguishing concern is the
+*outer skin*: portal is the only subsystem permitted to host public
+HTTP routes that aren't the spine read-API. Future external
+integrations (GitLab, Slack, Linear) attach to portal, not to a random
+factory subsystem.
+
+The lint-seams check already permits portal HTTP, so no enforcement
+change is required. The structural surgery — moving routes, schema, and
+the GitHub side-effects of `workflow_activation` — is scoped under
+spec #222 and gated on #149 (Lever D, landed) and #161 children A/B
+(workspace as first-class scope, landed).

--- a/docs/adr/0004-tighten-the-seams.md
+++ b/docs/adr/0004-tighten-the-seams.md
@@ -232,9 +232,14 @@ is in its sub-issue. Status as of 2026-04-30:
       `synodic.gate_verdict` and `forge.shaping_dispatched` /
       `stiglab.session_completed` (with
       `stiglab.shaping_result_ready` emitted alongside it)._
-- [ ] **Lever D** — spine as SoT for workflows; remove
+- [x] **Lever D** — spine as SoT for workflows; remove
       `workflow_spine_mirror.rs` and the `BundleId` alias.
-      _Open: mirror module and alias still in tree._
+      _Landed: closed by PR #225. `workflow_spine_mirror.rs` is gone,
+      stiglab's `workspace_workflows` / `workspace_workflow_stages`
+      collapsed into spine `workflows` / `workflow_stages` (migration
+      013), and `workspace_install_ref` was renamed `install_id`
+      (#219). The `BundleId` → `ArtifactVersionId` alias was removed
+      in #219._
 - [ ] **Lever E** — registry-backed event types + capability
       advertisement (#150). _Open: `lint_seams` carries the producer-
       without-consumer reminder pending the registry manifest._


### PR DESCRIPTION
## Summary

Foundation slice of #222. Names `onsager-portal` as the owner of clause 1 of the seam rule (external HTTP boundary) so the route, schema, and `workflow_activation` migrations can land as follow-up PRs against a stable framing.

- **ADR 0004 amendment** with the clause-1/clause-2 framing note — stiglab carrying clause 1 by default is the drift #222 closes; clause 2 (no sibling-subsystem HTTP) still applies to portal too.
- **Root `CLAUDE.md`** topology updated to show portal alongside the factory subsystems, with the seam-rule clause-1 attribution.
- **`crates/onsager-portal/CLAUDE.md`** added — mirrors the per-subsystem pattern that stiglab/synodic/spine already follow, and documents the in-flight migration status so future contributors don't extend the kitchen-sink-stiglab pattern.
- **`area:portal`** added to `spec-format.md`'s label taxonomy.

Per the spec's resolution comment, #222 lands as multiple PRs under the same spec: this is the foundation; route migrations and the schema split are gated on the framing being in place. Both prereqs (#149 Lever D and #161 children A/B) are closed, so the structural work is unblocked once this lands.

`Part of #222`

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo run -p xtask -- lint-seams` clean
- [x] `cargo run -p xtask -- check-api-contract` clean
- [ ] CI green

https://claude.ai/code/session_01Tt6q9yVGxRt4KPFLStAVKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt6q9yVGxRt4KPFLStAVKm)_