### PR TITLE
feat(spine): events_ext.workspace_id as a real column

### DIFF
--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -1002,14 +1002,21 @@ async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
     // #183: events_ext.workspace_id is a real column. Resolve from the
     // event's artifact when present; system-scoped events (forge.error,
     // bundle-sealed warehouse rows that lost their artifact ref) fall
-    // back to "default".
+    // back to "default". Lookup errors are logged so a real DB problem
+    // doesn't silently mis-scope every event (Copilot review on #235).
     let workspace_id = match pipeline_event_artifact_id(event) {
-        Some(art) => spine
-            .lookup_workspace_for_artifact(art)
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| "default".to_string()),
+        Some(art) => match spine.lookup_workspace_for_artifact(art).await {
+            Ok(Some(ws)) => ws,
+            Ok(None) => "default".to_string(),
+            Err(e) => {
+                tracing::warn!(
+                    artifact_id = art,
+                    event_type,
+                    "forge workspace lookup failed; falling back to 'default': {e}"
+                );
+                "default".to_string()
+            }
+        },
         None => "default".to_string(),
     };
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -999,11 +999,49 @@ async fn emit_pipeline_event(spine: &EventStore, event: &PipelineEvent) {
         ),
     };
 
+    // #183: events_ext.workspace_id is a real column. Resolve from the
+    // event's artifact when present; system-scoped events (forge.error,
+    // bundle-sealed warehouse rows that lost their artifact ref) fall
+    // back to "default".
+    let workspace_id = match pipeline_event_artifact_id(event) {
+        Some(art) => spine
+            .lookup_workspace_for_artifact(art)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "default".to_string()),
+        None => "default".to_string(),
+    };
+
     if let Err(e) = spine
-        .append_ext(&stream_id, "forge", event_type, data, &metadata, None)
+        .append_ext(
+            &workspace_id,
+            &stream_id,
+            "forge",
+            event_type,
+            data,
+            &metadata,
+            None,
+        )
         .await
     {
         tracing::warn!("failed to emit forge event: {e}");
+    }
+}
+
+/// Extract the artifact_id a pipeline event is scoped to, when one
+/// exists. Used to resolve `events_ext.workspace_id` (#183) without
+/// duplicating the variant match.
+fn pipeline_event_artifact_id(event: &PipelineEvent) -> Option<&str> {
+    match event {
+        PipelineEvent::DecisionMade(d) => Some(d.artifact_id.as_str()),
+        PipelineEvent::ShapingDispatched { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::ShapingReturned { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::GateRequested { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::GateVerdictReceived { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::ArtifactAdvanced { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::BundleSealed { artifact_id, .. } => Some(artifact_id.as_str()),
+        PipelineEvent::IdleTick | PipelineEvent::Error(_) => None,
     }
 }
 
@@ -1096,7 +1134,15 @@ async fn emit_stage_event(spine: &EventStore, workflow: &Workflow, event: &Stage
     };
 
     if let Err(e) = spine
-        .append_ext(&stream_id, "workflow", event_type, data, &metadata, None)
+        .append_ext(
+            workspace_id,
+            &stream_id,
+            "workflow",
+            event_type,
+            data,
+            &metadata,
+            None,
+        )
         .await
     {
         tracing::warn!("failed to emit workflow stage event: {e}");

--- a/crates/forge/src/core/workflow_gates.rs
+++ b/crates/forge/src/core/workflow_gates.rs
@@ -68,11 +68,16 @@ pub trait GateEmitter: Send + Sync {
     /// accepted the append; `false` lets the caller defer marking the
     /// gate as dispatched so a transient append failure doesn't strand
     /// the artifact (see `evaluate_agent_session`).
-    fn emit_shaping_dispatched(&self, request: &ShapingRequest) -> bool;
+    ///
+    /// `workspace_id` (#183) is the tenant scope for the emitted
+    /// `events_ext` row — sourced from the workflow that owns the
+    /// dispatching artifact.
+    fn emit_shaping_dispatched(&self, workspace_id: &str, request: &ShapingRequest) -> bool;
 
     /// Emit `forge.gate_requested` keyed on `gate_id`. Same return
     /// semantics as [`Self::emit_shaping_dispatched`].
-    fn emit_gate_requested(&self, gate_id: &str, request: &GateRequest) -> bool;
+    fn emit_gate_requested(&self, workspace_id: &str, gate_id: &str, request: &GateRequest)
+        -> bool;
 }
 
 /// Production [`GateEmitter`] backed by an [`EventStore`]. Calls into
@@ -89,7 +94,7 @@ impl SpineGateEmitter {
         Self { store }
     }
 
-    fn emit(&self, stream_id: &str, kind: FactoryEventKind) -> bool {
+    fn emit(&self, workspace_id: &str, stream_id: &str, kind: FactoryEventKind) -> bool {
         let metadata = EventMetadata {
             actor: "forge".into(),
             ..Default::default()
@@ -97,10 +102,15 @@ impl SpineGateEmitter {
         let event_type = kind.event_type();
         let data = serde_json::to_value(&kind).expect("FactoryEventKind must serialize");
         let outcome = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(
-                self.store
-                    .append_ext(stream_id, "forge", event_type, data, &metadata, None),
-            )
+            tokio::runtime::Handle::current().block_on(self.store.append_ext(
+                workspace_id,
+                stream_id,
+                "forge",
+                event_type,
+                data,
+                &metadata,
+                None,
+            ))
         });
         match outcome {
             Ok(_) => true,
@@ -117,8 +127,9 @@ impl SpineGateEmitter {
 }
 
 impl GateEmitter for SpineGateEmitter {
-    fn emit_shaping_dispatched(&self, request: &ShapingRequest) -> bool {
+    fn emit_shaping_dispatched(&self, workspace_id: &str, request: &ShapingRequest) -> bool {
         self.emit(
+            workspace_id,
             &format!("forge:{}", request.artifact_id),
             FactoryEventKind::ForgeShapingDispatched {
                 request_id: request.request_id.clone(),
@@ -129,8 +140,14 @@ impl GateEmitter for SpineGateEmitter {
         )
     }
 
-    fn emit_gate_requested(&self, gate_id: &str, request: &GateRequest) -> bool {
+    fn emit_gate_requested(
+        &self,
+        workspace_id: &str,
+        gate_id: &str,
+        request: &GateRequest,
+    ) -> bool {
         self.emit(
+            workspace_id,
             &format!("forge:{}", request.context.artifact_id),
             FactoryEventKind::ForgeGateRequested {
                 gate_id: gate_id.to_string(),
@@ -246,6 +263,7 @@ impl<E: GateEmitter> LiveGateEvaluator<E> {
     fn evaluate_agent_session(
         &self,
         artifact: &Artifact,
+        workspace_id: &str,
         stage_index: u32,
         shaping_intent: &serde_json::Value,
         created_by: Option<&str>,
@@ -299,7 +317,7 @@ impl<E: GateEmitter> LiveGateEvaluator<E> {
             // postgres/network errors — `already_dispatched` would
             // suppress retries forever, and the completion signal
             // can't arrive for a session that was never created.
-            if self.emitter.emit_shaping_dispatched(&request) {
+            if self.emitter.emit_shaping_dispatched(workspace_id, &request) {
                 self.mark_dispatched(
                     artifact.artifact_id.as_str(),
                     stage_index,
@@ -322,6 +340,7 @@ impl<E: GateEmitter> LiveGateEvaluator<E> {
     fn evaluate_governance(
         &self,
         artifact: &Artifact,
+        workspace_id: &str,
         stage_index: u32,
         gate_point: &Option<String>,
     ) -> GateOutcome {
@@ -387,7 +406,10 @@ impl<E: GateEmitter> LiveGateEvaluator<E> {
             },
         };
         let gate_id = ulid::Ulid::new().to_string();
-        if self.emitter.emit_gate_requested(&gate_id, &request) {
+        if self
+            .emitter
+            .emit_gate_requested(workspace_id, &gate_id, &request)
+        {
             self.governance_in_flight
                 .lock()
                 .expect("governance_in_flight poisoned")
@@ -416,6 +438,7 @@ impl<E: GateEmitter> super::stage_runner::GateEvaluator for LiveGateEvaluator<E>
         match gate {
             GateSpec::AgentSession { shaping_intent } => self.evaluate_agent_session(
                 artifact,
+                &workflow.workspace_id,
                 stage_index,
                 shaping_intent,
                 workflow.created_by.as_deref(),
@@ -424,7 +447,7 @@ impl<E: GateEmitter> super::stage_runner::GateEvaluator for LiveGateEvaluator<E>
                 self.evaluate_external_check(artifact, check_name)
             }
             GateSpec::Governance { gate_point } => {
-                self.evaluate_governance(artifact, stage_index, gate_point)
+                self.evaluate_governance(artifact, &workflow.workspace_id, stage_index, gate_point)
             }
             GateSpec::ManualApproval { signal_kind } => {
                 self.evaluate_manual_approval(artifact, signal_kind)
@@ -477,6 +500,10 @@ mod tests {
         gate_requests: AtomicU32,
         last_shaping_request: Mutex<Option<ShapingRequest>>,
         last_gate_id: Mutex<Option<String>>,
+        /// Workspace_id passed to the most recent emit (#183). Lets the
+        /// regression test assert the workspace propagates from the
+        /// owning workflow into the spine row.
+        last_workspace_id: Mutex<Option<String>>,
         /// When set to false, both emit methods return false to
         /// simulate a transient spine failure.
         accept: std::sync::atomic::AtomicBool,
@@ -490,21 +517,28 @@ mod tests {
         }
     }
     impl GateEmitter for CapturingEmitter {
-        fn emit_shaping_dispatched(&self, request: &ShapingRequest) -> bool {
+        fn emit_shaping_dispatched(&self, workspace_id: &str, request: &ShapingRequest) -> bool {
             if !self.accept.load(Ordering::SeqCst) {
                 return false;
             }
             self.shaping.fetch_add(1, Ordering::SeqCst);
             *self.last_shaping_request.lock().unwrap() = Some(request.clone());
+            *self.last_workspace_id.lock().unwrap() = Some(workspace_id.to_string());
             true
         }
 
-        fn emit_gate_requested(&self, gate_id: &str, _request: &GateRequest) -> bool {
+        fn emit_gate_requested(
+            &self,
+            workspace_id: &str,
+            gate_id: &str,
+            _request: &GateRequest,
+        ) -> bool {
             if !self.accept.load(Ordering::SeqCst) {
                 return false;
             }
             self.gate_requests.fetch_add(1, Ordering::SeqCst);
             *self.last_gate_id.lock().unwrap() = Some(gate_id.to_string());
+            *self.last_workspace_id.lock().unwrap() = Some(workspace_id.to_string());
             true
         }
     }

--- a/crates/forge/tests/workflow_runtime.rs
+++ b/crates/forge/tests/workflow_runtime.rs
@@ -34,10 +34,15 @@ struct AutoAllowEmitter {
     pending: PendingVerdicts,
 }
 impl GateEmitter for AutoAllowEmitter {
-    fn emit_shaping_dispatched(&self, _request: &ShapingRequest) -> bool {
+    fn emit_shaping_dispatched(&self, _workspace_id: &str, _request: &ShapingRequest) -> bool {
         true
     }
-    fn emit_gate_requested(&self, gate_id: &str, _request: &GateRequest) -> bool {
+    fn emit_gate_requested(
+        &self,
+        _workspace_id: &str,
+        gate_id: &str,
+        _request: &GateRequest,
+    ) -> bool {
         self.pending.insert(gate_id, GateVerdict::Allow);
         true
     }

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -364,14 +364,21 @@ async fn append_insight_emitted(
 
     // #183: events_ext.workspace_id is a real column. `subject_ref`
     // is free-form (artifact id, artifact kind, rule id) — try
-    // lookup_workspace_for_artifact and fall back to "default" for
-    // non-artifact subjects.
-    let workspace_id = spine
-        .lookup_workspace_for_artifact(subject_ref)
-        .await
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "default".to_string());
+    // lookup_workspace_for_artifact; non-artifact subjects fall back
+    // to "default" via Ok(None). Lookup errors are logged distinctly
+    // so a DB problem doesn't silently mis-scope every insight
+    // (Copilot review on #235).
+    let workspace_id = match spine.lookup_workspace_for_artifact(subject_ref).await {
+        Ok(Some(ws)) => ws,
+        Ok(None) => "default".to_string(),
+        Err(e) => {
+            tracing::warn!(
+                subject_ref,
+                "ising workspace lookup for insight_emitted failed; falling back to 'default': {e}"
+            );
+            "default".to_string()
+        }
+    };
 
     let id = spine
         .append_ext(
@@ -411,13 +418,20 @@ async fn append_rule_proposed(
 
     // #183: same pattern as insight_emitted — `subject_ref` may name
     // an artifact, an artifact kind, or a rule id. Try the artifact
-    // lookup and fall back to "default" for non-artifact subjects.
-    let workspace_id = spine
-        .lookup_workspace_for_artifact(subject_ref)
-        .await
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "default".to_string());
+    // lookup; non-artifact subjects fall back to "default" via
+    // Ok(None). Lookup errors are logged distinctly (Copilot review
+    // on #235).
+    let workspace_id = match spine.lookup_workspace_for_artifact(subject_ref).await {
+        Ok(Some(ws)) => ws,
+        Ok(None) => "default".to_string(),
+        Err(e) => {
+            tracing::warn!(
+                subject_ref,
+                "ising workspace lookup for rule_proposed failed; falling back to 'default': {e}"
+            );
+            "default".to_string()
+        }
+    };
 
     let id = spine
         .append_ext(

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -362,8 +362,20 @@ async fn append_insight_emitted(
         ..Default::default()
     };
 
+    // #183: events_ext.workspace_id is a real column. `subject_ref`
+    // is free-form (artifact id, artifact kind, rule id) — try
+    // lookup_workspace_for_artifact and fall back to "default" for
+    // non-artifact subjects.
+    let workspace_id = spine
+        .lookup_workspace_for_artifact(subject_ref)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "default".to_string());
+
     let id = spine
         .append_ext(
+            &workspace_id,
             &stream_id,
             "ising",
             "ising.insight_emitted",
@@ -384,11 +396,11 @@ async fn append_rule_proposed(
     spine: &EventStore,
     event: &FactoryEventKind,
 ) -> Result<i64, anyhow::Error> {
-    if !matches!(event, FactoryEventKind::IsingRuleProposed { .. }) {
+    let FactoryEventKind::IsingRuleProposed { subject_ref, .. } = event else {
         return Err(anyhow::anyhow!(
             "append_rule_proposed called with non-IsingRuleProposed variant"
         ));
-    }
+    };
 
     let stream_id = event.stream_id();
     let data = serde_json::to_value(event)?;
@@ -397,8 +409,19 @@ async fn append_rule_proposed(
         ..Default::default()
     };
 
+    // #183: same pattern as insight_emitted — `subject_ref` may name
+    // an artifact, an artifact kind, or a rule id. Try the artifact
+    // lookup and fall back to "default" for non-artifact subjects.
+    let workspace_id = spine
+        .lookup_workspace_for_artifact(subject_ref)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "default".to_string());
+
     let id = spine
         .append_ext(
+            &workspace_id,
             &stream_id,
             "ising",
             "ising.rule_proposed",

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -153,6 +153,7 @@ pub async fn run(
         let stream_id = crate::handlers::pull_request::pr_stream_id(&project.id, pr.number);
         spine
             .append_ext(
+                &artifact.workspace_id,
                 &stream_id,
                 "git",
                 event.event_type(),
@@ -178,6 +179,7 @@ pub async fn run(
         let stream_id = format!("portal:issue:{}", artifact.artifact_id);
         spine
             .append_ext(
+                &artifact.workspace_id,
                 &stream_id,
                 "portal",
                 "portal.task_materialized",

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -127,6 +127,10 @@ pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Opti
 pub struct PrArtifactRow {
     pub artifact_id: String,
     pub current_version: i32,
+    /// Tenant scope copied off the spine row (#183). Callers stamp it
+    /// onto every `events_ext` emit so the dashboard's per-workspace
+    /// stream sees the event.
+    pub workspace_id: String,
 }
 
 /// Issue artifact lookup result. Same shape as `PrArtifactRow` but typed
@@ -136,6 +140,8 @@ pub struct PrArtifactRow {
 pub struct IssueArtifactRow {
     pub artifact_id: String,
     pub current_version: i32,
+    /// Tenant scope copied off the spine row (#183).
+    pub workspace_id: String,
 }
 
 /// Look up the artifact previously upserted for `(project_id, pr_number)`.
@@ -146,16 +152,19 @@ pub async fn find_pr_artifact(
     pr_number: u64,
 ) -> anyhow::Result<Option<PrArtifactRow>> {
     let external_ref = pr_external_ref(project_id, pr_number);
-    let row: Option<(String, i32)> = sqlx::query_as(
-        "SELECT artifact_id, current_version FROM artifacts WHERE external_ref = $1",
+    let row: Option<(String, i32, String)> = sqlx::query_as(
+        "SELECT artifact_id, current_version, workspace_id FROM artifacts WHERE external_ref = $1",
     )
     .bind(&external_ref)
     .fetch_optional(pool)
     .await?;
-    Ok(row.map(|(artifact_id, current_version)| PrArtifactRow {
-        artifact_id,
-        current_version,
-    }))
+    Ok(row.map(
+        |(artifact_id, current_version, workspace_id)| PrArtifactRow {
+            artifact_id,
+            current_version,
+            workspace_id,
+        },
+    ))
 }
 
 /// Upsert the canonical reference-only PR artifact for `(project_id, pr_number)`.
@@ -190,16 +199,17 @@ pub async fn upsert_pr_artifact_ref(
         .execute(&mut *tx)
         .await?;
 
-    let row: (String, i32) = if let Some(existing) = sqlx::query_as::<_, (String, i32)>(
-        "UPDATE artifacts \
+    let row: (String, i32, String) = if let Some(existing) =
+        sqlx::query_as::<_, (String, i32, String)>(
+            "UPDATE artifacts \
             SET state = $2, last_observed_at = NOW() \
           WHERE external_ref = $1 \
-      RETURNING artifact_id, current_version",
-    )
-    .bind(&external_ref)
-    .bind(artifact_state)
-    .fetch_optional(&mut *tx)
-    .await?
+      RETURNING artifact_id, current_version, workspace_id",
+        )
+        .bind(&external_ref)
+        .bind(artifact_state)
+        .fetch_optional(&mut *tx)
+        .await?
     {
         existing
     } else {
@@ -209,7 +219,7 @@ pub async fn upsert_pr_artifact_ref(
                  external_ref, workspace_id, metadata, last_observed_at) \
              VALUES ($1, 'pull_request', NULL, NULL, 'onsager-portal', $2, 1, $3, $4, \
                      jsonb_build_object('project_id', $4::text, 'pr_number', $5::bigint), NOW()) \
-             RETURNING artifact_id, current_version",
+             RETURNING artifact_id, current_version, workspace_id",
         )
         .bind(&new_id)
         .bind(artifact_state)
@@ -225,6 +235,7 @@ pub async fn upsert_pr_artifact_ref(
     Ok(PrArtifactRow {
         artifact_id: row.0,
         current_version: row.1,
+        workspace_id: row.2,
     })
 }
 
@@ -251,16 +262,17 @@ pub async fn upsert_issue_artifact_ref(
         .execute(&mut *tx)
         .await?;
 
-    let row: (String, i32) = if let Some(existing) = sqlx::query_as::<_, (String, i32)>(
-        "UPDATE artifacts \
+    let row: (String, i32, String) = if let Some(existing) =
+        sqlx::query_as::<_, (String, i32, String)>(
+            "UPDATE artifacts \
             SET state = $2, last_observed_at = NOW() \
           WHERE external_ref = $1 \
-      RETURNING artifact_id, current_version",
-    )
-    .bind(&external_ref)
-    .bind(artifact_state)
-    .fetch_optional(&mut *tx)
-    .await?
+      RETURNING artifact_id, current_version, workspace_id",
+        )
+        .bind(&external_ref)
+        .bind(artifact_state)
+        .fetch_optional(&mut *tx)
+        .await?
     {
         existing
     } else {
@@ -270,7 +282,7 @@ pub async fn upsert_issue_artifact_ref(
                  external_ref, workspace_id, metadata, last_observed_at) \
              VALUES ($1, 'github_issue', NULL, NULL, 'onsager-portal', $2, 1, $3, $4, \
                      jsonb_build_object('project_id', $4::text, 'issue_number', $5::bigint), NOW()) \
-             RETURNING artifact_id, current_version",
+             RETURNING artifact_id, current_version, workspace_id",
         )
         .bind(&new_id)
         .bind(artifact_state)
@@ -286,6 +298,7 @@ pub async fn upsert_issue_artifact_ref(
     Ok(IssueArtifactRow {
         artifact_id: row.0,
         current_version: row.1,
+        workspace_id: row.2,
     })
 }
 

--- a/crates/onsager-portal/src/handlers/issues.rs
+++ b/crates/onsager-portal/src/handlers/issues.rs
@@ -110,6 +110,7 @@ pub async fn handle(
     state
         .spine
         .append_ext(
+            &artifact.workspace_id,
             &stream_id,
             "portal",
             "portal.task_materialized",

--- a/crates/onsager-portal/src/handlers/pull_request.rs
+++ b/crates/onsager-portal/src/handlers/pull_request.rs
@@ -176,6 +176,7 @@ pub async fn handle(
     let event_id = state
         .spine
         .append_ext(
+            &artifact.workspace_id,
             &stream_id,
             GIT_NAMESPACE,
             event.event_type(),
@@ -244,6 +245,7 @@ pub async fn handle(
             state
                 .spine
                 .append_ext(
+                    &artifact.workspace_id,
                     &artifact.artifact_id,
                     "forge",
                     "forge.gate_verdict",
@@ -316,6 +318,7 @@ pub async fn handle(
                 state
                     .spine
                     .append_ext(
+                        &artifact.workspace_id,
                         &artifact.artifact_id,
                         "synodic",
                         "synodic.escalation_started",

--- a/crates/onsager-spine/migrations/016_events_ext_workspace_id.sql
+++ b/crates/onsager-spine/migrations/016_events_ext_workspace_id.sql
@@ -6,15 +6,18 @@
 -- has been a JSONB predicate. JSONB lookup is unindexed at our row
 -- counts and silently drops events whose payload is missing the field.
 --
--- Promote workspace_id to a first-class column on `events_ext`, with
--- a 3-stage backfill so the column can carry NOT NULL by the end of
--- the migration:
+-- Promote workspace_id to a first-class column on `events_ext`. The
+-- migration is rolling-deploy safe: the column lands NOT NULL DEFAULT
+-- 'default' on stage 1, so older writers that don't yet bind the
+-- column can still INSERT — they pick up the default. The backfill in
+-- stage 2 then rewrites pre-existing rows from the JSONB hint when
+-- present.
 --
---   1. ADD COLUMN nullable.
---   2. UPDATE rows in place — prefer the existing JSONB hint when set,
---      else 'default' (a few legacy rows from before #230 carry no
---      tenant; system events never will).
---   3. ALTER COLUMN ... SET NOT NULL DEFAULT 'default'.
+-- (An earlier draft staged ADD nullable → UPDATE → SET NOT NULL.
+-- Copilot review on PR #235 flagged the race: a concurrent INSERT
+-- between the UPDATE and the SET NOT NULL would land workspace_id =
+-- NULL and break the final ALTER. Setting the default at stage 1
+-- closes that window.)
 --
 -- After the migration every events_ext row carries workspace_id; the
 -- dashboard read at `crates/stiglab/src/server/routes/spine.rs` swaps
@@ -26,21 +29,20 @@
 --   - FK to `workspaces(id)` — that's a separate spec when the
 --     `workspaces` table lives definitively in spine vs. portal.
 
--- Stage 1: add the column nullable so the backfill UPDATE can run.
+-- Stage 1: add the column NOT NULL with a default so concurrent
+-- writers can't land NULL during the rest of this migration.
 ALTER TABLE events_ext
-    ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT 'default';
 
--- Stage 2: backfill. Prefer the JSONB-stamped value (PR #230 / #232),
--- fall back to 'default' for legacy or system rows that never had a
--- tenant scope.
+-- Stage 2: backfill pre-existing rows that carried the JSONB hint
+-- (PR #230 / #232) but were stamped 'default' by stage 1. Rows that
+-- never had a tenant — legacy / system events — keep 'default'.
 UPDATE events_ext
-SET workspace_id = COALESCE(NULLIF(data->>'workspace_id', ''), 'default')
-WHERE workspace_id IS NULL;
-
--- Stage 3: lock the contract — every row has a tenant, default 'default'.
-ALTER TABLE events_ext
-    ALTER COLUMN workspace_id SET NOT NULL,
-    ALTER COLUMN workspace_id SET DEFAULT 'default';
+SET workspace_id = data->>'workspace_id'
+WHERE workspace_id = 'default'
+  AND data ? 'workspace_id'
+  AND data->>'workspace_id' <> ''
+  AND data->>'workspace_id' <> 'default';
 
 -- Composite index supports the dashboard's per-workspace stream read
 -- (`WHERE workspace_id = $1 ORDER BY id DESC`); leading on workspace_id

--- a/crates/onsager-spine/migrations/016_events_ext_workspace_id.sql
+++ b/crates/onsager-spine/migrations/016_events_ext_workspace_id.sql
@@ -1,0 +1,49 @@
+-- Onsager #183 — events_ext.workspace_id as a real column.
+--
+-- Until now extension events stamped workspace scope into the JSONB
+-- payload (data->>'workspace_id'). PR #232 made every forge stage
+-- event carry that field; the dashboard's `/api/spine/events` filter
+-- has been a JSONB predicate. JSONB lookup is unindexed at our row
+-- counts and silently drops events whose payload is missing the field.
+--
+-- Promote workspace_id to a first-class column on `events_ext`, with
+-- a 3-stage backfill so the column can carry NOT NULL by the end of
+-- the migration:
+--
+--   1. ADD COLUMN nullable.
+--   2. UPDATE rows in place — prefer the existing JSONB hint when set,
+--      else 'default' (a few legacy rows from before #230 carry no
+--      tenant; system events never will).
+--   3. ALTER COLUMN ... SET NOT NULL DEFAULT 'default'.
+--
+-- After the migration every events_ext row carries workspace_id; the
+-- dashboard read at `crates/stiglab/src/server/routes/spine.rs` swaps
+-- its `data->>'workspace_id' = $1` predicate for `workspace_id = $1`
+-- and the composite index below covers the read pattern.
+--
+-- Out of scope:
+--   - `events` (factory event) table — this spec is events_ext only.
+--   - FK to `workspaces(id)` — that's a separate spec when the
+--     `workspaces` table lives definitively in spine vs. portal.
+
+-- Stage 1: add the column nullable so the backfill UPDATE can run.
+ALTER TABLE events_ext
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT;
+
+-- Stage 2: backfill. Prefer the JSONB-stamped value (PR #230 / #232),
+-- fall back to 'default' for legacy or system rows that never had a
+-- tenant scope.
+UPDATE events_ext
+SET workspace_id = COALESCE(NULLIF(data->>'workspace_id', ''), 'default')
+WHERE workspace_id IS NULL;
+
+-- Stage 3: lock the contract — every row has a tenant, default 'default'.
+ALTER TABLE events_ext
+    ALTER COLUMN workspace_id SET NOT NULL,
+    ALTER COLUMN workspace_id SET DEFAULT 'default';
+
+-- Composite index supports the dashboard's per-workspace stream read
+-- (`WHERE workspace_id = $1 ORDER BY id DESC`); leading on workspace_id
+-- prunes to a tenant first, then `id DESC` falls out as a covered scan.
+CREATE INDEX IF NOT EXISTS idx_events_ext_workspace_id
+    ON events_ext (workspace_id, id DESC);

--- a/crates/onsager-spine/src/extension_event.rs
+++ b/crates/onsager-spine/src/extension_event.rs
@@ -19,6 +19,12 @@ pub struct ExtensionEventRecord {
     /// [`crate::store::EventRecord::correlation_id`].
     #[serde(default)]
     pub correlation_id: Option<Uuid>,
+    /// Tenant scope (`#183`). Promoted from `data->>'workspace_id'`
+    /// to a real column with a backing index in migration 016 so the
+    /// dashboard's per-workspace stream read filters cheaply and
+    /// can't drop events whose payload is missing the field.
+    /// `'default'` for legacy/system events with no tenant.
+    pub workspace_id: String,
 }
 
 impl ExtensionEventRecord {

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -104,8 +104,15 @@ impl EventStore {
 
     /// Append an extension event linked to a stream.
     /// Returns the assigned event id.
+    ///
+    /// `workspace_id` is mandatory (`#183`) — it lives in a real column
+    /// on `events_ext` with a backing index. Use `"default"` for system
+    /// events that have no tenant; for events tied to an artifact prefer
+    /// [`Self::lookup_workspace_for_artifact`].
+    #[allow(clippy::too_many_arguments)]
     pub async fn append_ext(
         &self,
+        workspace_id: &str,
         stream_id: &str,
         namespace: &str,
         event_type: &str,
@@ -118,8 +125,8 @@ impl EventStore {
 
         let row: (i64,) = sqlx::query_as(
             r#"
-            INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, ref_event_id, correlation_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, ref_event_id, correlation_id, workspace_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING id
             "#,
         )
@@ -130,10 +137,26 @@ impl EventStore {
         .bind(&meta)
         .bind(ref_event_id)
         .bind(correlation_id)
+        .bind(workspace_id)
         .fetch_one(&self.pool)
         .await?;
 
         Ok(row.0)
+    }
+
+    /// Resolve an artifact's workspace_id. Returns `Ok(None)` when the
+    /// artifact isn't in the spine (e.g. system events that name a
+    /// stream key but no row). Producers feed this into
+    /// [`Self::append_ext`] so every emitter pays the same workspace
+    /// resolution path.
+    pub async fn lookup_workspace_for_artifact(
+        &self,
+        artifact_id: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        sqlx::query_scalar::<_, String>("SELECT workspace_id FROM artifacts WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .fetch_optional(&self.pool)
+            .await
     }
 
     /// Query core events for a stream, ordered by sequence.
@@ -163,7 +186,7 @@ impl EventStore {
     ) -> Result<Vec<ExtensionEventRecord>, sqlx::Error> {
         sqlx::query_as::<_, ExtensionEventRecord>(
             r#"
-            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id
+            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id, workspace_id
             FROM events_ext
             WHERE stream_id = $1
             ORDER BY created_at ASC
@@ -251,7 +274,7 @@ impl EventStore {
     ) -> Result<Option<ExtensionEventRecord>, sqlx::Error> {
         sqlx::query_as::<_, ExtensionEventRecord>(
             r#"
-            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id
+            SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id, workspace_id
             FROM events_ext
             WHERE id = $1
             "#,
@@ -278,7 +301,7 @@ impl EventStore {
 
         let where_clause = conditions.join(" AND ");
         let sql = format!(
-            "SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id \
+            "SELECT id, stream_id, namespace, event_type, data, metadata, ref_event_id, created_at, correlation_id, workspace_id \
              FROM events_ext WHERE {where_clause} ORDER BY id DESC LIMIT {limit}"
         );
 
@@ -462,6 +485,7 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for ExtensionEventRecord {
             ref_event_id: row.try_get("ref_event_id")?,
             created_at: row.try_get("created_at")?,
             correlation_id: row.try_get("correlation_id")?,
+            workspace_id: row.try_get("workspace_id")?,
         })
     }
 }
@@ -562,6 +586,51 @@ mod tests {
             rows.is_empty(),
             "found unexpected rows after rollback: {rows:?}"
         );
+    }
+
+    /// `workspace_id` round-trips through `append_ext` → `query_ext_stream`
+    /// (#183). Pinning the column wiring here so a future refactor of the
+    /// SELECT list or the FromRow impl can't silently drop the field.
+    #[tokio::test]
+    async fn append_ext_round_trips_workspace_id() {
+        let Some(url) = db_url() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let store = EventStore::connect(&url).await.unwrap();
+        let stream_id = format!("forge:art_ws_test_{}", ulid::Ulid::new());
+        let workspace_id = format!("ws_round_trip_{}", ulid::Ulid::new());
+        let metadata = test_metadata();
+
+        let id = store
+            .append_ext(
+                &workspace_id,
+                &stream_id,
+                "forge",
+                "test.workspace_round_trip",
+                serde_json::json!({"hello": "world"}),
+                &metadata,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let rows = store.query_ext_stream(&stream_id).await.unwrap();
+        let row = rows
+            .iter()
+            .find(|r| r.id == id)
+            .expect("appended row visible on read");
+        assert_eq!(row.workspace_id, workspace_id);
+
+        let by_id = store.get_ext_event_by_id(id).await.unwrap().unwrap();
+        assert_eq!(by_id.workspace_id, workspace_id);
+
+        // Clean up.
+        sqlx::query("DELETE FROM events_ext WHERE id = $1")
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .unwrap();
     }
 
     /// Dropped transaction (simulating panic path): event does not persist.

--- a/crates/refract/src/runtime.rs
+++ b/crates/refract/src/runtime.rs
@@ -117,15 +117,23 @@ impl Refract {
         // artifact layer (an intent fans out into artifacts that may
         // span workspaces); when the decompose result names artifacts
         // we resolve from the first one, else fall back to "default".
+        // Lookup errors are logged distinctly so a real DB problem
+        // doesn't silently mis-scope every refract event (Copilot
+        // review on #235).
         let workspace_id = match event {
             FactoryEventKind::RefractDecomposed { artifact_ids, .. } => {
                 match artifact_ids.first() {
-                    Some(id) => spine
-                        .lookup_workspace_for_artifact(id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or_else(|| "default".to_string()),
+                    Some(id) => match spine.lookup_workspace_for_artifact(id).await {
+                        Ok(Some(ws)) => ws,
+                        Ok(None) => "default".to_string(),
+                        Err(e) => {
+                            tracing::warn!(
+                                artifact_id = id,
+                                "refract workspace lookup failed; falling back to 'default': {e}"
+                            );
+                            "default".to_string()
+                        }
+                    },
                     None => "default".to_string(),
                 }
             }

--- a/crates/refract/src/runtime.rs
+++ b/crates/refract/src/runtime.rs
@@ -111,8 +111,37 @@ impl Refract {
         let data = serde_json::to_value(event)?;
         let stream_id = event.stream_id();
         let event_type = event.event_type();
+
+        // #183: events_ext.workspace_id is a real column. Refract's
+        // intent / decomposed / failed events all live above the
+        // artifact layer (an intent fans out into artifacts that may
+        // span workspaces); when the decompose result names artifacts
+        // we resolve from the first one, else fall back to "default".
+        let workspace_id = match event {
+            FactoryEventKind::RefractDecomposed { artifact_ids, .. } => {
+                match artifact_ids.first() {
+                    Some(id) => spine
+                        .lookup_workspace_for_artifact(id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or_else(|| "default".to_string()),
+                    None => "default".to_string(),
+                }
+            }
+            _ => "default".to_string(),
+        };
+
         spine
-            .append_ext(&stream_id, "refract", event_type, data, &metadata, None)
+            .append_ext(
+                &workspace_id,
+                &stream_id,
+                "refract",
+                event_type,
+                data,
+                &metadata,
+                None,
+            )
             .await
             .map_err(|e| RuntimeError::Spine(e.to_string()))?;
         Ok(())

--- a/crates/stiglab/src/server/routes/projects.rs
+++ b/crates/stiglab/src/server/routes/projects.rs
@@ -1243,6 +1243,7 @@ pub async fn replay_issue_trigger(
             }
             match spine
                 .emit_raw(
+                    &project.workspace_id,
                     &ev.kind.stream_id(),
                     spine_namespace(&ev.kind),
                     "stiglab",

--- a/crates/stiglab/src/server/routes/spine.rs
+++ b/crates/stiglab/src/server/routes/spine.rs
@@ -145,10 +145,9 @@ pub struct OverrideGateRequest {
 
 /// GET /api/spine/events?workspace=W — query the events_ext table.
 ///
-/// Filters event rows whose payload references the requested workspace
-/// (matched on `data->>'workspace_id'`). The `?workspace=` query param
-/// is required (#164) — a missing value returns 400 so a caller can't
-/// silently scan every workspace's stream.
+/// Filters event rows by `events_ext.workspace_id` (#183). The
+/// `?workspace=` query param is required (#164) — a missing value
+/// returns 400 so a caller can't silently scan every workspace's stream.
 pub async fn list_events(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -186,13 +185,14 @@ pub async fn list_events(
     // `metadata`. The API surfaces them as `stream_type` / `actor` for clients,
     // so we alias on the way out.
     //
-    // Workspace scope is matched on `data->>'workspace_id'`; events that
-    // don't carry the field (legacy, infrastructure-level) are excluded
-    // so a workspace listing never includes another workspace's rows.
+    // Workspace scope is matched on the `workspace_id` column (#183 —
+    // promoted from `data->>'workspace_id'` to a real column with a
+    // backing index). Legacy and system events that have no tenant
+    // carry `'default'` and aren't returned to a tenant-scoped read.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
                 COALESCE(metadata->>'actor', '') AS actor, created_at \
-         FROM events_ext WHERE data->>'workspace_id' = ",
+         FROM events_ext WHERE workspace_id = ",
     );
     qb.push_bind(workspace_id.to_string());
     if let Some(st) = params.stream_type.as_deref() {
@@ -381,6 +381,7 @@ pub async fn register_artifact(
                 });
                 if let Err(e) = spine
                     .emit_raw(
+                        workspace_id,
                         &format!("forge:{artifact_id}"),
                         "forge",
                         "dashboard",
@@ -709,7 +710,6 @@ pub async fn retry_artifact(
             return r;
         }
     }
-    let _ = workspace_id;
 
     if state_str == "archived" || state_str == "released" {
         return (
@@ -729,6 +729,7 @@ pub async fn retry_artifact(
     });
     if let Err(e) = spine
         .emit_raw(
+            &workspace_id,
             &format!("forge:{id}"),
             "forge",
             actor,
@@ -844,6 +845,7 @@ pub async fn abort_artifact(
     });
     if let Err(e) = spine
         .emit_raw(
+            &workspace_id,
             &format!("forge:{id}"),
             "forge",
             actor,
@@ -952,6 +954,7 @@ pub async fn override_gate(
     });
     if let Err(e) = spine
         .emit_raw(
+            &workspace_id,
             &format!("forge:{id}"),
             "synodic",
             actor,

--- a/crates/stiglab/src/server/routes/webhooks.rs
+++ b/crates/stiglab/src/server/routes/webhooks.rs
@@ -304,6 +304,7 @@ async fn emit_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: &
         let namespace = spine_namespace(&ev.kind);
         if let Err(e) = spine
             .emit_raw(
+                workspace_id,
                 &ev.kind.stream_id(),
                 namespace,
                 "stiglab",

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -4,6 +4,12 @@
 use onsager_spine::factory_event::{FactoryEventKind, TokenUsage};
 use onsager_spine::{EventMetadata, EventStore};
 
+/// Default workspace_id stamped on `events_ext` rows whose source event
+/// has no resolvable tenant (system telemetry — node lifecycle, idle
+/// ticks, catch-up completions). Per #183 the column is NOT NULL; this
+/// is the canonical fallback for cross-workspace events.
+const SYSTEM_WORKSPACE: &str = "default";
+
 /// Emits factory events to the Onsager event spine under the "stiglab" namespace.
 #[derive(Clone)]
 pub struct SpineEmitter {
@@ -28,10 +34,38 @@ impl SpineEmitter {
         let data = serde_json::to_value(&event).unwrap_or_default();
         let stream_id = event.stream_id();
         let event_type = event.event_type();
+        let workspace_id = self.resolve_workspace(&event).await;
 
         self.store
-            .append_ext(&stream_id, "stiglab", event_type, data, &metadata, None)
+            .append_ext(
+                &workspace_id,
+                &stream_id,
+                "stiglab",
+                event_type,
+                data,
+                &metadata,
+                None,
+            )
             .await
+    }
+
+    /// Resolve the tenant scope for a factory event (#183). Per-variant
+    /// match lives here so every call site shares the same policy:
+    /// look up the artifact's workspace when the event names one,
+    /// fall back to `"default"` for system events that genuinely have
+    /// no tenant (node lifecycle, idle ticks, etc.).
+    async fn resolve_workspace(&self, event: &FactoryEventKind) -> String {
+        let artifact_id = artifact_id_for_workspace_lookup(event);
+        match artifact_id {
+            Some(id) => self
+                .store
+                .lookup_workspace_for_artifact(id)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| SYSTEM_WORKSPACE.to_string()),
+            None => SYSTEM_WORKSPACE.to_string(),
+        }
     }
 
     /// Get a reference to the underlying PostgreSQL pool for direct queries.
@@ -51,10 +85,13 @@ impl SpineEmitter {
     /// Used for events that don't map to a `FactoryEventKind` variant (e.g.,
     /// artifact registration from the dashboard).
     ///
-    /// `namespace` identifies the event store partition; `actor` identifies
-    /// the service or user that originated the event.
+    /// `workspace_id` (#183) is the tenant scope; pass `"default"` for
+    /// system events with no tenant. `namespace` identifies the event
+    /// store partition; `actor` identifies the service or user that
+    /// originated the event.
     pub async fn emit_raw(
         &self,
+        workspace_id: &str,
         stream_id: &str,
         namespace: &str,
         actor: &str,
@@ -68,6 +105,7 @@ impl SpineEmitter {
         };
         self.store
             .append_ext(
+                workspace_id,
                 stream_id,
                 namespace,
                 event_type,
@@ -167,5 +205,91 @@ impl SpineEmitter {
             artifact_id: artifact_id.map(str::to_owned),
         })
         .await
+    }
+}
+
+/// Extract the artifact_id a `FactoryEventKind` is scoped to, for
+/// `events_ext.workspace_id` resolution (#183). Returns `None` for
+/// system events that genuinely have no tenant — node lifecycle,
+/// catch-up completions, idle ticks — those land under `"default"`.
+fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
+    match event {
+        FactoryEventKind::ArtifactRegistered { artifact_id, .. }
+        | FactoryEventKind::ArtifactStateChanged { artifact_id, .. }
+        | FactoryEventKind::ArtifactVersionCreated { artifact_id, .. }
+        | FactoryEventKind::ArtifactLineageExtended { artifact_id, .. }
+        | FactoryEventKind::ArtifactQualityRecorded { artifact_id, .. }
+        | FactoryEventKind::ArtifactRouted { artifact_id, .. }
+        | FactoryEventKind::ArtifactArchived { artifact_id, .. }
+        | FactoryEventKind::BundleSealed { artifact_id, .. }
+        | FactoryEventKind::GitBranchCreated { artifact_id, .. }
+        | FactoryEventKind::GitCommitPushed { artifact_id, .. }
+        | FactoryEventKind::GitPrOpened { artifact_id, .. }
+        | FactoryEventKind::GitPrReviewReceived { artifact_id, .. }
+        | FactoryEventKind::GitCiCompleted { artifact_id, .. }
+        | FactoryEventKind::GitPrMerged { artifact_id, .. }
+        | FactoryEventKind::GitPrClosed { artifact_id, .. }
+        | FactoryEventKind::ForgeShapingDispatched { artifact_id, .. }
+        | FactoryEventKind::ForgeShapingReturned { artifact_id, .. }
+        | FactoryEventKind::ForgeGateRequested { artifact_id, .. }
+        | FactoryEventKind::ForgeGateVerdict { artifact_id, .. }
+        | FactoryEventKind::ForgeDecisionMade { artifact_id, .. }
+        | FactoryEventKind::StiglabShapingResultReady { artifact_id, .. }
+        | FactoryEventKind::SynodicGateEvaluated { artifact_id, .. }
+        | FactoryEventKind::SynodicGateDenied { artifact_id, .. }
+        | FactoryEventKind::SynodicGateModified { artifact_id, .. }
+        | FactoryEventKind::SynodicGateVerdict { artifact_id, .. }
+        | FactoryEventKind::SynodicEscalationStarted { artifact_id, .. }
+        | FactoryEventKind::SynodicEscalationResolved { artifact_id, .. }
+        | FactoryEventKind::SynodicEscalationTimedOut { artifact_id, .. }
+        | FactoryEventKind::SynodicGateResolutionProposed { artifact_id, .. }
+        | FactoryEventKind::DeliverableUpdated { artifact_id, .. }
+        | FactoryEventKind::StageEntered { artifact_id, .. }
+        | FactoryEventKind::StageGatePassed { artifact_id, .. }
+        | FactoryEventKind::StageGateFailed { artifact_id, .. }
+        | FactoryEventKind::StageAdvanced { artifact_id, .. } => Some(artifact_id.as_str()),
+        FactoryEventKind::StiglabSessionCompleted { artifact_id, .. }
+        | FactoryEventKind::StiglabSessionFailed { artifact_id, .. } => artifact_id.as_deref(),
+        // Variants below name no artifact — system / cross-workspace
+        // telemetry. Fall back to "default".
+        FactoryEventKind::DeliverySucceeded { .. }
+        | FactoryEventKind::DeliveryFailed { .. }
+        | FactoryEventKind::DeliverableCreated { .. }
+        | FactoryEventKind::ForgeInsightObserved { .. }
+        | FactoryEventKind::ForgeIdleTick
+        | FactoryEventKind::ForgeStateChanged { .. }
+        | FactoryEventKind::StiglabSessionCreated { .. }
+        | FactoryEventKind::StiglabSessionDispatched { .. }
+        | FactoryEventKind::StiglabSessionRunning { .. }
+        | FactoryEventKind::StiglabSessionAborted { .. }
+        | FactoryEventKind::StiglabEventUpgraded { .. }
+        | FactoryEventKind::StiglabNodeRegistered { .. }
+        | FactoryEventKind::StiglabNodeDeregistered { .. }
+        | FactoryEventKind::StiglabNodeHeartbeatMissed { .. }
+        | FactoryEventKind::SynodicRuleProposed { .. }
+        | FactoryEventKind::SynodicRuleApproved { .. }
+        | FactoryEventKind::SynodicRuleDisabled { .. }
+        | FactoryEventKind::SynodicRuleVersionCreated { .. }
+        | FactoryEventKind::IsingInsightDetected { .. }
+        | FactoryEventKind::IsingInsightEmitted { .. }
+        | FactoryEventKind::IsingInsightSuppressed { .. }
+        | FactoryEventKind::IsingRuleProposed { .. }
+        | FactoryEventKind::IsingAnalyzerError { .. }
+        | FactoryEventKind::IsingCatchupCompleted { .. }
+        | FactoryEventKind::IntentSubmitted { .. }
+        | FactoryEventKind::RefractDecomposed { .. }
+        | FactoryEventKind::RefractFailed { .. }
+        | FactoryEventKind::TriggerFired { .. }
+        | FactoryEventKind::TypeProposed { .. }
+        | FactoryEventKind::TypeApproved { .. }
+        | FactoryEventKind::TypeDeprecated { .. }
+        | FactoryEventKind::AdapterRegistered { .. }
+        | FactoryEventKind::AdapterDeprecated { .. }
+        | FactoryEventKind::GateRegistered { .. }
+        | FactoryEventKind::GateDeprecated { .. }
+        | FactoryEventKind::ProfileRegistered { .. }
+        | FactoryEventKind::ProfileDeprecated { .. }
+        | FactoryEventKind::GateCheckUpdated { .. }
+        | FactoryEventKind::GateManualApprovalSignal { .. } => None,
     }
 }

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -54,17 +54,25 @@ impl SpineEmitter {
     /// look up the artifact's workspace when the event names one,
     /// fall back to `"default"` for system events that genuinely have
     /// no tenant (node lifecycle, idle ticks, etc.).
+    ///
+    /// Lookup errors are logged distinctly from `Ok(None)` so a real
+    /// DB problem doesn't silently mis-scope every event into the
+    /// default workspace (Copilot review on #235).
     async fn resolve_workspace(&self, event: &FactoryEventKind) -> String {
-        let artifact_id = artifact_id_for_workspace_lookup(event);
-        match artifact_id {
-            Some(id) => self
-                .store
-                .lookup_workspace_for_artifact(id)
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| SYSTEM_WORKSPACE.to_string()),
-            None => SYSTEM_WORKSPACE.to_string(),
+        let Some(artifact_id) = artifact_id_for_workspace_lookup(event) else {
+            return SYSTEM_WORKSPACE.to_string();
+        };
+        match self.store.lookup_workspace_for_artifact(artifact_id).await {
+            Ok(Some(ws)) => ws,
+            Ok(None) => SYSTEM_WORKSPACE.to_string(),
+            Err(e) => {
+                tracing::warn!(
+                    artifact_id,
+                    event_type = event.event_type(),
+                    "spine workspace lookup failed; falling back to {SYSTEM_WORKSPACE}: {e}"
+                );
+                SYSTEM_WORKSPACE.to_string()
+            }
         }
     }
 

--- a/crates/stiglab/tests/spine_events_workspace_scoping.rs
+++ b/crates/stiglab/tests/spine_events_workspace_scoping.rs
@@ -44,7 +44,7 @@ async fn spine_events_filter_excludes_other_workspaces() {
             &stream_id,
             "forge",
             "test.scope_w1",
-            serde_json::json!({"workspace_id": w1}),
+            serde_json::json!({"workspace_id": w1.clone()}),
             &metadata,
             None,
         )
@@ -56,7 +56,7 @@ async fn spine_events_filter_excludes_other_workspaces() {
             &stream_id,
             "forge",
             "test.scope_w2",
-            serde_json::json!({"workspace_id": w2}),
+            serde_json::json!({"workspace_id": w2.clone()}),
             &metadata,
             None,
         )

--- a/crates/stiglab/tests/spine_events_workspace_scoping.rs
+++ b/crates/stiglab/tests/spine_events_workspace_scoping.rs
@@ -1,0 +1,98 @@
+//! Spec #183 contract test: `/api/spine/events?workspace=W` filters
+//! `events_ext` by the column-level `workspace_id` (replacing the prior
+//! JSONB predicate `data->>'workspace_id'`). Two events under different
+//! tenants must not leak across the workspace boundary.
+//!
+//! Pinned at the SQL layer rather than via the HTTP handler so the
+//! test doesn't require auth, workspace membership tables, or the
+//! `state.spine` wiring — those are exercised by `workspace_scoping.rs`.
+//! What matters here is that the swap from
+//! `WHERE data->>'workspace_id' = $1` to `WHERE workspace_id = $1`
+//! (`crates/stiglab/src/server/routes/spine.rs`) keeps tenant isolation.
+//!
+//! Skipped when `DATABASE_URL` is unset so a sqlite-only test run still
+//! passes; CI's `postgres:16` service container provides the URL.
+
+use onsager_spine::{EventMetadata, EventStore};
+
+async fn try_store() -> Option<EventStore> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(EventStore::connect(&url).await.expect("spine connect"))
+}
+
+#[tokio::test]
+async fn spine_events_filter_excludes_other_workspaces() {
+    let Some(store) = try_store().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    // Two random workspaces so a parallel test run can't see each
+    // other's rows. Stream id is shared on purpose — workspace scope
+    // is what we're asserting, not stream-key namespacing.
+    let w1 = format!("ws_a_{}", ulid::Ulid::new());
+    let w2 = format!("ws_b_{}", ulid::Ulid::new());
+    let stream_id = format!("forge:art_scope_{}", ulid::Ulid::new());
+    let metadata = EventMetadata {
+        actor: "test".into(),
+        ..Default::default()
+    };
+
+    let id_w1 = store
+        .append_ext(
+            &w1,
+            &stream_id,
+            "forge",
+            "test.scope_w1",
+            serde_json::json!({"workspace_id": w1}),
+            &metadata,
+            None,
+        )
+        .await
+        .unwrap();
+    let id_w2 = store
+        .append_ext(
+            &w2,
+            &stream_id,
+            "forge",
+            "test.scope_w2",
+            serde_json::json!({"workspace_id": w2}),
+            &metadata,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Same SELECT shape the route uses (`crates/stiglab/src/server/
+    // routes/spine.rs::list_events`). If a future refactor swaps the
+    // column back to a JSONB predicate, this test fails.
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT id, workspace_id FROM events_ext WHERE workspace_id = $1 \
+         ORDER BY id DESC LIMIT 50",
+    )
+    .bind(&w1)
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+
+    assert!(
+        rows.iter().any(|(id, _)| *id == id_w1),
+        "W1 query must return the W1 row"
+    );
+    assert!(
+        rows.iter().all(|(_, ws)| ws == &w1),
+        "W1 query must not return rows tagged with another workspace; got {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|(id, _)| *id != id_w2),
+        "W1 query must not return the W2 row"
+    );
+
+    // Clean up.
+    sqlx::query("DELETE FROM events_ext WHERE id IN ($1, $2)")
+        .bind(id_w1)
+        .bind(id_w2)
+        .execute(store.pool())
+        .await
+        .unwrap();
+}

--- a/crates/synodic/src/core/gate_listener.rs
+++ b/crates/synodic/src/core/gate_listener.rs
@@ -79,14 +79,25 @@ impl Dispatcher {
         // #183: events_ext.workspace_id is a real column. Resolve from
         // the artifact this verdict is about; fall back to "default"
         // for the (rare) case where the artifact is no longer present
-        // (e.g. archived between request and verdict).
-        let workspace_id = self
+        // (e.g. archived between request and verdict). Lookup errors
+        // are logged so a real DB problem doesn't silently mis-scope
+        // every verdict (Copilot review on #235).
+        let workspace_id = match self
             .store
             .lookup_workspace_for_artifact(artifact_id.as_str())
             .await
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| "default".to_string());
+        {
+            Ok(Some(ws)) => ws,
+            Ok(None) => "default".to_string(),
+            Err(e) => {
+                tracing::warn!(
+                    %artifact_id,
+                    %gate_id,
+                    "synodic workspace lookup failed; falling back to 'default': {e}"
+                );
+                "default".to_string()
+            }
+        };
         let event = FactoryEventKind::SynodicGateVerdict {
             gate_id: gate_id.to_string(),
             artifact_id,

--- a/crates/synodic/src/core/gate_listener.rs
+++ b/crates/synodic/src/core/gate_listener.rs
@@ -76,6 +76,17 @@ impl Dispatcher {
         gate_point: onsager_spine::factory_event::GatePoint,
         verdict: GateVerdict,
     ) -> anyhow::Result<()> {
+        // #183: events_ext.workspace_id is a real column. Resolve from
+        // the artifact this verdict is about; fall back to "default"
+        // for the (rare) case where the artifact is no longer present
+        // (e.g. archived between request and verdict).
+        let workspace_id = self
+            .store
+            .lookup_workspace_for_artifact(artifact_id.as_str())
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "default".to_string());
         let event = FactoryEventKind::SynodicGateVerdict {
             gate_id: gate_id.to_string(),
             artifact_id,
@@ -89,6 +100,7 @@ impl Dispatcher {
         };
         self.store
             .append_ext(
+                &workspace_id,
                 gate_id,
                 "synodic",
                 event.event_type(),


### PR DESCRIPTION
## Summary

Closes #183.

Promote `workspace_id` from a JSONB hint inside `events_ext.data` to a real `NOT NULL` column with a `(workspace_id, id DESC)` covering index. The dashboard's `/api/spine/events?workspace=W` swaps its `data->>'workspace_id' = $1` predicate for `workspace_id = $1`, dropping the OR-on-LIKE artifact-JOIN workaround that #181 introduced.

Per ADR 0004 / project-review reaffirmation (#216 closed not-planned): bridges aren't a destination — schema, producers, and read-side filter all land in one PR. PR #232 was the predecessor that stamped the JSONB hint into stage event payloads; this PR replaces that hint with the real column and threads workspace_id through every emitter.

## Delivers (Plan items from #183)

- [x] **Migration**: `016_events_ext_workspace_id.sql` — 3-stage backfill (ADD nullable → UPDATE from JSONB or `'default'` → SET NOT NULL DEFAULT `'default'`) + `idx_events_ext_workspace_id` covering index. Renumbered from 015 to 016 to avoid collision with #234's migration on main.
- [x] **Producers updated** — every `append_ext` call site threads workspace_id:
  - Spine: `EventStore::append_ext` takes `workspace_id` as first arg; new `lookup_workspace_for_artifact` helper; `ExtensionEventRecord` gains the field; FromRow + every SELECT updated.
  - Forge: stage events use `workflow.workspace_id`; pipeline events resolve via `lookup_workspace_for_artifact`; `GateEmitter` / `SpineGateEmitter` thread workspace_id from the workflow into shaping + gate dispatches.
  - Stiglab: `SpineEmitter::emit` resolves via a new `artifact_id_for_workspace_lookup` helper covering every `FactoryEventKind` variant; `emit_raw` takes workspace_id explicitly.
  - Synodic: gate-verdict emit looks up the artifact's workspace.
  - Ising: `insight_emitted` / `rule_proposed` try the artifact lookup, fall back to `"default"` for non-artifact subjects.
  - Portal: handlers + backfill stamp the artifact's workspace; `PrArtifactRow` / `IssueArtifactRow` now carry it.
  - Refract: decomposed events resolve from the first produced artifact; intent / failed events fall back to `"default"`.
- [x] **Read-side swap**: `crates/stiglab/src/server/routes/spine.rs::list_events` now `WHERE workspace_id = $1`; the index covers it.
- [x] **Contract test**: `crates/stiglab/tests/spine_events_workspace_scoping.rs` — events for two workspaces under the same `stream_id` don't leak across the predicate. Plus a spine-level round-trip test pinning the column wiring through `append_ext` → `query_ext_stream` → `get_ext_event_by_id`.

## Out of scope

- `events` (factory event) table — this spec is `events_ext` only.
- FK to `workspaces(id)` — separate when `workspaces` lives definitively in spine vs. portal.
- Lint guarding workspace_id on other event types — column-level NOT NULL is the authoritative enforcement.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace --all-targets`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- lint-seams` — clean
- [x] `cargo run -p xtask -- check-api-contract` — clean
- [x] `cargo run -p xtask -- check-events` — clean
- [ ] CI postgres-gated tests (round-trip + workspace-scoping contract)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBy8W6xWSyaGntakpjg6N4)_