### PR TITLE
Add Codex-compatible symlinks for Claude prompts and skills

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/onsager-portal/AGENTS.md
+++ b/crates/onsager-portal/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/onsager-registry/AGENTS.md
+++ b/crates/onsager-registry/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/onsager-spine/AGENTS.md
+++ b/crates/onsager-spine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/stiglab/.codex/skills
+++ b/crates/stiglab/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/crates/stiglab/AGENTS.md
+++ b/crates/stiglab/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/synodic/AGENTS.md
+++ b/crates/synodic/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
### Motivation

- Allow Codex tooling to reuse existing Claude system prompts and skills without duplicating files by providing Codex-compatible entry points. 
- Keep repository agent documentation and skill sets DRY by making `AGENTS.md` reference existing `CLAUDE.md` files and by exposing `.codex/skills` that point at `.claude/skills`.

### Description

- Create `AGENTS.md` symlinks that point to `CLAUDE.md` in the repository root and in the crates: `crates/onsager-spine`, `crates/synodic`, `crates/stiglab`, `crates/onsager-portal`, and `crates/onsager-registry`.
- Add `.codex/skills` symlink at the repository root that points to `../.claude/skills` and add `crates/stiglab/.codex/skills` that points to `../.claude/skills` so Codex can discover existing skills under `.claude/skills`.
- All additions are symbolic links (mode `120000`) and do not duplicate the original `CLAUDE.md` or `.claude/skills` content.

### Testing

- Verified symlink creation and targets with `find . -maxdepth 3 \( -name AGENTS.md -o -path '*/.codex/skills' \) -print -exec ls -l {} \;` and the command completed successfully.
- Confirmed symlink resolution via `find . -path '*/.codex/skills' -print -exec readlink {} \;` and `readlink` outputs matched the intended `../.claude/skills` targets successfully.
- Inspected committed symlink contents with `git show HEAD:AGENTS.md` and `git show HEAD:.codex/skills` and observed the expected link targets, with all checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9656e23c083229a35851f2e5cdf00)