### PR TITLE
feat(registry): event-type manifest + CI check (Lever E)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,8 @@ jobs:
         run: cargo run -p xtask --quiet -- lint-seams
       - name: API/UI contract lint (spec #131 Lever F / #151)
         run: cargo run -p xtask --quiet -- check-api-contract
+      - name: Event-type registry manifest check (spec #131 Lever E / #150)
+        run: cargo run -p xtask --quiet -- check-events
       - name: Apply database migrations
         run: |
           for f in crates/onsager-spine/migrations/*.sql; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "onsager-registry",
  "quote",
  "serde",
  "serde_json",

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -453,9 +453,8 @@ export interface WorkflowKindInfo {
 
 // Wire shape of `GET /api/registry/events` — one row of the event-type
 // registry manifest (spec #131 Lever E / #150). Mirrors
-// `onsager_registry::EventDefinition`. Exact parity with the Rust
-// definition is enforced by the manifest's `manifest_serializes_to_json`
-// test on the backend side.
+// `onsager_registry::EventDefinition`; keep field names + the
+// `EventSubsystem` union in sync by hand when the Rust struct changes.
 export type EventSubsystem = 'forge' | 'stiglab' | 'synodic' | 'ising' | 'portal';
 
 export interface EventManifestEntry {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -451,6 +451,22 @@ export interface WorkflowKindInfo {
   intrinsic_schema: JsonValue;
 }
 
+// Wire shape of `GET /api/registry/events` — one row of the event-type
+// registry manifest (spec #131 Lever E / #150). Mirrors
+// `onsager_registry::EventDefinition`. Exact parity with the Rust
+// definition is enforced by the manifest's `manifest_serializes_to_json`
+// test on the backend side.
+export type EventSubsystem = 'forge' | 'stiglab' | 'synodic' | 'ising' | 'portal';
+
+export interface EventManifestEntry {
+  kind: string;
+  schema_version: number;
+  producers: EventSubsystem[];
+  consumers: EventSubsystem[];
+  audit_only: boolean;
+  description: string;
+}
+
 export interface WorkflowStage {
   id: string;
   name: string;
@@ -992,6 +1008,13 @@ export const api = {
   // stiglab).
   listWorkflowKinds: () =>
     request<{ kinds: WorkflowKindInfo[] }>('/workflow/kinds'),
+  // Event-type registry manifest (spec #131 Lever E / #150). Returns
+  // every `FactoryEventKind` variant with its declared producers and
+  // consumers — the dashboard renders this in the architecture / event
+  // catalog view so reviewers can see the cross-subsystem contract
+  // without reading source.
+  listEventManifest: () =>
+    request<{ events: EventManifestEntry[] }>('/registry/events'),
   // GitHub labels for a workspace install + repo. Used by the trigger card
   // combobox so the user selects from existing labels (with an inline
   // create-new affordance) instead of free-texting.

--- a/crates/onsager-registry/CLAUDE.md
+++ b/crates/onsager-registry/CLAUDE.md
@@ -1,0 +1,99 @@
+# Onsager registry
+
+Factory pipeline registry — the single source of truth for what types,
+adapters, gate evaluators, agent profiles, and **event types** exist in
+the system. Per [ADR 0003](../../docs/adr/0003-registry-as-source-of-truth.md)
+the registry crate is the authoritative catalog; runtime tables are
+projections of the registry's mutation events.
+
+## Contents
+
+- `catalog.rs` — built-in seed catalog (artifact kinds, workflow kinds).
+- `evaluators.rs` — gate evaluator trait and registry plug points.
+- `events.rs` — **event-type registry manifest** (spec #131 Lever E / #150).
+- `registry.rs` — `TypeDefinition`, `RegistryId`, `RegistryStatus`, etc.
+- `registry_store.rs` — DB projection / CRUD.
+- `seed.rs` — idempotent seed loader.
+
+## Event manifest update process (#150)
+
+`events.rs` carries `pub const EVENTS: EventManifest`, a static, human-
+reviewed table of every `FactoryEventKind` variant. Each row declares:
+
+- `kind` — wire `event_type` string (matches `FactoryEventKind::event_type()`).
+- `schema_version` — bumped on backwards-incompatible payload changes.
+  Additive `Option<T>` fields with `#[serde(default,
+  skip_serializing_if = "Option::is_none")]` do **not** bump.
+- `producers` — subsystems that emit this event onto the spine.
+  `Subsystem::Portal` is the catch-all for `onsager-portal` /
+  webhook-driven emitters.
+- `consumers` — subsystems that act on this event (dispatch off the
+  `event_type` string and parse the payload). Dashboard-only reads do
+  not count.
+- `audit_only` — `true` when no subsystem consumer is expected (the
+  event exists for audit / dashboard rendering only).
+
+### When to update
+
+| Change | Action |
+| --- | --- |
+| Add a `FactoryEventKind` variant | Add a row to `EVENTS` in the same PR. Producer + consumer must be wired or the event tagged `audit_only`. |
+| Add a new producer for an existing event | Append the subsystem to `producers`. |
+| Add a new listener for an existing event | Append the subsystem to `consumers`; flip `audit_only` to `false` if it was set. |
+| Backwards-incompatible payload change | Bump `schema_version`. Producer + consumer for the new version must ship together (Lever B's producer-without-consumer check enforces this once flipped to hard-fail). |
+| Backwards-compatible payload change (new optional field) | No version bump; manifest review still required — flag the change in the PR description. |
+| Remove a `FactoryEventKind` variant | Remove the manifest row in the same PR. |
+
+### Schema-version policy
+
+`schema_version` is a strictly increasing `u32` per event type. Skipping
+versions is allowed (e.g. `1 → 3`); going backwards is not. The version
+exists so consumers can branch on it during a rolling upgrade — once
+all consumers have shipped past version `N-1`, version `N-1` rows can
+be deleted from `events` if needed.
+
+### Even-non-bumping payload edits need review
+
+A `serde(default)`-guarded additive field is wire-compatible, but it
+still changes the contract every consumer reads. Edits to a payload
+field — even additive ones — must bump nothing on the manifest yet
+**must** include a manifest review (the PR diff touches `events.rs` or
+the producer/consumer fields are stale). Reviewers should ask: does the
+new field land with both a producer that sets it and a consumer that
+reads it? If not, hold the PR or tag the event `audit_only`.
+
+### CI enforcement
+
+`cargo run -p xtask -- check-events` runs in CI (see
+`.github/workflows/rust.yml`) and asserts:
+
+1. Every `FactoryEventKind` variant has a manifest row.
+2. Every manifest row declares ≥1 producer and either ≥1 consumer or
+   `audit_only = true`.
+3. Every `append_ext(_, _, "<event_type>", ...)` literal under
+   `crates/{forge,stiglab,synodic,ising}/src/` references an event whose
+   `producers` list includes that subsystem.
+4. Every `notification.event_type [!=|==] "<event_type>"` filter under
+   the same source trees references an event whose `consumers` list
+   includes that subsystem.
+
+Tests (modules guarded by `#[cfg(test)]`) are excluded from checks 3
+and 4. Helper-style emitters that pass `event_type` as a variable
+rather than a literal (e.g. stiglab's generic
+`SpineEmitter::emit(FactoryEventKind)`) are not detected by check 3 —
+that's an accepted false negative; the manifest is still the source of
+truth and reviewers verify the producer subsystem matches.
+
+### Read API
+
+The manifest is exposed at `GET /api/registry/events` (stiglab) so the
+dashboard can render the catalog without a hardcoded copy. Public by
+design — same pattern as `/api/workflow/kinds`.
+
+## Related
+
+- ADR 0001 — event-bus coordination model.
+- ADR 0003 — registry as source of truth.
+- ADR 0004 — six-lever seam-tightening plan.
+- Spec #131 — strategic plan; this manifest is **Lever E**.
+- Spec #150 — this lever's implementation.

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -1,0 +1,766 @@
+//! Event-type registry manifest — Lever E of spec #131 / ADR 0004.
+//!
+//! This module is the **single source of truth** for which subsystem
+//! produces and consumes each `FactoryEventKind` variant. It is a static,
+//! human-reviewed manifest. Subsystems do **not** self-register at runtime;
+//! the manifest is reviewed when changes land and CI (`cargo xtask
+//! check-events`) enforces the contract.
+//!
+//! See spec issue #150 and the registry CLAUDE.md for the update process.
+
+use serde::Serialize;
+
+/// Subsystem that produces or consumes events on the spine.
+///
+/// `Portal` is the umbrella for `onsager-portal` (GitHub webhooks) and any
+/// other external boundary that writes to the spine without being one of
+/// the four core subsystems. It exists so events whose only producer is a
+/// webhook receiver still satisfy the "every event has a producer" check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Subsystem {
+    Forge,
+    Stiglab,
+    Synodic,
+    Ising,
+    Portal,
+}
+
+impl Subsystem {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Forge => "forge",
+            Self::Stiglab => "stiglab",
+            Self::Synodic => "synodic",
+            Self::Ising => "ising",
+            Self::Portal => "portal",
+        }
+    }
+
+    /// Subsystems that own source under `crates/<name>/` and whose emit /
+    /// listener call sites the CI check scans. `Portal` is excluded: its
+    /// emitters live outside the workspace's lint surface.
+    pub const SCANNED: &'static [Subsystem] =
+        &[Self::Forge, Self::Stiglab, Self::Synodic, Self::Ising];
+}
+
+/// One row of the event-type registry manifest.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventDefinition {
+    /// Wire `event_type` string, matching `FactoryEventKind::event_type()`
+    /// (e.g. `"forge.shaping_dispatched"`).
+    pub kind: &'static str,
+    /// Schema version for this event's payload. Bumped on backwards-
+    /// incompatible payload changes; additive `Option<T>` fields with
+    /// `#[serde(default)]` do **not** bump.
+    pub schema_version: u32,
+    /// Subsystems that emit this event onto the spine.
+    pub producers: &'static [Subsystem],
+    /// Subsystems that listen for this event and act on it (i.e. dispatch
+    /// off the `event_type` string and parse the payload). Dashboard-only
+    /// reads do not count — set [`audit_only`] for those.
+    ///
+    /// [`audit_only`]: EventDefinition::audit_only
+    pub consumers: &'static [Subsystem],
+    /// `true` when no subsystem consumer is expected — the event exists for
+    /// the dashboard / audit log only. Lets the "every event has a consumer"
+    /// check stay strict for events that should have one, while honestly
+    /// labelling events that shouldn't.
+    pub audit_only: bool,
+    /// One-line description for the manifest read API and dashboard.
+    pub description: &'static str,
+}
+
+/// The full registry of factory event types.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventManifest {
+    pub events: &'static [EventDefinition],
+}
+
+impl EventManifest {
+    pub fn lookup(&self, kind: &str) -> Option<&EventDefinition> {
+        self.events.iter().find(|e| e.kind == kind)
+    }
+}
+
+/// The canonical event manifest. Every variant in `FactoryEventKind` must
+/// have a row here; CI's `cargo xtask check-events` enforces it.
+pub const EVENTS: EventManifest = EventManifest {
+    events: &[
+        // -- Artifact lifecycle (forge writes "artifact.state_changed"
+        //    via `emit_pipeline_event`; the others are written by the
+        //    portal / ingestion side). -------------------------------
+        EventDefinition {
+            kind: "artifact.registered",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "New artifact accepted and ID assigned.",
+        },
+        EventDefinition {
+            kind: "artifact.state_changed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "Artifact transitioned between lifecycle states.",
+        },
+        EventDefinition {
+            kind: "artifact.version_created",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "New version committed for an artifact.",
+        },
+        EventDefinition {
+            kind: "artifact.lineage_extended",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "New vertical or horizontal lineage entry recorded.",
+        },
+        EventDefinition {
+            kind: "artifact.quality_recorded",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "New quality signal appended.",
+        },
+        EventDefinition {
+            kind: "artifact.routed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "Released artifact dispatched to a consumer sink.",
+        },
+        EventDefinition {
+            kind: "artifact.archived",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "Artifact reached terminal state (archived).",
+        },
+        // -- Warehouse / delivery / deliverable -------------------------
+        EventDefinition {
+            kind: "warehouse.bundle_sealed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A new bundle was sealed for an artifact.",
+        },
+        EventDefinition {
+            kind: "delivery.succeeded",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A delivery attempt succeeded.",
+        },
+        EventDefinition {
+            kind: "delivery.failed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A delivery attempt failed; carries retry/abandoned flag.",
+        },
+        EventDefinition {
+            kind: "deliverable.created",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A workflow run produced its first artifact reference.",
+        },
+        EventDefinition {
+            kind: "deliverable.updated",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A workflow run added an artifact reference to its deliverable.",
+        },
+        // -- Git lifecycle (onsager-portal webhooks) --------------------
+        EventDefinition {
+            kind: "git.branch_created",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "A working branch was pushed for an artifact.",
+        },
+        EventDefinition {
+            kind: "git.commit_pushed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "A commit was pushed to an artifact's branch.",
+        },
+        EventDefinition {
+            kind: "git.pr_opened",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "A pull request was opened for an artifact.",
+        },
+        EventDefinition {
+            kind: "git.pr_review_received",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "A reviewer left a verdict on a PR.",
+        },
+        EventDefinition {
+            kind: "git.ci_completed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A CI check finished for a PR.",
+        },
+        EventDefinition {
+            kind: "git.pr_merged",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Forge, Subsystem::Ising],
+            audit_only: false,
+            description: "A PR was merged.",
+        },
+        EventDefinition {
+            kind: "git.pr_closed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A PR was closed without merging.",
+        },
+        // -- Forge process events ---------------------------------------
+        EventDefinition {
+            kind: "forge.shaping_dispatched",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Stiglab],
+            audit_only: false,
+            description: "ShapingRequest sent to Stiglab via the spine (replaces POST /api/shaping).",
+        },
+        EventDefinition {
+            kind: "forge.shaping_returned",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "ShapingResult received from Stiglab and recorded by Forge.",
+        },
+        EventDefinition {
+            kind: "forge.gate_requested",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Synodic],
+            audit_only: false,
+            description: "GateRequest sent to Synodic via the spine (replaces POST /api/gate).",
+        },
+        EventDefinition {
+            kind: "forge.gate_verdict",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Ising],
+            audit_only: false,
+            description: "GateVerdict observed by Forge after Synodic responded.",
+        },
+        EventDefinition {
+            kind: "forge.insight_observed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "Insight forwarded to the scheduling kernel.",
+        },
+        EventDefinition {
+            kind: "forge.decision_made",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "Scheduling kernel produced a ShapingDecision.",
+        },
+        EventDefinition {
+            kind: "forge.idle_tick",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "Scheduling kernel returned None (idle, reduced frequency).",
+        },
+        EventDefinition {
+            kind: "forge.state_changed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "Forge process state machine transitioned.",
+        },
+        // -- Stiglab events --------------------------------------------
+        EventDefinition {
+            kind: "stiglab.session_created",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A new session was allocated for a shaping request.",
+        },
+        EventDefinition {
+            kind: "stiglab.session_dispatched",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A session was dispatched to a Stiglab node.",
+        },
+        EventDefinition {
+            kind: "stiglab.session_running",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A session began active execution.",
+        },
+        EventDefinition {
+            kind: "stiglab.session_completed",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A session finished successfully; carries optional artifact_id, token usage, branch, and PR number.",
+        },
+        EventDefinition {
+            kind: "stiglab.shaping_result_ready",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "Full ShapingResult ready for Forge to act on (replaces POST /api/shaping response).",
+        },
+        EventDefinition {
+            kind: "stiglab.session_failed",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A session terminated with an error.",
+        },
+        EventDefinition {
+            kind: "stiglab.session_aborted",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A session was aborted (node lost, deadline exceeded).",
+        },
+        EventDefinition {
+            kind: "stiglab.event_upgraded",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A session-internal event was promoted to a factory event.",
+        },
+        EventDefinition {
+            kind: "stiglab.node_registered",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A new Stiglab node joined the pool.",
+        },
+        EventDefinition {
+            kind: "stiglab.node_deregistered",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A Stiglab node left the pool.",
+        },
+        EventDefinition {
+            kind: "stiglab.node_heartbeat_missed",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[],
+            audit_only: true,
+            description: "A node missed its expected heartbeat.",
+        },
+        // -- Synodic events --------------------------------------------
+        EventDefinition {
+            kind: "synodic.gate_evaluated",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "Gate request evaluated and a verdict issued (summary; full payload on synodic.gate_verdict).",
+        },
+        EventDefinition {
+            kind: "synodic.gate_denied",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "Gate request denied (subset of gate_evaluated, for filtering).",
+        },
+        EventDefinition {
+            kind: "synodic.gate_modified",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "Gate request resolved with verdict Modify (subset of gate_evaluated).",
+        },
+        EventDefinition {
+            kind: "synodic.gate_verdict",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "Full GateVerdict in response to forge.gate_requested (replaces POST /api/gate response).",
+        },
+        EventDefinition {
+            kind: "synodic.escalation_started",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An escalation was initiated.",
+        },
+        EventDefinition {
+            kind: "synodic.escalation_resolved",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An escalation was resolved (human, delegate, or timeout).",
+        },
+        EventDefinition {
+            kind: "synodic.escalation_timed_out",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An escalation timed out and the default verdict was applied.",
+        },
+        EventDefinition {
+            kind: "synodic.gate_resolution_proposed",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A delegate proposed a resolution for an active escalation.",
+        },
+        EventDefinition {
+            kind: "synodic.rule_proposed",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A crystallization candidate rule was created.",
+        },
+        EventDefinition {
+            kind: "synodic.rule_approved",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A proposed rule was approved and entered the active set.",
+        },
+        EventDefinition {
+            kind: "synodic.rule_disabled",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A rule was disabled.",
+        },
+        EventDefinition {
+            kind: "synodic.rule_version_created",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A rule was modified, producing a new version.",
+        },
+        // -- Ising events ----------------------------------------------
+        EventDefinition {
+            kind: "ising.insight_detected",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[],
+            audit_only: true,
+            description: "An insight passed validation and was recorded on the spine.",
+        },
+        EventDefinition {
+            kind: "ising.insight_emitted",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "Machine-readable signal emitted on the spine for other subsystems to consume.",
+        },
+        EventDefinition {
+            kind: "ising.insight_suppressed",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[],
+            audit_only: true,
+            description: "An insight was deduplicated or fell below confidence threshold.",
+        },
+        EventDefinition {
+            kind: "ising.rule_proposed",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[Subsystem::Synodic],
+            audit_only: false,
+            description: "An insight was packaged as a rule proposal for Synodic.",
+        },
+        EventDefinition {
+            kind: "ising.analyzer_error",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[],
+            audit_only: true,
+            description: "An analyzer encountered an error during its run.",
+        },
+        EventDefinition {
+            kind: "ising.catchup_completed",
+            schema_version: 1,
+            producers: &[Subsystem::Ising],
+            consumers: &[],
+            audit_only: true,
+            description: "Ising finished catching up from a lag position.",
+        },
+        // -- Refract (intent decomposition) ----------------------------
+        EventDefinition {
+            kind: "refract.intent_submitted",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "A new intent was submitted for decomposition.",
+        },
+        EventDefinition {
+            kind: "refract.decomposed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "A decomposer produced an artifact tree for an intent.",
+        },
+        EventDefinition {
+            kind: "refract.failed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description: "Decomposition failed — no decomposer matched, or the matched decomposer errored out.",
+        },
+        // -- Workflow runtime (issue #80 / #81) ------------------------
+        EventDefinition {
+            kind: "trigger.fired",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A trigger (e.g. a GitHub issue webhook) fired.",
+        },
+        EventDefinition {
+            kind: "stage.entered",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A workflow-tagged artifact entered a new stage.",
+        },
+        EventDefinition {
+            kind: "stage.gate_passed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A gate on the current stage resolved successfully.",
+        },
+        EventDefinition {
+            kind: "stage.gate_failed",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "A gate on the current stage failed; the artifact is parked.",
+        },
+        EventDefinition {
+            kind: "stage.advanced",
+            schema_version: 1,
+            producers: &[Subsystem::Forge],
+            consumers: &[],
+            audit_only: true,
+            description: "All gates on a stage resolved and the artifact advanced.",
+        },
+        // -- Registry events (issue #14) -------------------------------
+        EventDefinition {
+            kind: "registry.type_proposed",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A new artifact type was proposed (not yet active).",
+        },
+        EventDefinition {
+            kind: "registry.type_approved",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A proposed type was approved and entered the active catalog.",
+        },
+        EventDefinition {
+            kind: "registry.type_deprecated",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A type was deprecated (retained for audit).",
+        },
+        EventDefinition {
+            kind: "registry.adapter_registered",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An adapter implementation was registered in the catalog.",
+        },
+        EventDefinition {
+            kind: "registry.adapter_deprecated",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An adapter was deprecated.",
+        },
+        EventDefinition {
+            kind: "registry.gate_registered",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A gate evaluator was registered.",
+        },
+        EventDefinition {
+            kind: "registry.gate_deprecated",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "A gate evaluator was deprecated.",
+        },
+        EventDefinition {
+            kind: "registry.profile_registered",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An agent profile was registered.",
+        },
+        EventDefinition {
+            kind: "registry.profile_deprecated",
+            schema_version: 1,
+            producers: &[Subsystem::Synodic],
+            consumers: &[],
+            audit_only: true,
+            description: "An agent profile was deprecated.",
+        },
+        // -- Gate adapters (GitHub webhooks) ---------------------------
+        EventDefinition {
+            kind: "gate.check_updated",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A GitHub check_suite/check_run/status arrived for a tracked PR.",
+        },
+        EventDefinition {
+            kind: "gate.manual_approval_signal",
+            schema_version: 1,
+            producers: &[Subsystem::Stiglab],
+            consumers: &[Subsystem::Forge],
+            audit_only: false,
+            description: "A manual-approval gate received a signal (e.g. PR merged).",
+        },
+    ],
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// Manifest invariant: every `kind` is unique. A duplicate would let two
+    /// rows disagree on producers/consumers and silently win the "first
+    /// match" race in `lookup`.
+    #[test]
+    fn manifest_kinds_are_unique() {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for e in EVENTS.events {
+            assert!(seen.insert(e.kind), "duplicate manifest kind: {}", e.kind);
+        }
+    }
+
+    /// Strict version of the Lever E "every event has a producer and a
+    /// consumer" check: an event must declare a producer, and must either
+    /// declare a consumer or be `audit_only`.
+    #[test]
+    fn manifest_every_event_has_producer_and_consumer_or_audit_only() {
+        for e in EVENTS.events {
+            assert!(
+                !e.producers.is_empty(),
+                "event `{}` has no producer",
+                e.kind
+            );
+            assert!(
+                !e.consumers.is_empty() || e.audit_only,
+                "event `{}` has no consumer and is not audit_only",
+                e.kind
+            );
+        }
+    }
+
+    /// Round-trips through `serde_json` so the dashboard read API gets the
+    /// shape the frontend expects.
+    #[test]
+    fn manifest_serializes_to_json() {
+        let json = serde_json::to_value(&EVENTS).expect("manifest serializes");
+        let events = json
+            .get("events")
+            .and_then(|v| v.as_array())
+            .expect("events array present");
+        assert_eq!(events.len(), EVENTS.events.len());
+        let first = &events[0];
+        assert!(first.get("kind").is_some());
+        assert!(first.get("producers").is_some());
+        assert!(first.get("consumers").is_some());
+    }
+
+    #[test]
+    fn lookup_finds_known_kind_and_misses_unknown() {
+        let def = EVENTS
+            .lookup("forge.shaping_dispatched")
+            .expect("known kind");
+        assert!(def.producers.contains(&Subsystem::Forge));
+        assert!(def.consumers.contains(&Subsystem::Stiglab));
+        assert!(EVENTS.lookup("does.not_exist").is_none());
+    }
+}

--- a/crates/onsager-registry/src/lib.rs
+++ b/crates/onsager-registry/src/lib.rs
@@ -9,12 +9,14 @@
 
 pub mod catalog;
 pub mod evaluators;
+pub mod events;
 pub mod registry;
 pub mod registry_store;
 pub mod seed;
 
 pub use catalog::*;
 pub use evaluators::*;
+pub use events::{EventDefinition, EventManifest, Subsystem, EVENTS};
 pub use registry::*;
 pub use registry_store::*;
 pub use seed::*;

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -218,6 +218,13 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/workflow/kinds",
             get(routes::workflow_kinds::list_workflow_kinds),
         )
+        // Event-type registry manifest (spec #131 Lever E / #150).
+        // Static, human-reviewed manifest of every FactoryEventKind
+        // variant — which subsystems produce it and which consume it.
+        .route(
+            "/api/registry/events",
+            get(routes::registry_events::list_events),
+        )
         // Spine API — exposes shared event spine data to the dashboard
         .route("/api/spine/events", get(routes::spine::list_events))
         .route(

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod nodes;
 pub mod pats;
 pub mod portal;
 pub mod projects;
+pub mod registry_events;
 pub mod sessions;
 pub mod shaping;
 pub mod spine;

--- a/crates/stiglab/src/server/routes/registry_events.rs
+++ b/crates/stiglab/src/server/routes/registry_events.rs
@@ -1,0 +1,57 @@
+//! Event-type registry manifest read API (spec #131 Lever E / #150).
+//!
+//! Surfaces `onsager_registry::EVENTS` to the dashboard as JSON. The
+//! manifest is the static source of truth for which subsystem produces
+//! and consumes each `FactoryEventKind` variant; this route is the
+//! runtime read path that lets the dashboard render the catalog without
+//! hardcoding the list.
+//!
+//! Public by design (matches `workflow_kinds`): the manifest is part of
+//! the architecture documentation, not user data.
+
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use onsager_registry::EVENTS;
+
+/// GET /api/registry/events — return the event-type registry manifest.
+pub async fn list_events() -> Response {
+    Json(&EVENTS).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn list_returns_manifest_as_json() {
+        let resp = list_events().await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let events = parsed["events"].as_array().expect("events array");
+        assert_eq!(events.len(), EVENTS.events.len());
+        // Spot-check shape.
+        let first = &events[0];
+        assert!(first["kind"].as_str().is_some());
+        assert!(first["producers"].as_array().is_some());
+        assert!(first["consumers"].as_array().is_some());
+        assert!(first["audit_only"].as_bool().is_some());
+    }
+
+    #[tokio::test]
+    async fn manifest_contains_known_kinds() {
+        let resp = list_events().await;
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let kinds: Vec<&str> = parsed["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e["kind"].as_str())
+            .collect();
+        assert!(kinds.contains(&"forge.shaping_dispatched"));
+        assert!(kinds.contains(&"synodic.gate_verdict"));
+        assert!(kinds.contains(&"ising.insight_emitted"));
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,6 +16,7 @@ serde_json.workspace = true
 syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 quote = "1"
 toml = "0.8"
+onsager-registry = { path = "../crates/onsager-registry" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -388,7 +388,10 @@ fn extract_first_string(s: &str) -> Option<String> {
                 }
                 j += 1;
             }
-            if j <= bytes.len() {
+            // Only return when the closing `"` is actually found on this
+            // line — an unterminated open-quote (e.g. a multi-line raw
+            // string) must not be mis-parsed as an event kind.
+            if j < bytes.len() && bytes[j] == b'"' {
                 return Some(s[start..j].to_string());
             }
             return None;
@@ -531,6 +534,15 @@ mod tests {
             extract_first_string(r#"if x == "hello\"world""#),
             Some(r#"hello\"world"#.to_string())
         );
+    }
+
+    /// Regression: an unterminated quote on the line (e.g. the start of a
+    /// multi-line raw string) must not produce a partial match. Without
+    /// the `j < bytes.len()` guard this returned `Some("foo")` for the
+    /// fragment, which would mis-parse as an event kind.
+    #[test]
+    fn extract_first_string_returns_none_for_unterminated_quote() {
+        assert_eq!(extract_first_string(r#"let s = "foo"#), None);
     }
 
     #[test]

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -1,0 +1,541 @@
+//! Lever E (#150) — registry-backed event-type manifest check.
+//!
+//! Walks `onsager_registry::EVENTS` and verifies the four assertions
+//! from spec #150:
+//!
+//! 1. **Coverage**: every `FactoryEventKind` variant has a manifest entry
+//!    keyed by its wire `event_type` string.
+//! 2. **Both ends declared**: every manifest entry has at least one
+//!    producer, and either at least one consumer or `audit_only = true`.
+//! 3. **Emit call sites match producers**: every `append_ext(_, _,
+//!    "<event_type>", ...)` literal under
+//!    `crates/{forge,stiglab,synodic,ising}/src/` references an event
+//!    whose manifest `producers` list includes that subsystem.
+//! 4. **Listener call sites match consumers**: every
+//!    `notification.event_type [!=|==] "<event_type>"` filter under the
+//!    same source trees references an event whose `consumers` list
+//!    includes that subsystem.
+//!
+//! Coverage is parsed via `syn` from
+//! `crates/onsager-spine/src/factory_event.rs` — same approach as
+//! `gen-event-docs`. Emit and listener scans are line-grep with a
+//! deliberately conservative pattern set; false negatives (a missed
+//! emit) are preferred to false positives (a flagged legitimate
+//! reference). Tests must be excluded — `#[cfg(test)]` modules and
+//! `*_test.rs` files do not count.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use onsager_registry::{EventDefinition, Subsystem, EVENTS};
+use syn::{Expr, ExprLit, ImplItem, Item, Lit, Pat, Stmt, Type, Visibility};
+
+const SPINE_SRC: &str = "crates/onsager-spine/src/factory_event.rs";
+const ENUM_NAME: &str = "FactoryEventKind";
+
+pub fn run() -> Result<()> {
+    let root = workspace_root()?;
+    let mut errors: Vec<String> = Vec::new();
+
+    // Check 1+2: coverage and producer/consumer declared.
+    let variants_to_kinds = parse_variant_kinds(&root.join(SPINE_SRC))?;
+    check_coverage(&variants_to_kinds, &mut errors);
+    check_both_ends_declared(&mut errors);
+
+    // Check 3+4: emit / listener call sites.
+    for sub in Subsystem::SCANNED {
+        let src = root.join("crates").join(sub.as_str()).join("src");
+        if !src.is_dir() {
+            continue;
+        }
+        for file in rust_files(&src)? {
+            scan_file(&root, *sub, &file, &mut errors)?;
+        }
+    }
+
+    if !errors.is_empty() {
+        eprintln!("check-events: {} violation(s)", errors.len());
+        for e in &errors {
+            eprintln!("  {e}");
+        }
+        eprintln!();
+        eprintln!("See spec #150 and crates/onsager-registry/src/events.rs.");
+        bail!("event-manifest check failed");
+    }
+
+    println!(
+        "check-events: clean ({} events, {} subsystems scanned)",
+        EVENTS.events.len(),
+        Subsystem::SCANNED.len()
+    );
+    Ok(())
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+fn rel(root: &Path, p: &Path) -> PathBuf {
+    p.strip_prefix(root).unwrap_or(p).to_path_buf()
+}
+
+fn rust_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    walk(dir, &mut |p| {
+        if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(p.to_path_buf());
+        }
+    })?;
+    out.sort();
+    Ok(out)
+}
+
+fn walk(dir: &Path, visit: &mut dyn FnMut(&Path)) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, visit)?;
+        } else {
+            visit(&path);
+        }
+    }
+    Ok(())
+}
+
+fn def_for(kind: &str) -> Option<&'static EventDefinition> {
+    EVENTS.lookup(kind)
+}
+
+// ---------------------------------------------------------------------------
+// Coverage: parse FactoryEventKind enum + event_type() match arms
+// ---------------------------------------------------------------------------
+
+/// Parse the spine source and return a map of `variant_name → event_type`
+/// (e.g. `ArtifactRegistered → "artifact.registered"`). Re-uses the same
+/// shape as `gen-event-docs` but produces a flat map instead of doc rows.
+fn parse_variant_kinds(spine_src: &Path) -> Result<BTreeMap<String, String>> {
+    let text = std::fs::read_to_string(spine_src)
+        .with_context(|| format!("read {}", spine_src.display()))?;
+    let file = syn::parse_file(&text).with_context(|| format!("parse {}", spine_src.display()))?;
+
+    let mut variants: Vec<String> = Vec::new();
+    let mut event_type_arms: Vec<(String, String)> = Vec::new();
+
+    for item in &file.items {
+        match item {
+            Item::Enum(en) if en.ident == ENUM_NAME => {
+                if !matches!(en.vis, Visibility::Public(_)) {
+                    bail!("{ENUM_NAME} is not pub");
+                }
+                variants = en.variants.iter().map(|v| v.ident.to_string()).collect();
+            }
+            Item::Impl(im)
+                if im.trait_.is_none() && type_ident(&im.self_ty).as_deref() == Some(ENUM_NAME) =>
+            {
+                for it in &im.items {
+                    let ImplItem::Fn(f) = it else { continue };
+                    if f.sig.ident == "event_type" {
+                        event_type_arms = extract_match_arms(&f.block.stmts)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if variants.is_empty() {
+        bail!(
+            "could not find pub enum {ENUM_NAME} in {}",
+            spine_src.display()
+        );
+    }
+
+    let mut out = BTreeMap::new();
+    for v in &variants {
+        let kind = event_type_arms
+            .iter()
+            .find(|(name, _)| name == v)
+            .map(|(_, s)| s.clone())
+            .ok_or_else(|| anyhow!("event_type() has no arm for variant {v}"))?;
+        out.insert(v.clone(), kind);
+    }
+    Ok(out)
+}
+
+fn type_ident(ty: &Type) -> Option<String> {
+    if let Type::Path(p) = ty {
+        p.path.segments.last().map(|s| s.ident.to_string())
+    } else {
+        None
+    }
+}
+
+fn extract_match_arms(stmts: &[Stmt]) -> Result<Vec<(String, String)>> {
+    let match_expr = stmts
+        .iter()
+        .find_map(|s| match s {
+            Stmt::Expr(Expr::Match(m), _) => Some(m),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow!("function body has no top-level match expression"))?;
+
+    let mut out = Vec::new();
+    for arm in &match_expr.arms {
+        let lit = match arm.body.as_ref() {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) => s.value(),
+            _ => bail!("event_type() match arm body is not a string literal"),
+        };
+        for variant in collect_variants_from_pat(&arm.pat) {
+            out.push((variant, lit.clone()));
+        }
+    }
+    Ok(out)
+}
+
+fn collect_variants_from_pat(pat: &Pat) -> Vec<String> {
+    let mut out = Vec::new();
+    walk_pat(pat, &mut out);
+    out
+}
+
+fn walk_pat(pat: &Pat, out: &mut Vec<String>) {
+    match pat {
+        Pat::Or(or) => {
+            for p in &or.cases {
+                walk_pat(p, out);
+            }
+        }
+        Pat::Struct(s) => push_last_segment(&s.path, out),
+        Pat::TupleStruct(t) => push_last_segment(&t.path, out),
+        Pat::Path(p) => push_last_segment(&p.path, out),
+        _ => {}
+    }
+}
+
+fn push_last_segment(path: &syn::Path, out: &mut Vec<String>) {
+    if let Some(seg) = path.segments.last() {
+        out.push(seg.ident.to_string());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: every FactoryEventKind variant has a manifest entry
+// ---------------------------------------------------------------------------
+
+fn check_coverage(variants_to_kinds: &BTreeMap<String, String>, errors: &mut Vec<String>) {
+    let manifest_kinds: BTreeSet<&'static str> = EVENTS.events.iter().map(|e| e.kind).collect();
+
+    for (variant, kind) in variants_to_kinds {
+        if !manifest_kinds.contains(kind.as_str()) {
+            errors.push(format!(
+                "[coverage] FactoryEventKind::{variant} (`{kind}`) is missing from the registry manifest"
+            ));
+        }
+    }
+
+    let known_kinds: BTreeSet<&str> = variants_to_kinds.values().map(|s| s.as_str()).collect();
+    for kind in &manifest_kinds {
+        if !known_kinds.contains(kind) {
+            errors.push(format!(
+                "[coverage] manifest entry `{kind}` does not match any FactoryEventKind variant"
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: every manifest entry has at least one producer + (consumer | audit_only)
+// ---------------------------------------------------------------------------
+
+fn check_both_ends_declared(errors: &mut Vec<String>) {
+    for e in EVENTS.events {
+        if e.producers.is_empty() {
+            errors.push(format!("[manifest] `{}` declares no producer", e.kind));
+        }
+        if e.consumers.is_empty() && !e.audit_only {
+            errors.push(format!(
+                "[manifest] `{}` declares no consumer and is not audit_only",
+                e.kind
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checks 3 + 4: scan subsystem source for emit and listener call sites.
+//
+// Conservative grep-style detection. False negatives are preferred to false
+// positives:
+//
+//   - **Emit**: any line containing `append_ext` or `append_factory_event`
+//     where the same line (or the next 4 lines) carry a `"<event_type>"`
+//     literal known to the manifest.
+//   - **Listener**: any line of the form
+//     `notification.event_type [!=|==] "<event_type>"` or `event_type:
+//     "<event_type>"` inside an EventRef construction. Matching the
+//     listener subsystem against the manifest's `consumers` list.
+//
+// Tests are excluded by skipping `#[cfg(test)]` modules per file (we
+// consider any line after the first `#[cfg(test)]` attribute outside a
+// brace context to be in test scope; this is a coarse heuristic, but the
+// test-block is always the last item in our subsystem source files).
+// ---------------------------------------------------------------------------
+
+fn scan_file(root: &Path, sub: Subsystem, path: &Path, errors: &mut Vec<String>) -> Result<()> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let lines: Vec<&str> = text.lines().collect();
+    let test_start = first_cfg_test_line(&lines);
+
+    for (idx, line) in lines.iter().enumerate() {
+        if idx >= test_start {
+            break;
+        }
+        let line_no = idx + 1;
+        let code = strip_line_comment(line);
+
+        // -- Check 3: emit call site --------------------------------
+        if code.contains("append_ext") || code.contains("append_factory_event") {
+            // event_type literal may be on the same line or within the
+            // next 4 lines (multi-line append_ext call).
+            let window: String = lines[idx..lines.len().min(idx + 6)].join("\n");
+            for kind in find_event_type_literals(&window) {
+                let Some(def) = def_for(&kind) else {
+                    continue; // unknown literal; coverage check handles enum gaps
+                };
+                if !def.producers.contains(&sub) {
+                    errors.push(format!(
+                        "[emit] {}:{} subsystem `{}` emits `{}`, but manifest producers = {:?}",
+                        rel(root, path).display(),
+                        line_no,
+                        sub.as_str(),
+                        kind,
+                        def.producers.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    ));
+                }
+            }
+        }
+
+        // -- Check 4: listener filter --------------------------------
+        if let Some(kind) = parse_event_type_filter(code) {
+            let Some(def) = def_for(&kind) else { continue };
+            if !def.consumers.contains(&sub) {
+                errors.push(format!(
+                    "[listener] {}:{} subsystem `{}` filters on `{}`, but manifest consumers = {:?}",
+                    rel(root, path).display(),
+                    line_no,
+                    sub.as_str(),
+                    kind,
+                    def.consumers
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Find all event-type literals known to the manifest in `s`. Returns the
+/// matched kind strings (deduplicated).
+fn find_event_type_literals(s: &str) -> Vec<String> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for def in EVENTS.events {
+        let needle = format!("\"{}\"", def.kind);
+        if s.contains(&needle) {
+            out.insert(def.kind.to_string());
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Parse `notification.event_type != "<kind>"` or `== "<kind>"` and return
+/// the kind. Returns `None` if the line isn't a listener filter.
+fn parse_event_type_filter(code: &str) -> Option<String> {
+    // Look for `notification.event_type` and then a `"..."` literal.
+    if !code.contains("event_type") {
+        return None;
+    }
+    if !(code.contains("notification.event_type")
+        || code.contains("event_type !=")
+        || code.contains("event_type =="))
+    {
+        return None;
+    }
+    extract_first_string(code)
+}
+
+fn extract_first_string(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && bytes[j] != b'"' {
+                if bytes[j] == b'\\' {
+                    j += 2;
+                    continue;
+                }
+                j += 1;
+            }
+            if j <= bytes.len() {
+                return Some(s[start..j].to_string());
+            }
+            return None;
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the line index of the first `#[cfg(test)]` at module scope so we
+/// can stop scanning before tests. Returns `lines.len()` (i.e. "no test
+/// block") if none found.
+fn first_cfg_test_line(lines: &[&str]) -> usize {
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("#[cfg(test)]") {
+            return i;
+        }
+    }
+    lines.len()
+}
+
+/// Strip a trailing `//` line comment outside string literals — same shape
+/// as `lint_seams::strip_line_comment` but inlined to keep this module
+/// self-contained.
+fn strip_line_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut in_str = false;
+    let mut prev_backslash = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if c == b'\\' && !prev_backslash {
+                prev_backslash = true;
+            } else {
+                if c == b'"' && !prev_backslash {
+                    in_str = false;
+                }
+                prev_backslash = false;
+            }
+            i += 1;
+            continue;
+        }
+        if c == b'"' {
+            in_str = true;
+        } else if c == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            return &line[..i];
+        }
+        i += 1;
+    }
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic: pretend we have a manifest with a producer but no
+    /// consumer + audit_only=false. Mirrors `check_both_ends_declared`'s
+    /// branch directly since we can't mutate the static `EVENTS`.
+    #[test]
+    fn predicate_flags_no_consumer_non_audit_event() {
+        fn declared_ok(
+            producers: &[Subsystem],
+            consumers: &[Subsystem],
+            audit_only: bool,
+        ) -> Vec<&'static str> {
+            let mut errs = Vec::new();
+            if producers.is_empty() {
+                errs.push("no producer");
+            }
+            if consumers.is_empty() && !audit_only {
+                errs.push("no consumer");
+            }
+            errs
+        }
+        assert_eq!(
+            declared_ok(&[Subsystem::Forge], &[], false),
+            vec!["no consumer"]
+        );
+        assert_eq!(
+            declared_ok(&[Subsystem::Forge], &[], true),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            declared_ok(&[], &[Subsystem::Forge], false),
+            vec!["no producer"]
+        );
+    }
+
+    /// Synthetic: an emit literal whose subsystem is not in the manifest
+    /// `producers` list. Mirrors how `scan_file` would fire on a real
+    /// repository — we drive `find_event_type_literals` and the
+    /// producer membership check directly.
+    #[test]
+    fn emit_outside_manifest_producers_is_flagged() {
+        let kind = "forge.shaping_dispatched";
+        let line = format!("spine.append_ext(stream, \"forge\", \"{kind}\", data, &m, None)");
+        let hits = find_event_type_literals(&line);
+        assert_eq!(hits, vec![kind.to_string()]);
+        let def = def_for(kind).unwrap();
+        // Pretending stiglab emits forge.shaping_dispatched: must NOT be
+        // in producers (real producer is forge).
+        assert!(!def.producers.contains(&Subsystem::Stiglab));
+    }
+
+    /// Synthetic: a `Listener` filter whose subsystem is not in the
+    /// manifest `consumers` list. Drives `parse_event_type_filter` +
+    /// consumer membership.
+    #[test]
+    fn listener_outside_manifest_consumers_is_flagged() {
+        let kind = "synodic.gate_verdict";
+        let line = format!("if notification.event_type != \"{kind}\" {{ return Ok(()); }}");
+        let parsed = parse_event_type_filter(&line).expect("filter parses");
+        assert_eq!(parsed, kind);
+        let def = def_for(kind).unwrap();
+        // Real consumer is forge — synodic must not appear.
+        assert!(!def.consumers.contains(&Subsystem::Synodic));
+        assert!(def.consumers.contains(&Subsystem::Forge));
+    }
+
+    /// Synthetic: a `FactoryEventKind` variant missing from the
+    /// manifest. We can't mutate EVENTS at runtime, so we exercise
+    /// `check_coverage` against a forged variant map.
+    #[test]
+    fn coverage_flags_variant_not_in_manifest() {
+        let mut variants = BTreeMap::new();
+        variants.insert("FakeVariant".to_string(), "fake.kind".to_string());
+        let mut errs = Vec::new();
+        check_coverage(&variants, &mut errs);
+        assert!(
+            errs.iter().any(|e| e.contains("FakeVariant")),
+            "expected coverage error, got {errs:?}"
+        );
+    }
+
+    #[test]
+    fn extract_first_string_handles_escaped_quotes() {
+        assert_eq!(
+            extract_first_string(r#"if x == "hello\"world""#),
+            Some(r#"hello\"world"#.to_string())
+        );
+    }
+
+    #[test]
+    fn cfg_test_marker_is_detected() {
+        let lines = ["fn x() {}", "", "#[cfg(test)]", "mod tests { }"];
+        assert_eq!(first_cfg_test_line(&lines), 2);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,6 +4,7 @@
 //!     cargo run -p xtask -- gen-event-docs --check   # verify in sync
 //!     cargo run -p xtask -- lint-seams               # check the seam rule
 //!     cargo run -p xtask -- check-api-contract       # check dashboard ↔ backend surface
+//!     cargo run -p xtask -- check-events             # check event-type registry manifest (#150)
 //!     cargo run -p xtask -- slot <subcommand>        # per-worktree dev slot allocator (#194)
 //!
 //! The event catalog is derived from `crates/onsager-spine/src/factory_event.rs`
@@ -23,6 +24,7 @@
 //! `slot` allocates and manages per-worktree dev slots backed by docker-compose
 //! projects on disjoint ports. See [`slot`] for the full surface.
 
+mod check_events;
 mod lint_api_contract;
 mod lint_seams;
 mod slot;
@@ -57,10 +59,17 @@ fn main() -> ExitCode {
                 lint_api_contract::run()
             }
         }
+        Some("check-events") => {
+            if args.next().is_some() {
+                Err(anyhow!("check-events takes no arguments"))
+            } else {
+                check_events::run()
+            }
+        }
         Some("slot") => slot::run(args.collect()),
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
+            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
         )),
     };
 


### PR DESCRIPTION
## Summary

Lever E of the #131 six-lever plan. Lands a static, human-reviewed
manifest of every `FactoryEventKind` variant in `onsager-registry`,
mapping each to its declared producer / consumer subsystems, and a CI
check that enforces the contract.

## Delivers

- Defines `EventManifest` / `EventDefinition` / `Subsystem` in
  `crates/onsager-registry/src/events.rs`. The manifest is a static
  `pub const EVENTS` — subsystems do not self-register at runtime.
- Populates 75 rows, one per `FactoryEventKind` variant. `Portal` is
  the producer for events written by `onsager-portal` / GitHub
  webhooks. Events with no in-tree consumer are tagged `audit_only`
  so the "every event has a consumer" check stays strict where it
  should.
- New `cargo run -p xtask -- check-events` (in
  `xtask/src/check_events.rs`) asserts:
  1. **Coverage** — every `FactoryEventKind` variant has a manifest
     row, parsed from `factory_event.rs` via `syn` (same approach as
     `gen-event-docs`).
  2. **Both ends declared** — every row has ≥1 producer and either
     ≥1 consumer or `audit_only = true`.
  3. **Emit call sites match producers** — every `append_ext(_, _,
     "<event_type>", ...)` literal under
     `crates/{forge,stiglab,synodic,ising}/src/` references an event
     whose `producers` list includes that subsystem.
  4. **Listener call sites match consumers** — every
     `notification.event_type [!=|==] "<event_type>"` filter is
     similarly matched against `consumers`.
  Tests (`#[cfg(test)]` modules) are excluded from checks 3 and 4.
- Wires the check into `.github/workflows/rust.yml` next to
  `lint-seams` and `check-api-contract`.
- Surfaces the manifest at `GET /api/registry/events` (stiglab) with
  a paired `dashboardApi.listEventManifest()` caller in
  `apps/dashboard/src/lib/api.ts` so `check-api-contract` stays
  satisfied. The route is public, matching `/api/workflow/kinds`.
- Documents the update process — when to bump `schema_version`,
  what counts as a producer / consumer, the `audit_only` semantics —
  in `crates/onsager-registry/CLAUDE.md`.
- Synthetic tests cover the manifest invariants and the four CI
  predicates (coverage, both-ends, emit, listener).

Per the issue's Open Questions, the Lever B flip from warn → hard-
fail is **not** in this PR; it lands as a separate small follow-up
once the manifest is in `main`.

## Test plan

- [x] `cargo test -p onsager-registry --lib events::` — manifest
      invariants (uniqueness, both-ends, JSON shape, lookup).
- [x] `cargo test -p xtask` — synthetic tests for the four CI
      predicates.
- [x] `cargo test -p stiglab --lib server::routes::registry_events`
      — the new read API.
- [x] `cargo run -p xtask -- check-events` is green on `main` +
      this branch.
- [x] `cargo run -p xtask -- gen-event-docs --check`,
      `lint-seams`, `check-api-contract` all clean.
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` and
      `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `pnpm --filter dashboard tsc --noEmit` clean.

Closes #150

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDcjLFaEHfn7BoJ7HJaU3p)_