### PR TITLE
fix(spine,stiglab): unblock workflow delete with parked artifacts

### DIFF
--- a/crates/onsager-spine/migrations/015_artifacts_workflow_fk_set_null.sql
+++ b/crates/onsager-spine/migrations/015_artifacts_workflow_fk_set_null.sql
@@ -1,0 +1,34 @@
+-- Onsager #233 — workflow delete blocked by artifact FK.
+--
+-- Migration 006 added `artifacts.workflow_id ... REFERENCES
+-- workflows(workflow_id)` with no `ON DELETE` clause, so the FK
+-- defaults to NO ACTION. The sibling FK on `workflow_stages` declared
+-- ON DELETE CASCADE in the same migration — asymmetric behavior on
+-- two columns of the same name pointing at the same parent. Result:
+-- `DELETE FROM workflows WHERE workflow_id = $1` raised whenever any
+-- artifact still pointed at the row, even if the workflow was already
+-- deactivated, leaving the dashboard's delete button broken.
+--
+-- Switch to ON DELETE SET NULL: workflow lifecycle no longer cascades
+-- through artifacts (which represent real work product), but the
+-- workflow row can be deleted without leaving the FK in a violated
+-- state. Symmetric with `workflow_stages` in spirit (parent goes,
+-- child relinquishes its tag) without the data-destroying cascade.
+--
+-- The application-side `workflow_db::delete_workflow` (#233 PR) wraps
+-- the delete in a transaction that also NULLs `current_stage_index`
+-- and `workflow_parked_reason` on the orphaned artifacts in the same
+-- step, so the read side ("not workflow-tagged" iff
+-- workflow_id IS NULL) stays consistent. This migration is the
+-- defense-in-depth half: any future code path that DELETEs from
+-- `workflows` directly still won't violate the FK, even if it forgets
+-- the application cleanup.
+
+ALTER TABLE artifacts
+    DROP CONSTRAINT IF EXISTS artifacts_workflow_id_fkey;
+
+ALTER TABLE artifacts
+    ADD CONSTRAINT artifacts_workflow_id_fkey
+    FOREIGN KEY (workflow_id)
+    REFERENCES workflows(workflow_id)
+    ON DELETE SET NULL;

--- a/crates/onsager-spine/migrations/015_artifacts_workflow_fk_set_null.sql
+++ b/crates/onsager-spine/migrations/015_artifacts_workflow_fk_set_null.sql
@@ -24,11 +24,13 @@
 -- `workflows` directly still won't violate the FK, even if it forgets
 -- the application cleanup.
 
+-- Combine DROP + ADD into one ALTER TABLE so the constraint change is
+-- atomic — split statements would leave a window with no FK at all,
+-- and a concurrent INSERT with a stale workflow_id could violate the
+-- new ADD when it's re-applied.
 ALTER TABLE artifacts
-    DROP CONSTRAINT IF EXISTS artifacts_workflow_id_fkey;
-
-ALTER TABLE artifacts
-    ADD CONSTRAINT artifacts_workflow_id_fkey
-    FOREIGN KEY (workflow_id)
-    REFERENCES workflows(workflow_id)
-    ON DELETE SET NULL;
+    DROP CONSTRAINT IF EXISTS artifacts_workflow_id_fkey,
+    ADD  CONSTRAINT artifacts_workflow_id_fkey
+         FOREIGN KEY (workflow_id)
+         REFERENCES workflows(workflow_id)
+         ON DELETE SET NULL;

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -244,8 +244,22 @@ pub async fn set_workflow_active(
 /// state) holds. Without this the FK switched to `ON DELETE SET NULL`
 /// in migration 015 would clear `workflow_id` but leave stale stage
 /// indices and park reasons behind on the orphan rows. See #233.
+///
+/// We row-lock the workflow up front (`SELECT ... FOR UPDATE`) so a
+/// concurrent forge `register_artifact_from_trigger` can't tag a new
+/// artifact with this workflow_id between the artifact UPDATE and the
+/// workflow DELETE. Without the lock such a late writer's artifact
+/// would have its `workflow_id` cleared by the FK cascade but keep
+/// stale `current_stage_index` / `workflow_parked_reason` columns
+/// behind. With the lock, the trigger handler blocks on the SELECT,
+/// the DELETE commits, the trigger's workflow lookup then misses and
+/// it drops the trigger — no orphan stage state can leak.
 pub async fn delete_workflow(pool: &PgPool, workflow_id: &str) -> anyhow::Result<()> {
     let mut tx = pool.begin().await?;
+    sqlx::query("SELECT workflow_id FROM workflows WHERE workflow_id = $1 FOR UPDATE")
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
     sqlx::query(
         "UPDATE artifacts \
             SET workflow_id            = NULL, \

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -236,11 +236,31 @@ pub async fn set_workflow_active(
 
 /// Delete the workflow row. `workflow_stages` is `ON DELETE CASCADE` so
 /// the stage chain goes with it — no explicit per-stage DELETE.
+///
+/// Artifacts that still reference this workflow are detached in the
+/// same transaction: `workflow_id`, `current_stage_index` and
+/// `workflow_parked_reason` all NULL out together so the read side's
+/// "not workflow-tagged" invariant (workflow_id IS NULL ⇒ no stage
+/// state) holds. Without this the FK switched to `ON DELETE SET NULL`
+/// in migration 015 would clear `workflow_id` but leave stale stage
+/// indices and park reasons behind on the orphan rows. See #233.
 pub async fn delete_workflow(pool: &PgPool, workflow_id: &str) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "UPDATE artifacts \
+            SET workflow_id            = NULL, \
+                current_stage_index    = NULL, \
+                workflow_parked_reason = NULL \
+          WHERE workflow_id = $1",
+    )
+    .bind(workflow_id)
+    .execute(&mut *tx)
+    .await?;
     sqlx::query("DELETE FROM workflows WHERE workflow_id = $1")
         .bind(workflow_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 

--- a/crates/stiglab/tests/workflow_delete.rs
+++ b/crates/stiglab/tests/workflow_delete.rs
@@ -54,16 +54,22 @@ async fn seed_workflow(spine: &PgPool, workspace_id: &str) -> String {
     id
 }
 
-async fn seed_parked_artifact(spine: &PgPool, workflow_id: &str) -> String {
+async fn seed_parked_artifact(spine: &PgPool, workspace_id: &str, workflow_id: &str) -> String {
+    // Match the production invariant: an artifact parked by a workflow
+    // shares that workflow's workspace. Without this, the row would
+    // default to `workspace_id = 'default'` while the workflow has a
+    // random UUID, which is a fixture state that can't happen at
+    // runtime.
     let artifact_id = format!("art_{}", Uuid::new_v4());
     sqlx::query(
         "INSERT INTO artifacts \
-            (artifact_id, kind, name, owner, created_by, state, \
+            (artifact_id, kind, name, owner, created_by, state, workspace_id, \
              workflow_id, current_stage_index, workflow_parked_reason) \
          VALUES ($1, 'code', 'delete-test', 'tester', 'tester', \
-                 'under_review', $2, 0, 'agent_session: stuck')",
+                 'under_review', $2, $3, 0, 'agent_session: stuck')",
     )
     .bind(&artifact_id)
+    .bind(workspace_id)
     .bind(workflow_id)
     .execute(spine)
     .await
@@ -79,7 +85,7 @@ async fn delete_workflow_with_parked_artifact_succeeds() {
     };
     let workspace_id = format!("ws-{}", Uuid::new_v4());
     let workflow_id = seed_workflow(&spine, &workspace_id).await;
-    let artifact_id = seed_parked_artifact(&spine, &workflow_id).await;
+    let artifact_id = seed_parked_artifact(&spine, &workspace_id, &workflow_id).await;
 
     workflow_db::delete_workflow(&spine, &workflow_id)
         .await

--- a/crates/stiglab/tests/workflow_delete.rs
+++ b/crates/stiglab/tests/workflow_delete.rs
@@ -1,0 +1,160 @@
+//! Integration test for `workflow_db::delete_workflow` (#233).
+//!
+//! Pre-fix, deleting a workflow that still had a parked artifact pointing
+//! at it raised an FK violation — `artifacts.workflow_id` had no
+//! `ON DELETE` clause in migration 006. Migration 015 switches the FK to
+//! `ON DELETE SET NULL` and `delete_workflow` now wraps the cleanup in a
+//! transaction that NULLs `current_stage_index` and
+//! `workflow_parked_reason` alongside `workflow_id`. This test pins both
+//! halves: the workflow row goes away, the artifact survives detached.
+//!
+//! Skipped when `DATABASE_URL` is unset — the artifact ↔ workflow FK
+//! lives on the spine, which only the Postgres-backed harness exercises.
+
+use chrono::Utc;
+use sqlx::{PgPool, Row};
+use stiglab::core::workflow::{TriggerKind, Workflow, WorkflowStage};
+use stiglab::core::GateKind;
+use stiglab::server::workflow_db;
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+async fn seed_workflow(spine: &PgPool, workspace_id: &str) -> String {
+    let now = Utc::now();
+    let wf = Workflow {
+        id: format!("wf_{}", Uuid::new_v4()),
+        workspace_id: workspace_id.to_string(),
+        name: "delete-test".into(),
+        trigger_kind: TriggerKind::GithubIssueWebhook,
+        repo_owner: "acme".into(),
+        repo_name: "widgets".into(),
+        trigger_label: "ai".into(),
+        install_id: 1,
+        preset_id: None,
+        active: false,
+        created_by: "u1".into(),
+        created_at: now,
+        updated_at: now,
+    };
+    let stage = WorkflowStage {
+        id: Uuid::new_v4().to_string(),
+        workflow_id: wf.id.clone(),
+        seq: 0,
+        gate_kind: GateKind::AgentSession,
+        params: serde_json::json!({}),
+    };
+    let id = wf.id.clone();
+    workflow_db::insert_workflow_with_stages(spine, &wf, &[stage])
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_parked_artifact(spine: &PgPool, workflow_id: &str) -> String {
+    let artifact_id = format!("art_{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, \
+             workflow_id, current_stage_index, workflow_parked_reason) \
+         VALUES ($1, 'code', 'delete-test', 'tester', 'tester', \
+                 'under_review', $2, 0, 'agent_session: stuck')",
+    )
+    .bind(&artifact_id)
+    .bind(workflow_id)
+    .execute(spine)
+    .await
+    .unwrap();
+    artifact_id
+}
+
+#[tokio::test]
+async fn delete_workflow_with_parked_artifact_succeeds() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let workflow_id = seed_workflow(&spine, &workspace_id).await;
+    let artifact_id = seed_parked_artifact(&spine, &workflow_id).await;
+
+    workflow_db::delete_workflow(&spine, &workflow_id)
+        .await
+        .expect("delete should succeed even with a parked artifact");
+
+    // Workflow row + cascading stage rows are gone.
+    let wf_count: i64 = sqlx::query("SELECT COUNT(*) FROM workflows WHERE workflow_id = $1")
+        .bind(&workflow_id)
+        .fetch_one(&spine)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(wf_count, 0, "workflow row should be deleted");
+
+    let stage_count: i64 =
+        sqlx::query("SELECT COUNT(*) FROM workflow_stages WHERE workflow_id = $1")
+            .bind(&workflow_id)
+            .fetch_one(&spine)
+            .await
+            .unwrap()
+            .get(0);
+    assert_eq!(stage_count, 0, "workflow_stages should cascade-delete");
+
+    // Artifact survives, all workflow tagging cleared.
+    let row = sqlx::query(
+        "SELECT workflow_id, current_stage_index, workflow_parked_reason, state \
+           FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&artifact_id)
+    .fetch_one(&spine)
+    .await
+    .unwrap();
+    let workflow_id_after: Option<String> = row.try_get("workflow_id").unwrap();
+    let stage_index_after: Option<i32> = row.try_get("current_stage_index").unwrap();
+    let parked_reason_after: Option<String> = row.try_get("workflow_parked_reason").unwrap();
+    let state_after: String = row.get("state");
+    assert!(workflow_id_after.is_none(), "workflow_id should be cleared");
+    assert!(
+        stage_index_after.is_none(),
+        "current_stage_index should be cleared"
+    );
+    assert!(
+        parked_reason_after.is_none(),
+        "workflow_parked_reason should be cleared"
+    );
+    assert_eq!(
+        state_after, "under_review",
+        "non-workflow artifact columns survive untouched"
+    );
+
+    // Cleanup: drop the orphaned artifact so reruns don't accumulate.
+    let _ = sqlx::query("DELETE FROM artifacts WHERE artifact_id = $1")
+        .bind(&artifact_id)
+        .execute(&spine)
+        .await;
+}
+
+#[tokio::test]
+async fn delete_workflow_without_artifacts_still_works() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let workflow_id = seed_workflow(&spine, &workspace_id).await;
+
+    workflow_db::delete_workflow(&spine, &workflow_id)
+        .await
+        .expect("delete with zero artifacts should succeed");
+
+    let wf_count: i64 = sqlx::query("SELECT COUNT(*) FROM workflows WHERE workflow_id = $1")
+        .bind(&workflow_id)
+        .fetch_one(&spine)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(wf_count, 0);
+}


### PR DESCRIPTION
## Summary

Closes #233.

The dashboard's workflow delete fails with a 500 whenever any artifact still references the workflow. Reproduced today on `wf_cca7b514-1b4f-4878-8378-679b7feb3fdf` — the workflow ended up half-deleted (deactivation hook ran, FK violation blocked the row delete).

Root cause is in `crates/onsager-spine/migrations/006_workflows.sql`: two FKs back to `workflows(workflow_id)` declared in the same migration, asymmetric `ON DELETE` behavior:

- `workflow_stages.workflow_id` (line 34): `ON DELETE CASCADE` ✓
- `artifacts.workflow_id` (line 54): no clause → defaults to `NO ACTION`, blocks the parent delete ✗

## Changes

- **Migration `015_artifacts_workflow_fk_set_null.sql`** — drops the existing `artifacts.workflow_id` FK and re-adds it with `ON DELETE SET NULL`. Defense in depth so any code path (admin tooling, future routes, manual SQL) can drop a workflow without violating the FK.
- **`crates/stiglab/src/server/workflow_db.rs::delete_workflow`** — rewrites the function to run an explicit transaction: `UPDATE artifacts SET workflow_id=NULL, current_stage_index=NULL, workflow_parked_reason=NULL WHERE workflow_id=$1`, then `DELETE FROM workflows WHERE workflow_id=$1`. The application cleanup zeros all three workflow-tagging columns at once so the read side's "not workflow-tagged ⇒ no stage state" invariant holds; `ON DELETE SET NULL` alone would leave stale `current_stage_index` / `workflow_parked_reason` behind on orphan artifacts.
- **`crates/stiglab/tests/workflow_delete.rs`** — new Postgres-only integration test (skipped without `DATABASE_URL`, matching `workflow_webhook.rs` convention) covering both:
  - `delete_workflow_with_parked_artifact_succeeds` — seeds workflow + parked artifact, deletes workflow, asserts the workflow row + cascading stages are gone and the artifact survives with all three workflow columns NULLed and its non-workflow state untouched.
  - `delete_workflow_without_artifacts_still_works` — regression guard.

## Internal symmetry note (per `CLAUDE.md`)

Two FKs on the same column name pointing at the same parent should agree on cascade behavior. They didn't, and the asymmetry only surfaced once a real artifact got stuck. The migration brings them into spirit-aligned shape (`workflow_stages` cascades because the chain is meaningless without its workflow; `artifacts` SET NULLs because artifacts have lives independent of the workflow that produced them) and the application transaction enforces the corollary at the application layer.

## Why not `ON DELETE CASCADE` on artifacts

CASCADE would bulldoze through `artifact_versions`, `bundles`, and any other downstream FKs from `artifacts`. Artifacts represent real work product; a workflow's lifecycle shouldn't cascade-destroy them. SET NULL is the conservative choice — workflow row goes, artifact survives detached.

## Out of scope

- Surfacing a typed 409 instead of the existing 500 error path. With migration 015 applied the FK is no longer reachable from the route, so the 500 path becomes dead code; not worth a typed error for an unreachable case.
- Cascading delete to artifacts or events. Workflows don't own artifacts that strongly.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` — clean.
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` — all subsystems green.
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo run -p xtask --quiet -- lint-seams` — clean.
- [x] `cargo run -p xtask --quiet -- check-api-contract` — clean.
- [ ] CI's Postgres-backed `cargo test` runs `workflow_delete::*` (skipped locally without `DATABASE_URL`).
- [ ] Manual on staging: redeploy main, click delete on a workflow that has a parked artifact — workflow row goes away; artifact survives detached on the artifacts page.
- [ ] One-shot prod cleanup for `wf_cca7b514-…`: same SQL the new code path runs, applied manually since the row predates the deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxTt5cenccmSzd8n84qV9j)_