### PR TITLE
feat(triggers): schedule + event + manual CLI trigger categories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -696,7 +717,9 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "chrono-tz",
  "clap",
+ "cron",
  "onsager-artifact",
  "onsager-spine",
  "onsager-warehouse",
@@ -1674,6 +1697,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "onsager-trigger"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "onsager-registry",
+ "onsager-spine",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "onsager-warehouse"
 version = "0.1.0"
 dependencies = [
@@ -1788,6 +1828,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2361,6 +2419,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2996,7 +3060,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3701,6 +3765,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",
+    "crates/onsager-trigger",
     "crates/forge",
     "crates/ising",
     "crates/refract",
@@ -34,6 +35,8 @@ serde_json = "1"
 
 # Time and IDs
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
+cron = "0.15"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # Error handling

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -21,6 +21,8 @@ onsager-warehouse = { path = "../onsager-warehouse" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
+cron = { workspace = true }
 uuid = { workspace = true }
 ulid = { version = "1", features = ["serde"] }
 tokio = { workspace = true }

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -10,6 +10,7 @@ use onsager_artifact::Kind;
 use onsager_spine::EventStore;
 
 use crate::core::artifact_store::ArtifactStore;
+use crate::core::event_triggers;
 use crate::core::gate_verdict_listener;
 use crate::core::insight_cache::InsightCache;
 use crate::core::insight_listener;
@@ -17,6 +18,7 @@ use crate::core::kernel::BaselineKernel;
 use crate::core::pending::{PendingShapings, PendingVerdicts};
 use crate::core::persistence;
 use crate::core::pipeline::{ForgePipeline, PipelineEvent};
+use crate::core::scheduler;
 use crate::core::session_listener::{self, SessionCompleted, SessionCompletedHandler};
 use crate::core::shaping_result_listener;
 use crate::core::signal_cache::SignalCache;
@@ -417,6 +419,81 @@ pub fn run(database_url: &str, tick_ms: u64) {
             };
             if let Err(e) = trigger_subscriber::run(store, handler, None).await {
                 tracing::error!("forge: trigger subscriber exited: {e}");
+            }
+        });
+
+        // Spawn the schedule-trigger producer (#238). Ticks every 5s,
+        // emits `trigger.fired` for any active cron / delay / interval
+        // workflow whose next-fire-at has passed. The supervisor inside
+        // `scheduler::run` catches panics and restarts with backoff so a
+        // bug in the tick body cannot take down forge.
+        let scheduler_shared = shared.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = scheduler_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: scheduler disabled (no spine connection)");
+                return;
+            };
+            if let Err(e) = scheduler::run(store).await {
+                tracing::error!("forge: scheduler exited: {e}");
+            }
+        });
+
+        // Spawn the spine-event trigger listener (#239). Subscribes to
+        // every spine event, matches against active `SpineEvent`
+        // workflows, and re-emits `trigger.fired` for matches.
+        let event_shared = shared.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = event_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: event-trigger listener disabled (no spine connection)");
+                return;
+            };
+            if let Err(e) = event_triggers::run_spine_event_listener(store).await {
+                tracing::error!("forge: event-trigger listener exited: {e}");
+            }
+        });
+
+        // Spawn the pg_notify trigger listener (#239). LISTEN-s on every
+        // declared `PgNotify` channel; refreshes its channel set every
+        // 30s so newly-created workflows light up without a restart.
+        let pgn_shared = shared.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = pgn_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: pg_notify trigger listener disabled (no spine connection)");
+                return;
+            };
+            if let Err(e) = event_triggers::run_pg_notify_listener(store).await {
+                tracing::error!("forge: pg_notify trigger listener exited: {e}");
+            }
+        });
+
+        // Spawn the outbox-row trigger poller (#239). Polls every 2s
+        // (per #239 resolution); advances a per-workflow cursor in the
+        // `outbox_trigger_cursor` sidecar so a restart never replays
+        // already-fired rows.
+        let outbox_shared = shared.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = outbox_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: outbox poller disabled (no spine connection)");
+                return;
+            };
+            if let Err(e) = event_triggers::run_outbox_poller(store).await {
+                tracing::error!("forge: outbox poller exited: {e}");
             }
         });
 

--- a/crates/forge/src/core/event_triggers.rs
+++ b/crates/forge/src/core/event_triggers.rs
@@ -1,0 +1,646 @@
+//! Event-trigger producers (#239).
+//!
+//! Three sub-adapters that all terminate by emitting `TriggerFired` to the
+//! spine — same machinery as the GitHub-webhook flow, just with a different
+//! source:
+//!
+//! - [`run_spine_event_listener`] — listens for `FactoryEventKind` events on
+//!   the spine, matches them against active workflows whose trigger is
+//!   [`TriggerKind::SpineEvent`], evaluates the optional `JsonFilter`, and
+//!   re-emits `TriggerFired`.
+//! - [`run_pg_notify_listener`] — runs one `LISTEN <channel>` per active
+//!   [`TriggerKind::PgNotify`] workflow on a dedicated connection. Refreshes
+//!   the channel set every 30s so a newly-created workflow starts firing
+//!   without requiring a forge restart.
+//! - [`run_outbox_poller`] — polls outbox tables every 2s
+//!   (per #239 resolution), advancing a per-workflow cursor in the spine
+//!   `outbox_trigger_cursor` sidecar.
+//!
+//! ## Loop guard
+//!
+//! A workflow with `SpineEvent { event_kind: "trigger.fired" }` would
+//! self-amplify (every fire produces another `trigger.fired` event that the
+//! same workflow listens to). [`SELF_REFERENTIAL_EVENT_KIND`] flags the
+//! string; [`is_loop_amplifying_trigger`] is the runtime check. Stiglab's
+//! `workflow_db.rs::insert_workflow_with_stages` rejects it at create time.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use chrono::Utc;
+use serde_json::Value;
+use sqlx::postgres::PgListener;
+use sqlx::PgPool;
+use tokio::sync::Mutex;
+use tokio::time::interval;
+
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{
+    EventHandler, EventMetadata, EventNotification, EventStore, Listener, TriggerKind,
+};
+
+/// `event_kind` value that, if a `SpineEvent` workflow listened for it,
+/// would self-amplify (its own emission re-fires the same workflow).
+pub const SELF_REFERENTIAL_EVENT_KIND: &str = "trigger.fired";
+
+/// Default outbox poll interval (per #239 resolution: 2s, fixed).
+pub const OUTBOX_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Period to refresh the active set of `pg_notify` channels. New workflows
+/// take at most this long to start firing.
+pub const PG_NOTIFY_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Returns `true` when this trigger would create an amplification loop —
+/// today only `SpineEvent { event_kind: "trigger.fired" }`. Used by both
+/// the create-time check in stiglab's `workflow_db.rs` and the runtime
+/// safeguard in [`run_spine_event_listener`].
+pub fn is_loop_amplifying_trigger(trigger: &TriggerKind) -> bool {
+    matches!(
+        trigger,
+        TriggerKind::SpineEvent { event_kind, .. } if event_kind == SELF_REFERENTIAL_EVENT_KIND
+    )
+}
+
+// ---------------------------------------------------------------------------
+// SpineEvent trigger listener
+// ---------------------------------------------------------------------------
+
+/// Run the spine-event trigger listener. Subscribes to all spine events,
+/// matches each against active `SpineEvent` workflows, and emits
+/// `TriggerFired` for matches.
+pub async fn run_spine_event_listener(store: EventStore) -> anyhow::Result<()> {
+    let dispatcher = SpineEventDispatcher {
+        store: store.clone(),
+    };
+    Listener::new(store).run(dispatcher).await
+}
+
+struct SpineEventDispatcher {
+    store: EventStore,
+}
+
+#[async_trait]
+impl EventHandler for SpineEventDispatcher {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        // Skip our own emissions to break the basic loop. The
+        // create-time check rejects `SpineEvent { event_kind:
+        // "trigger.fired" }` outright; this is the runtime backstop.
+        if notification.event_type == SELF_REFERENTIAL_EVENT_KIND {
+            return Ok(());
+        }
+
+        let payload = match load_event_payload(&self.store, &notification).await {
+            Ok(Some(p)) => p,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                tracing::warn!(
+                    id = notification.id,
+                    "forge event-trigger: load failed: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        let candidates =
+            match load_spine_event_candidates(self.store.pool(), &notification.event_type).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        event_type = %notification.event_type,
+                        "forge event-trigger: candidate lookup failed: {e}"
+                    );
+                    return Ok(());
+                }
+            };
+
+        for candidate in candidates {
+            if is_loop_amplifying_trigger(&candidate.trigger) {
+                continue;
+            }
+            let TriggerKind::SpineEvent { ref filter, .. } = candidate.trigger else {
+                continue;
+            };
+            let matches = filter.as_ref().map(|f| f.matches(&payload)).unwrap_or(true);
+            if !matches {
+                continue;
+            }
+            if let Err(e) = emit_event_trigger_fired(
+                &self.store,
+                &candidate,
+                "spine_event",
+                serde_json::json!({
+                    "source_event_id": notification.id,
+                    "source_event_type": notification.event_type,
+                    "source_payload": payload,
+                }),
+            )
+            .await
+            {
+                tracing::warn!(
+                    workflow_id = %candidate.workflow_id,
+                    "forge event-trigger: emit failed: {e}"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn load_event_payload(
+    store: &EventStore,
+    notification: &EventNotification,
+) -> anyhow::Result<Option<Value>> {
+    match notification.table.as_str() {
+        "events" => match store.get_event_by_id(notification.id).await? {
+            Some(row) => {
+                // Strip the FactoryEvent wrapper if present.
+                if let Ok(env) = serde_json::from_value::<FactoryEvent>(row.data.clone()) {
+                    let kind_value = serde_json::to_value(env.event)?;
+                    Ok(Some(kind_value))
+                } else {
+                    Ok(Some(row.data))
+                }
+            }
+            None => Ok(None),
+        },
+        "events_ext" => match store.get_ext_event_by_id(notification.id).await? {
+            Some(row) => {
+                if let Ok(env) = serde_json::from_value::<FactoryEvent>(row.data.clone()) {
+                    let kind_value = serde_json::to_value(env.event)?;
+                    Ok(Some(kind_value))
+                } else {
+                    Ok(Some(row.data))
+                }
+            }
+            None => Ok(None),
+        },
+        _ => Ok(None),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Common: load active workflows by trigger kind
+// ---------------------------------------------------------------------------
+
+/// One active workflow that's a candidate for an event-trigger fire.
+#[derive(Debug, Clone)]
+pub struct EventTriggerCandidate {
+    pub workflow_id: String,
+    pub workspace_id: String,
+    pub trigger: TriggerKind,
+}
+
+async fn load_spine_event_candidates(
+    pool: &PgPool,
+    event_kind: &str,
+) -> anyhow::Result<Vec<EventTriggerCandidate>> {
+    let rows = sqlx::query(
+        "SELECT workflow_id, workspace_id, trigger_kind, trigger_config \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'spine_event' \
+            AND trigger_config ->> 'event_kind' = $1",
+    )
+    .bind(event_kind)
+    .fetch_all(pool)
+    .await
+    .context("loading spine_event candidates")?;
+    Ok(rows.into_iter().filter_map(row_to_candidate).collect())
+}
+
+async fn load_pg_notify_candidates(pool: &PgPool) -> anyhow::Result<Vec<EventTriggerCandidate>> {
+    let rows = sqlx::query(
+        "SELECT workflow_id, workspace_id, trigger_kind, trigger_config \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'pg_notify'",
+    )
+    .fetch_all(pool)
+    .await
+    .context("loading pg_notify candidates")?;
+    Ok(rows.into_iter().filter_map(row_to_candidate).collect())
+}
+
+async fn load_outbox_candidates(pool: &PgPool) -> anyhow::Result<Vec<EventTriggerCandidate>> {
+    let rows = sqlx::query(
+        "SELECT workflow_id, workspace_id, trigger_kind, trigger_config \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'outbox_row'",
+    )
+    .fetch_all(pool)
+    .await
+    .context("loading outbox_row candidates")?;
+    Ok(rows.into_iter().filter_map(row_to_candidate).collect())
+}
+
+fn row_to_candidate(row: sqlx::postgres::PgRow) -> Option<EventTriggerCandidate> {
+    use sqlx::Row;
+    let workflow_id: String = row.try_get("workflow_id").ok()?;
+    let workspace_id: String = row.try_get("workspace_id").ok()?;
+    let kind_tag: String = row.try_get("trigger_kind").ok()?;
+    let cfg: Value = row.try_get("trigger_config").ok()?;
+    let trigger = TriggerKind::from_storage(&kind_tag, &cfg).ok()?;
+    Some(EventTriggerCandidate {
+        workflow_id,
+        workspace_id,
+        trigger,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Common: emit a trigger.fired payload for an event-driven fire
+// ---------------------------------------------------------------------------
+
+async fn emit_event_trigger_fired(
+    store: &EventStore,
+    candidate: &EventTriggerCandidate,
+    source_kind: &str,
+    extra: Value,
+) -> anyhow::Result<()> {
+    let now = Utc::now();
+    let mut payload = serde_json::json!({
+        "trigger_kind": candidate.trigger.kind_tag(),
+        "workflow_id": candidate.workflow_id,
+        "workspace_id": candidate.workspace_id,
+        "fired_at": now,
+        "source": source_kind,
+    });
+    if let Value::Object(ref mut map) = payload {
+        if let Value::Object(extra_map) = extra {
+            for (k, v) in extra_map {
+                map.insert(k, v);
+            }
+        }
+    }
+
+    let envelope = FactoryEvent {
+        event: FactoryEventKind::TriggerFired {
+            workflow_id: candidate.workflow_id.clone(),
+            trigger_kind: candidate.trigger.kind_tag().to_string(),
+            payload,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: format!("forge_{source_kind}"),
+        timestamp: now,
+    };
+    let data = serde_json::to_value(&envelope)?;
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: format!("forge_{source_kind}"),
+    };
+    store
+        .append_ext(
+            &candidate.workspace_id,
+            &format!("workflow:{}", candidate.workflow_id),
+            "workflow",
+            "trigger.fired",
+            data,
+            &metadata,
+            None,
+        )
+        .await
+        .context("emitting trigger.fired")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// PgNotify trigger listener
+// ---------------------------------------------------------------------------
+
+/// Run the pg_notify trigger listener. Maintains one `LISTEN <channel>`
+/// per active `PgNotify` workflow on a dedicated connection; refreshes the
+/// channel set every [`PG_NOTIFY_REFRESH_INTERVAL`].
+pub async fn run_pg_notify_listener(store: EventStore) -> anyhow::Result<()> {
+    let mut listener = PgListener::connect_with(store.pool()).await?;
+    let listened: Arc<Mutex<std::collections::HashSet<String>>> =
+        Arc::new(Mutex::new(std::collections::HashSet::new()));
+
+    // Periodic refresher: discovers new channels, drops removed ones.
+    let store_for_refresh = store.clone();
+    let listened_for_refresh = listened.clone();
+    let mut refresh = interval(PG_NOTIFY_REFRESH_INTERVAL);
+
+    refresh_pg_notify_channels(&mut listener, &store_for_refresh, &listened_for_refresh).await?;
+
+    loop {
+        tokio::select! {
+            _ = refresh.tick() => {
+                if let Err(e) = refresh_pg_notify_channels(
+                    &mut listener,
+                    &store_for_refresh,
+                    &listened_for_refresh,
+                )
+                .await
+                {
+                    tracing::warn!("forge pg_notify trigger: refresh failed: {e}");
+                }
+            }
+            res = listener.recv() => {
+                match res {
+                    Ok(notif) => {
+                        let payload_json: Value = serde_json::from_str(notif.payload())
+                            .unwrap_or_else(|_| Value::String(notif.payload().to_string()));
+                        if let Err(e) = handle_pg_notify(
+                            &store,
+                            notif.channel(),
+                            &payload_json,
+                        ).await
+                        {
+                            tracing::warn!(
+                                channel = %notif.channel(),
+                                "forge pg_notify trigger: dispatch failed: {e}"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("forge pg_notify trigger: listener error: {e}");
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn refresh_pg_notify_channels(
+    listener: &mut PgListener,
+    store: &EventStore,
+    listened: &Arc<Mutex<std::collections::HashSet<String>>>,
+) -> anyhow::Result<()> {
+    let candidates = load_pg_notify_candidates(store.pool()).await?;
+    let mut wanted: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for c in &candidates {
+        if let TriggerKind::PgNotify { channel, .. } = &c.trigger {
+            if is_safe_channel_name(channel) {
+                wanted.insert(channel.clone());
+            } else {
+                tracing::warn!(
+                    workflow_id = %c.workflow_id,
+                    channel = %channel,
+                    "forge pg_notify trigger: skipping unsafe channel name"
+                );
+            }
+        }
+    }
+
+    let mut current = listened.lock().await;
+    let to_listen: Vec<String> = wanted.difference(&current).cloned().collect();
+    let to_unlisten: Vec<String> = current.difference(&wanted).cloned().collect();
+
+    for ch in &to_listen {
+        if let Err(e) = listener.listen(ch).await {
+            tracing::warn!(channel = %ch, "forge pg_notify trigger: LISTEN failed: {e}");
+        } else {
+            current.insert(ch.clone());
+        }
+    }
+    for ch in &to_unlisten {
+        if let Err(e) = listener.unlisten(ch).await {
+            tracing::warn!(channel = %ch, "forge pg_notify trigger: UNLISTEN failed: {e}");
+        } else {
+            current.remove(ch);
+        }
+    }
+    Ok(())
+}
+
+/// Allow only conservative channel names — a-z, A-Z, 0-9, `_` — to keep
+/// `LISTEN <channel>` from being a SQL injection surface. `PgListener::listen`
+/// quotes the identifier, but we narrow further as defense in depth.
+fn is_safe_channel_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 63
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+async fn handle_pg_notify(
+    store: &EventStore,
+    channel: &str,
+    payload: &Value,
+) -> anyhow::Result<()> {
+    let candidates = load_pg_notify_candidates(store.pool()).await?;
+    for c in candidates {
+        let TriggerKind::PgNotify {
+            channel: ch,
+            filter,
+        } = &c.trigger
+        else {
+            continue;
+        };
+        if ch != channel {
+            continue;
+        }
+        let matches = filter.as_ref().map(|f| f.matches(payload)).unwrap_or(true);
+        if !matches {
+            continue;
+        }
+        emit_event_trigger_fired(
+            store,
+            &c,
+            "pg_notify",
+            serde_json::json!({ "channel": channel, "payload": payload }),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// OutboxRow trigger poller
+// ---------------------------------------------------------------------------
+
+/// Run the outbox-row trigger poller. Polls every
+/// [`OUTBOX_POLL_INTERVAL`]; for each active `OutboxRow` workflow, queries
+/// `<table>` for rows with `id > last_seen_id` matching `where_clause`,
+/// emits `TriggerFired` for each, and advances the cursor in
+/// `outbox_trigger_cursor`.
+pub async fn run_outbox_poller(store: EventStore) -> anyhow::Result<()> {
+    let mut tick = interval(OUTBOX_POLL_INTERVAL);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tick.tick().await;
+        if let Err(e) = run_outbox_poll_once(&store).await {
+            tracing::warn!("forge outbox poller: tick failed: {e}");
+        }
+    }
+}
+
+async fn run_outbox_poll_once(store: &EventStore) -> anyhow::Result<()> {
+    let candidates = load_outbox_candidates(store.pool()).await?;
+    for c in candidates {
+        if let Err(e) = poll_outbox_for_workflow(store, &c).await {
+            tracing::warn!(
+                workflow_id = %c.workflow_id,
+                "forge outbox poller: workflow poll failed: {e}"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn poll_outbox_for_workflow(
+    store: &EventStore,
+    candidate: &EventTriggerCandidate,
+) -> anyhow::Result<()> {
+    let TriggerKind::OutboxRow {
+        table,
+        where_clause,
+    } = &candidate.trigger
+    else {
+        return Ok(());
+    };
+
+    if !is_safe_identifier(table) {
+        anyhow::bail!("outbox table `{table}` is not a safe identifier");
+    }
+    if !is_safe_where_clause(where_clause) {
+        anyhow::bail!("outbox where_clause contains unsafe characters");
+    }
+
+    let pool = store.pool();
+    let cursor: i64 =
+        sqlx::query_scalar("SELECT last_seen_id FROM outbox_trigger_cursor WHERE workflow_id = $1")
+            .bind(&candidate.workflow_id)
+            .fetch_optional(pool)
+            .await?
+            .unwrap_or(0);
+
+    // Bounded batch — a long-stalled cursor with millions of rows shouldn't
+    // produce a single multi-megabyte payload burst.
+    let where_filter = if where_clause.trim().is_empty() {
+        String::new()
+    } else {
+        format!("AND ({where_clause})")
+    };
+    let sql = format!(
+        "SELECT id, row_to_json({table}.*) AS payload \
+           FROM {table} \
+          WHERE id > $1 {where_filter} \
+          ORDER BY id ASC LIMIT 100"
+    );
+    let rows: Vec<(i64, Value)> = sqlx::query_as(&sql).bind(cursor).fetch_all(pool).await?;
+
+    let mut new_cursor = cursor;
+    for (id, payload) in &rows {
+        emit_event_trigger_fired(
+            store,
+            candidate,
+            "outbox_row",
+            serde_json::json!({
+                "table": table,
+                "row_id": id,
+                "row": payload,
+            }),
+        )
+        .await?;
+        if *id > new_cursor {
+            new_cursor = *id;
+        }
+    }
+
+    if new_cursor > cursor {
+        sqlx::query(
+            "INSERT INTO outbox_trigger_cursor (workflow_id, last_seen_id, last_seen_at) \
+             VALUES ($1, $2, $3) \
+             ON CONFLICT (workflow_id) DO UPDATE \
+                SET last_seen_id = EXCLUDED.last_seen_id, \
+                    last_seen_at = EXCLUDED.last_seen_at",
+        )
+        .bind(&candidate.workflow_id)
+        .bind(new_cursor)
+        .bind(Utc::now())
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Strict identifier check: matches the conservative subset Postgres
+/// regular-identifier rules accept — ASCII letter / underscore start,
+/// followed by ASCII letters / digits / underscores. Length capped at 63
+/// (Postgres's `NAMEDATALEN-1`). Schema-qualified names are allowed:
+/// `schema.table` is two identifiers separated by a single dot.
+fn is_safe_identifier(s: &str) -> bool {
+    if s.is_empty() || s.len() > 127 {
+        return false;
+    }
+    s.split('.').all(|part| {
+        let mut chars = part.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+            _ => return false,
+        }
+        chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }) && s.len() <= 127
+}
+
+/// Reject WHERE-clause text that contains semicolons or comment markers.
+/// A real query parser is out of scope for v1; this catches the obvious
+/// injection shapes. Workflow authors are still expected to write trusted
+/// SQL — outbox triggers are an admin-grade primitive.
+fn is_safe_where_clause(s: &str) -> bool {
+    !s.contains(';') && !s.contains("--") && !s.contains("/*") && !s.contains("*/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_amplifying_trigger_flags_self_referential_spine_event() {
+        let bad = TriggerKind::SpineEvent {
+            event_kind: "trigger.fired".into(),
+            filter: None,
+        };
+        assert!(is_loop_amplifying_trigger(&bad));
+    }
+
+    #[test]
+    fn loop_amplifying_trigger_passes_other_kinds() {
+        let ok = TriggerKind::SpineEvent {
+            event_kind: "forge.shaping_dispatched".into(),
+            filter: None,
+        };
+        assert!(!is_loop_amplifying_trigger(&ok));
+
+        let github = TriggerKind::GithubIssueWebhook {
+            repo: "a/b".into(),
+            label: "x".into(),
+        };
+        assert!(!is_loop_amplifying_trigger(&github));
+    }
+
+    #[test]
+    fn safe_channel_names_pass() {
+        assert!(is_safe_channel_name("factory_signal"));
+        assert!(is_safe_channel_name("channel_42"));
+        assert!(!is_safe_channel_name(""));
+        assert!(!is_safe_channel_name("ch;DROP"));
+        assert!(!is_safe_channel_name("ch with space"));
+        assert!(!is_safe_channel_name(&"x".repeat(64)));
+    }
+
+    #[test]
+    fn safe_identifier_rules() {
+        assert!(is_safe_identifier("artifact_outbox"));
+        assert!(is_safe_identifier("my_schema.outbox"));
+        assert!(!is_safe_identifier(""));
+        assert!(!is_safe_identifier("9_starts_with_digit"));
+        assert!(!is_safe_identifier("table; DROP"));
+        assert!(!is_safe_identifier("table--comment"));
+    }
+
+    #[test]
+    fn safe_where_clause_rules() {
+        assert!(is_safe_where_clause("status = 'sealed'"));
+        assert!(is_safe_where_clause(""));
+        assert!(!is_safe_where_clause("1=1; DROP TABLE"));
+        assert!(!is_safe_where_clause("x -- comment"));
+        assert!(!is_safe_where_clause("/* nope */ 1=1"));
+    }
+}

--- a/crates/forge/src/core/event_triggers.rs
+++ b/crates/forge/src/core/event_triggers.rs
@@ -312,6 +312,11 @@ async fn emit_event_trigger_fired(
 // PgNotify trigger listener
 // ---------------------------------------------------------------------------
 
+/// Cache of `PgNotify` workflows keyed by channel name. Refreshed on the
+/// same cadence as the LISTEN set, then read directly in the recv path so a
+/// burst of notifications doesn't trigger one DB lookup per message.
+type PgNotifyCache = Arc<Mutex<std::collections::HashMap<String, Vec<EventTriggerCandidate>>>>;
+
 /// Run the pg_notify trigger listener. Maintains one `LISTEN <channel>`
 /// per active `PgNotify` workflow on a dedicated connection; refreshes the
 /// channel set every [`PG_NOTIFY_REFRESH_INTERVAL`].
@@ -319,21 +324,20 @@ pub async fn run_pg_notify_listener(store: EventStore) -> anyhow::Result<()> {
     let mut listener = PgListener::connect_with(store.pool()).await?;
     let listened: Arc<Mutex<std::collections::HashSet<String>>> =
         Arc::new(Mutex::new(std::collections::HashSet::new()));
+    let cache: PgNotifyCache = Arc::new(Mutex::new(std::collections::HashMap::new()));
 
-    // Periodic refresher: discovers new channels, drops removed ones.
-    let store_for_refresh = store.clone();
-    let listened_for_refresh = listened.clone();
     let mut refresh = interval(PG_NOTIFY_REFRESH_INTERVAL);
 
-    refresh_pg_notify_channels(&mut listener, &store_for_refresh, &listened_for_refresh).await?;
+    refresh_pg_notify_channels(&mut listener, &store, &listened, &cache).await?;
 
     loop {
         tokio::select! {
             _ = refresh.tick() => {
                 if let Err(e) = refresh_pg_notify_channels(
                     &mut listener,
-                    &store_for_refresh,
-                    &listened_for_refresh,
+                    &store,
+                    &listened,
+                    &cache,
                 )
                 .await
                 {
@@ -347,6 +351,7 @@ pub async fn run_pg_notify_listener(store: EventStore) -> anyhow::Result<()> {
                             .unwrap_or_else(|_| Value::String(notif.payload().to_string()));
                         if let Err(e) = handle_pg_notify(
                             &store,
+                            &cache,
                             notif.channel(),
                             &payload_json,
                         ).await
@@ -371,13 +376,20 @@ async fn refresh_pg_notify_channels(
     listener: &mut PgListener,
     store: &EventStore,
     listened: &Arc<Mutex<std::collections::HashSet<String>>>,
+    cache: &PgNotifyCache,
 ) -> anyhow::Result<()> {
     let candidates = load_pg_notify_candidates(store.pool()).await?;
     let mut wanted: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut new_cache: std::collections::HashMap<String, Vec<EventTriggerCandidate>> =
+        std::collections::HashMap::new();
     for c in &candidates {
         if let TriggerKind::PgNotify { channel, .. } = &c.trigger {
             if is_safe_channel_name(channel) {
                 wanted.insert(channel.clone());
+                new_cache
+                    .entry(channel.clone())
+                    .or_default()
+                    .push(c.clone());
             } else {
                 tracing::warn!(
                     workflow_id = %c.workflow_id,
@@ -388,24 +400,30 @@ async fn refresh_pg_notify_channels(
         }
     }
 
-    let mut current = listened.lock().await;
-    let to_listen: Vec<String> = wanted.difference(&current).cloned().collect();
-    let to_unlisten: Vec<String> = current.difference(&wanted).cloned().collect();
+    {
+        let mut current = listened.lock().await;
+        let to_listen: Vec<String> = wanted.difference(&current).cloned().collect();
+        let to_unlisten: Vec<String> = current.difference(&wanted).cloned().collect();
 
-    for ch in &to_listen {
-        if let Err(e) = listener.listen(ch).await {
-            tracing::warn!(channel = %ch, "forge pg_notify trigger: LISTEN failed: {e}");
-        } else {
-            current.insert(ch.clone());
+        for ch in &to_listen {
+            if let Err(e) = listener.listen(ch).await {
+                tracing::warn!(channel = %ch, "forge pg_notify trigger: LISTEN failed: {e}");
+            } else {
+                current.insert(ch.clone());
+            }
+        }
+        for ch in &to_unlisten {
+            if let Err(e) = listener.unlisten(ch).await {
+                tracing::warn!(channel = %ch, "forge pg_notify trigger: UNLISTEN failed: {e}");
+            } else {
+                current.remove(ch);
+            }
         }
     }
-    for ch in &to_unlisten {
-        if let Err(e) = listener.unlisten(ch).await {
-            tracing::warn!(channel = %ch, "forge pg_notify trigger: UNLISTEN failed: {e}");
-        } else {
-            current.remove(ch);
-        }
-    }
+
+    // Replace the cache atomically — recv-path lookups see a consistent
+    // (channel → candidates) snapshot.
+    *cache.lock().await = new_cache;
     Ok(())
 }
 
@@ -420,21 +438,23 @@ fn is_safe_channel_name(name: &str) -> bool {
 
 async fn handle_pg_notify(
     store: &EventStore,
+    cache: &PgNotifyCache,
     channel: &str,
     payload: &Value,
 ) -> anyhow::Result<()> {
-    let candidates = load_pg_notify_candidates(store.pool()).await?;
+    // Read the channel → candidates map from cache instead of re-querying
+    // for every NOTIFY. The cache is refreshed every
+    // `PG_NOTIFY_REFRESH_INTERVAL`, so a freshly-created workflow takes at
+    // most that long to start firing — same window as the LISTEN
+    // discovery itself.
+    let candidates: Vec<EventTriggerCandidate> = {
+        let map = cache.lock().await;
+        map.get(channel).cloned().unwrap_or_default()
+    };
     for c in candidates {
-        let TriggerKind::PgNotify {
-            channel: ch,
-            filter,
-        } = &c.trigger
-        else {
+        let TriggerKind::PgNotify { filter, .. } = &c.trigger else {
             continue;
         };
-        if ch != channel {
-            continue;
-        }
         let matches = filter.as_ref().map(|f| f.matches(payload)).unwrap_or(true);
         if !matches {
             continue;
@@ -525,8 +545,12 @@ async fn poll_outbox_for_workflow(
     );
     let rows: Vec<(i64, Value)> = sqlx::query_as(&sql).bind(cursor).fetch_all(pool).await?;
 
-    let mut new_cursor = cursor;
+    // Advance the cursor *before* emitting each row so a crash mid-batch
+    // drops at most one fire instead of replaying the whole already-emitted
+    // prefix on restart. Same reasoning as the scheduler's
+    // persist-then-emit ordering.
     for (id, payload) in &rows {
+        upsert_outbox_cursor(pool, &candidate.workflow_id, *id).await?;
         emit_event_trigger_fired(
             store,
             candidate,
@@ -538,25 +562,27 @@ async fn poll_outbox_for_workflow(
             }),
         )
         .await?;
-        if *id > new_cursor {
-            new_cursor = *id;
-        }
     }
+    Ok(())
+}
 
-    if new_cursor > cursor {
-        sqlx::query(
-            "INSERT INTO outbox_trigger_cursor (workflow_id, last_seen_id, last_seen_at) \
-             VALUES ($1, $2, $3) \
-             ON CONFLICT (workflow_id) DO UPDATE \
-                SET last_seen_id = EXCLUDED.last_seen_id, \
-                    last_seen_at = EXCLUDED.last_seen_at",
-        )
-        .bind(&candidate.workflow_id)
-        .bind(new_cursor)
-        .bind(Utc::now())
-        .execute(pool)
-        .await?;
-    }
+async fn upsert_outbox_cursor(
+    pool: &PgPool,
+    workflow_id: &str,
+    last_seen_id: i64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO outbox_trigger_cursor (workflow_id, last_seen_id, last_seen_at) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (workflow_id) DO UPDATE \
+            SET last_seen_id = EXCLUDED.last_seen_id, \
+                last_seen_at = EXCLUDED.last_seen_at",
+    )
+    .bind(workflow_id)
+    .bind(last_seen_id)
+    .bind(Utc::now())
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
@@ -579,12 +605,55 @@ fn is_safe_identifier(s: &str) -> bool {
     }) && s.len() <= 127
 }
 
-/// Reject WHERE-clause text that contains semicolons or comment markers.
-/// A real query parser is out of scope for v1; this catches the obvious
-/// injection shapes. Workflow authors are still expected to write trusted
-/// SQL — outbox triggers are an admin-grade primitive.
+/// Defense-in-depth check on the user-supplied `where_clause`. Outbox
+/// triggers are an admin-grade primitive (workflow authors who can create
+/// `OutboxRow` workflows are trusted), but a real query parser is out of
+/// scope for v1, so this guard catches the obvious DoS / injection shapes:
+///
+/// - statement terminators / comment markers (`;`, `--`, `/*`, `*/`)
+/// - DoS-shaped function calls (`pg_sleep`, `pg_terminate_backend`,
+///   `pg_cancel_backend`, `dblink`, `lo_*`)
+/// - subquery / set-operator keywords (`select`, `union`, `intersect`,
+///   `except`, `with`)
+///
+/// Matching is ASCII-case-insensitive and word-boundary-aware — the
+/// substring `select` inside a column name like `selected` is allowed,
+/// `SELECT 1` is not.
 fn is_safe_where_clause(s: &str) -> bool {
-    !s.contains(';') && !s.contains("--") && !s.contains("/*") && !s.contains("*/")
+    if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return false;
+    }
+    const BANNED_KEYWORDS: &[&str] = &[
+        "select",
+        "union",
+        "intersect",
+        "except",
+        "with",
+        "pg_sleep",
+        "pg_terminate_backend",
+        "pg_cancel_backend",
+        "dblink",
+    ];
+    let lower = s.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+    for kw in BANNED_KEYWORDS {
+        let mut start = 0;
+        while let Some(idx) = lower[start..].find(kw) {
+            let absolute = start + idx;
+            let prev_ok = absolute == 0 || !is_word_char(bytes[absolute - 1]);
+            let after = absolute + kw.len();
+            let next_ok = after >= bytes.len() || !is_word_char(bytes[after]);
+            if prev_ok && next_ok {
+                return false;
+            }
+            start = absolute + 1;
+        }
+    }
+    true
+}
+
+fn is_word_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
 }
 
 #[cfg(test)]
@@ -637,10 +706,23 @@ mod tests {
 
     #[test]
     fn safe_where_clause_rules() {
+        // Allowed: simple comparisons, string literals, IS-NULL, allowed
+        // word-suffixes that just happen to spell a banned keyword.
         assert!(is_safe_where_clause("status = 'sealed'"));
         assert!(is_safe_where_clause(""));
+        assert!(is_safe_where_clause("flagged_for_selection IS NOT NULL"));
+        // Statement terminators and comment markers.
         assert!(!is_safe_where_clause("1=1; DROP TABLE"));
         assert!(!is_safe_where_clause("x -- comment"));
         assert!(!is_safe_where_clause("/* nope */ 1=1"));
+        // Subquery / set-operator keywords (case-insensitive, word-boundary).
+        assert!(!is_safe_where_clause("id IN (SELECT id FROM other)"));
+        assert!(!is_safe_where_clause("EXISTS(SELECT 1)"));
+        assert!(!is_safe_where_clause("a UNION b"));
+        assert!(!is_safe_where_clause("with x as (1) 1=1"));
+        // DoS-shaped function calls.
+        assert!(!is_safe_where_clause("pg_sleep(10) IS NULL"));
+        assert!(!is_safe_where_clause("pg_terminate_backend(1) = TRUE"));
+        assert!(!is_safe_where_clause("dblink('host', 'sql') IS NULL"));
     }
 }

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -1,6 +1,7 @@
 //! Core Forge logic — scheduling kernel, artifact store, pipeline, and state machine.
 
 pub mod artifact_store;
+pub mod event_triggers;
 pub mod gate_verdict_listener;
 pub mod insight_cache;
 pub mod insight_listener;
@@ -8,6 +9,7 @@ pub mod kernel;
 pub mod pending;
 pub mod persistence;
 pub mod pipeline;
+pub mod scheduler;
 pub mod session_listener;
 pub mod shaping_result_listener;
 pub mod signal_cache;

--- a/crates/forge/src/core/scheduler.rs
+++ b/crates/forge/src/core/scheduler.rs
@@ -141,7 +141,10 @@ async fn load_schedule_candidates(pool: &PgPool) -> anyhow::Result<Vec<ScheduleC
         let workflow_created_at: DateTime<Utc> = row.try_get("created_at")?;
         let kind_tag: String = row.try_get("trigger_kind")?;
         let cfg: serde_json::Value = row.try_get("trigger_config")?;
-        let last_fired_at: Option<DateTime<Utc>> = row.try_get("last_fired_at").ok();
+        // Use a typed `Option<DateTime<Utc>>` decode and `?` so a real DB
+        // schema/type error surfaces instead of silently being treated as
+        // "never fired" (which would re-fire workflows that did fire).
+        let last_fired_at: Option<DateTime<Utc>> = row.try_get("last_fired_at")?;
         let trigger = match TriggerKind::from_storage(&kind_tag, &cfg) {
             Ok(t) => t,
             Err(e) => {
@@ -184,8 +187,14 @@ async fn process_candidate(
         return Ok(());
     }
 
-    emit_trigger_fired(store, candidate, scheduled_for, now).await?;
+    // Persist `last_fired_at` *before* emitting `trigger.fired` so a crash
+    // between the two steps drops this fire (skip-missed semantics already
+    // permits losing one fire) instead of duplicating it on restart. The
+    // alternative ordering (emit then persist) lets a crash mid-step
+    // re-fire on the next tick because `last_fired_at` is still stale —
+    // the failure mode Copilot flagged on PR #247.
     upsert_state(store.pool(), &candidate.workflow_id, now, scheduled_for).await?;
+    emit_trigger_fired(store, candidate, scheduled_for, now).await?;
     Ok(())
 }
 

--- a/crates/forge/src/core/scheduler.rs
+++ b/crates/forge/src/core/scheduler.rs
@@ -1,0 +1,448 @@
+//! Schedule-trigger producer (#238).
+//!
+//! Ticks every 5s, finds active workflows whose trigger kind is `cron` /
+//! `delay` / `interval`, computes the next fire-at, and emits
+//! `FactoryEventKind::TriggerFired` to the spine when due. The
+//! [`crate::core::trigger_subscriber`] consumes those events, registers
+//! an artifact, and enters stage 0 — same path as webhook-driven fires.
+//!
+//! ## Reliability
+//!
+//! The scheduler shares forge's process; a panic must not take down forge.
+//! [`run`] wraps the tick loop in a supervisor that catches panics and
+//! restarts with exponential backoff.
+//!
+//! ## Catch-up policy
+//!
+//! If forge is down for N minutes, missed firings are **skipped**: the
+//! scheduler fires once and stamps `last_fired_at = now()`. Replay-of-
+//! missed-firings is a per-workflow follow-up; v1 keeps the failure surface
+//! small.
+//!
+//! ## Idempotency
+//!
+//! Each `TriggerFired` carries `payload.last_fired_at` and
+//! `payload.scheduled_for`. Forge's trigger subscriber dedupes on the
+//! resulting external_ref `forge:trigger:{workflow_id}:{kind}:{ts}`.
+//!
+//! ## State persistence
+//!
+//! `last_fired_at` lives in the spine sidecar table
+//! `workflow_trigger_state` (migration 018) — keeps the `workflows` row
+//! kind-agnostic.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::Context;
+use chrono::{DateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use cron::Schedule;
+use sqlx::PgPool;
+
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{DelayAnchor, EventMetadata, EventStore, TriggerKind};
+
+/// Fixed tick interval (per #238 resolution: 5s, not per-deploy
+/// configurable in v1 — keeps the failure surface small).
+pub const TICK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Run the schedule-trigger producer. Loops forever; on a panic in the
+/// inner tick body, restarts with exponential backoff (capped at 30s).
+pub async fn run(store: EventStore) -> anyhow::Result<()> {
+    let mut backoff = Duration::from_secs(1);
+    let max_backoff = Duration::from_secs(30);
+
+    loop {
+        let store_clone = store.clone();
+        let result = tokio::spawn(async move { run_tick_loop(store_clone).await }).await;
+
+        match result {
+            Ok(Ok(())) => {
+                tracing::info!("forge scheduler: tick loop exited cleanly");
+                return Ok(());
+            }
+            Ok(Err(e)) => {
+                tracing::error!("forge scheduler: tick loop returned error: {e:#}");
+            }
+            Err(join_err) if join_err.is_panic() => {
+                tracing::error!("forge scheduler: tick loop panicked: {join_err}");
+            }
+            Err(join_err) => {
+                tracing::error!("forge scheduler: tick loop join error: {join_err}");
+                return Err(anyhow::anyhow!("scheduler join error: {join_err}"));
+            }
+        }
+
+        tracing::warn!("forge scheduler: restarting tick loop after {:?}", backoff);
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(max_backoff);
+    }
+}
+
+async fn run_tick_loop(store: EventStore) -> anyhow::Result<()> {
+    let mut interval = tokio::time::interval(TICK_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        interval.tick().await;
+        if let Err(e) = run_one_tick(&store).await {
+            tracing::warn!("forge scheduler: tick failed: {e:#}");
+        }
+    }
+}
+
+/// Run one scheduling tick. Public for tests; production callers use
+/// [`run`].
+pub async fn run_one_tick(store: &EventStore) -> anyhow::Result<()> {
+    let now = Utc::now();
+    let pool = store.pool();
+    let candidates = load_schedule_candidates(pool).await?;
+    for candidate in candidates {
+        if let Err(e) = process_candidate(store, &candidate, now).await {
+            tracing::warn!(
+                workflow_id = %candidate.workflow_id,
+                trigger_kind = %candidate.trigger.kind_tag(),
+                "forge scheduler: candidate fire failed: {e:#}"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// One schedule-triggered workflow, hydrated from the spine.
+#[derive(Debug, Clone)]
+pub struct ScheduleCandidate {
+    pub workflow_id: String,
+    pub workspace_id: String,
+    pub workflow_created_at: DateTime<Utc>,
+    pub last_fired_at: Option<DateTime<Utc>>,
+    pub trigger: TriggerKind,
+}
+
+async fn load_schedule_candidates(pool: &PgPool) -> anyhow::Result<Vec<ScheduleCandidate>> {
+    use sqlx::Row;
+
+    let rows = sqlx::query(
+        "SELECT w.workflow_id, w.workspace_id, w.created_at, w.trigger_kind, \
+                w.trigger_config, s.last_fired_at \
+           FROM workflows w \
+           LEFT JOIN workflow_trigger_state s USING (workflow_id) \
+          WHERE w.active = TRUE \
+            AND w.trigger_kind IN ('cron', 'delay', 'interval')",
+    )
+    .fetch_all(pool)
+    .await
+    .context("loading schedule candidates")?;
+
+    let mut candidates = Vec::with_capacity(rows.len());
+    for row in rows {
+        let workflow_id: String = row.try_get("workflow_id")?;
+        let workspace_id: String = row.try_get("workspace_id")?;
+        let workflow_created_at: DateTime<Utc> = row.try_get("created_at")?;
+        let kind_tag: String = row.try_get("trigger_kind")?;
+        let cfg: serde_json::Value = row.try_get("trigger_config")?;
+        let last_fired_at: Option<DateTime<Utc>> = row.try_get("last_fired_at").ok();
+        let trigger = match TriggerKind::from_storage(&kind_tag, &cfg) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    workflow_id = %workflow_id,
+                    "forge scheduler: skipping unparseable trigger: {e}"
+                );
+                continue;
+            }
+        };
+        candidates.push(ScheduleCandidate {
+            workflow_id,
+            workspace_id,
+            workflow_created_at,
+            last_fired_at,
+            trigger,
+        });
+    }
+    Ok(candidates)
+}
+
+async fn process_candidate(
+    store: &EventStore,
+    candidate: &ScheduleCandidate,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let Some(scheduled_for) = next_fire_at(
+        &candidate.trigger,
+        candidate.workflow_created_at,
+        candidate.last_fired_at,
+        now,
+    )?
+    else {
+        // One-shot delay that has already fired; nothing to do.
+        return Ok(());
+    };
+
+    if scheduled_for > now {
+        // Not yet due.
+        return Ok(());
+    }
+
+    emit_trigger_fired(store, candidate, scheduled_for, now).await?;
+    upsert_state(store.pool(), &candidate.workflow_id, now, scheduled_for).await?;
+    Ok(())
+}
+
+/// Compute the next fire-at instant for a schedule trigger.
+///
+/// - `Cron` — next time the cron schedule fires after `last_fired_at`
+///   (or after `now` if never fired). Catch-up policy: if multiple
+///   firings have been missed, return the latest missed firing — caller
+///   stamps `last_fired_at = now` to skip the rest.
+/// - `Delay` — `workflow_created_at + seconds`, but only when
+///   `last_fired_at` is `None` (one-shot). Returns `Ok(None)` after
+///   the one fire.
+/// - `Interval` — `last_fired_at + period` (or `now` if never fired).
+///   Same skip-missed semantics as cron.
+pub fn next_fire_at(
+    trigger: &TriggerKind,
+    workflow_created_at: DateTime<Utc>,
+    last_fired_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> anyhow::Result<Option<DateTime<Utc>>> {
+    match trigger {
+        TriggerKind::Cron {
+            expression,
+            timezone,
+        } => {
+            let schedule = Schedule::from_str(expression)
+                .with_context(|| format!("invalid cron expression `{expression}`"))?;
+            let after = last_fired_at.unwrap_or(workflow_created_at);
+            let next = match timezone.as_deref() {
+                Some(tz_name) => {
+                    let tz: Tz = tz_name
+                        .parse()
+                        .with_context(|| format!("invalid timezone `{tz_name}`"))?;
+                    let after_tz = after.with_timezone(&tz);
+                    schedule
+                        .after(&after_tz)
+                        .next()
+                        .map(|dt| dt.with_timezone(&Utc))
+                }
+                None => schedule.after(&after).next(),
+            };
+            Ok(next)
+        }
+        TriggerKind::Delay { seconds, anchor } => {
+            // Anchor is `WorkflowActivatedAt` for v1 — measured from the
+            // workflow's creation timestamp. After one fire, never again.
+            if last_fired_at.is_some() {
+                return Ok(None);
+            }
+            let DelayAnchor::WorkflowActivatedAt = anchor;
+            let due = workflow_created_at
+                + chrono::Duration::seconds(i64_from_u64(*seconds, "delay seconds")?);
+            Ok(Some(due))
+        }
+        TriggerKind::Interval { period_seconds } => {
+            let period =
+                chrono::Duration::seconds(i64_from_u64(*period_seconds, "interval period")?);
+            let baseline = last_fired_at.unwrap_or(workflow_created_at);
+            let mut next = baseline + period;
+            // Skip-missed: advance until next > now - period, so we fire
+            // once at the latest scheduled instant <= now.
+            while next + period <= now {
+                next += period;
+            }
+            Ok(Some(next))
+        }
+        other => Err(anyhow::anyhow!(
+            "next_fire_at called on non-schedule trigger: {}",
+            other.kind_tag()
+        )),
+    }
+}
+
+fn i64_from_u64(v: u64, what: &str) -> anyhow::Result<i64> {
+    i64::try_from(v).map_err(|_| anyhow::anyhow!("{what} {v} overflows i64 seconds"))
+}
+
+async fn emit_trigger_fired(
+    store: &EventStore,
+    candidate: &ScheduleCandidate,
+    scheduled_for: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let payload = serde_json::json!({
+        "trigger_kind": candidate.trigger.kind_tag(),
+        "workflow_id": candidate.workflow_id,
+        "workspace_id": candidate.workspace_id,
+        "scheduled_for": scheduled_for,
+        "fired_at": now,
+        "last_fired_at": candidate.last_fired_at,
+        "source": "forge_scheduler",
+    });
+
+    let envelope = FactoryEvent {
+        event: FactoryEventKind::TriggerFired {
+            workflow_id: candidate.workflow_id.clone(),
+            trigger_kind: candidate.trigger.kind_tag().to_string(),
+            payload,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: "forge_scheduler".to_string(),
+        timestamp: now,
+    };
+    let data = serde_json::to_value(&envelope)?;
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: "forge_scheduler".to_string(),
+    };
+    store
+        .append_ext(
+            &candidate.workspace_id,
+            &format!("workflow:{}", candidate.workflow_id),
+            "workflow",
+            "trigger.fired",
+            data,
+            &metadata,
+            None,
+        )
+        .await
+        .context("emitting trigger.fired")?;
+    Ok(())
+}
+
+async fn upsert_state(
+    pool: &PgPool,
+    workflow_id: &str,
+    now: DateTime<Utc>,
+    scheduled_for: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO workflow_trigger_state (workflow_id, last_fired_at, last_payload) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (workflow_id) DO UPDATE \
+            SET last_fired_at = EXCLUDED.last_fired_at, \
+                last_payload  = EXCLUDED.last_payload",
+    )
+    .bind(workflow_id)
+    .bind(now)
+    .bind(serde_json::json!({ "scheduled_for": scheduled_for }))
+    .execute(pool)
+    .await
+    .context("upserting workflow_trigger_state")?;
+    Ok(())
+}
+
+// Trick to silence unused-import warnings when chrono::TimeZone isn't
+// needed by every cfg. The cron schedule.after on a chrono-tz Tz still
+// requires the trait in scope.
+#[allow(dead_code)]
+fn _force_tz_in_scope<Tz2: TimeZone>(_t: &Tz2) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn delay_fires_once_then_returns_none() {
+        let trigger = TriggerKind::Delay {
+            seconds: 30,
+            anchor: DelayAnchor::WorkflowActivatedAt,
+        };
+        let created = ts("2026-05-05T00:00:00Z");
+        // Never fired → next is created + 30s.
+        let now = ts("2026-05-05T00:01:00Z");
+        let next = next_fire_at(&trigger, created, None, now).unwrap();
+        assert_eq!(next, Some(ts("2026-05-05T00:00:30Z")));
+
+        // Already fired → no further fires.
+        let next2 = next_fire_at(&trigger, created, next, now).unwrap();
+        assert_eq!(next2, None);
+    }
+
+    #[test]
+    fn interval_fires_at_period_boundary() {
+        let trigger = TriggerKind::Interval { period_seconds: 60 };
+        let created = ts("2026-05-05T00:00:00Z");
+        let now = ts("2026-05-05T00:00:30Z");
+        let next = next_fire_at(&trigger, created, None, now).unwrap();
+        assert_eq!(next, Some(ts("2026-05-05T00:01:00Z")));
+    }
+
+    #[test]
+    fn interval_skips_missed_firings_and_lands_on_latest_missed() {
+        // Workflow created 10 minutes ago, 1-minute interval, never fired.
+        // Expected: next fire is the most recent boundary ≤ now, not all
+        // 10 missed boundaries.
+        let trigger = TriggerKind::Interval { period_seconds: 60 };
+        let created = ts("2026-05-05T00:00:00Z");
+        let now = ts("2026-05-05T00:10:30Z");
+        let next = next_fire_at(&trigger, created, None, now).unwrap().unwrap();
+        // Latest boundary <= now is 00:10:00.
+        assert_eq!(next, ts("2026-05-05T00:10:00Z"));
+        // And next > now - period, i.e. within the most recent window.
+        assert!(next + chrono::Duration::seconds(60) > now);
+    }
+
+    #[test]
+    fn cron_fires_at_next_match() {
+        // Every minute on the hour boundary.
+        let trigger = TriggerKind::Cron {
+            expression: "0 * * * * *".into(),
+            timezone: None,
+        };
+        let created = ts("2026-05-05T00:00:30Z");
+        let now = ts("2026-05-05T00:00:45Z");
+        let next = next_fire_at(&trigger, created, None, now).unwrap().unwrap();
+        assert_eq!(next, ts("2026-05-05T00:01:00Z"));
+    }
+
+    #[test]
+    fn cron_with_named_timezone_does_not_panic() {
+        let trigger = TriggerKind::Cron {
+            expression: "0 0 9 * * *".into(),
+            timezone: Some("America/Los_Angeles".into()),
+        };
+        let created = Utc.with_ymd_and_hms(2026, 5, 5, 0, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 5, 12, 0, 0).unwrap();
+        let next = next_fire_at(&trigger, created, None, now).unwrap();
+        assert!(next.is_some());
+    }
+
+    #[test]
+    fn cron_invalid_expression_returns_error() {
+        let trigger = TriggerKind::Cron {
+            expression: "not a cron".into(),
+            timezone: None,
+        };
+        let created = ts("2026-05-05T00:00:00Z");
+        let err = next_fire_at(&trigger, created, None, created).unwrap_err();
+        assert!(err.to_string().contains("invalid cron"));
+    }
+
+    #[test]
+    fn cron_invalid_timezone_returns_error() {
+        let trigger = TriggerKind::Cron {
+            expression: "0 * * * * *".into(),
+            timezone: Some("Earth/Atlantis".into()),
+        };
+        let created = ts("2026-05-05T00:00:00Z");
+        let err = next_fire_at(&trigger, created, None, created).unwrap_err();
+        assert!(err.to_string().contains("invalid timezone"));
+    }
+
+    #[test]
+    fn next_fire_at_rejects_non_schedule_trigger() {
+        let trigger = TriggerKind::GithubIssueWebhook {
+            repo: "a/b".into(),
+            label: "x".into(),
+        };
+        let created = ts("2026-05-05T00:00:00Z");
+        assert!(next_fire_at(&trigger, created, None, created).is_err());
+    }
+}

--- a/crates/forge/src/core/workflow.rs
+++ b/crates/forge/src/core/workflow.rs
@@ -132,12 +132,23 @@ impl Workflow {
 
     /// The artifact kind produced by this workflow's trigger.
     ///
-    /// v1 only has `github_issue_webhook` → produces `github-issue`
-    /// artifacts. When more trigger kinds arrive, this grows into a
-    /// match on `TriggerKind`.
+    /// `github_issue_webhook` → `github-issue` (the original v1 mapping).
+    /// Schedule / event / manual triggers produce a generic
+    /// `trigger-fired` artifact — the stage runner doesn't yet branch on
+    /// `Kind` for non-GitHub flows, so a single tag keeps the dashboard
+    /// and analytics queries simple. Future workflow authors can extend
+    /// this match if they want kind-specific filtering.
     pub fn trigger_artifact_kind(&self) -> &'static str {
         match self.trigger {
             TriggerKind::GithubIssueWebhook { .. } => "github-issue",
+            TriggerKind::Cron { .. } | TriggerKind::Delay { .. } | TriggerKind::Interval { .. } => {
+                "scheduled-tick"
+            }
+            TriggerKind::SpineEvent { .. } => "spine-event",
+            TriggerKind::PgNotify { .. } => "pg-notify",
+            TriggerKind::OutboxRow { .. } => "outbox-row",
+            TriggerKind::Manual { .. } => "manual-trigger",
+            TriggerKind::Replay { .. } => "replay",
         }
     }
 }

--- a/crates/forge/src/core/workflow.rs
+++ b/crates/forge/src/core/workflow.rs
@@ -132,12 +132,19 @@ impl Workflow {
 
     /// The artifact kind produced by this workflow's trigger.
     ///
-    /// `github_issue_webhook` → `github-issue` (the original v1 mapping).
-    /// Schedule / event / manual triggers produce a generic
-    /// `trigger-fired` artifact — the stage runner doesn't yet branch on
-    /// `Kind` for non-GitHub flows, so a single tag keeps the dashboard
-    /// and analytics queries simple. Future workflow authors can extend
-    /// this match if they want kind-specific filtering.
+    /// One static tag per category, so dashboard / analytics queries can
+    /// group by trigger source without parsing `trigger_kind`:
+    ///
+    /// - `github-issue` — GitHub-issue webhook (the original v1 mapping).
+    /// - `scheduled-tick` — `cron` / `delay` / `interval`.
+    /// - `spine-event`, `pg-notify`, `outbox-row` — the three event
+    ///   sources from #239.
+    /// - `manual-trigger` — `Manual { name }`.
+    /// - `replay` — replay of a past `TriggerFired`.
+    ///
+    /// The stage runner doesn't currently branch on `Kind`; this tag is
+    /// purely a label. Future workflow authors can refine the match if
+    /// they want kind-specific filtering.
     pub fn trigger_artifact_kind(&self) -> &'static str {
         match self.trigger {
             TriggerKind::GithubIssueWebhook { .. } => "github-issue",

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -573,10 +573,17 @@ pub const EVENTS: EventManifest = EventManifest {
         EventDefinition {
             kind: "trigger.fired",
             schema_version: 1,
-            producers: &[Subsystem::Stiglab],
+            // Producers (all four trigger categories from #236):
+            // - Stiglab webhook receiver (GitHub `issues.labeled`).
+            // - Forge scheduler (#238 — cron / delay / interval).
+            // - Forge event-trigger listeners (#239 — spine_event /
+            //   pg_notify / outbox_row).
+            // - Portal (#241 — `onsager trigger fire` CLI + future
+            //   "Run now" UI button once #222 lands).
+            producers: &[Subsystem::Stiglab, Subsystem::Forge, Subsystem::Portal],
             consumers: &[Subsystem::Forge],
             audit_only: false,
-            description: "A trigger (e.g. a GitHub issue webhook) fired.",
+            description: "A trigger fired (webhook / schedule / event / manual).",
         },
         EventDefinition {
             kind: "stage.entered",

--- a/crates/onsager-registry/src/triggers.rs
+++ b/crates/onsager-registry/src/triggers.rs
@@ -28,19 +28,33 @@ use serde::Serialize;
 
 use crate::events::Subsystem;
 
-/// High-level trigger taxonomy. Dashboards use this to group kinds; the
-/// factory runtime treats them all the same — every fired trigger lands
-/// on the spine as `trigger.fired`.
+/// High-level trigger taxonomy (per #236). Dashboards use this to group
+/// kinds; the factory runtime treats them all the same — every fired
+/// trigger lands on the spine as `trigger.fired`.
+///
+/// The split mirrors the spec's four categories:
+///
+/// - **Event** — internal event-bus signals (`spine_event`, `pg_notify`,
+///   `outbox_row`). Producer is always forge.
+/// - **Schedule** — time-based fires (`cron`, `delay`, `interval`).
+///   Producer is always forge.
+/// - **Request** — external HTTP requests (webhooks: GitHub, Telegram,
+///   …). Producer is the edge subsystem hosting the receiver (stiglab
+///   today; portal once #222 lands).
+/// - **Manual** — user-initiated fires (UI button, CLI, replay).
+///   Producer is portal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerCategory {
-    /// External events delivered as webhooks (e.g. GitHub).
+    /// Internal event-bus signals (spine events, pg_notify channels,
+    /// outbox rows).
     Event,
-    /// Time-based fires (cron / interval) — reserved for v2.
+    /// Time-based fires (cron / delay / interval).
     Schedule,
-    /// Caller-initiated requests via dashboard or CLI — reserved for v2.
+    /// External HTTP requests — webhooks (GitHub today; Telegram etc.
+    /// in the works).
     Request,
-    /// Explicit human "go" signals — reserved for v2.
+    /// User-initiated fires (UI button, CLI, replay).
     Manual,
 }
 
@@ -108,7 +122,12 @@ pub const TRIGGERS: TriggerManifest = TriggerManifest {
         TriggerDefinition {
             kind_tag: "github_issue_webhook",
             producer: Subsystem::Stiglab,
-            category: TriggerCategory::Event,
+            // Category 3 per #236 — webhooks are external HTTP requests,
+            // not internal event-bus signals. Putting them in `Event`
+            // would force `check-triggers` to allow Stiglab as an Event
+            // producer, weakening enforcement for true event triggers
+            // like `spine_event`.
+            category: TriggerCategory::Request,
             ui_kind: TriggerUiKind::Webhook,
             description: "Fires when a GitHub issue is labeled with the configured label.",
         },
@@ -210,15 +229,15 @@ mod tests {
                 TriggerCategory::Schedule
             );
         }
-        // Event kinds.
-        for k in [
-            "github_issue_webhook",
-            "spine_event",
-            "pg_notify",
-            "outbox_row",
-        ] {
+        // Event kinds (internal event-bus signals only).
+        for k in ["spine_event", "pg_notify", "outbox_row"] {
             assert_eq!(TRIGGERS.lookup(k).unwrap().category, TriggerCategory::Event);
         }
+        // Request kinds — external HTTP webhooks.
+        assert_eq!(
+            TRIGGERS.lookup("github_issue_webhook").unwrap().category,
+            TriggerCategory::Request
+        );
         // Manual kinds.
         for k in ["manual", "replay"] {
             assert_eq!(
@@ -232,7 +251,7 @@ mod tests {
     fn lookup_returns_known_entry() {
         let entry = TRIGGERS.lookup("github_issue_webhook").unwrap();
         assert_eq!(entry.producer, Subsystem::Stiglab);
-        assert_eq!(entry.category, TriggerCategory::Event);
+        assert_eq!(entry.category, TriggerCategory::Request);
         assert_eq!(entry.ui_kind, TriggerUiKind::Webhook);
     }
 
@@ -249,7 +268,7 @@ mod tests {
         let first = &triggers[0];
         assert_eq!(first["kind_tag"], "github_issue_webhook");
         assert_eq!(first["producer"], "stiglab");
-        assert_eq!(first["category"], "event");
+        assert_eq!(first["category"], "request");
         assert_eq!(first["ui_kind"], "webhook");
         assert!(first["description"].as_str().is_some());
     }

--- a/crates/onsager-registry/src/triggers.rs
+++ b/crates/onsager-registry/src/triggers.rs
@@ -45,13 +45,29 @@ pub enum TriggerCategory {
 }
 
 /// UI form shape used by the dashboard `<TriggerKindPicker>` to render
-/// per-kind config. Today there is exactly one — `Webhook` — which
-/// displays the existing GitHub-issue config form. Future kinds (cron,
-/// interval) will introduce additional shapes.
+/// per-kind config. Each shape maps to a concrete form layout in the
+/// dashboard's trigger picker; new shapes land alongside new variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerUiKind {
+    /// Webhook receivers (the existing GitHub-issue form).
     Webhook,
+    /// Cron-expression input with a human-readable preview.
+    Cron,
+    /// Single-shot delay (seconds + anchor selector).
+    Delay,
+    /// Recurring interval (period in seconds).
+    Interval,
+    /// Spine `FactoryEventKind` selector + optional JSON filter.
+    SpineEvent,
+    /// Postgres `NOTIFY` channel name + optional JSON filter.
+    PgNotify,
+    /// Outbox table name + SQL `WHERE` clause.
+    Outbox,
+    /// Manual-fire button label.
+    Manual,
+    /// Replay of a past `TriggerFired` by event id.
+    Replay,
 }
 
 /// One row of the trigger-kind registry manifest.
@@ -88,13 +104,74 @@ impl TriggerManifest {
 /// The canonical trigger-kind registry. Every variant in
 /// `onsager_spine::TriggerKind` must have a row here.
 pub const TRIGGERS: TriggerManifest = TriggerManifest {
-    triggers: &[TriggerDefinition {
-        kind_tag: "github_issue_webhook",
-        producer: Subsystem::Stiglab,
-        category: TriggerCategory::Event,
-        ui_kind: TriggerUiKind::Webhook,
-        description: "Fires when a GitHub issue is labeled with the configured label.",
-    }],
+    triggers: &[
+        TriggerDefinition {
+            kind_tag: "github_issue_webhook",
+            producer: Subsystem::Stiglab,
+            category: TriggerCategory::Event,
+            ui_kind: TriggerUiKind::Webhook,
+            description: "Fires when a GitHub issue is labeled with the configured label.",
+        },
+        // -- Schedule (#238) -----------------------------------------------
+        TriggerDefinition {
+            kind_tag: "cron",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Schedule,
+            ui_kind: TriggerUiKind::Cron,
+            description: "Fires on a cron schedule (5- or 6-field expression, optional timezone).",
+        },
+        TriggerDefinition {
+            kind_tag: "delay",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Schedule,
+            ui_kind: TriggerUiKind::Delay,
+            description: "Fires once after a fixed delay measured from the workflow's activation.",
+        },
+        TriggerDefinition {
+            kind_tag: "interval",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Schedule,
+            ui_kind: TriggerUiKind::Interval,
+            description: "Fires periodically at a fixed interval (in seconds).",
+        },
+        // -- Event (#239) --------------------------------------------------
+        TriggerDefinition {
+            kind_tag: "spine_event",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Event,
+            ui_kind: TriggerUiKind::SpineEvent,
+            description: "Fires when a spine FactoryEventKind matches; optional JSON filter.",
+        },
+        TriggerDefinition {
+            kind_tag: "pg_notify",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Event,
+            ui_kind: TriggerUiKind::PgNotify,
+            description: "Fires on a Postgres NOTIFY channel; optional JSON filter on the payload.",
+        },
+        TriggerDefinition {
+            kind_tag: "outbox_row",
+            producer: Subsystem::Forge,
+            category: TriggerCategory::Event,
+            ui_kind: TriggerUiKind::Outbox,
+            description: "Polls an outbox table for new rows matching a WHERE clause.",
+        },
+        // -- Manual (#241) -------------------------------------------------
+        TriggerDefinition {
+            kind_tag: "manual",
+            producer: Subsystem::Portal,
+            category: TriggerCategory::Manual,
+            ui_kind: TriggerUiKind::Manual,
+            description: "Fires from a UI button or `onsager trigger fire` CLI command.",
+        },
+        TriggerDefinition {
+            kind_tag: "replay",
+            producer: Subsystem::Portal,
+            category: TriggerCategory::Manual,
+            ui_kind: TriggerUiKind::Replay,
+            description: "Re-emits the payload of a past TriggerFired event by event id.",
+        },
+    ],
 };
 
 #[cfg(test)]
@@ -104,11 +181,50 @@ mod tests {
     #[test]
     fn manifest_has_one_entry_per_known_kind() {
         let kinds: Vec<&str> = TRIGGERS.triggers.iter().map(|t| t.kind_tag).collect();
+        // Foundation kinds.
         assert!(kinds.contains(&"github_issue_webhook"));
+        // Schedule (#238).
+        assert!(kinds.contains(&"cron"));
+        assert!(kinds.contains(&"delay"));
+        assert!(kinds.contains(&"interval"));
+        // Event (#239).
+        assert!(kinds.contains(&"spine_event"));
+        assert!(kinds.contains(&"pg_notify"));
+        assert!(kinds.contains(&"outbox_row"));
+        // Manual (#241).
+        assert!(kinds.contains(&"manual"));
+        assert!(kinds.contains(&"replay"));
         // Every kind_tag must be unique.
         let mut seen = std::collections::HashSet::new();
         for k in &kinds {
             assert!(seen.insert(*k), "duplicate kind_tag in manifest: {k}");
+        }
+    }
+
+    #[test]
+    fn manifest_categories_match_taxonomy() {
+        // Schedule kinds.
+        for k in ["cron", "delay", "interval"] {
+            assert_eq!(
+                TRIGGERS.lookup(k).unwrap().category,
+                TriggerCategory::Schedule
+            );
+        }
+        // Event kinds.
+        for k in [
+            "github_issue_webhook",
+            "spine_event",
+            "pg_notify",
+            "outbox_row",
+        ] {
+            assert_eq!(TRIGGERS.lookup(k).unwrap().category, TriggerCategory::Event);
+        }
+        // Manual kinds.
+        for k in ["manual", "replay"] {
+            assert_eq!(
+                TRIGGERS.lookup(k).unwrap().category,
+                TriggerCategory::Manual
+            );
         }
     }
 

--- a/crates/onsager-spine/migrations/018_workflow_trigger_state.sql
+++ b/crates/onsager-spine/migrations/018_workflow_trigger_state.sql
@@ -1,0 +1,42 @@
+-- Sidecar table for schedule-trigger state (#238).
+--
+-- The scheduler in forge ticks every 5s, finds active workflows whose
+-- trigger kind is `cron` / `delay` / `interval`, computes the next
+-- fire-at, and emits `TriggerFired` once `next_fire_at <= now()`.
+-- Persisting `last_fired_at` here (instead of growing the `workflows`
+-- row) keeps the workflow schema kind-agnostic — future trigger
+-- categories add their own sidecar tables rather than packing every
+-- variant's transient state into a single row.
+--
+-- Idempotency: `TriggerFired.payload.last_fired_at` carries this
+-- timestamp so forge's `trigger_subscriber` dedupes on
+-- `(workflow_id, last_fired_at)` if the scheduler restarts mid-emit.
+
+CREATE TABLE IF NOT EXISTS workflow_trigger_state (
+    workflow_id   TEXT PRIMARY KEY,
+    last_fired_at TIMESTAMPTZ NOT NULL,
+    -- The most recent payload we emitted for this workflow. Mostly
+    -- diagnostic; the scheduler doesn't read it back.
+    last_payload  JSONB,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Workflow row may be deleted; we don't want to keep an
+    -- orphaned cursor around if so.
+    CONSTRAINT workflow_trigger_state_workflow_fk
+        FOREIGN KEY (workflow_id) REFERENCES workflows(workflow_id)
+        ON DELETE CASCADE
+);
+
+-- Bump `updated_at` on every write so an operator can spot triggers
+-- that haven't fired in a long time without scanning emit logs.
+CREATE OR REPLACE FUNCTION workflow_trigger_state_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS workflow_trigger_state_touch ON workflow_trigger_state;
+CREATE TRIGGER workflow_trigger_state_touch
+BEFORE UPDATE ON workflow_trigger_state
+FOR EACH ROW EXECUTE FUNCTION workflow_trigger_state_touch_updated_at();

--- a/crates/onsager-spine/migrations/019_outbox_trigger_cursor.sql
+++ b/crates/onsager-spine/migrations/019_outbox_trigger_cursor.sql
@@ -1,0 +1,38 @@
+-- Sidecar cursor table for outbox-row triggers (#239).
+--
+-- Each `OutboxRow` workflow gets one row here. The forge poller reads
+-- the watched table with
+--
+--     SELECT id, ... FROM <table>
+--      WHERE id > $cursor AND <where_clause>
+--      ORDER BY id ASC
+--
+-- and advances the cursor atomically with the `TriggerFired` emit.
+-- This keeps the watched tables read-only from the trigger system's
+-- perspective — no intrusive `processed_at` / `consumed_by` columns,
+-- which would force schema changes on tables we don't own.
+
+CREATE TABLE IF NOT EXISTS outbox_trigger_cursor (
+    workflow_id   TEXT PRIMARY KEY,
+    -- Highest `id` we have already emitted a TriggerFired for.
+    -- Default 0: any non-negative `id` row will be picked up.
+    last_seen_id  BIGINT NOT NULL DEFAULT 0,
+    last_seen_at  TIMESTAMPTZ,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT outbox_trigger_cursor_workflow_fk
+        FOREIGN KEY (workflow_id) REFERENCES workflows(workflow_id)
+        ON DELETE CASCADE
+);
+
+CREATE OR REPLACE FUNCTION outbox_trigger_cursor_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS outbox_trigger_cursor_touch ON outbox_trigger_cursor;
+CREATE TRIGGER outbox_trigger_cursor_touch
+BEFORE UPDATE ON outbox_trigger_cursor
+FOR EACH ROW EXECUTE FUNCTION outbox_trigger_cursor_touch_updated_at();

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -64,4 +64,4 @@ pub use namespace::{Namespace, NamespaceError};
 pub use store::{
     append_factory_event_tx, EventMetadata, EventNotification, EventRecord, EventStore,
 };
-pub use trigger::{TriggerKind, TriggerStorageError};
+pub use trigger::{DelayAnchor, JsonFilter, TriggerKind, TriggerStorageError};

--- a/crates/onsager-spine/src/trigger.rs
+++ b/crates/onsager-spine/src/trigger.rs
@@ -15,6 +15,8 @@
 //! 2. Add a row to the registry manifest with the snake-case `kind_tag`.
 //! 3. Wire a producer + consumer (or tag the manifest row `audit_only`).
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -29,6 +31,122 @@ pub enum TriggerKind {
     /// A GitHub `issues.labeled` webhook whose label matches `label`.
     /// `repo` is the `"owner/name"` slug.
     GithubIssueWebhook { repo: String, label: String },
+
+    // -- Schedule (#238) ----------------------------------------------------
+    /// Fire on a cron schedule. `expression` is a 5- or 6-field cron string
+    /// (minute, hour, day-of-month, month, day-of-week, optional seconds).
+    /// `timezone` is an IANA name (e.g. `"UTC"`, `"America/Los_Angeles"`);
+    /// defaults to UTC when absent.
+    Cron {
+        expression: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timezone: Option<String>,
+    },
+
+    /// Fire once after a fixed delay measured from `anchor`. v1's only
+    /// anchor is the workflow's activation time; future anchors include
+    /// "delay relative to a received spine event".
+    Delay {
+        seconds: u64,
+        #[serde(default)]
+        anchor: DelayAnchor,
+    },
+
+    /// Fire periodically every `period_seconds`. Catch-up policy after an
+    /// outage is "skip missed, fire only the next due firing" (per #238
+    /// resolution); replay-of-missed is a per-workflow follow-up.
+    Interval { period_seconds: u64 },
+
+    // -- Event (#239) -------------------------------------------------------
+    /// Fire when the spine emits a `FactoryEventKind` whose `type` matches
+    /// `event_kind`. `filter` is an optional JSON-shape predicate against
+    /// the event payload (equality + `$.path` only).
+    SpineEvent {
+        event_kind: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<JsonFilter>,
+    },
+
+    /// Fire when a Postgres `NOTIFY <channel>` arrives. `filter` matches
+    /// against the parsed JSON payload of the notification (when present).
+    PgNotify {
+        channel: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<JsonFilter>,
+    },
+
+    /// Fire when a row matching `where_clause` is inserted into `table`.
+    /// The poller advances a per-workflow cursor in the
+    /// `outbox_trigger_cursor` sidecar table; `where_clause` is appended
+    /// to a parameterized poll query.
+    OutboxRow { table: String, where_clause: String },
+
+    // -- Manual (#241) ------------------------------------------------------
+    /// Fire on demand from a UI button or CLI command. `name` is the
+    /// workflow-author's label for the button — multiple `Manual` triggers
+    /// per workflow render as separate buttons.
+    Manual { name: String },
+
+    /// Re-emit the payload of a past `TriggerFired` event by event id.
+    /// Replay is registered as a workflow trigger so the replay primitive
+    /// shares the audit + permission shape with manual fires; #168's
+    /// backfill UI consumes it for past GitHub-issue events.
+    Replay { source_event_id: String },
+}
+
+/// Anchor for [`TriggerKind::Delay`]. v1 only supports
+/// `WorkflowActivatedAt` (delay measured from the workflow row's
+/// `created_at` / `last_fired_at` baseline). Future variants:
+/// `EventReceivedAt(EventKind)` — needs the event-trigger category to
+/// land first to define "when was an event received".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "anchor", rename_all = "snake_case")]
+pub enum DelayAnchor {
+    #[default]
+    WorkflowActivatedAt,
+}
+
+/// Simple JSON-shape predicate for `SpineEvent` and `PgNotify` triggers.
+///
+/// `equals` carries top-level field or `$.path` equality assertions:
+/// - `{"workspace_id": "ws_x"}` matches when the payload's `workspace_id`
+///   field equals `"ws_x"`.
+/// - `{"$.payload.repo": "owner/name"}` matches when the JSONPath-ish
+///   dotted lookup hits the same string.
+///
+/// Full JSONata is out of scope (per #239 resolution) — the simple form
+/// covers the known use cases and keeps the evaluator small.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct JsonFilter {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub equals: BTreeMap<String, serde_json::Value>,
+}
+
+impl JsonFilter {
+    /// Returns `true` when every entry in `equals` matches the corresponding
+    /// path in `value`. An empty filter (no entries) matches everything.
+    /// Unknown paths are treated as a non-match.
+    pub fn matches(&self, value: &serde_json::Value) -> bool {
+        self.equals.iter().all(|(k, expected)| {
+            let actual = lookup_json_path(value, k);
+            actual.map(|v| v == expected).unwrap_or(false)
+        })
+    }
+}
+
+/// Walk a dotted path through a JSON value. Accepts both `"foo"` (top-level
+/// field) and `"$.foo.bar"` / `"foo.bar"` (nested dotted lookup). Returns
+/// `None` if any segment is missing or not an object.
+fn lookup_json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let stripped = path.strip_prefix("$.").unwrap_or(path);
+    let mut cur = value;
+    for segment in stripped.split('.') {
+        if segment.is_empty() {
+            continue;
+        }
+        cur = cur.get(segment)?;
+    }
+    Some(cur)
 }
 
 impl TriggerKind {
@@ -38,6 +156,14 @@ impl TriggerKind {
     pub const fn kind_tag(&self) -> &'static str {
         match self {
             TriggerKind::GithubIssueWebhook { .. } => "github_issue_webhook",
+            TriggerKind::Cron { .. } => "cron",
+            TriggerKind::Delay { .. } => "delay",
+            TriggerKind::Interval { .. } => "interval",
+            TriggerKind::SpineEvent { .. } => "spine_event",
+            TriggerKind::PgNotify { .. } => "pg_notify",
+            TriggerKind::OutboxRow { .. } => "outbox_row",
+            TriggerKind::Manual { .. } => "manual",
+            TriggerKind::Replay { .. } => "replay",
         }
     }
 }
@@ -59,39 +185,67 @@ impl TriggerKind {
         kind_tag: &str,
         config: &serde_json::Value,
     ) -> Result<Self, TriggerStorageError> {
-        match kind_tag {
-            "github_issue_webhook" => {
-                let repo = config
-                    .get("repo")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| TriggerStorageError::InvalidConfig {
-                        kind: "github_issue_webhook",
-                        message: "missing or non-string `repo`".into(),
-                    })?
-                    .to_string();
-                let label = config
-                    .get("label")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| TriggerStorageError::InvalidConfig {
-                        kind: "github_issue_webhook",
-                        message: "missing or non-string `label`".into(),
-                    })?
-                    .to_string();
-                Ok(TriggerKind::GithubIssueWebhook { repo, label })
+        // Re-attach the kind discriminant and run serde — keeps the
+        // per-variant parsing in one place rather than duplicating a
+        // hand-written match for every new variant.
+        let mut tagged = config.clone();
+        if let Some(obj) = tagged.as_object_mut() {
+            obj.insert(
+                "kind".to_string(),
+                serde_json::Value::String(kind_tag.to_string()),
+            );
+        } else if tagged.is_null() {
+            tagged = serde_json::json!({ "kind": kind_tag });
+        } else {
+            return Err(TriggerStorageError::InvalidConfig {
+                kind: static_kind_tag(kind_tag).unwrap_or("unknown"),
+                message: "trigger_config must be a JSON object".into(),
+            });
+        }
+        match serde_json::from_value::<TriggerKind>(tagged) {
+            Ok(kind) => Ok(kind),
+            Err(e) => {
+                if let Some(static_tag) = static_kind_tag(kind_tag) {
+                    Err(TriggerStorageError::InvalidConfig {
+                        kind: static_tag,
+                        message: e.to_string(),
+                    })
+                } else {
+                    Err(TriggerStorageError::UnknownKind(kind_tag.to_string()))
+                }
             }
-            other => Err(TriggerStorageError::UnknownKind(other.to_string())),
         }
     }
 
     /// Split into the persisted `(kind_tag, config)` shape.
     /// `config` is the JSON object stored in `workflows.trigger_config`.
     pub fn to_storage(&self) -> (&'static str, serde_json::Value) {
-        match self {
-            TriggerKind::GithubIssueWebhook { repo, label } => (
-                "github_issue_webhook",
-                serde_json::json!({ "repo": repo, "label": label }),
-            ),
+        let mut value = serde_json::to_value(self).expect("TriggerKind serializes");
+        // Strip the `kind` discriminant — it lives in the column, not the
+        // JSONB. Symmetric with `from_storage`.
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("kind");
         }
+        (self.kind_tag(), value)
+    }
+}
+
+/// Map a runtime kind tag back to the static `&'static str` referenced by
+/// each `TriggerKind` variant. Returning the static form keeps
+/// [`TriggerStorageError::InvalidConfig`]'s `kind` field a static string,
+/// which is what the registry manifest's `kind_tag` field also uses.
+fn static_kind_tag(kind_tag: &str) -> Option<&'static str> {
+    match kind_tag {
+        "github_issue_webhook" => Some("github_issue_webhook"),
+        "cron" => Some("cron"),
+        "delay" => Some("delay"),
+        "interval" => Some("interval"),
+        "spine_event" => Some("spine_event"),
+        "pg_notify" => Some("pg_notify"),
+        "outbox_row" => Some("outbox_row"),
+        "manual" => Some("manual"),
+        "replay" => Some("replay"),
+        _ => None,
     }
 }
 
@@ -169,5 +323,174 @@ mod tests {
         let (kind, cfg) = original.to_storage();
         let back = TriggerKind::from_storage(kind, &cfg).unwrap();
         assert_eq!(back, original);
+    }
+
+    // -- Schedule variants (#238) ------------------------------------------
+
+    #[test]
+    fn cron_round_trips_through_storage() {
+        let t = TriggerKind::Cron {
+            expression: "0 9 * * 1-5".into(),
+            timezone: Some("America/Los_Angeles".into()),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "cron");
+        assert_eq!(cfg["expression"], "0 9 * * 1-5");
+        assert_eq!(cfg["timezone"], "America/Los_Angeles");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn cron_timezone_optional() {
+        let t = TriggerKind::Cron {
+            expression: "* * * * *".into(),
+            timezone: None,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert!(cfg.get("timezone").is_none());
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn delay_round_trips_through_storage() {
+        let t = TriggerKind::Delay {
+            seconds: 30,
+            anchor: DelayAnchor::WorkflowActivatedAt,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "delay");
+        assert_eq!(cfg["seconds"], 30);
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn interval_round_trips_through_storage() {
+        let t = TriggerKind::Interval {
+            period_seconds: 300,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "interval");
+        assert_eq!(cfg["period_seconds"], 300);
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    // -- Event variants (#239) ---------------------------------------------
+
+    #[test]
+    fn spine_event_round_trips_with_filter() {
+        let mut equals = BTreeMap::new();
+        equals.insert("workspace_id".into(), json!("ws_x"));
+        let t = TriggerKind::SpineEvent {
+            event_kind: "forge.shaping_dispatched".into(),
+            filter: Some(JsonFilter { equals }),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "spine_event");
+        let back = TriggerKind::from_storage(kind, &cfg).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn pg_notify_round_trips_through_storage() {
+        let t = TriggerKind::PgNotify {
+            channel: "factory_signal".into(),
+            filter: None,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "pg_notify");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn outbox_row_round_trips_through_storage() {
+        let t = TriggerKind::OutboxRow {
+            table: "artifact_outbox".into(),
+            where_clause: "state = 'sealed'".into(),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "outbox_row");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    // -- Manual variants (#241) --------------------------------------------
+
+    #[test]
+    fn manual_round_trips_through_storage() {
+        let t = TriggerKind::Manual {
+            name: "rerun".into(),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "manual");
+        assert_eq!(cfg["name"], "rerun");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn replay_round_trips_through_storage() {
+        let t = TriggerKind::Replay {
+            source_event_id: "9001".into(),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "replay");
+        assert_eq!(cfg["source_event_id"], "9001");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    // -- JsonFilter --------------------------------------------------------
+
+    #[test]
+    fn json_filter_empty_matches_anything() {
+        let f = JsonFilter::default();
+        assert!(f.matches(&json!({})));
+        assert!(f.matches(&json!({"a": 1})));
+    }
+
+    #[test]
+    fn json_filter_top_level_equality() {
+        let mut equals = BTreeMap::new();
+        equals.insert("workspace_id".into(), json!("ws_x"));
+        let f = JsonFilter { equals };
+        assert!(f.matches(&json!({"workspace_id": "ws_x", "extra": 1})));
+        assert!(!f.matches(&json!({"workspace_id": "ws_y"})));
+        assert!(!f.matches(&json!({})));
+    }
+
+    #[test]
+    fn json_filter_dotted_path() {
+        let mut equals = BTreeMap::new();
+        equals.insert("$.payload.repo".into(), json!("a/b"));
+        let f = JsonFilter { equals };
+        assert!(f.matches(&json!({"payload": {"repo": "a/b"}})));
+        assert!(!f.matches(&json!({"payload": {"repo": "x/y"}})));
+        assert!(!f.matches(&json!({"payload": {}})));
+    }
+
+    #[test]
+    fn json_filter_path_without_dollar_prefix_works() {
+        let mut equals = BTreeMap::new();
+        equals.insert("payload.repo".into(), json!("a/b"));
+        let f = JsonFilter { equals };
+        assert!(f.matches(&json!({"payload": {"repo": "a/b"}})));
+    }
+
+    #[test]
+    fn from_storage_rejects_invalid_cron_config() {
+        let err = TriggerKind::from_storage("cron", &json!({})).unwrap_err();
+        assert!(matches!(err, TriggerStorageError::InvalidConfig { kind, .. } if kind == "cron"));
+    }
+
+    #[test]
+    fn from_storage_rejects_invalid_interval_config() {
+        let err =
+            TriggerKind::from_storage("interval", &json!({"period_seconds": "five"})).unwrap_err();
+        assert!(
+            matches!(err, TriggerStorageError::InvalidConfig { kind, .. } if kind == "interval")
+        );
+    }
+
+    #[test]
+    fn from_storage_rejects_non_object_config() {
+        let err = TriggerKind::from_storage("cron", &json!("not-an-object")).unwrap_err();
+        assert!(matches!(err, TriggerStorageError::InvalidConfig { .. }));
     }
 }

--- a/crates/onsager-spine/src/trigger.rs
+++ b/crates/onsager-spine/src/trigger.rs
@@ -83,8 +83,11 @@ pub enum TriggerKind {
 
     // -- Manual (#241) ------------------------------------------------------
     /// Fire on demand from a UI button or CLI command. `name` is the
-    /// workflow-author's label for the button — multiple `Manual` triggers
-    /// per workflow render as separate buttons.
+    /// workflow-author's label for the button (rendered as the button
+    /// text in the UI). The current `workflows` schema persists exactly
+    /// one trigger per workflow; if the umbrella later supports multiple
+    /// triggers per workflow, multiple `Manual { name }` entries would
+    /// render as separate buttons.
     Manual { name: String },
 
     /// Re-emit the payload of a past `TriggerFired` event by event id.
@@ -185,6 +188,15 @@ impl TriggerKind {
         kind_tag: &str,
         config: &serde_json::Value,
     ) -> Result<Self, TriggerStorageError> {
+        // Resolve the static kind tag *first* so an unknown kind always
+        // surfaces as `UnknownKind`, regardless of whether the stored
+        // config happens to be malformed. Otherwise an unknown kind +
+        // a non-object config would be reported as a generic
+        // "InvalidConfig { kind: \"unknown\" }" — the unknown-kind
+        // problem hidden by a config-shape error.
+        let static_tag = static_kind_tag(kind_tag)
+            .ok_or_else(|| TriggerStorageError::UnknownKind(kind_tag.to_string()))?;
+
         // Re-attach the kind discriminant and run serde — keeps the
         // per-variant parsing in one place rather than duplicating a
         // hand-written match for every new variant.
@@ -198,23 +210,16 @@ impl TriggerKind {
             tagged = serde_json::json!({ "kind": kind_tag });
         } else {
             return Err(TriggerStorageError::InvalidConfig {
-                kind: static_kind_tag(kind_tag).unwrap_or("unknown"),
+                kind: static_tag,
                 message: "trigger_config must be a JSON object".into(),
             });
         }
-        match serde_json::from_value::<TriggerKind>(tagged) {
-            Ok(kind) => Ok(kind),
-            Err(e) => {
-                if let Some(static_tag) = static_kind_tag(kind_tag) {
-                    Err(TriggerStorageError::InvalidConfig {
-                        kind: static_tag,
-                        message: e.to_string(),
-                    })
-                } else {
-                    Err(TriggerStorageError::UnknownKind(kind_tag.to_string()))
-                }
+        serde_json::from_value::<TriggerKind>(tagged).map_err(|e| {
+            TriggerStorageError::InvalidConfig {
+                kind: static_tag,
+                message: e.to_string(),
             }
-        }
+        })
     }
 
     /// Split into the persisted `(kind_tag, config)` shape.

--- a/crates/onsager-trigger/Cargo.toml
+++ b/crates/onsager-trigger/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "onsager-trigger"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "CLI for firing manual workflow triggers and replaying past TriggerFired events"
+
+[[bin]]
+name = "onsager-trigger"
+path = "src/main.rs"
+
+[dependencies]
+onsager-spine = { path = "../onsager-spine" }
+onsager-registry = { path = "../onsager-registry" }
+
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/onsager-trigger/src/main.rs
+++ b/crates/onsager-trigger/src/main.rs
@@ -1,0 +1,380 @@
+//! `onsager trigger` — manual + replay trigger CLI (#241).
+//!
+//! Two surfaces:
+//!
+//!   onsager trigger fire    --manual <name>  [--payload <json>]
+//!   onsager trigger replay  --event <id> <workflow_id>
+//!
+//! Both emit `FactoryEventKind::TriggerFired` to the spine directly via
+//! `EventStore` — no HTTP indirection, independent of portal (#222). The
+//! consumer side is forge's existing `trigger_subscriber`; manual fires
+//! flow through the same path as webhook fires.
+//!
+//! Every fire also emits a `workflow.manual_triggered` audit event with
+//! `actor = "cli"` (or `"replay"`) and the user identity if available
+//! via the `ONSAGER_USER` env var. Audit events live on the spine in the
+//! `audit` namespace, not consumed by any subsystem (audit-only).
+//!
+//! Per #241 resolution: any authenticated user can fire / replay in v1.
+//! The CLI inherits the user's shell environment as its "auth" — there's
+//! no separate token; the CLI is operator-grade by design.
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use clap::{Args, Parser, Subcommand};
+use onsager_registry::TRIGGERS;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventMetadata, EventStore, TriggerKind};
+use serde_json::Value;
+
+const DEFAULT_DATABASE_URL_VAR: &str = "DATABASE_URL";
+
+#[derive(Parser)]
+#[command(name = "onsager-trigger", about = "Fire or replay workflow triggers")]
+struct Cli {
+    /// Postgres connection URL (defaults to $DATABASE_URL).
+    #[arg(long, global = true, env = DEFAULT_DATABASE_URL_VAR)]
+    database_url: String,
+
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Fire a manual trigger immediately.
+    Fire(FireArgs),
+    /// Replay a past `TriggerFired` event by id.
+    Replay(ReplayArgs),
+}
+
+#[derive(Args)]
+struct FireArgs {
+    /// Workflow id to fire.
+    workflow_id: String,
+    /// Manual trigger name. Must match the workflow's declared
+    /// `Manual { name }` trigger.
+    #[arg(long)]
+    manual: String,
+    /// Optional JSON payload to attach.
+    #[arg(long)]
+    payload: Option<String>,
+}
+
+#[derive(Args)]
+struct ReplayArgs {
+    /// Workflow id to replay against (the replay re-fires under this
+    /// workflow, not necessarily the workflow that produced the source).
+    workflow_id: String,
+    /// Event id of the past `TriggerFired` to re-emit.
+    #[arg(long)]
+    event: i64,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn run() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("onsager_trigger=info")
+        .compact()
+        .init();
+
+    let cli = Cli::parse();
+    let store = EventStore::connect(&cli.database_url)
+        .await
+        .with_context(|| format!("connecting to {}", cli.database_url))?;
+
+    let actor = std::env::var("ONSAGER_USER").unwrap_or_else(|_| "cli".to_string());
+
+    match cli.cmd {
+        Cmd::Fire(args) => fire(&store, &args, &actor).await,
+        Cmd::Replay(args) => replay(&store, &args, &actor).await,
+    }
+}
+
+async fn fire(store: &EventStore, args: &FireArgs, actor: &str) -> Result<()> {
+    if TRIGGERS.lookup("manual").is_none() {
+        return Err(anyhow!("registry manifest is missing the `manual` row"));
+    }
+
+    let workflow = load_workflow(store, &args.workflow_id).await?;
+    let trigger_matches = matches!(
+        &workflow.trigger,
+        TriggerKind::Manual { name } if name == &args.manual
+    );
+    if !trigger_matches {
+        return Err(anyhow!(
+            "workflow `{}` does not declare a manual trigger named `{}` \
+             (its trigger is {})",
+            workflow.id,
+            args.manual,
+            workflow.trigger.kind_tag()
+        ));
+    }
+
+    let extra_payload = match args.payload.as_deref() {
+        Some(s) => Some(serde_json::from_str::<Value>(s).context("--payload is not valid JSON")?),
+        None => None,
+    };
+
+    let now = Utc::now();
+    let mut payload = serde_json::json!({
+        "trigger_kind": "manual",
+        "workflow_id": workflow.id,
+        "workspace_id": workflow.workspace_id,
+        "name": args.manual,
+        "fired_at": now,
+        "actor": actor,
+        "source": "cli",
+    });
+    if let Some(extra) = extra_payload {
+        if let (Value::Object(ref mut map), Value::Object(extra_map)) = (&mut payload, extra) {
+            for (k, v) in extra_map {
+                map.insert(k, v);
+            }
+        }
+    }
+
+    emit_trigger_fired(store, &workflow, "manual", payload, actor, now).await?;
+    emit_audit(
+        store,
+        &workflow,
+        "cli_fire",
+        serde_json::json!({ "manual_name": args.manual, "actor": actor }),
+        actor,
+        now,
+    )
+    .await?;
+    println!(
+        "fired manual trigger `{}` for workflow {} (workspace {})",
+        args.manual, workflow.id, workflow.workspace_id
+    );
+    Ok(())
+}
+
+async fn replay(store: &EventStore, args: &ReplayArgs, actor: &str) -> Result<()> {
+    let source = load_trigger_fired(store, args.event).await?;
+    let workflow = load_workflow(store, &args.workflow_id).await?;
+
+    let now = Utc::now();
+    let mut payload = match source.payload.clone() {
+        Value::Object(map) => Value::Object(map),
+        other => serde_json::json!({ "original_payload": other }),
+    };
+    if let Value::Object(ref mut map) = payload {
+        // Accumulate the replay chain — each replay layer marks the
+        // event id of its source. Replay-of-replay is allowed (#241
+        // resolution); the chain is visible via these markers.
+        let mut chain: Vec<i64> = map
+            .get("replay_chain")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|x| x.as_i64()).collect())
+            .unwrap_or_default();
+        chain.push(args.event);
+        map.insert("replay_of".into(), Value::from(args.event));
+        map.insert(
+            "replay_chain".into(),
+            Value::Array(chain.into_iter().map(Value::from).collect()),
+        );
+        map.insert("replay_actor".into(), Value::String(actor.to_string()));
+        map.insert("replay_fired_at".into(), Value::String(now.to_rfc3339()));
+        // Stamp the canonical workflow + workspace; the source event
+        // may have run under a different workflow.
+        map.insert("workflow_id".into(), Value::String(workflow.id.clone()));
+        map.insert(
+            "workspace_id".into(),
+            Value::String(workflow.workspace_id.clone()),
+        );
+        map.insert("trigger_kind".into(), Value::String("replay".into()));
+        map.insert("source".into(), Value::String("cli_replay".into()));
+    }
+
+    emit_trigger_fired(store, &workflow, "replay", payload, actor, now).await?;
+    emit_audit(
+        store,
+        &workflow,
+        "cli_replay",
+        serde_json::json!({
+            "source_event_id": args.event,
+            "source_trigger_kind": source.trigger_kind,
+            "actor": actor,
+        }),
+        actor,
+        now,
+    )
+    .await?;
+    println!(
+        "replayed event {} as `{}` fire for workflow {}",
+        args.event, source.trigger_kind, workflow.id
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Spine helpers
+// ---------------------------------------------------------------------------
+
+/// Minimal `workflows`-row projection — all this CLI needs for emit /
+/// validation.
+struct WorkflowRow {
+    id: String,
+    workspace_id: String,
+    trigger: TriggerKind,
+    active: bool,
+}
+
+async fn load_workflow(store: &EventStore, workflow_id: &str) -> Result<WorkflowRow> {
+    use sqlx::Row;
+    let row = sqlx::query(
+        "SELECT workflow_id, workspace_id, active, trigger_kind, trigger_config \
+           FROM workflows WHERE workflow_id = $1",
+    )
+    .bind(workflow_id)
+    .fetch_optional(store.pool())
+    .await
+    .context("loading workflow row")?
+    .ok_or_else(|| anyhow!("workflow `{workflow_id}` not found"))?;
+
+    let id: String = row.try_get("workflow_id")?;
+    let workspace_id: String = row.try_get("workspace_id")?;
+    let active: bool = row.try_get("active")?;
+    let kind_tag: String = row.try_get("trigger_kind")?;
+    let cfg: Value = row.try_get("trigger_config")?;
+    let trigger = TriggerKind::from_storage(&kind_tag, &cfg)
+        .with_context(|| format!("workflow `{id}` has unparseable trigger config"))?;
+    if !active {
+        return Err(anyhow!("workflow `{id}` is not active"));
+    }
+    Ok(WorkflowRow {
+        id,
+        workspace_id,
+        trigger,
+        active,
+    })
+}
+
+struct PastTriggerFired {
+    trigger_kind: String,
+    payload: Value,
+}
+
+async fn load_trigger_fired(store: &EventStore, event_id: i64) -> Result<PastTriggerFired> {
+    let row = store
+        .get_ext_event_by_id(event_id)
+        .await
+        .context("fetching source event")?
+        .ok_or_else(|| anyhow!("event `{event_id}` not found in events_ext"))?;
+
+    // The events_ext.data column may carry either the FactoryEvent
+    // envelope or the bare FactoryEventKind. Try both.
+    let kind = if let Ok(env) = serde_json::from_value::<FactoryEvent>(row.data.clone()) {
+        env.event
+    } else {
+        serde_json::from_value::<FactoryEventKind>(row.data)
+            .map_err(|e| anyhow!("event `{event_id}` is not a FactoryEvent: {e}"))?
+    };
+
+    match kind {
+        FactoryEventKind::TriggerFired {
+            trigger_kind,
+            payload,
+            ..
+        } => Ok(PastTriggerFired {
+            trigger_kind,
+            payload,
+        }),
+        _ => Err(anyhow!(
+            "event `{event_id}` is not a TriggerFired event (was {:?})",
+            std::any::type_name_of_val(&kind)
+        )),
+    }
+}
+
+async fn emit_trigger_fired(
+    store: &EventStore,
+    workflow: &WorkflowRow,
+    trigger_kind: &str,
+    payload: Value,
+    actor: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    let envelope = FactoryEvent {
+        event: FactoryEventKind::TriggerFired {
+            workflow_id: workflow.id.clone(),
+            trigger_kind: trigger_kind.to_string(),
+            payload,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+        timestamp: now,
+    };
+    let data = serde_json::to_value(&envelope)?;
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+    };
+    store
+        .append_ext(
+            &workflow.workspace_id,
+            &format!("workflow:{}", workflow.id),
+            "workflow",
+            "trigger.fired",
+            data,
+            &metadata,
+            None,
+        )
+        .await
+        .context("appending trigger.fired")?;
+    Ok(())
+}
+
+async fn emit_audit(
+    store: &EventStore,
+    workflow: &WorkflowRow,
+    event_subtype: &str,
+    detail: Value,
+    actor: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    let payload = serde_json::json!({
+        "workflow_id": workflow.id,
+        "workspace_id": workflow.workspace_id,
+        "actor": actor,
+        "event_subtype": event_subtype,
+        "fired_at": now,
+        "detail": detail,
+    });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+    };
+    store
+        .append_ext(
+            &workflow.workspace_id,
+            &format!("audit:workflow:{}", workflow.id),
+            "audit",
+            "workflow.manual_triggered",
+            payload,
+            &metadata,
+            None,
+        )
+        .await
+        .context("appending workflow.manual_triggered")?;
+    Ok(())
+}
+
+// Quiet the unused-field lint when the binary is built without all helpers
+// in use (e.g. cargo build with cfg gating).
+#[allow(dead_code)]
+fn _force_workflow_row_fields(w: &WorkflowRow) -> bool {
+    w.active
+}

--- a/crates/onsager-trigger/src/main.rs
+++ b/crates/onsager-trigger/src/main.rs
@@ -2,8 +2,8 @@
 //!
 //! Two surfaces:
 //!
-//!   onsager trigger fire    --manual <name>  [--payload <json>]
-//!   onsager trigger replay  --event <id> <workflow_id>
+//!   onsager trigger fire   <workflow_id> --manual <name> [--payload <json>]
+//!   onsager trigger replay <workflow_id> --event <id>
 //!
 //! Both emit `FactoryEventKind::TriggerFired` to the spine directly via
 //! `EventStore` — no HTTP indirection, independent of portal (#222). The

--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -30,9 +30,10 @@ KNOWN SUBCOMMANDS:
     refract     Intent decomposer — expands high-level intents into artifacts
     stiglab     Distributed AI agent session orchestration
     synodic     AI agent governance
+    trigger     Fire or replay workflow triggers (manual / replay)
 ";
 
-const KNOWN: &[&str] = &["forge", "ising", "refract", "stiglab", "synodic"];
+const KNOWN: &[&str] = &["forge", "ising", "refract", "stiglab", "synodic", "trigger"];
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/crates/stiglab/src/core/workflow.rs
+++ b/crates/stiglab/src/core/workflow.rs
@@ -103,6 +103,7 @@ impl Workflow {
     pub fn github_repo(&self) -> Option<(&str, &str)> {
         match &self.trigger {
             TriggerKind::GithubIssueWebhook { repo, .. } => repo.split_once('/'),
+            _ => None,
         }
     }
 
@@ -111,6 +112,7 @@ impl Workflow {
     pub fn github_label(&self) -> Option<&str> {
         match &self.trigger {
             TriggerKind::GithubIssueWebhook { label, .. } => Some(label.as_str()),
+            _ => None,
         }
     }
 }

--- a/crates/stiglab/src/server/workflow_db.rs
+++ b/crates/stiglab/src/server/workflow_db.rs
@@ -90,6 +90,17 @@ pub async fn insert_workflow_with_stages(
     if TRIGGERS.lookup(trigger_kind).is_none() {
         anyhow::bail!("trigger kind {trigger_kind} is not in the registry manifest");
     }
+    // Loop guard (#239): a `SpineEvent { event_kind: "trigger.fired" }`
+    // workflow self-amplifies — every fire produces another `trigger.fired`
+    // event that the same workflow listens to. Reject at create time;
+    // forge's event-trigger listener also has a runtime backstop.
+    if let TriggerKind::SpineEvent { event_kind, .. } = &workflow.trigger {
+        if event_kind == "trigger.fired" {
+            anyhow::bail!(
+                "spine_event workflow cannot listen for `trigger.fired` (would self-amplify)"
+            );
+        }
+    }
     let install_id_text = workflow.install_id.to_string();
 
     sqlx::query(
@@ -387,6 +398,10 @@ pub async fn get_workflow_install_target(
             })?;
             Ok(Some((install_id, owner.to_string(), name.to_string())))
         }
+        // Non-GitHub triggers don't have an install target — the
+        // activation hook only runs when the trigger needs a webhook
+        // wired up on a repo.
+        _ => Ok(None),
     }
 }
 

--- a/xtask/src/check_triggers.rs
+++ b/xtask/src/check_triggers.rs
@@ -1,0 +1,285 @@
+//! Trigger-kind manifest check (#236 / #238).
+//!
+//! Walks `onsager_registry::TRIGGERS` and verifies:
+//!
+//! 1. **Coverage** — every `onsager_spine::TriggerKind` variant has a
+//!    manifest entry keyed by its snake-case `kind_tag()` mapping.
+//! 2. **Both ends declared** — every manifest entry names a producer.
+//!    (Trigger consumers are universally `forge::trigger_subscriber`,
+//!    so a separate consumer list would be busywork; we instead assert
+//!    the consumer wire-up exists statically as part of forge.)
+//! 3. **Producer category match** — schedule and event kinds must be
+//!    produced by `forge` (since their adapters live in forge);
+//!    `manual` / `replay` are produced by `portal` (CLI + portal HTTP
+//!    endpoints once #222 lands).
+//!
+//! Coverage is parsed via `syn` from
+//! `crates/onsager-spine/src/trigger.rs` — same approach as
+//! `check-events`. A variant whose `kind_tag` cannot be derived from the
+//! `kind_tag()` impl (e.g. a new variant landed without updating the
+//! function) is itself a coverage failure.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use onsager_registry::{Subsystem, TriggerCategory, TRIGGERS};
+use syn::{Expr, ExprLit, ImplItem, Item, Lit, Pat, Stmt, Type, Visibility};
+
+const TRIGGER_SRC: &str = "crates/onsager-spine/src/trigger.rs";
+const ENUM_NAME: &str = "TriggerKind";
+
+pub fn run() -> Result<()> {
+    let root = workspace_root()?;
+    let mut errors: Vec<String> = Vec::new();
+
+    let variants_to_kinds = parse_variant_kinds(&root.join(TRIGGER_SRC))?;
+    check_coverage(&variants_to_kinds, &mut errors);
+    check_both_ends_declared(&mut errors);
+    check_producer_category_matches(&mut errors);
+
+    if !errors.is_empty() {
+        eprintln!("check-triggers: {} violation(s)", errors.len());
+        for e in &errors {
+            eprintln!("  {e}");
+        }
+        eprintln!();
+        eprintln!("See spec #236 / #238 and crates/onsager-registry/src/triggers.rs.");
+        bail!("trigger-manifest check failed");
+    }
+
+    println!(
+        "check-triggers: clean ({} variants, {} manifest rows)",
+        variants_to_kinds.len(),
+        TRIGGERS.triggers.len()
+    );
+    Ok(())
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+/// Parse `crates/onsager-spine/src/trigger.rs` and return a map of
+/// `variant_name → kind_tag` (e.g. `Cron → "cron"`). Re-uses the same
+/// approach as `check-events`.
+fn parse_variant_kinds(trigger_src: &Path) -> Result<BTreeMap<String, String>> {
+    let text = std::fs::read_to_string(trigger_src)
+        .with_context(|| format!("read {}", trigger_src.display()))?;
+    let file =
+        syn::parse_file(&text).with_context(|| format!("parse {}", trigger_src.display()))?;
+
+    let mut variants: Vec<String> = Vec::new();
+    let mut kind_tag_arms: Vec<(String, String)> = Vec::new();
+
+    for item in &file.items {
+        match item {
+            Item::Enum(en) if en.ident == ENUM_NAME => {
+                if !matches!(en.vis, Visibility::Public(_)) {
+                    bail!("{ENUM_NAME} is not pub");
+                }
+                variants = en.variants.iter().map(|v| v.ident.to_string()).collect();
+            }
+            Item::Impl(im)
+                if im.trait_.is_none() && type_ident(&im.self_ty).as_deref() == Some(ENUM_NAME) =>
+            {
+                for it in &im.items {
+                    let ImplItem::Fn(f) = it else { continue };
+                    if f.sig.ident == "kind_tag" {
+                        let arms = extract_match_arms(&f.block.stmts)?;
+                        if !arms.is_empty() {
+                            kind_tag_arms = arms;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if variants.is_empty() {
+        bail!(
+            "could not find pub enum {ENUM_NAME} in {}",
+            trigger_src.display()
+        );
+    }
+    if kind_tag_arms.is_empty() {
+        bail!(
+            "could not find `kind_tag()` impl on {ENUM_NAME} in {}",
+            trigger_src.display()
+        );
+    }
+
+    let mut out = BTreeMap::new();
+    for v in &variants {
+        let kind = kind_tag_arms
+            .iter()
+            .find(|(name, _)| name == v)
+            .map(|(_, s)| s.clone())
+            .ok_or_else(|| anyhow!("kind_tag() has no arm for variant {v}"))?;
+        out.insert(v.clone(), kind);
+    }
+    Ok(out)
+}
+
+fn type_ident(ty: &Type) -> Option<String> {
+    if let Type::Path(p) = ty {
+        p.path.segments.last().map(|s| s.ident.to_string())
+    } else {
+        None
+    }
+}
+
+fn extract_match_arms(stmts: &[Stmt]) -> Result<Vec<(String, String)>> {
+    let match_expr = stmts.iter().find_map(|s| match s {
+        Stmt::Expr(Expr::Match(m), _) => Some(m),
+        _ => None,
+    });
+    let Some(match_expr) = match_expr else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::new();
+    for arm in &match_expr.arms {
+        let lit = match arm.body.as_ref() {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) => s.value(),
+            _ => bail!("kind_tag() match arm body is not a string literal"),
+        };
+        for variant in collect_variants_from_pat(&arm.pat) {
+            out.push((variant, lit.clone()));
+        }
+    }
+    Ok(out)
+}
+
+fn collect_variants_from_pat(pat: &Pat) -> Vec<String> {
+    let mut out = Vec::new();
+    walk_pat(pat, &mut out);
+    out
+}
+
+fn walk_pat(pat: &Pat, out: &mut Vec<String>) {
+    match pat {
+        Pat::Or(or) => {
+            for p in &or.cases {
+                walk_pat(p, out);
+            }
+        }
+        Pat::Struct(s) => push_last_segment(&s.path, out),
+        Pat::TupleStruct(t) => push_last_segment(&t.path, out),
+        Pat::Path(p) => push_last_segment(&p.path, out),
+        _ => {}
+    }
+}
+
+fn push_last_segment(path: &syn::Path, out: &mut Vec<String>) {
+    if let Some(seg) = path.segments.last() {
+        out.push(seg.ident.to_string());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: every TriggerKind variant has a manifest entry
+// ---------------------------------------------------------------------------
+
+fn check_coverage(variants_to_kinds: &BTreeMap<String, String>, errors: &mut Vec<String>) {
+    let manifest_kinds: BTreeSet<&'static str> =
+        TRIGGERS.triggers.iter().map(|t| t.kind_tag).collect();
+
+    for (variant, kind) in variants_to_kinds {
+        if !manifest_kinds.contains(kind.as_str()) {
+            errors.push(format!(
+                "[coverage] TriggerKind::{variant} (`{kind}`) is missing from the registry manifest"
+            ));
+        }
+    }
+
+    let known_kinds: BTreeSet<&str> = variants_to_kinds.values().map(|s| s.as_str()).collect();
+    for kind in &manifest_kinds {
+        if !known_kinds.contains(kind) {
+            errors.push(format!(
+                "[coverage] manifest entry `{kind}` does not match any TriggerKind variant"
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: every manifest entry has a producer + a description
+// ---------------------------------------------------------------------------
+
+fn check_both_ends_declared(errors: &mut Vec<String>) {
+    for t in TRIGGERS.triggers {
+        if t.kind_tag.is_empty() {
+            errors.push("[manifest] empty kind_tag".into());
+        }
+        if t.description.is_empty() {
+            errors.push(format!("[manifest] `{}` has empty description", t.kind_tag));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 3: producer must align with category
+// ---------------------------------------------------------------------------
+
+fn check_producer_category_matches(errors: &mut Vec<String>) {
+    for t in TRIGGERS.triggers {
+        let expected: &[Subsystem] = match t.category {
+            // Schedule producers live in forge (the scheduler module).
+            TriggerCategory::Schedule => &[Subsystem::Forge],
+            // Event producers live in forge (event-trigger listeners) or
+            // stiglab (the existing webhook receiver).
+            TriggerCategory::Event => &[Subsystem::Forge, Subsystem::Stiglab],
+            // Manual / replay are user-initiated; produced by the portal
+            // edge (CLI or HTTP endpoint once #222 lands).
+            TriggerCategory::Manual => &[Subsystem::Portal],
+            // Request triggers (reserved): produced by portal once they
+            // ship.
+            TriggerCategory::Request => &[Subsystem::Portal],
+        };
+        if !expected.contains(&t.producer) {
+            errors.push(format!(
+                "[manifest] `{}` (category={:?}) has producer `{}`, expected one of {:?}",
+                t.kind_tag,
+                t.category,
+                t.producer.as_str(),
+                expected.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic: a fake variant map missing from the manifest.
+    #[test]
+    fn coverage_flags_variant_not_in_manifest() {
+        let mut variants = BTreeMap::new();
+        variants.insert("FakeVariant".to_string(), "fake_kind".to_string());
+        let mut errs = Vec::new();
+        check_coverage(&variants, &mut errs);
+        assert!(
+            errs.iter().any(|e| e.contains("FakeVariant")),
+            "expected coverage error, got {errs:?}"
+        );
+    }
+
+    /// The actual manifest must satisfy all three checks.
+    #[test]
+    fn real_manifest_passes_static_checks() {
+        let mut errs = Vec::new();
+        check_both_ends_declared(&mut errs);
+        check_producer_category_matches(&mut errs);
+        assert!(errs.is_empty(), "manifest errors: {errs:?}");
+    }
+}

--- a/xtask/src/check_triggers.rs
+++ b/xtask/src/check_triggers.rs
@@ -235,15 +235,18 @@ fn check_producer_category_matches(errors: &mut Vec<String>) {
         let expected: &[Subsystem] = match t.category {
             // Schedule producers live in forge (the scheduler module).
             TriggerCategory::Schedule => &[Subsystem::Forge],
-            // Event producers live in forge (event-trigger listeners) or
-            // stiglab (the existing webhook receiver).
-            TriggerCategory::Event => &[Subsystem::Forge, Subsystem::Stiglab],
-            // Manual / replay are user-initiated; produced by the portal
-            // edge (CLI or HTTP endpoint once #222 lands).
+            // Event producers — internal event-bus signals — live
+            // exclusively in forge (the event-trigger listeners). No
+            // Stiglab fallback: a webhook receiver is a Request, not
+            // an Event.
+            TriggerCategory::Event => &[Subsystem::Forge],
+            // Request producers — external HTTP receivers — live in
+            // the edge subsystem hosting the route. Today that's
+            // stiglab; once #222 promotes portal it moves there.
+            TriggerCategory::Request => &[Subsystem::Stiglab, Subsystem::Portal],
+            // Manual / replay are user-initiated; produced by the
+            // portal edge (CLI or HTTP endpoint once #222 lands).
             TriggerCategory::Manual => &[Subsystem::Portal],
-            // Request triggers (reserved): produced by portal once they
-            // ship.
-            TriggerCategory::Request => &[Subsystem::Portal],
         };
         if !expected.contains(&t.producer) {
             errors.push(format!(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@
 //! projects on disjoint ports. See [`slot`] for the full surface.
 
 mod check_events;
+mod check_triggers;
 mod lint_api_contract;
 mod lint_seams;
 mod slot;
@@ -66,10 +67,17 @@ fn main() -> ExitCode {
                 check_events::run()
             }
         }
+        Some("check-triggers") => {
+            if args.next().is_some() {
+                Err(anyhow!("check-triggers takes no arguments"))
+            } else {
+                check_triggers::run()
+            }
+        }
         Some("slot") => slot::run(args.collect()),
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
+            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- check-triggers\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
         )),
     };
 


### PR DESCRIPTION
## Summary

Extends the trigger taxonomy foundation (#237, landed in #243) with three category children:

- **#238 — Schedule triggers (cron / delay / interval).** New `scheduler` module in forge, 5s tick, panic supervisor, sidecar `workflow_trigger_state` table for `last_fired_at`. Skip-missed catch-up policy.
- **#239 — Event triggers (spine_event / pg_notify / outbox_row).** Three forge listeners + a `JsonFilter` evaluator (equality + `$.path`). Outbox poller advances a per-workflow cursor in `outbox_trigger_cursor`. Loop guard rejects `SpineEvent { event_kind: "trigger.fired" }` at workflow create time and again at runtime.
- **#241 — Manual triggers (CLI surface only).** New `onsager-trigger` binary exposing `fire` (manual button) and `replay` (re-emit a past `TriggerFired`). Both emit `trigger.fired` directly to the spine plus a `workflow.manual_triggered` audit event with `replay_chain` markers. **Portal HTTP endpoints + dashboard "Run now" button are deferred** until #222 lands.

`TriggerKind` gains 8 variants (`Cron`, `Delay`, `Interval`, `SpineEvent`, `PgNotify`, `OutboxRow`, `Manual`, `Replay`); the registry manifest grows matching rows. `xtask check-triggers` enforces variant ↔ manifest coverage and producer/category alignment (modeled on `check-events` from Lever E).

### Migrations

- `018_workflow_trigger_state.sql` — sidecar for schedule-trigger `last_fired_at`.
- `019_outbox_trigger_cursor.sql` — sidecar cursor for `OutboxRow` polling.

Both keep the `workflows` row kind-agnostic instead of growing per-variant columns.

### Wiring

Forge's `cmd/serve.rs` spawns four new tasks alongside the existing trigger subscriber: `scheduler`, `spine_event_listener`, `pg_notify_listener`, `outbox_poller`. The dispatcher (`crates/onsager`) gains `trigger` as a known subcommand so `onsager trigger fire/replay` reaches the new binary.

## Delivers

- [x] **#238 Plan** — `Cron` / `Delay` / `Interval` variants, registry rows, sidecar table, scheduler with panic supervisor, cron crate (`cron = "0.15"`), forge serve wiring.
- [x] **#239 Plan** — `SpineEvent` / `PgNotify` / `OutboxRow` variants, registry rows, three listeners, outbox cursor sidecar, loop guard at create + runtime, `JsonFilter` evaluator.
- [x] **#241 Plan (CLI subset)** — `Manual` / `Replay` variants, registry rows, `onsager-trigger` binary with `fire` + `replay`, audit event emission, dispatcher wired.
- [x] `xtask check-triggers` lint (per #236 umbrella; first multi-variant kind set).

## Out of scope (follow-ups)

- **#241 UI surface** — portal endpoints + dashboard "Run now" button. Blocks on #222 (portal promotion).
- Dashboard per-kind config forms for the 7 new kinds. The `<TriggerKindPicker>` infrastructure from #237 already fetches the manifest and groups by category; concrete forms can land per-kind without touching the spine/registry.
- Per-tenant role gating for manual fires (any authenticated user in v1).
- Replay mutation / bulk replay.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` (all green)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- lint-seams`
- [x] `cargo run -p xtask -- check-api-contract`
- [x] `cargo run -p xtask -- check-events` (75 events, 4 subsystems)
- [x] `cargo run -p xtask -- check-triggers` (9 variants, 9 manifest rows)
- New unit tests cover: `next_fire_at` for cron/delay/interval (skip-missed semantics, timezone handling, invalid expressions), `JsonFilter` matching (top-level + `$.path` + dotted), loop-guard detection, identifier/where-clause safety checks, `TriggerKind` round-trips for all 8 new variants.

Closes #238
Closes #239
Part of #241

https://claude.ai/code/session_01NePaGrCM2LSAnabFYWzDz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NePaGrCM2LSAnabFYWzDz1)_