### PR TITLE
docs: add architecture overview + ADR index; modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,53 @@ AI factory stack — monorepo for the Onsager event bus and its subsystems.
 
 ## Architecture
 
-Onsager is a **factory event bus** architecture. Subsystems are runtime-decoupled
+Onsager is an **AI factory event bus**. Subsystems are runtime-decoupled
 via a shared PostgreSQL `events` / `events_ext` table + `pg_notify` channel.
 They coordinate through stigmergy (indirect signals via shared medium), not
 direct calls.
 
 ```
-         onsager-spine (event bus lib)
-        /       |        |        \
-   forge    stiglab   synodic    ising
+                       onsager-spine  (event bus library)
+                              │
+        ┌─────────┬───────────┼───────────┬──────────┬──────────┐
+        │         │           │           │          │          │
+     portal    forge       stiglab     synodic     ising     refract
+     (edge)                                                  (decomposer)
 ```
 
-Subsystems must NOT import each other and must NOT be statically linked into
-the same binary. The `onsager` dispatcher has zero business dependencies — it
-discovers subsystem binaries on `PATH`.
+The seam rule has two clauses (see [ADR 0004](docs/adr/0004-tighten-the-seams.md)):
+
+1. **External boundary.** HTTP routes exist only at external boundaries —
+   the dashboard API and external webhooks (GitHub, etc.). The external
+   boundary is owned by `portal` (the edge subsystem).
+2. **Internal coordination.** Factory subsystems (`forge`, `stiglab`,
+   `synodic`, `ising`, `refract`) coordinate **exclusively** via the spine —
+   no sibling-subsystem HTTP, no cross-subsystem Cargo deps. The `onsager`
+   dispatcher has zero business deps and discovers subsystem binaries on
+   `PATH`.
+
+Both clauses are mechanically enforced by `xtask lint-seams`,
+`xtask check-events`, and `xtask check-api-contract`.
+
+For the navigable map of how everything fits together, what's enforced,
+and what's still in flight, see [`docs/architecture.md`](docs/architecture.md)
+and the ADRs under [`docs/adr/`](docs/adr/).
 
 ## Subsystems
 
-| Crate           | Role                                                          |
-|-----------------|---------------------------------------------------------------|
-| `onsager-spine` | Shared event bus library (PostgreSQL + `pg_notify`)           |
-| `onsager`       | Unified CLI dispatcher (`onsager <subsystem> ...`)            |
-| `forge`         | Production line — drives artifacts through their lifecycle    |
-| `stiglab`       | Distributed AI agent session orchestration                    |
-| `synodic`       | AI agent governance (hooks + spine integration)               |
-| `ising`         | Continuous improvement engine — observes and surfaces insights|
-| `onsager-portal`| GitHub webhook ingress — verifies HMAC, materializes factory tasks, posts check-run verdicts |
+| Crate            | Role                                                                             |
+|------------------|----------------------------------------------------------------------------------|
+| `onsager-spine`  | Shared event bus library (PostgreSQL + `pg_notify`); SoT for shared workflow tables |
+| `onsager`        | Unified CLI dispatcher (`onsager <subsystem> ...`)                               |
+| `onsager-portal` | Edge subsystem — public HTTP, GitHub webhooks, OAuth, credentials                |
+| `forge`          | Production line — drives artifacts through their lifecycle                       |
+| `stiglab`        | Distributed AI agent session orchestration                                       |
+| `synodic`        | AI agent governance — gates, verdicts, escalations                               |
+| `ising`          | Continuous improvement — observes the spine and surfaces insights                |
+| `refract`        | Intent decomposer — expands a high-level intent into an artifact tree            |
+
+Library crates (`onsager-{artifact, warehouse, delivery, registry, github}`)
+are typed shared building blocks consumed by the subsystems above.
 
 A single React app at `apps/dashboard/` surfaces sessions, nodes, governance,
 and factory views.
@@ -114,12 +135,23 @@ Every open PR gets an ephemeral Railway deploy at
 See [`docs/preview-environments.md`](docs/preview-environments.md) for
 setup and troubleshooting.
 
-## Per-crate context
+## Documentation
+
+- [`docs/architecture.md`](docs/architecture.md) — top-level architecture
+  overview: subsystems, the seam rule, lever status, what's in flight.
+- [`docs/adr/`](docs/adr/) — architecture decision records (start with the
+  [index](docs/adr/README.md)).
+- [`docs/events.md`](docs/events.md) — event catalog (auto-generated from
+  `FactoryEventKind`; regenerate with `just gen-event-docs`).
+- [`docs/preview-environments.md`](docs/preview-environments.md) — per-PR
+  Railway previews.
 
 Each subsystem has its own `CLAUDE.md` or `.claude/` directory with
 subsystem-specific instructions:
 
 - `crates/onsager-spine/CLAUDE.md`
+- `crates/onsager-portal/CLAUDE.md`
+- `crates/onsager-registry/CLAUDE.md`
 - `crates/stiglab/.claude/`
 - `crates/synodic/.claude/`
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,21 @@ direct calls.
 The seam rule has two clauses (see [ADR 0004](docs/adr/0004-tighten-the-seams.md)):
 
 1. **External boundary.** HTTP routes exist only at external boundaries —
-   the dashboard API and external webhooks (GitHub, etc.). The external
-   boundary is owned by `portal` (the edge subsystem).
+   the dashboard API and external webhooks (GitHub, etc.). The 2026-04-30
+   amendment names `portal` (the edge subsystem) as clause 1's owner;
+   stiglab still hosts the bulk of the public HTTP today, and the
+   migration is staged under [#220](https://github.com/onsager-ai/onsager/issues/220) /
+   [#222](https://github.com/onsager-ai/onsager/issues/222).
 2. **Internal coordination.** Factory subsystems (`forge`, `stiglab`,
    `synodic`, `ising`, `refract`) coordinate **exclusively** via the spine —
    no sibling-subsystem HTTP, no cross-subsystem Cargo deps. The `onsager`
    dispatcher has zero business deps and discovers subsystem binaries on
    `PATH`.
 
-Both clauses are mechanically enforced by `xtask lint-seams`,
-`xtask check-events`, and `xtask check-api-contract`.
+Clause 2 is mechanically enforced today by `xtask lint-seams`,
+`xtask check-events`, and `xtask check-api-contract`. Clause 1's lint
+already permits portal HTTP; the migration that consolidates external
+routes into portal is in flight.
 
 For the navigable map of how everything fits together, what's enforced,
 and what's still in flight, see [`docs/architecture.md`](docs/architecture.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture decision records
+
+Onsager's architectural decisions live as numbered ADRs. Each ADR records
+the context, the decision, the rejected alternatives, and the consequences
+— and (per ADR 0002) the dev-process analog of the decision it records.
+
+For the navigable overview that ties these together with current status,
+see [`../architecture.md`](../architecture.md).
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-event-bus-coordination-model.md) | Event bus is the coordination medium (Option A) | Accepted (2026-04-19) — migration completed via ADR 0004 Lever C |
+| [0002](0002-process-product-isomorphism.md) | Process ↔ product isomorphism as design discipline | Accepted (2026-04-19, amended 2026-05-01) |
+| [0003](0003-deliverable-and-registry-backed-kinds.md) | Deliverable as the workflow-run output; registry-backed artifact kinds | Accepted (2026-04-22) — v1 partially landed under #100 |
+| [0004](0004-tighten-the-seams.md) | Tighten the seams: HTTP at external boundaries, spine for everything internal | Accepted (2026-04-26, amended 2026-04-30) — all six levers landed (2026-04-30) |
+
+## How to add an ADR
+
+1. Pick the next sequential number.
+2. Write `NNNN-short-slug.md` following the existing template:
+   Status / Date / Tracking issues / Context / Decision / Rejected alternatives /
+   Consequences / **Dev-process counterpart** (per ADR 0002) /
+   Adoption checklist / Out of scope.
+3. Link it from `CLAUDE.md` and from this index.
+4. If the ADR introduces an architectural invariant that should be enforced,
+   open a follow-up spec for the lint or contract test that makes it
+   machine-checkable (per ADR 0004's no-escape-hatch posture).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,290 @@
+# Onsager architecture
+
+A navigable map of how Onsager is built today, what shape it is moving toward,
+and which ADR or spec issue carries each decision. The canonical statements
+live in `CLAUDE.md` and the four ADRs under [`docs/adr/`](adr/) — this doc is
+the index that ties them together.
+
+If you are an AI session, the operational rules you need are in root
+`CLAUDE.md` and the per-subsystem `CLAUDE.md` files. Read this doc when you
+need the *why* behind a rule or want to see what's still in flight.
+
+## At a glance
+
+Onsager is an **AI factory event bus**. A shared PostgreSQL `events` /
+`events_ext` table plus `pg_notify` is the single coordination medium;
+subsystems coordinate through *stigmergy* (indirect signals via the shared
+medium), not direct calls. The `onsager` dispatcher is a ~100-line CLI with
+zero business deps that discovers subsystem binaries on `PATH`.
+
+```
+                       onsager-spine  (event bus library)
+                              │
+        ┌─────────┬───────────┼───────────┬──────────┬──────────┐
+        │         │           │           │          │          │
+     portal    forge       stiglab     synodic     ising     refract
+     (edge)                                                  (decomposer)
+```
+
+- **Edge subsystem:** `portal` — the only subsystem permitted to host public
+  HTTP routes (dashboard API, GitHub webhooks, OAuth, credentials).
+- **Factory subsystems:** `forge`, `stiglab`, `synodic`, `ising`, `refract` —
+  AI-native concerns. Coordinate exclusively via the spine.
+- **Library plane:** `onsager-{spine, artifact, warehouse, delivery, registry,
+  github}` — typed shared building blocks. No runtime of their own.
+
+The dashboard (`apps/dashboard/`) is a single React app surfacing every
+subsystem.
+
+## The two-clause seam rule
+
+The seam rule is the canonical architectural invariant. It has two clauses:
+
+> **Clause 1 — external boundary.**
+> HTTP APIs exist only at external boundaries: user-facing endpoints called
+> by the dashboard, and webhooks called by external services (GitHub, etc.).
+> The external HTTP boundary is owned by `portal` (the edge subsystem).
+>
+> **Clause 2 — internal coordination.**
+> Factory subsystems (`forge`, `stiglab`, `synodic`, `ising`, `refract`)
+> coordinate **exclusively** via the spine: events on the bus + reads against
+> shared spine tables. No subsystem makes HTTP calls to another subsystem.
+> No subsystem imports another subsystem's crate.
+
+Clause 2 is fully enforced (ADR 0004). Clause 1 is being concretized
+(spec [#220](https://github.com/onsager-ai/onsager/issues/220)) — see "In
+flight" below.
+
+## Architecture decision records
+
+| ADR | Decision | Status |
+|---|---|---|
+| [0001](adr/0001-event-bus-coordination-model.md) | Event bus is the coordination medium (stigmergy over sync RPC) | Accepted; migration complete via ADR 0004 Lever C |
+| [0002](adr/0002-process-product-isomorphism.md) | Process ↔ product isomorphism as design discipline | Accepted (amended 2026-05-01 to scope down the explicit five-primitive outer-loop programme) |
+| [0003](adr/0003-deliverable-and-registry-backed-kinds.md) | Deliverable as workflow-run output; registry-backed artifact kinds | Accepted; v1 landed (children #101–#105 partial) |
+| [0004](adr/0004-tighten-the-seams.md) | Tighten the seams: HTTP at external boundaries, spine for everything internal | Accepted; all six levers landed (2026-04-30) |
+
+[`docs/adr/README.md`](adr/README.md) carries one-line summaries for navigation.
+
+## Subsystems
+
+| Subsystem | Role | `CLAUDE.md` |
+|---|---|---|
+| [`portal`](../crates/onsager-portal/) | **Edge** — public HTTP, GitHub webhooks, OAuth, credentials, workflow CRUD (in-flight handover from stiglab) | [crates/onsager-portal/CLAUDE.md](../crates/onsager-portal/CLAUDE.md) |
+| [`forge`](../crates/forge/) | Production line — drives artifacts through their lifecycle; pure state machine over the spine | — |
+| [`stiglab`](../crates/stiglab/) | Distributed AI agent session orchestration; today still hosts most external HTTP | [crates/stiglab/.claude/](../crates/stiglab/.claude/) |
+| [`synodic`](../crates/synodic/) | AI agent governance (gates, verdicts, escalations) | [crates/synodic/.claude/](../crates/synodic/.claude/) |
+| [`ising`](../crates/ising/) | Continuous improvement — observes spine, surfaces insights, proposes rules | — |
+| [`refract`](../crates/refract/) | Intent decomposer — expands a high-level intent into an artifact tree | — |
+
+Library crates (no runtime; consumed by subsystems):
+
+| Crate | Role |
+|---|---|
+| [`onsager-spine`](../crates/onsager-spine/) | Event bus client: `EventStore`, `Listener`, `Namespace`, `FactoryEvent`. Single source of truth for events and shared workflow tables. |
+| [`onsager-artifact`](../crates/onsager-artifact/) | Domain value objects: `Artifact`, `ArtifactId`, `ArtifactVersionId`, `Kind`, lineage, quality. |
+| [`onsager-warehouse`](../crates/onsager-warehouse/) | Bundle sealing + `Warehouse` trait. |
+| [`onsager-delivery`](../crates/onsager-delivery/) | Consumer routing for sealed bundles. |
+| [`onsager-registry`](../crates/onsager-registry/) | Type registry, seed catalog, evaluators; SoT for artifact kinds (ADR 0003) and event manifest (ADR 0004 Lever E). |
+| [`onsager-github`](../crates/onsager-github/) | Typed GitHub API + webhook verification + OAuth; library plane (spec [#220](https://github.com/onsager-ai/onsager/issues/220) Sub-A landed). |
+| [`onsager`](../crates/onsager/) | Dispatcher CLI (~100 LOC, no business deps). |
+
+Subsystem ↔ support-crate dependencies (canonical):
+
+- `forge`   → `onsager-{artifact, warehouse, spine}` (DTOs in spine since #131 Lever C; no separate `protocol` crate)
+- `stiglab` → `onsager-{artifact, spine}`
+- `synodic` → `onsager-{artifact, spine}`
+- `ising`   → `onsager-{artifact, spine}`
+- `refract` → `onsager-{artifact, spine}`
+- `portal`  → `onsager-{artifact, spine, github, registry}` — never depends on a sibling subsystem
+
+## What's enforced, mechanically
+
+The seam rule is no longer review-time discipline. Three xtask lints
+hard-fail at CI and pre-push:
+
+| Lint | Catches |
+|---|---|
+| [`xtask lint-seams`](../xtask/src/lint_seams.rs) | Subsystem-to-subsystem Cargo deps; sibling-subsystem HTTP (well-known ports / `*_URL` env vars / `localhost:<port>` literals); new `serde(alias)`; new `*_mirror.rs`; legacy type aliases. |
+| [`xtask check-events`](../xtask/src/check_events.rs) | Coverage of [`crates/onsager-registry/src/events.rs`](../crates/onsager-registry/src/events.rs) (75 rows, one per `FactoryEventKind`); both-ends declared; emit-call-sites match producers; listener-call-sites match consumers. Producer-without-consumer hard-fails (PR [#229](https://github.com/onsager-ai/onsager/pull/229)). |
+| [`xtask check-api-contract`](../xtask/src/lint_api_contract.rs) | Every backend route has a dashboard caller (or an allowlisted external-only reason) and every dashboard call lands on a backend route. |
+
+The event manifest is exposed at `GET /api/registry/events` for runtime
+introspection, and the human-readable event catalog is regenerated from
+`FactoryEventKind` into [`docs/events.md`](events.md).
+
+## ADR 0004 lever status
+
+ADR 0004's six levers are the canonical project-wide checklist. As of
+2026-04-30 all six have landed.
+
+| Lever | What it does | Status |
+|---|---|---|
+| **A** — Persist the rule | Verbatim in root + subsystem `CLAUDE.md` and three skills (`issue-spec`, `onsager-pre-push`, `onsager-dev-process`) | Landed (PR [#144](https://github.com/onsager-ai/onsager/pull/144)) |
+| **B** — Mechanical guardrails | `lint-seams` arch-deps, sibling-subsystem HTTP, `serde(alias)`, `*_mirror.rs`, legacy type aliases | Landed (PR [#155](https://github.com/onsager-ai/onsager/pull/155)) |
+| **C** — Complete the ADR 0001 migration | Delete `HttpStiglabDispatcher` + `HttpSynodicGate`; coordinate via `forge.gate_requested` / `synodic.gate_verdict` and `forge.shaping_dispatched` / `stiglab.shaping_result_ready`; delete `onsager-protocol` | Landed (PR [#148](https://github.com/onsager-ai/onsager/pull/148)) |
+| **D** — Spine as SoT | Collapse `workspace_workflows` / `workspace_workflow_stages` into spine `workflows` / `workflow_stages`; remove `workflow_spine_mirror.rs` and `BundleId` alias | Landed (PR [#225](https://github.com/onsager-ai/onsager/pull/225), [#219](https://github.com/onsager-ai/onsager/pull/219)) |
+| **E** — Registry-backed event types | Static manifest in `crates/onsager-registry/src/events.rs`; CI enforces coverage and call-site agreement; manifest at `GET /api/registry/events` | Landed (PR [#227](https://github.com/onsager-ai/onsager/pull/227)) |
+| **F** — API/UI contract | `lint-api-contract` asserts every route has a caller and every call has a route | Landed (PR [#207](https://github.com/onsager-ai/onsager/pull/207)) |
+
+## Where we are now vs. where we want to be
+
+Active migrations the project is steering toward. Each links the ADR or spec
+that owns the target state.
+
+### Edge subsystem promotion — `onsager-portal` becomes clause-1's owner
+
+> Spec: [#220](https://github.com/onsager-ai/onsager/issues/220) (umbrella) /
+> [#222](https://github.com/onsager-ai/onsager/issues/222) (portal promotion) /
+> [#223](https://github.com/onsager-ai/onsager/issues/223) (feedback patterns)
+> · ADR 0004 amendment 2026-04-30
+
+**Now.** Portal exists and owns GitHub webhook ingest, the new
+`correlation_id` column, dispatch/await helpers, and the (foundational) edge
+posture. Stiglab still hosts most of the public HTTP — workflow CRUD,
+credential CRUD, OAuth callbacks, the preset registry — and is doing two
+jobs (agent-session execution *plus* edge).
+
+**Target.** Portal is a first-class peer of forge / stiglab / synodic /
+ising. The full public-HTTP surface lives in portal:
+`/api/webhooks/github`, `/api/workflows/*`, `/api/credentials/*`,
+`/api/installations/*`, `/api/workspaces/*`, `/auth/github/*`, preset
+registry. Stiglab shrinks to its real role — agent session orchestration —
+and `cargo build -p stiglab` no longer pulls in `axum`'s server feature.
+Schema split: `workspaces` / `workspace_members` / `projects` live in spine
+(landed via #161); `user_credentials` / `github_app_installations` /
+`user_pats` / `portal_webhook_secrets` live in portal.
+
+**Glue.** Portal coordinates with factory subsystems via the spine only:
+when portal needs stiglab to act (e.g. activate a workflow → flip state +
+dispatch), portal emits `workflow.activate_requested`; stiglab consumes.
+The ≤2s synchronous-wait + 202+SSE feedback contract is owned by #223 and
+rides on Lever E's manifest.
+
+### Open-schema artifact kinds — ADR 0003 wave-2
+
+> Spec: [#100](https://github.com/onsager-ai/onsager/issues/100) (umbrella) ·
+> ADR [0003](adr/0003-deliverable-and-registry-backed-kinds.md)
+
+**Now.** `Deliverable`, `DeliverableId`, `WorkflowRunId`, `KindId` exist;
+`DeliverableCreated` / `DeliverableUpdated` events are on the bus; the
+dashboard reads kinds from the registry; the seed-catalog `Spec` kind is
+renamed `Issue`; `BundleId` is renamed `ArtifactVersionId` and the alias
+is gone. Parts of #101 + #102 + #105 are landed.
+
+**Target.** Per-kind merge rules (`Overwrite` / `MergeByKey` / `Append` /
+`DeepMerge`) on `TypeDefinition` so gates emit partial updates that fold
+deterministically into the Deliverable; PR consolidated as a rich artifact
+with intrinsic `commits` / `checks` / `reviews` / `merged` and a
+referential `closes_issue` link; the dashboard's flow strip splits cleanly
+from the Deliverable panel; `Deployment` and `Session` registered as
+first-class kinds.
+
+**Open children.** [#102](https://github.com/onsager-ai/onsager/issues/102)
+(merge rules) · [#103](https://github.com/onsager-ai/onsager/issues/103)
+(PR consolidation) · [#104](https://github.com/onsager-ai/onsager/issues/104)
+(WorkflowRun / Deliverable split) ·
+[#105](https://github.com/onsager-ai/onsager/issues/105) (Deployment +
+Session kinds).
+
+### Reference-only external artifacts
+
+> Spec: [#170](https://github.com/onsager-ai/onsager/issues/170) (mechanism) /
+> [#171](https://github.com/onsager-ai/onsager/issues/171) (Kind::PullRequest
+> migration)
+
+**Now.** External items (PRs, issues) are projected into Onsager's artifact
+tables with full state copies, which means Onsager's row drifts from
+GitHub's row whenever GitHub changes out-of-band — the
+*divergent-state-shapes-from-multiple-write-paths* drift pattern.
+
+**Target.** A reference-only artifact kind that stores `(provider, ref)`
+and reads through to the source of truth on demand, eliminating the local
+shadow row. `Kind::PullRequest` becomes the first reference-only kind.
+
+### Trigger taxonomy v2
+
+> Spec: [#236](https://github.com/onsager-ai/onsager/issues/236) (umbrella) /
+> [#237](https://github.com/onsager-ai/onsager/issues/237) (foundation:
+> unify `TriggerKind` / `TriggerSpec`, registry-backed)
+
+**Now.** Trigger kinds live in two divergent types (`stiglab::TriggerKind`
+kebab-case, no params; `forge::TriggerSpec` snake_case, carries
+`{repo, label}`). `workflows.trigger_kind` is locked to a single value via
+a `CHECK` constraint, and the dashboard hardcodes `'github-issue-webhook'`
+in four places. The internal-symmetry defect from `CLAUDE.md`.
+
+**Target.** Single `TriggerKind` in `onsager-spine`, registry-backed, with
+v2 categories: schedule / event / request / manual. Per-kind config rides
+in `workflows.trigger_config` JSONB. Adding a new trigger kind becomes a
+registry add, not a cross-subsystem refactor.
+
+### Internal-aesthetic / interior cleanup
+
+> Spec: [#153](https://github.com/onsager-ai/onsager/issues/153)
+> (internal-aesthetic refactor) /
+> [#218](https://github.com/onsager-ai/onsager/issues/218)
+> (synodic orchestration TODOs)
+
+**Now.** A handful of large modules and dangling-wire patterns survive
+inside subsystems — the kind of asymmetry the *internal aesthetic* section
+of `CLAUDE.md` calls out (files >~500 LOC, equivalent concepts under
+different names, `#[allow(dead_code)]` "for later"). Several have been
+addressed in PRs [#212](https://github.com/onsager-ai/onsager/pull/212),
+[#213](https://github.com/onsager-ai/onsager/pull/213), [#231](https://github.com/onsager-ai/onsager/pull/231).
+
+**Target.** Interior parity with the seam rule — symmetric naming across
+subsystems where two things are the same concept; no `#[allow(dead_code)]`
+without an open consumer ticket; no module mixing unrelated concerns.
+
+## Drift patterns the architecture is designed against
+
+`CLAUDE.md` lists six drift patterns that recur in PRs. They are now caught
+mechanically by the lints above; the list below is the glossary of failure
+modes those checks were designed against.
+
+1. **Parallel schemas across subsystems** (e.g. former
+   `workspace_workflows` ↔ spine `workflows`). Resolved by Lever D; future
+   shared concepts collapse into the spine table with a discriminator.
+2. **Producer with no consumer** (PR #127). Caught by `check-events`.
+3. **In-memory caches drifting from the bus** (PR #123). Default to spine
+   reads; cache only with an explicit invalidation tied to a spine event.
+4. **Half-wired API/UI contracts** (PR #108). Caught by `check-api-contract`.
+5. **Divergent shapes from multiple write paths** (PR #122). Either both
+   paths produce the same shape, or the read side is defensive in one
+   named place — never at every call site.
+6. **Compat aliases that ossify** (PR #107: `BundleId` → `ArtifactVersionId`
+   "for one release"). Hard-failed by `lint-seams`.
+
+The seam rule and the six lints are operational projections of the
+*internal aesthetic* value stated in `CLAUDE.md`: care about the inside the
+same way you'd care about the outside.
+
+## Process ↔ product isomorphism
+
+Per ADR [0002](adr/0002-process-product-isomorphism.md): every factory
+primitive ships with its dev-process counterpart enabled, and every durable
+dev-process pattern is filed as evidence for a future primitive. The
+two-loop framing — *inner loop* (spec → PR → merge), *outer loop* (observe
+drift → propose rule → activate rule → modify inner loop) — describes how
+the system operates today.
+
+The 2026-05-01 amendment scoped down the explicit five-primitive outer-loop
+programme (#35 / #36 / #37 / #38 / #39); the dev-process surfaces those
+primitives would have automated (umbrella trackers, manual tracker refresh,
+skills + CLAUDE.md, weekly comments, `claude/*` session tokens) continue to
+fulfil their roles. The principle and the "Dev-process counterpart" section
+in ADR / skill templates remain.
+
+## Pointers
+
+- Event vocabulary: [`docs/events.md`](events.md) — auto-generated from
+  `FactoryEventKind`; regenerate with `just gen-event-docs`.
+- API surface: [`crates/stiglab/src/server/`](../crates/stiglab/src/server/)
+  (today) → [`crates/onsager-portal/src/server/`](../crates/onsager-portal/src/)
+  (target).
+- Preview environments: [`docs/preview-environments.md`](preview-environments.md).
+- Worktree-based parallel dev environments: see `just worktree-new` (root
+  `CLAUDE.md` § Parallel dev environments).
+- Per-subsystem operational notes: `crates/<subsystem>/CLAUDE.md` or
+  `crates/<subsystem>/.claude/`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,11 +139,13 @@ that owns the target state.
 > [#223](https://github.com/onsager-ai/onsager/issues/223) (feedback patterns)
 > · ADR 0004 amendment 2026-04-30
 
-**Now.** Portal exists and owns GitHub webhook ingest, the new
-`correlation_id` column, dispatch/await helpers, and the (foundational) edge
-posture. Stiglab still hosts most of the public HTTP — workflow CRUD,
-credential CRUD, OAuth callbacks, the preset registry — and is doing two
-jobs (agent-session execution *plus* edge).
+**Now.** Portal exists, hosts the legacy `/webhooks/github` receiver and
+the (foundational) edge posture, and has landed the new `correlation_id`
+column plus dispatch/await helpers (PR [#228](https://github.com/onsager-ai/onsager/pull/228)).
+Stiglab still hosts the bulk of the public HTTP — the workflow-runtime
+webhook receiver at `/api/webhooks/github`, workflow CRUD, credential CRUD,
+OAuth callbacks, the preset registry — and is doing two jobs
+(agent-session execution *plus* edge).
 
 **Target.** Portal is a first-class peer of forge / stiglab / synodic /
 ising. The full public-HTTP surface lives in portal:
@@ -193,14 +195,18 @@ Session kinds).
 > [#171](https://github.com/onsager-ai/onsager/issues/171) (Kind::PullRequest
 > migration)
 
-**Now.** External items (PRs, issues) are projected into Onsager's artifact
-tables with full state copies, which means Onsager's row drifts from
-GitHub's row whenever GitHub changes out-of-band — the
-*divergent-state-shapes-from-multiple-write-paths* drift pattern.
+**Now.** The mechanism is in: spine migration
+[`011_artifacts_external_ref_only.sql`](../crates/onsager-spine/migrations/011_artifacts_external_ref_only.sql)
+makes `name` / `owner` nullable and adds `last_observed_at`; portal's
+`upsert_pr_artifact_ref` / `upsert_issue_artifact_ref` write reference-only
+skeleton rows for PRs and issues, and provider-authored fields are
+hydrated live through the portal proxy instead of being denormalized into
+the spine.
 
-**Target.** A reference-only artifact kind that stores `(provider, ref)`
-and reads through to the source of truth on demand, eliminating the local
-shadow row. `Kind::PullRequest` becomes the first reference-only kind.
+**Target.** Close out the migration: drop any remaining call sites that
+still write the legacy denormalized shape, retire the best-effort cached
+display path for stale rows, and generalize the pattern beyond GitHub
+(Linear, Slack, etc.). `#170` and `#171` track the remaining work.
 
 ### Trigger taxonomy v2
 
@@ -256,9 +262,10 @@ modes those checks were designed against.
 6. **Compat aliases that ossify** (PR #107: `BundleId` → `ArtifactVersionId`
    "for one release"). Hard-failed by `lint-seams`.
 
-The seam rule and the six lints are operational projections of the
-*internal aesthetic* value stated in `CLAUDE.md`: care about the inside the
-same way you'd care about the outside.
+The seam rule and the three lints (`lint-seams`, `check-events`,
+`check-api-contract`) are operational projections of the *internal
+aesthetic* value stated in `CLAUDE.md`: care about the inside the same way
+you'd care about the outside.
 
 ## Process ↔ product isomorphism
 


### PR DESCRIPTION
## Summary

Adds the missing top-level architecture doc and an ADR index so the four ADRs and the in-flight architectural specs are navigable from one place. Refreshes the README so its architecture section reflects the current state (ADR 0004's two-clause seam rule, portal as the edge subsystem, mechanical lints).

The new docs **reflect existing decisions** — they don't introduce new architecture. Every claim links back to its ADR, spec issue, or PR.

### What's added

- **`docs/architecture.md`** — navigable map of how the system is built today, structured as "where we are now vs. where we want to be":
  - Conceptual model (factory event bus + stigmergy + the seam rule's two clauses)
  - Subsystem table with current/target roles
  - ADR 0004 lever status (all six landed as of 2026-04-30)
  - In-flight migrations linked to specs: portal promotion (#220 / #222 / #223), open-schema kinds (#100 → #102/#103/#104/#105), reference-only artifacts (#170/#171), trigger taxonomy (#236/#237), interior cleanup (#153/#218)
  - The six drift patterns from `CLAUDE.md` rephrased as a glossary of failure modes the lints were designed against
  - Pointers to `docs/events.md`, `docs/preview-environments.md`, per-subsystem `CLAUDE.md` files
- **`docs/adr/README.md`** — lightweight index of the four ADRs with one-line statuses.
- **`README.md`** — architecture section now includes portal in the topology diagram, states the two-clause seam rule, references the xtask lints that enforce it, and links to the new architecture doc and ADR index. Adds a Documentation section.

### What's intentionally not included

- No new architecture decisions. The "where we want to be" content is pulled from existing ADRs and open spec bodies — adding ADR 0005 or rewriting any decision is out of scope for a doc-sync PR.
- No changes to per-subsystem `CLAUDE.md` files (they're already current; the new `docs/architecture.md` complements rather than duplicates them).

## Test plan

- [ ] Render check: GitHub renders the topology diagram (uses box-drawing chars, no Mermaid).
- [ ] Link check: every ADR link, spec issue link, and `crates/...` path resolves.
- [ ] CI green (no code changed; doc lints only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwyYRQY56SoR8YfXcLXodj)_