### PR TITLE
docs(spec-131): mark Lever E landed; flip producer-without-consumer to fail

### DIFF
--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -270,8 +270,9 @@ hint — see `xtask/src/lint_seams.rs` for the full set):
   doc-comment contains "legacy" / "deprecated" / "compat" / "alias
   for" / "renamed" / "for backwards" / "until …".
 
-(`producer-without-consumer` is gated on Lever E #150 and currently
-warn-only.)
+(`producer-without-consumer` is enforced by `check-events` (Lever E /
+#150) against the manifest in `crates/onsager-registry/src/events.rs`
+— a separate hard-fail step in CI.)
 
 What `check-api-contract` catches (Lever F / #151 — see
 `xtask/src/lint_api_contract.rs`):

--- a/crates/onsager-registry/CLAUDE.md
+++ b/crates/onsager-registry/CLAUDE.md
@@ -40,7 +40,7 @@ reviewed table of every `FactoryEventKind` variant. Each row declares:
 | Add a `FactoryEventKind` variant | Add a row to `EVENTS` in the same PR. Producer + consumer must be wired or the event tagged `audit_only`. |
 | Add a new producer for an existing event | Append the subsystem to `producers`. |
 | Add a new listener for an existing event | Append the subsystem to `consumers`; flip `audit_only` to `false` if it was set. |
-| Backwards-incompatible payload change | Bump `schema_version`. Producer + consumer for the new version must ship together (Lever B's producer-without-consumer check enforces this once flipped to hard-fail). |
+| Backwards-incompatible payload change | Bump `schema_version`. Producer + consumer support for the new version must ship together — coordinated via PRs / tests / review (`check-events` only enforces that a manifest row has ≥1 producer and either ≥1 consumer or `audit_only = true`; it does not reason about `schema_version`). |
 | Backwards-compatible payload change (new optional field) | No version bump; manifest review still required — flag the change in the PR description. |
 | Remove a `FactoryEventKind` variant | Remove the manifest row in the same PR. |
 

--- a/xtask/src/lint_seams.rs
+++ b/xtask/src/lint_seams.rs
@@ -16,8 +16,9 @@
 //! 5. **Legacy `pub type X = Y;`** — a type alias whose adjacent doc-comment
 //!    contains "legacy" / "compat" / "deprecated" / "alias for" / "renamed".
 //!
-//! Producer-without-consumer is **gated on Lever E #150** — currently a
-//! reminder, not a check.
+//! Producer-without-consumer is enforced separately by `check-events`
+//! (Lever E / #150) against the registry manifest in
+//! `crates/onsager-registry/src/events.rs`.
 //!
 //! ## Escape hatch
 //!
@@ -123,10 +124,6 @@ pub fn run() -> Result<()> {
         "seam-rule lint: clean (subsystems: {}; {} allowed exemption(s))",
         SUBSYSTEMS.join(", "),
         allowed.len()
-    );
-    eprintln!(
-        "note: producer-without-consumer check is gated on Lever E (#150). \
-         Until that lands, new event types still need a manual reviewer."
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Lever E's manifest + `check-events` lint landed in PR #227 and run as a hard-fail step in CI. This is the explicit follow-up listed in spec #150's plan: "Flip Lever B's producer-without-consumer check from warn to hard-fail (separate small PR, after this one lands)."

The actual enforcement is already in place (`xtask/src/check_events.rs::check_both_ends_declared` calls `bail!`); what was left was a thicket of "warn / reminder / pending" hints scattered across the docs and `lint_seams.rs` that still described the old gated state. This PR removes them.

## Delivers

- **`xtask/src/lint_seams.rs`** — drop the stale "currently a reminder, not a check" doc-comment and the post-run `eprintln!` reminder. Point at `check-events` as the producer-without-consumer enforcer.
- **`CLAUDE.md`** — mark Lever E as landed and update the seam-rule preamble to reflect that all six levers are now CI-enforced (`lint_seams` + `check-events` + `lint_api_contract`).
- **`docs/adr/0004-tighten-the-seams.md`** — flip the Lever E checkbox to `[x]` and update the Lever B description (producer-without-consumer hard-fails via Lever E's `check-events`, not "once Lever E lands").
- **`.claude/skills/onsager-pre-push/SKILL.md`** — update the parenthetical from "warn-only" to "enforced by `check-events`".
- **`crates/onsager-spine/CLAUDE.md`** and **`crates/onsager-registry/CLAUDE.md`** — describe producer-without-consumer enforcement in the present tense, with the typo fix (the registry table referenced "Lever B's producer-without-consumer check enforces this once flipped to hard-fail" — that's now a fact, not a future state).

## Test plan

- [x] `cargo run -p xtask --quiet -- lint-seams` is clean and no longer prints the stale `note:` reminder
- [x] `cargo run -p xtask --quiet -- check-events` is clean (75 events, 4 subsystems scanned)
- [x] `cargo test -p xtask` passes (64 tests)
- [x] `cargo fmt --all -- --check` is clean
- [ ] CI workflow `check` job stays green

Part of #131
Part of #150

https://claude.ai/code/session_01AggDnFx7rLpZ8ifAxaTPZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AggDnFx7rLpZ8ifAxaTPZF)_