### PR TITLE
feat(portal): operational shell + portal_webhook_secrets migration

### DIFF
--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -50,8 +50,16 @@ promotion plan.
 Spec #222 promotes portal from a thin webhook+proxy service to a
 first-class edge subsystem. The migration is staged:
 
-- **Foundation (this work).** ADR 0004 amendment, `area:portal`
+- **Foundation (landed).** ADR 0004 amendment, `area:portal`
   label, root `CLAUDE.md` topology update, this file.
+- **Operational shell (landed).** Portal runs alongside the factory
+  subsystems via `just dev` on `:3002` (matches the `PORTAL_PORT`
+  default stiglab's transitional proxy expects). `just dev-portal`
+  starts it standalone. The `crates/onsager-portal/migrations/`
+  directory is live and applied at startup (alongside the legacy
+  inline `CREATE TABLE` calls that haven't been migrated to `.sql`
+  files yet); first table to land via the new path is
+  `portal_webhook_secrets` (open question 3 of #222).
 - **Routes (follow-ups).** Move `/api/webhooks/github`,
   `/api/workflows/*`, `/api/credentials/*`, `/api/installations/*`,
   `/api/workspaces/*`, `/auth/github/*`, and the preset registry
@@ -60,9 +68,9 @@ first-class edge subsystem. The migration is staged:
 - **Schema split (follow-ups).** `workspaces` /
   `workspace_members` / `projects` move into
   `crates/onsager-spine/migrations/`; `user_credentials`,
-  `github_app_installations`, `user_pats`,
-  `portal_webhook_secrets` move into
-  `crates/onsager-portal/migrations/`. Atomic per-PR per Lever B.
+  `github_app_installations`, `user_pats` move into
+  `crates/onsager-portal/migrations/` next to the
+  `portal_webhook_secrets` migration. Atomic per-PR per Lever B.
 
 While the migration is in flight, stiglab still hosts most of the
 external HTTP surface — that is the drift #222 closes, not a pattern

--- a/crates/onsager-portal/migrations/001_portal_webhook_secrets.sql
+++ b/crates/onsager-portal/migrations/001_portal_webhook_secrets.sql
@@ -1,0 +1,23 @@
+-- Portal-owned schema: per-workspace webhook signature secret for self-hosted
+-- PAT mode (spec #222 open question 3 / parent #220).
+--
+-- When portal creates a repo webhook on the user's behalf via a workspace PAT
+-- with `admin:repo_hook`, the webhook secret needs a stable, per-workspace
+-- store separate from the App-level `GITHUB_APP_WEBHOOK_SECRET` env var.
+--
+-- One row per workspace (matches the workspace ↔ install scope established by
+-- #161). Generated at install time; surfaced to the user once via the
+-- dashboard; only `secret_hash` is persisted thereafter.
+--
+-- `workspace_id` is intentionally TEXT without a foreign key to `workspaces`:
+-- the `workspaces` table currently lives in stiglab's runtime migrations
+-- (target: spine, per spec #222's schema split slice). Once the workspaces
+-- move into spine, this FK can be added in a follow-up migration without
+-- relaxing any constraint here.
+
+CREATE TABLE IF NOT EXISTS portal_webhook_secrets (
+    workspace_id TEXT        PRIMARY KEY,
+    secret_hash  TEXT        NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at TIMESTAMPTZ
+);

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -1,17 +1,32 @@
 //! Portal-owned migrations.
 //!
-//! Runs at server startup. The portal owns three tables:
+//! Runs at server startup. The portal owns:
 //!
 //! - `factory_tasks` — backlog rows materialized from spec-labeled issues.
 //! - `pr_gate_verdicts` — one row per `(pr_artifact_id, head_sha)` for gate
 //!   evaluation idempotency.
 //! - `pr_branch_links` — per-session branch hint, used to attach
 //!   `vertical_lineage` when the PR webhook arrives.
+//! - `portal_webhook_secrets` — per-workspace webhook signature secret for
+//!   self-hosted PAT mode (spec #222 / parent #220). Loaded from the
+//!   `migrations/` directory rather than inline DDL — the first portal-owned
+//!   table that lives in a versioned `.sql` file, setting the precedent for
+//!   the schema-split slices to follow.
 //!
-//! Tables managed elsewhere (tenants / projects / installations / events /
+//! Tables managed elsewhere (workspaces / projects / installations / events /
 //! events_ext / artifacts / vertical_lineage) are not touched here.
 
 use sqlx::postgres::PgPool;
+
+/// Versioned `.sql` files under `crates/onsager-portal/migrations/`.
+///
+/// Inlined at compile time so the binary stays self-contained — no
+/// `include_str!`-of-disk path at runtime, no shipping the directory next to
+/// the binary. Order matches filename order and is the apply order.
+const MIGRATIONS: &[(&str, &str)] = &[(
+    "001_portal_webhook_secrets",
+    include_str!("../migrations/001_portal_webhook_secrets.sql"),
+)];
 
 /// Apply all portal-owned table migrations. Idempotent — safe to call on
 /// every startup.
@@ -73,5 +88,36 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    for (name, sql) in MIGRATIONS {
+        tracing::debug!(migration = name, "portal: applying migration");
+        sqlx::raw_sql(sql)
+            .execute(pool)
+            .await
+            .map_err(|e| anyhow::anyhow!("portal migration {name} failed: {e}"))?;
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The migrations array stays in lock-step with the filesystem. If a new
+    /// `.sql` file is added under `migrations/` without being wired into
+    /// `MIGRATIONS`, the include_str! call site below would fail at compile
+    /// time — but the inverse (a `MIGRATIONS` entry pointing at a missing
+    /// file) is also a compile-time error, so this test just sanity-checks
+    /// the contents are non-empty and parseable as SQL identifiers.
+    #[test]
+    fn migrations_are_non_empty_and_named_consistently() {
+        assert!(!MIGRATIONS.is_empty(), "expected at least one migration");
+        for (name, sql) in MIGRATIONS {
+            assert!(
+                name.starts_with(char::is_numeric),
+                "name {name} should start with a digit"
+            );
+            assert!(!sql.trim().is_empty(), "migration {name} has empty body");
+        }
+    }
 }

--- a/justfile
+++ b/justfile
@@ -58,6 +58,11 @@ dev: dev-infra
     set -euo pipefail
     trap 'pids=$(jobs -p); [ -n "$pids" ] && kill $pids 2>/dev/null || true' EXIT
 
+    echo "==> Starting portal on :3002..."
+    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+    PORTAL_BIND="0.0.0.0:3002" \
+        cargo run -p onsager-portal -- serve &
+
     echo "==> Starting stiglab on :3000..."
     ONSAGER_DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
         cargo run -p stiglab -- server &
@@ -78,6 +83,7 @@ dev: dev-infra
     echo "  Dashboard:  http://localhost:5173"
     echo "  Stiglab:    http://localhost:3000"
     echo "  Synodic:    http://localhost:3001"
+    echo "  Portal:     http://localhost:3002"
     echo "  Forge:      http://localhost:3003"
     echo "  Postgres:   postgres://onsager:onsager@localhost:5432/onsager"
     echo ""
@@ -107,6 +113,11 @@ dev-forge:
 
 dev-ising:
     cargo run -p ising -- serve --database-url "${DATABASE_URL}"
+
+dev-portal port="3002":
+    DATABASE_URL="${DATABASE_URL:-postgres://onsager:onsager@localhost:5432/onsager}" \
+    PORTAL_BIND="0.0.0.0:{{port}}" \
+        cargo run -p onsager-portal -- serve
 
 dev-stiglab:
     cargo run -p stiglab -- server


### PR DESCRIPTION
## Summary

Foundational slice of [spec #222](https://github.com/onsager-ai/onsager/issues/222) (promote `onsager-portal` to a first-class edge subsystem). Lands the operational shell so portal actually runs alongside the factory subsystems, and opens the `crates/onsager-portal/migrations/` directory with the first portal-owned `.sql` migration. The route migrations and the rest of the schema split land in follow-up PRs (one route group per PR, atomic with the stiglab-side delete, per the spec's risk note).

## Delivers

Ticks these items from the spec's Plan:

- [x] **just dev orchestration: portal starts before stiglab** — `just dev` now starts portal on `:3002`, matching the `PORTAL_PORT` default that stiglab's transitional `routes/portal.rs` proxy already expects. Adds `just dev-portal [port]` standalone recipe.
- [x] Open question 3 — **`portal_webhook_secrets` table** for self-hosted PAT mode (per the spec author's resolution comment): `(workspace_id PK, secret_hash, created_at, last_used_at)`. Lives in the new `crates/onsager-portal/migrations/` directory and is loaded via `include_str!` + `sqlx::raw_sql` in `migrate.rs`.

`workspace_id` is intentionally TEXT without an FK while `workspaces` still lives in stiglab's runtime migrations — the FK can be added once #222's schema-split slice moves the workspaces table into spine.

## Out of scope (follow-ups under #222)

The spec author's comment explicitly contemplates splitting #222 into multiple atomic PRs ("If schedule pressure arrives, this spec splits into two PRs… both PRs land under this same spec"). The remaining slices, each best landed atomically per Lever B:

- **Route migrations** — `/api/webhooks/github`, `/api/workflows/*`, `/api/credentials/*`, `/api/installations/*`, `/api/workspaces/*`, `/auth/github/*`, preset registry. Each route group lands as its own PR (portal handler live + stiglab handler deleted in same PR).
- **Schema split** — `workspaces` / `workspace_members` / `projects` → spine; `user_credentials` / `github_app_installations` / `user_pats` → portal (next to `portal_webhook_secrets`).
- **`workflow_activation` decomposition** — GitHub side-effects → portal handler; state transition → spine intent (`workflow.activate_requested` / `workflow.deactivate_requested`) + stiglab listener. Adding the event variants without both producer and consumer wired would fail Lever E's "every event has a producer + consumer" check, so they ship with the workflow CRUD route migration.
- **Dashboard `api.ts` cutover** — atomic when portal's last route lands.

The ADR 0004 amendment, `area:portal` label, root-`CLAUDE.md` topology update, and `crates/onsager-portal/CLAUDE.md` were already in tree prior to this PR (foundation slice landed earlier with the spec).

## Test plan

- [x] `cargo build --workspace` with `RUSTFLAGS="-D warnings"`
- [x] `cargo test --workspace --lib` with `RUSTFLAGS="-D warnings"` (114 passed, including new `migrate::tests::migrations_are_non_empty_and_named_consistently`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- lint-seams` (clean — portal already permitted to host HTTP)
- [x] `cargo run -p xtask -- check-events` (clean, 75 events)
- [x] `cargo run -p xtask -- check-api-contract` (clean)
- [ ] Manual: `just dev` → portal logs "starting webhook server" on `:3002`, `psql -c '\d portal_webhook_secrets'` shows the new table

Part of #222

https://claude.ai/code/session_01XykcHCh1VqPAxa7bCMHDvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XykcHCh1VqPAxa7bCMHDvi)_