### PR TITLE
feat(portal): correlation_id column + dispatch/await helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/onsager-portal/Cargo.toml
+++ b/crates/onsager-portal/Cargo.toml
@@ -37,3 +37,6 @@ ring = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 regex = "1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/onsager-portal/src/feedback/dispatch.rs
+++ b/crates/onsager-portal/src/feedback/dispatch.rs
@@ -1,0 +1,106 @@
+//! `dispatch` — mint a `correlation_id` and append a spine intent.
+//!
+//! Portal-minted is the v1 contract (`#223` open-question resolution).
+//! Subsystems propagate but never mint, so every spine intent has an
+//! HTTP origin and a unique handle the portal knows how to await on.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use onsager_spine::{EventMetadata, EventNotification, EventStore, FactoryEvent, FactoryEventKind};
+use uuid::Uuid;
+
+use super::registry::{AwaitError, CorrelationRegistry};
+
+/// Errors emitted by the dispatch helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum DispatchError {
+    #[error("spine append failed: {0}")]
+    Append(#[from] sqlx::Error),
+}
+
+/// Handle returned from a dispatch — opaque to the caller, but
+/// carries everything we need to either await synchronously or hand
+/// the `correlation_id` back to the dashboard for a 202 + subscribe.
+#[derive(Debug, Clone)]
+pub struct DispatchHandle {
+    pub correlation_id: Uuid,
+    pub event_id: i64,
+}
+
+/// Mint a fresh `correlation_id`, wrap `event` in a [`FactoryEvent`]
+/// envelope, and append it through `store`. Equivalent to
+/// [`dispatch_with_id`] with a brand-new UUID.
+pub async fn dispatch(
+    store: &EventStore,
+    event: FactoryEventKind,
+    actor: impl Into<String>,
+) -> Result<DispatchHandle, DispatchError> {
+    dispatch_with_id(store, event, actor, Uuid::new_v4()).await
+}
+
+/// Like [`dispatch`] but with a caller-supplied `correlation_id` —
+/// used by [`command_response`] (which has to register the waiter
+/// **before** dispatching to avoid a TOCTOU between the spine
+/// notification and the registry insert).
+pub async fn dispatch_with_id(
+    store: &EventStore,
+    event: FactoryEventKind,
+    actor: impl Into<String>,
+    correlation_id: Uuid,
+) -> Result<DispatchHandle, DispatchError> {
+    let actor = actor.into();
+    let envelope = FactoryEvent {
+        event,
+        correlation_id: Some(correlation_id.to_string()),
+        causation_id: None,
+        actor: actor.clone(),
+        timestamp: Utc::now(),
+    };
+    let metadata = EventMetadata {
+        correlation_id: Some(correlation_id.to_string()),
+        causation_id: None,
+        actor,
+    };
+    let event_id = store.append_factory_event(&envelope, &metadata).await?;
+    Ok(DispatchHandle {
+        correlation_id,
+        event_id,
+    })
+}
+
+/// Outcome of [`command_response`]: either the matching response
+/// arrived inside the timeout (sync), or it didn't and the caller
+/// should hand the dispatch handle to the dashboard for a 202 +
+/// subscribe (async).
+#[derive(Debug)]
+pub enum CommandResponse {
+    Synchronous(EventNotification),
+    Async(DispatchHandle),
+}
+
+/// Emit `event`, then wait up to `timeout` for a response event
+/// stamped with the same `correlation_id`. On timeout, returns
+/// `Async(handle)` so the HTTP handler can fall through to a 202
+/// without raising a user-visible error.
+///
+/// `timeout` is clamped to [`super::MAX_SYNC_TIMEOUT`] (`2s`); pass
+/// [`super::DEFAULT_SYNC_TIMEOUT`] if you have no specific budget.
+pub async fn command_response(
+    registry: &CorrelationRegistry,
+    store: &EventStore,
+    event: FactoryEventKind,
+    actor: impl Into<String>,
+    timeout: Duration,
+) -> Result<CommandResponse, DispatchError> {
+    let correlation_id = Uuid::new_v4();
+    // Register the waiter BEFORE dispatch so we never miss a
+    // response that lands faster than the registry insert.
+    let waiter = registry.register(correlation_id);
+    let handle = dispatch_with_id(store, event, actor, correlation_id).await?;
+    match waiter.timeout(timeout).await {
+        Ok(notification) => Ok(CommandResponse::Synchronous(notification)),
+        Err(AwaitError::Timeout) => Ok(CommandResponse::Async(handle)),
+        Err(AwaitError::Cancelled) => Ok(CommandResponse::Async(handle)),
+    }
+}

--- a/crates/onsager-portal/src/feedback/mod.rs
+++ b/crates/onsager-portal/src/feedback/mod.rs
@@ -1,0 +1,44 @@
+//! Portal feedback contract — the "three feedback shapes" plumbing
+//! (`#223`).
+//!
+//! Portal owns the public HTTP boundary. Behind that boundary, every
+//! mutating request has one of three shapes:
+//!
+//! 1. **Read** (`GET`): SELECT against the spine, return.
+//! 2. **Fast write** (`POST`/`PATCH`, `≤ 1s`): emit a spine intent
+//!    stamped with a fresh `correlation_id`, await the matching response
+//!    event, return synchronously.
+//! 3. **Slow / streaming write**: same emit, return `202` with the
+//!    `correlation_id`, dashboard subscribes for events tagged with it.
+//!
+//! This module is the type-system anchor for shapes 2 and 3. It owns:
+//!
+//! - [`dispatch`] — mint a `correlation_id`, write the intent through
+//!   `EventStore`, return the handle.
+//! - [`CorrelationRegistry`] — an in-process map of `correlation_id →
+//!   oneshot::Sender<EventNotification>`. A background task tails the
+//!   spine `pg_notify` channel and routes responses to the matching
+//!   waiter without a DB roundtrip (the typed column added in spine
+//!   migration 014 is mirrored on every notification).
+//! - [`Waiter`] / [`await_with_timeout`] — bounded sync wait. Default
+//!   `1s`, hard cap `2s` per the spec resolution comment on #223.
+//! - [`command_response`] — emit-and-await convenience that falls
+//!   through to the 202 path on timeout, so callers can write
+//!   `match command_response(...).await { Sync(ev) => ..., Async(h) =>
+//!   ... }` without juggling the registry directly.
+//!
+//! See <https://github.com/onsager-ai/onsager/issues/223> for the
+//! full contract.
+
+mod dispatch;
+mod registry;
+
+pub use dispatch::{
+    command_response, dispatch, dispatch_with_id, CommandResponse, DispatchError, DispatchHandle,
+};
+pub use registry::{await_with_timeout, AwaitError, CorrelationRegistry, Waiter, MAX_SYNC_TIMEOUT};
+
+/// Default timeout for fast-write helpers (`1s`). The hard cap is
+/// [`MAX_SYNC_TIMEOUT`] (`2s`) — anything that needs more should be a
+/// 202 + subscribe flow, not a longer await.
+pub const DEFAULT_SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1000);

--- a/crates/onsager-portal/src/feedback/registry.rs
+++ b/crates/onsager-portal/src/feedback/registry.rs
@@ -1,0 +1,296 @@
+//! `CorrelationRegistry` — in-process map from `correlation_id` to a
+//! oneshot waiter, fed by the spine `pg_notify` channel.
+//!
+//! The registry is the back end of the fast-write path. A handler
+//! mints a `correlation_id`, registers a [`Waiter`], dispatches the
+//! intent, and `await`s the waiter with a bounded timeout. A
+//! background task on the registry tails [`EventStore::subscribe`]
+//! and, when it sees a notification carrying a matching
+//! `correlation_id`, completes the waiter.
+//!
+//! Notifications without a `correlation_id` (background events,
+//! pre-#223 producers) are ignored. Multiple waiters per id are not
+//! supported — fresh UUIDs make collisions impossible in practice.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use onsager_spine::{EventNotification, EventStore};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+/// Hard cap on the synchronous-wait budget (`2s`, per #223). Helpers
+/// clamp callers to this regardless of the timeout they ask for —
+/// anything that needs more is misclassified.
+pub const MAX_SYNC_TIMEOUT: Duration = Duration::from_millis(2000);
+
+type WaiterMap = HashMap<Uuid, oneshot::Sender<EventNotification>>;
+
+/// Routes spine notifications back to the request handler that
+/// dispatched the originating intent.
+///
+/// Cheap to clone — the inner state is `Arc<Mutex<...>>`. Start the
+/// pg_notify pump exactly once via [`Self::start`]; subsequent calls
+/// would race two listeners against the same map.
+#[derive(Clone)]
+pub struct CorrelationRegistry {
+    waiters: Arc<Mutex<WaiterMap>>,
+}
+
+impl CorrelationRegistry {
+    pub fn new() -> Self {
+        Self {
+            waiters: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Subscribe to spine notifications and route correlation-tagged
+    /// events to the matching [`Waiter`]. Spawns a background task
+    /// that runs until the underlying `pg_notify` channel closes.
+    pub async fn start(&self, store: &EventStore) -> Result<(), sqlx::Error> {
+        let mut rx = store.subscribe().await?;
+        let waiters = Arc::clone(&self.waiters);
+        tokio::spawn(async move {
+            while let Some(notification) = rx.recv().await {
+                let Some(corr) = notification.correlation_id else {
+                    continue;
+                };
+                let sender = {
+                    let mut map = waiters.lock().expect("CorrelationRegistry poisoned");
+                    map.remove(&corr)
+                };
+                if let Some(tx) = sender {
+                    // Receiver may have dropped (timeout already fired);
+                    // ignore the send error in that case.
+                    let _ = tx.send(notification);
+                }
+            }
+            tracing::debug!("CorrelationRegistry pg_notify channel closed");
+        });
+        Ok(())
+    }
+
+    /// Reserve a slot for `correlation_id` and return a [`Waiter`]
+    /// that will resolve when the matching notification arrives.
+    /// Register **before** dispatching the intent — otherwise a
+    /// response that lands faster than the registry insert is lost.
+    pub fn register(&self, correlation_id: Uuid) -> Waiter {
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut map = self.waiters.lock().expect("CorrelationRegistry poisoned");
+            map.insert(correlation_id, tx);
+        }
+        Waiter {
+            correlation_id,
+            rx: Some(rx),
+            waiters: Arc::clone(&self.waiters),
+        }
+    }
+
+    /// Number of currently-registered waiters. Test helper.
+    #[doc(hidden)]
+    pub fn waiter_count(&self) -> usize {
+        self.waiters
+            .lock()
+            .expect("CorrelationRegistry poisoned")
+            .len()
+    }
+}
+
+impl Default for CorrelationRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Errors emitted by [`Waiter::timeout`] / [`await_with_timeout`].
+#[derive(Debug, thiserror::Error)]
+pub enum AwaitError {
+    /// Timed out before a matching notification arrived.
+    #[error("timed out waiting for correlation_id response")]
+    Timeout,
+    /// The registry was dropped before the notification arrived.
+    /// Should be unreachable in normal operation — the registry is
+    /// a process-lifetime singleton.
+    #[error("correlation registry dropped before response")]
+    Cancelled,
+}
+
+/// Reservation handle. Either resolves to a matching
+/// [`EventNotification`] or, on `Drop`, releases its slot in the
+/// registry so a leaked handle doesn't leak memory.
+pub struct Waiter {
+    correlation_id: Uuid,
+    rx: Option<oneshot::Receiver<EventNotification>>,
+    waiters: Arc<Mutex<WaiterMap>>,
+}
+
+impl Waiter {
+    pub fn correlation_id(&self) -> Uuid {
+        self.correlation_id
+    }
+
+    /// Wait up to `timeout` (clamped to [`MAX_SYNC_TIMEOUT`]) for the
+    /// notification to arrive.
+    pub async fn timeout(mut self, timeout: Duration) -> Result<EventNotification, AwaitError> {
+        let bounded = timeout.min(MAX_SYNC_TIMEOUT);
+        let rx = self.rx.take().expect("Waiter polled twice");
+        let result = match tokio::time::timeout(bounded, rx).await {
+            Ok(Ok(notification)) => Ok(notification),
+            Ok(Err(_)) => Err(AwaitError::Cancelled),
+            Err(_) => Err(AwaitError::Timeout),
+        };
+        if result.is_err() {
+            self.release_slot();
+        }
+        result
+    }
+
+    fn release_slot(&self) {
+        let _ = self
+            .waiters
+            .lock()
+            .expect("CorrelationRegistry poisoned")
+            .remove(&self.correlation_id);
+    }
+}
+
+impl Drop for Waiter {
+    fn drop(&mut self) {
+        // Release the slot if the caller dropped without awaiting.
+        // No-op if `timeout` already removed it.
+        if self.rx.is_some() {
+            self.release_slot();
+        }
+    }
+}
+
+/// Free-function form of [`Waiter::timeout`]. Useful for callers that
+/// already hold a [`Waiter`] and want a single line.
+pub async fn await_with_timeout(
+    waiter: Waiter,
+    timeout: Duration,
+) -> Result<EventNotification, AwaitError> {
+    waiter.timeout(timeout).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_notification(corr: Option<Uuid>) -> EventNotification {
+        EventNotification {
+            table: "events".into(),
+            id: 42,
+            stream_id: "art_test".into(),
+            event_type: "artifact.registered".into(),
+            correlation_id: corr,
+        }
+    }
+
+    /// `Waiter::timeout` returns the notification dispatched to the
+    /// matching slot, then the slot is removed (one-shot semantics).
+    #[tokio::test]
+    async fn waiter_resolves_on_matching_notification() {
+        let registry = CorrelationRegistry::new();
+        let id = Uuid::new_v4();
+        let waiter = registry.register(id);
+        assert_eq!(registry.waiter_count(), 1);
+
+        // Simulate the pg_notify pump delivering a matching notification.
+        let registry_clone = registry.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let sender = {
+                let mut map = registry_clone.waiters.lock().unwrap();
+                map.remove(&id)
+            };
+            if let Some(tx) = sender {
+                let _ = tx.send(fake_notification(Some(id)));
+            }
+        });
+
+        let n = waiter
+            .timeout(Duration::from_millis(500))
+            .await
+            .expect("notification");
+        assert_eq!(n.correlation_id, Some(id));
+        assert_eq!(registry.waiter_count(), 0);
+    }
+
+    /// Timeout fires when no notification arrives; the slot is released
+    /// so a future waiter on the same id is possible (and so the map
+    /// doesn't leak memory).
+    #[tokio::test]
+    async fn waiter_times_out_and_releases_slot() {
+        let registry = CorrelationRegistry::new();
+        let id = Uuid::new_v4();
+        let waiter = registry.register(id);
+        assert_eq!(registry.waiter_count(), 1);
+
+        let result = waiter.timeout(Duration::from_millis(20)).await;
+        assert!(matches!(result, Err(AwaitError::Timeout)));
+        assert_eq!(registry.waiter_count(), 0);
+    }
+
+    /// `MAX_SYNC_TIMEOUT` clamps overlong asks down to 2s — the cap
+    /// the spec contracts on (`#223`).
+    #[tokio::test]
+    async fn timeout_is_clamped_to_max_sync_timeout() {
+        let registry = CorrelationRegistry::new();
+        let id = Uuid::new_v4();
+        let waiter = registry.register(id);
+
+        // Ask for an hour — should fall back to 2s. Use a short polling
+        // window: the actual max is 2s but we don't want the test to
+        // wait that long. Instead, verify that asking for `Duration::MAX`
+        // resolves to a Timeout and that it returned within our budget.
+        let started = tokio::time::Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_millis(2200),
+            waiter.timeout(Duration::from_secs(3600)),
+        )
+        .await
+        .expect("clamped wait must finish inside 2.2s");
+        assert!(matches!(result, Err(AwaitError::Timeout)));
+        assert!(started.elapsed() <= Duration::from_millis(2200));
+    }
+
+    /// A waiter that's dropped without polling releases its slot —
+    /// otherwise leaked HTTP handler tasks would accumulate
+    /// dead entries.
+    #[tokio::test]
+    async fn dropped_waiter_releases_slot() {
+        let registry = CorrelationRegistry::new();
+        let id = Uuid::new_v4();
+        {
+            let _waiter = registry.register(id);
+            assert_eq!(registry.waiter_count(), 1);
+        }
+        assert_eq!(registry.waiter_count(), 0);
+    }
+
+    /// Notifications without a `correlation_id` are ignored — the
+    /// pump skips them rather than scanning the map. We model this
+    /// by exercising the same code path the pump uses.
+    #[tokio::test]
+    async fn unmatched_notification_does_not_resolve_waiter() {
+        let registry = CorrelationRegistry::new();
+        let id = Uuid::new_v4();
+        let waiter = registry.register(id);
+
+        // Different correlation_id — the pump's `remove` returns None,
+        // so nothing happens to our waiter.
+        let other = Uuid::new_v4();
+        {
+            let mut map = registry.waiters.lock().unwrap();
+            // Simulate the pump's check + remove for the wrong id.
+            assert!(map.remove(&other).is_none());
+        }
+
+        // Waiter still pending → times out cleanly.
+        let result = waiter.timeout(Duration::from_millis(20)).await;
+        assert!(matches!(result, Err(AwaitError::Timeout)));
+    }
+}

--- a/crates/onsager-portal/src/feedback/registry.rs
+++ b/crates/onsager-portal/src/feedback/registry.rs
@@ -25,6 +25,12 @@ use uuid::Uuid;
 /// anything that needs more is misclassified.
 pub const MAX_SYNC_TIMEOUT: Duration = Duration::from_millis(2000);
 
+/// Default bounded-channel capacity for the pg_notify pump. Generous
+/// enough to absorb bursts (a typical fast-write turnover is dozens of
+/// notifications/second) without giving slow consumers an OOM rope.
+/// Override via [`CorrelationRegistry::start_with_capacity`].
+pub const DEFAULT_NOTIFY_CAPACITY: usize = 1024;
+
 type WaiterMap = HashMap<Uuid, oneshot::Sender<EventNotification>>;
 
 /// Routes spine notifications back to the request handler that
@@ -48,8 +54,23 @@ impl CorrelationRegistry {
     /// Subscribe to spine notifications and route correlation-tagged
     /// events to the matching [`Waiter`]. Spawns a background task
     /// that runs until the underlying `pg_notify` channel closes.
+    /// Uses [`DEFAULT_NOTIFY_CAPACITY`]; call
+    /// [`Self::start_with_capacity`] to tune.
     pub async fn start(&self, store: &EventStore) -> Result<(), sqlx::Error> {
-        let mut rx = store.subscribe().await?;
+        self.start_with_capacity(store, DEFAULT_NOTIFY_CAPACITY)
+            .await
+    }
+
+    /// Like [`Self::start`] but with a caller-chosen channel capacity.
+    /// Backed by [`EventStore::subscribe_bounded`] so a stalled pump
+    /// applies backpressure on the sender rather than growing the
+    /// channel without bound (the warning on `EventStore::subscribe`).
+    pub async fn start_with_capacity(
+        &self,
+        store: &EventStore,
+        capacity: usize,
+    ) -> Result<(), sqlx::Error> {
+        let mut rx = store.subscribe_bounded(capacity).await?;
         let waiters = Arc::clone(&self.waiters);
         tokio::spawn(async move {
             while let Some(notification) = rx.recv().await {
@@ -79,7 +100,21 @@ impl CorrelationRegistry {
         let (tx, rx) = oneshot::channel();
         {
             let mut map = self.waiters.lock().expect("CorrelationRegistry poisoned");
-            map.insert(correlation_id, tx);
+            // Multiple waiters per id are not supported (UUIDs are
+            // unique by construction). Catch a double-register in
+            // debug builds; in release we'd cancel the previous
+            // waiter implicitly otherwise — log loudly so the bug
+            // surfaces in production too.
+            if let Some(_dup) = map.insert(correlation_id, tx) {
+                debug_assert!(
+                    false,
+                    "CorrelationRegistry: duplicate register for {correlation_id}"
+                );
+                tracing::error!(
+                    %correlation_id,
+                    "duplicate register; previous waiter cancelled"
+                );
+            }
         }
         Waiter {
             correlation_id,
@@ -235,26 +270,27 @@ mod tests {
     }
 
     /// `MAX_SYNC_TIMEOUT` clamps overlong asks down to 2s — the cap
-    /// the spec contracts on (`#223`).
-    #[tokio::test]
+    /// the spec contracts on (`#223`). Uses a paused clock so the
+    /// assertion is on logic (clamp value), not wall-clock timing
+    /// that can flake under CI load.
+    #[tokio::test(start_paused = true)]
     async fn timeout_is_clamped_to_max_sync_timeout() {
         let registry = CorrelationRegistry::new();
         let id = Uuid::new_v4();
         let waiter = registry.register(id);
 
-        // Ask for an hour — should fall back to 2s. Use a short polling
-        // window: the actual max is 2s but we don't want the test to
-        // wait that long. Instead, verify that asking for `Duration::MAX`
-        // resolves to a Timeout and that it returned within our budget.
+        // Ask for an hour. Paused clock + auto-advance means the
+        // sleep inside `tokio::time::timeout` virtually advances to
+        // exactly MAX_SYNC_TIMEOUT (2s) before the future resolves.
         let started = tokio::time::Instant::now();
-        let result = tokio::time::timeout(
-            Duration::from_millis(2200),
-            waiter.timeout(Duration::from_secs(3600)),
-        )
-        .await
-        .expect("clamped wait must finish inside 2.2s");
+        let result = waiter.timeout(Duration::from_secs(3600)).await;
+        let elapsed = started.elapsed();
+
         assert!(matches!(result, Err(AwaitError::Timeout)));
-        assert!(started.elapsed() <= Duration::from_millis(2200));
+        assert_eq!(
+            elapsed, MAX_SYNC_TIMEOUT,
+            "expected clamp to MAX_SYNC_TIMEOUT, got {elapsed:?}"
+        );
     }
 
     /// A waiter that's dropped without polling releases its slot —

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod backfill;
 pub mod config;
 pub mod db;
+pub mod feedback;
 pub mod gate;
 pub mod handlers;
 pub mod migrate;

--- a/crates/onsager-spine/Cargo.toml
+++ b/crates/onsager-spine/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 async-trait = "0.1"
+uuid = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/onsager-spine/migrations/014_events_correlation_id.sql
+++ b/crates/onsager-spine/migrations/014_events_correlation_id.sql
@@ -1,0 +1,52 @@
+-- Onsager #223 — typed correlation_id on the spine.
+--
+-- The portal-feedback contract (read / fast write / slow write) needs a
+-- first-class column to correlate an HTTP request with the events it
+-- produces. Until now correlation_id only lived inside the JSON payload
+-- and the metadata blob, which means:
+--   - filtering on it requires JSON traversal, no usable index;
+--   - the pg_notify payload doesn't carry it, so subscribers can't filter
+--     without round-tripping to the DB for every notification.
+--
+-- This migration:
+--   1. Adds a UUID column to both `events` and `events_ext` (NULL allowed
+--      — background events without an originating HTTP request).
+--   2. Adds a partial index on each so portal's `await_response` can
+--      lookup by correlation_id in O(log n) without scanning the JSONB.
+--   3. Extends the `notify_event` trigger to include `correlation_id` in
+--      the pg_notify payload, letting in-process subscribers filter
+--      without a DB roundtrip.
+--
+-- Adding a JSONB-derived column instead of refactoring every producer to
+-- pass the UUID through a new param keeps this migration backwards-
+-- compatible: anything writing the field into the existing JSON payload
+-- (FactoryEvent.correlation_id / EventMetadata.correlation_id) gets the
+-- column populated for free via the trigger.
+
+ALTER TABLE events     ADD COLUMN IF NOT EXISTS correlation_id UUID;
+ALTER TABLE events_ext ADD COLUMN IF NOT EXISTS correlation_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_events_correlation_id
+    ON events (correlation_id)
+    WHERE correlation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_events_ext_correlation_id
+    ON events_ext (correlation_id)
+    WHERE correlation_id IS NOT NULL;
+
+-- Extend the notify_event trigger to surface correlation_id in the
+-- pg_notify payload. Subscribers (notably portal::feedback::await_response)
+-- read the field directly off the notification and never have to query
+-- the row to know whether it belongs to the request they're awaiting.
+CREATE OR REPLACE FUNCTION notify_event() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify('onsager_events', json_build_object(
+        'table', TG_TABLE_NAME,
+        'id', NEW.id,
+        'stream_id', NEW.stream_id,
+        'event_type', NEW.event_type,
+        'correlation_id', NEW.correlation_id
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/crates/onsager-spine/migrations/014_events_correlation_id.sql
+++ b/crates/onsager-spine/migrations/014_events_correlation_id.sql
@@ -17,11 +17,13 @@
 --      the pg_notify payload, letting in-process subscribers filter
 --      without a DB roundtrip.
 --
--- Adding a JSONB-derived column instead of refactoring every producer to
--- pass the UUID through a new param keeps this migration backwards-
--- compatible: anything writing the field into the existing JSON payload
--- (FactoryEvent.correlation_id / EventMetadata.correlation_id) gets the
--- column populated for free via the trigger.
+-- The column is *not* derived from JSON by a trigger — writers must bind
+-- it explicitly. `EventStore::append_factory_event{,_tx}` /
+-- `append_ext` parse `EventMetadata.correlation_id` (with a fallback to
+-- `FactoryEvent.correlation_id`) as a UUID and bind to `$N`. Pre-#223
+-- producers that stop at the JSON envelope simply land NULL in the
+-- column — which is fine, the partial index is `WHERE correlation_id IS
+-- NOT NULL`, and only portal-minted UUIDs need to be awaited.
 
 ALTER TABLE events     ADD COLUMN IF NOT EXISTS correlation_id UUID;
 ALTER TABLE events_ext ADD COLUMN IF NOT EXISTS correlation_id UUID;

--- a/crates/onsager-spine/src/extension_event.rs
+++ b/crates/onsager-spine/src/extension_event.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// An extension event record as stored in the `events_ext` table.
 /// Extension events have a namespaced type and a wide JSON payload,
@@ -14,6 +15,10 @@ pub struct ExtensionEventRecord {
     pub metadata: serde_json::Value,
     pub ref_event_id: Option<i64>,
     pub created_at: DateTime<Utc>,
+    /// Portal-minted correlation handle (`#223`); see
+    /// [`crate::store::EventRecord::correlation_id`].
+    #[serde(default)]
+    pub correlation_id: Option<Uuid>,
 }
 
 impl ExtensionEventRecord {

--- a/crates/onsager-spine/src/listener.rs
+++ b/crates/onsager-spine/src/listener.rs
@@ -136,14 +136,14 @@ impl Listener {
         let mut max_ext_id: i64 = since_id;
 
         // Backfill core events.
-        let rows: Vec<(i64, String, String)> = sqlx::query_as(
-            "SELECT id, stream_id, event_type FROM events WHERE id > $1 ORDER BY id ASC",
+        let rows: Vec<(i64, String, String, Option<uuid::Uuid>)> = sqlx::query_as(
+            "SELECT id, stream_id, event_type, correlation_id FROM events WHERE id > $1 ORDER BY id ASC",
         )
         .bind(since_id)
         .fetch_all(pool)
         .await?;
 
-        for (id, stream_id, event_type) in rows {
+        for (id, stream_id, event_type, correlation_id) in rows {
             if !self.namespaces.is_empty() && !matches_any_namespace(&stream_id, &self.namespaces) {
                 if id > max_events_id {
                     max_events_id = id;
@@ -158,6 +158,7 @@ impl Listener {
                 id,
                 stream_id,
                 event_type,
+                correlation_id,
             };
             let h = Arc::clone(handler);
             tokio::spawn(async move {
@@ -168,14 +169,14 @@ impl Listener {
         }
 
         // Backfill extension events.
-        let ext_rows: Vec<(i64, String, String)> = sqlx::query_as(
-            "SELECT id, stream_id, event_type FROM events_ext WHERE id > $1 ORDER BY id ASC",
+        let ext_rows: Vec<(i64, String, String, Option<uuid::Uuid>)> = sqlx::query_as(
+            "SELECT id, stream_id, event_type, correlation_id FROM events_ext WHERE id > $1 ORDER BY id ASC",
         )
         .bind(since_id)
         .fetch_all(pool)
         .await?;
 
-        for (id, stream_id, event_type) in ext_rows {
+        for (id, stream_id, event_type, correlation_id) in ext_rows {
             if !self.namespaces.is_empty() && !matches_any_namespace(&stream_id, &self.namespaces) {
                 if id > max_ext_id {
                     max_ext_id = id;
@@ -190,6 +191,7 @@ impl Listener {
                 id,
                 stream_id,
                 event_type,
+                correlation_id,
             };
             let h = Arc::clone(handler);
             tokio::spawn(async move {

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::{PgListener, PgPool, PgPoolOptions};
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 use crate::extension_event::ExtensionEventRecord;
 use crate::factory_event::FactoryEvent;
@@ -17,6 +18,12 @@ pub struct EventRecord {
     pub metadata: serde_json::Value,
     pub sequence: i64,
     pub created_at: DateTime<Utc>,
+    /// Portal-minted correlation handle (`#223`). Lives in its own column —
+    /// not just inside `metadata` — so portal's `await_response` can index
+    /// on it and so the `notify_event` trigger can carry it on the
+    /// pg_notify payload without a row roundtrip.
+    #[serde(default)]
+    pub correlation_id: Option<Uuid>,
 }
 
 /// Metadata attached to every event for traceability.
@@ -36,6 +43,12 @@ pub struct EventNotification {
     pub id: i64,
     pub stream_id: String,
     pub event_type: String,
+    /// Mirror of the inserted row's `correlation_id` column. Carried on the
+    /// notification (per migration 014) so portal's `await_response` can
+    /// match a notification to the request that produced it without
+    /// querying the row.
+    #[serde(default)]
+    pub correlation_id: Option<Uuid>,
 }
 
 /// The PostgreSQL-backed event store — the spine of Onsager.
@@ -66,12 +79,14 @@ impl EventStore {
         let event_type = event.event.event_type();
         let data = serde_json::to_value(event).expect("FactoryEvent must be serializable");
         let meta = serde_json::to_value(metadata).expect("EventMetadata must be serializable");
+        let correlation_id = correlation_id_from(metadata, event);
 
         let row: (i64,) = sqlx::query_as(
             r#"
-            INSERT INTO events (stream_id, stream_type, event_type, data, metadata, sequence)
+            INSERT INTO events (stream_id, stream_type, event_type, data, metadata, sequence, correlation_id)
             VALUES ($1, $2, $3, $4, $5,
-                    COALESCE((SELECT MAX(sequence) + 1 FROM events WHERE stream_id = $1), 1))
+                    COALESCE((SELECT MAX(sequence) + 1 FROM events WHERE stream_id = $1), 1),
+                    $6)
             RETURNING id
             "#,
         )
@@ -80,6 +95,7 @@ impl EventStore {
         .bind(event_type)
         .bind(&data)
         .bind(&meta)
+        .bind(correlation_id)
         .fetch_one(&self.pool)
         .await?;
 
@@ -98,11 +114,12 @@ impl EventStore {
         ref_event_id: Option<i64>,
     ) -> Result<i64, sqlx::Error> {
         let meta = serde_json::to_value(metadata).expect("EventMetadata must be serializable");
+        let correlation_id = parse_correlation_id(metadata.correlation_id.as_deref());
 
         let row: (i64,) = sqlx::query_as(
             r#"
-            INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, ref_event_id)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, ref_event_id, correlation_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id
             "#,
         )
@@ -112,6 +129,7 @@ impl EventStore {
         .bind(&data)
         .bind(&meta)
         .bind(ref_event_id)
+        .bind(correlation_id)
         .fetch_one(&self.pool)
         .await?;
 
@@ -126,7 +144,7 @@ impl EventStore {
     ) -> Result<Vec<EventRecord>, sqlx::Error> {
         sqlx::query_as::<_, EventRecord>(
             r#"
-            SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at
+            SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at, correlation_id
             FROM events
             WHERE stream_id = $1 AND sequence >= $2
             ORDER BY sequence ASC
@@ -145,7 +163,7 @@ impl EventStore {
     ) -> Result<Vec<ExtensionEventRecord>, sqlx::Error> {
         sqlx::query_as::<_, ExtensionEventRecord>(
             r#"
-            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at
+            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id
             FROM events_ext
             WHERE stream_id = $1
             ORDER BY created_at ASC
@@ -178,7 +196,7 @@ impl EventStore {
 
         let where_clause = conditions.join(" AND ");
         let sql = format!(
-            "SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at \
+            "SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at, correlation_id \
              FROM events WHERE {where_clause} ORDER BY id DESC LIMIT {limit}"
         );
 
@@ -200,7 +218,7 @@ impl EventStore {
     pub async fn get_event_by_id(&self, id: i64) -> Result<Option<EventRecord>, sqlx::Error> {
         sqlx::query_as::<_, EventRecord>(
             r#"
-            SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at
+            SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at, correlation_id
             FROM events
             WHERE id = $1
             "#,
@@ -233,7 +251,7 @@ impl EventStore {
     ) -> Result<Option<ExtensionEventRecord>, sqlx::Error> {
         sqlx::query_as::<_, ExtensionEventRecord>(
             r#"
-            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at
+            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id
             FROM events_ext
             WHERE id = $1
             "#,
@@ -260,7 +278,7 @@ impl EventStore {
 
         let where_clause = conditions.join(" AND ");
         let sql = format!(
-            "SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at \
+            "SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id \
              FROM events_ext WHERE {where_clause} ORDER BY id DESC LIMIT {limit}"
         );
 
@@ -393,12 +411,14 @@ pub async fn append_factory_event_tx(
     let event_type = event.event.event_type();
     let data = serde_json::to_value(event).expect("FactoryEvent must be serializable");
     let meta = serde_json::to_value(metadata).expect("EventMetadata must be serializable");
+    let correlation_id = correlation_id_from(metadata, event);
 
     let row: (i64,) = sqlx::query_as(
         r#"
-        INSERT INTO events (stream_id, stream_type, event_type, data, metadata, sequence)
+        INSERT INTO events (stream_id, stream_type, event_type, data, metadata, sequence, correlation_id)
         VALUES ($1, $2, $3, $4, $5,
-                COALESCE((SELECT MAX(sequence) + 1 FROM events WHERE stream_id = $1), 1))
+                COALESCE((SELECT MAX(sequence) + 1 FROM events WHERE stream_id = $1), 1),
+                $6)
         RETURNING id
         "#,
     )
@@ -407,10 +427,25 @@ pub async fn append_factory_event_tx(
     .bind(event_type)
     .bind(&data)
     .bind(&meta)
+    .bind(correlation_id)
     .fetch_one(&mut **tx)
     .await?;
 
     Ok(row.0)
+}
+
+/// Resolve the correlation_id to write into the typed column. Prefers the
+/// metadata field (the canonical write site portal/forge/stiglab use today)
+/// and falls back to the envelope. Anything that doesn't parse as a UUID
+/// stores NULL — the column is for portal's `await_response` to index on,
+/// and only portal-minted values are guaranteed to be UUIDs.
+fn correlation_id_from(metadata: &EventMetadata, event: &FactoryEvent) -> Option<Uuid> {
+    parse_correlation_id(metadata.correlation_id.as_deref())
+        .or_else(|| parse_correlation_id(event.correlation_id.as_deref()))
+}
+
+fn parse_correlation_id(s: Option<&str>) -> Option<Uuid> {
+    s.and_then(|raw| Uuid::parse_str(raw).ok())
 }
 
 // Implement FromRow for ExtensionEventRecord manually since it has Option<i64>
@@ -426,6 +461,7 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for ExtensionEventRecord {
             metadata: row.try_get("metadata")?,
             ref_event_id: row.try_get("ref_event_id")?,
             created_at: row.try_get("created_at")?,
+            correlation_id: row.try_get("correlation_id").unwrap_or(None),
         })
     }
 }

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -461,7 +461,7 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for ExtensionEventRecord {
             metadata: row.try_get("metadata")?,
             ref_event_id: row.try_get("ref_event_id")?,
             created_at: row.try_get("created_at")?,
-            correlation_id: row.try_get("correlation_id").unwrap_or(None),
+            correlation_id: row.try_get("correlation_id")?,
         })
     }
 }


### PR DESCRIPTION
Part of #223 — the foundational slice of the portal feedback contract.

## Summary

- **Spine migration 014**: typed `correlation_id UUID` on `events` /
  `events_ext`, partial index for `WHERE correlation_id IS NOT NULL`,
  `notify_event` trigger surfaces the column on every pg_notify
  payload so subscribers can filter without a row roundtrip.
- **`onsager_spine`**: `EventStore::append_factory_event{,_tx}` and
  `append_ext` parse `EventMetadata.correlation_id` (best-effort UUID)
  and bind the new column. `EventRecord` / `ExtensionEventRecord` /
  `EventNotification` now carry `correlation_id: Option<Uuid>`;
  backfill SELECTs hydrate it.
- **`onsager_portal::feedback`** (new module):
  - `dispatch(store, event, actor)` — mints `Uuid::new_v4()`, stamps
    envelope + metadata, appends through the spine, returns a
    `DispatchHandle { correlation_id, event_id }`.
  - `CorrelationRegistry` — in-process map keyed on `correlation_id`.
    `start(store)` spawns a background task on
    `EventStore::subscribe` that routes notifications to a
    `oneshot::Sender<EventNotification>`.
  - `Waiter::timeout` — bounded wait, clamped to `MAX_SYNC_TIMEOUT`
    (`2s`). `Drop` releases the slot so leaked handlers don't leak
    map entries.
  - `command_response` — register-then-dispatch-then-await with a
    fall-through to `Async(handle)` on timeout.
  - `DEFAULT_SYNC_TIMEOUT = 1s` per the spec resolution comment.

## Aligned with #223 open-question resolutions

- Portal-minted UUIDs only (subsystems propagate, never mint) — the
  registry only exposes `register(correlation_id)`, no minting on
  any consumer-facing surface.
- 1s default fast-write timeout, 2s hard cap.

## Out of scope (future PRs against #223)

- WS subscribe endpoint and SSE deprecation.
- `adapter_reconciliation_state` + `Adapter::poll_since` reconciliation
  contract (subsumes #121).
- "No orphaned commands" + "missing poller" CI lints.
- Migrating existing portal handlers to the helpers.
- Dashboard switch from `/api/spine/events?stream_id=...` SSE to
  `WS /api/subscribe?correlation_id=...`.

## Test plan

- [x] `cargo test -p onsager-portal --lib` — new feedback registry tests
      (matching notification resolves; timeout releases slot; clamp to
      2s; dropped waiter releases slot; unmatched id ignored).
- [x] `cargo test --workspace --lib` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo run -p xtask -- gen-event-docs --check` — clean.
- [x] `cargo run -p xtask -- lint-seams` — clean.
- [x] `cargo run -p xtask -- check-events` — clean.
- [x] `cargo run -p xtask -- check-api-contract` — clean.
- [ ] Spine integration tests (`just test-spine`) require a live DB —
      run pre-merge.

https://claude.ai/code/session_01JdYVnVCX1Lnf69sHsgaTwi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdYVnVCX1Lnf69sHsgaTwi)_