### PR TITLE
Add S5 identity layer (ADR 0005)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ its production discipline.
 
 - **Event-bus factory, not service mesh.** Subsystems coordinate through
   the spine (events, pg_notify, shared tables), not through synchronous
-  calls. ADR 0001 is this commitment's first concretization. Scope:
-  factory only.
+  calls. [ADR 0001](docs/adr/0001-event-bus-coordination-model.md) is
+  this commitment's first concretization. Scope: factory only.
 - **Artifacts are the unit of meaning.** Every persistent, lifecycle-bearing
   object in the factory is an artifact — internal-authored ones (specs,
   designs) and external-referenced ones (PRs, Issues) alike. Factory
@@ -37,10 +37,12 @@ its production discipline.
 
 Changes to the four bullets above carry an `Identity impact: yes` flag
 in the modifying ADR and require explicit rationale. Changes to anything
-below in this file or in derived ADRs do not.
+below in this file are by default `Identity impact: no`. ADRs themselves
+may carry either value — the flag tracks whether the ADR touches the
+four bullets above, not where the change lives.
 
-See ADR 0005 for the meta-rule on how this S5 layer evolves with
-operational scale.
+See [ADR 0005](docs/adr/0005-s5-governance-scales-with-scale.md) for
+the meta-rule on how this S5 layer evolves with operational scale.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,50 @@
 
 AI factory stack — monorepo for the Onsager event bus and its subsystems.
 
+## What makes Onsager Onsager
+
+These commitments define Onsager-the-factory's identity — the monorepo and
+its subsystems. They do not, in general, prescribe the internal structure
+of what the factory produces; downstream artifacts and deployed systems
+are their own viable systems with their own identities.
+
+The exception is **how** the factory operates on its work (specs as ground
+truth, below) — that commitment binds both Onsager's self-construction and
+its production discipline.
+
+- **Event-bus factory, not service mesh.** Subsystems coordinate through
+  the spine (events, pg_notify, shared tables), not through synchronous
+  calls. ADR 0001 is this commitment's first concretization. Scope:
+  factory only.
+- **Artifacts are the unit of meaning.** Every persistent, lifecycle-bearing
+  object in the factory is an artifact — internal-authored ones (specs,
+  designs) and external-referenced ones (PRs, Issues) alike. Factory
+  subsystems (Forge, Refract, Synodic, Ising) operate on artifacts; events
+  are state-change notifications, not first-class entities. Scope: factory
+  only — products of the factory have their own ontology.
+- **Specs are ground truth, code is downstream.** When spec and code
+  conflict, the code is wrong. Specs are amended deliberately; code is
+  amended to match. Scope: both factory self-construction and factory
+  production discipline — Onsager sessions producing artifacts inherit
+  this constraint.
+- **Internal symmetry is load-bearing.** Equivalent concepts must have
+  equivalent shapes (names, types, error models, write paths). Asymmetry
+  between equivalents is a defect, not a polish concern. The seam rule
+  and three lints (`lint-seams`, `check-events`, `check-api-contract`)
+  are this commitment's enforcement surface. Scope: factory only;
+  applies to session-produced code when it lands in the monorepo.
+
+Changes to the four bullets above carry an `Identity impact: yes` flag
+in the modifying ADR and require explicit rationale. Changes to anything
+below in this file or in derived ADRs do not.
+
+See ADR 0005 for the meta-rule on how this S5 layer evolves with
+operational scale.
+
 ## Architecture
+
+See § What makes Onsager Onsager (above) for the identity commitments
+these architectural choices instantiate.
 
 Onsager is a **factory event bus** architecture. Subsystems are runtime-decoupled
 via a shared PostgreSQL `events` / `events_ext` table + `pg_notify` channel.

--- a/docs/adr/0005-s5-governance-scales-with-scale.md
+++ b/docs/adr/0005-s5-governance-scales-with-scale.md
@@ -2,10 +2,15 @@
 
 - **Status**: Accepted
 - **Date**: 2026-05-05
-- **Identity impact**: yes (establishes the meta-rule for governance evolution)
+- **Identity impact**: yes
 - **Tracking issues**: #249
 - **Supersedes**: none
 - **Superseded by**: none
+
+This ADR carries `Identity impact: yes` because it establishes the
+meta-rule for how the four identity commitments — and the governance
+around them — evolve. The rationale lives in Context and Decision
+below.
 
 ## Context
 

--- a/docs/adr/0005-s5-governance-scales-with-scale.md
+++ b/docs/adr/0005-s5-governance-scales-with-scale.md
@@ -1,0 +1,198 @@
+# ADR 0005 — S5 governance scales with scale
+
+- **Status**: Accepted
+- **Date**: 2026-05-05
+- **Identity impact**: yes (establishes the meta-rule for governance evolution)
+- **Tracking issues**: #249
+- **Supersedes**: none
+- **Superseded by**: none
+
+## Context
+
+A VSM (Viable System Model) read of Onsager confirms it is a viable
+system in the technical sense, with most of its subsystems already
+mapped:
+
+- **S1 — operations**: agent sessions (the units that do the work).
+- **S2 — coordination substrate**: the spine, including `events` /
+  `events_ext`, `pg_notify`, and the workflow tables. Coordination
+  happens through this substrate, not through direct calls.
+- **S3 — operational management**: Forge (kernel and lifecycle),
+  Stiglab (orchestration), Synodic (gates).
+- **S3\* — audit channel**: Ising as the advisory continuous-improvement
+  surface.
+
+Two layers are not yet mapped:
+
+- **S4 — outside-and-future**: there is no typed channel today that
+  watches the environment and forecasts (market, ecosystem, longer
+  arcs). Substance exists in scattered planning notes; structure does
+  not.
+- **S5 — identity**: substance exists ambient in `CLAUDE.md` (the
+  seam rule, the internal-aesthetic value, the architectural-drift
+  glossary) and in the four ADRs that precede this one, but it has
+  never been *named* as identity. Reviewers and AI sessions infer it
+  from the writing rather than reading it as such.
+
+This ADR addresses S5. S4 stays unmapped for now.
+
+The driving question is not whether to make S5 explicit — that's
+clearly worth doing — but **how much governance machinery to stand
+up around it**. Imposing nation-state-grade infrastructure (a separate
+`PRINCIPLES.md`, mandatory amendment cooldowns, sunset audits, a
+case-law repository of past arbitrations) at tribal scale is net cost.
+Unused mechanisms decay; when they're finally needed, they aren't
+reachable because nobody has been exercising them. Tribal-scale
+societies operate without written constitutions and function fine.
+The problems that constitutions solve begin at city-state scale.
+
+Onsager today runs at tribal scale: 1–5 active agents, fewer than 5
+arbitrations per month, one human arbiter (Marvin) in the loop on
+every meaningful decision. Building governance for a scale we do not
+yet operate at would generate paperwork without producing legitimacy.
+
+## Decision
+
+S5 governance evolves in stages, with infrastructure built **only
+when scale forces it**. The current stage is tribal; subsequent stages
+are sketched so that scale changes do not require greenfield
+governance design.
+
+| Stage | Signal | S5 form |
+|---|---|---|
+| Tribal (current) | <5 arbitrations/month, 1–5 active agents | `CLAUDE.md` identity section + ADR `Identity impact` flag + Marvin's direct arbitration |
+| City-state | Recurring arbitration conflicts; different sessions giving conflicting interpretations of the same rule | Promote identity section to standalone `PRINCIPLES.md` (still amendable via regular PR) |
+| Nation | Bus factor risk materializes; need to onboard collaborators who weren't present for the original decisions | Add ADR-only amendment process, sunset audit |
+| Federation | Not yet planned | Not yet planned |
+
+Triggers are **intentionally not pre-quantified**. At tribal scale,
+quantitative thresholds add complexity without value — they require
+metrics infrastructure that itself has to be maintained, and the
+numbers chosen would be guesses against a regime we have no data for.
+Real signals appear as qualitative shifts:
+
+- "I'm starting to forget how I ruled last month."
+- "Two sessions are giving conflicting interpretations of the same
+  rule, and I can't tell which is right without re-deriving from
+  first principles."
+- "I'm spending more time arbitrating than building."
+
+Marvin's judgment identifies these. When the upgrade signal fires, the
+next stage's S5 form lands as its own ADR, building on this one.
+
+The four identity commitments themselves (in root `CLAUDE.md` under
+"What makes Onsager Onsager") are settled by the same prior discussion
+that produced this ADR; they are not litigated here. This ADR is the
+meta-rule about how those commitments — and the governance around them
+— evolve.
+
+## Rejected alternatives
+
+- **Standalone `PRINCIPLES.md` now.** Considered. Rejected at current
+  scale. A standalone file implies separate amendment process, which
+  implies process around the process — all of which atrophies if used
+  fewer than 5 times per month. The `CLAUDE.md` section captures ~80%
+  of the P0 benefit (identity is named, AI sessions read it on every
+  task, ADRs can flag impact) at <20% of the maintenance cost. Promote
+  to standalone when the city-state signal fires.
+- **Quantitative upgrade triggers** (e.g. "promote to city-state when
+  >10 arbitrations/month for 3 consecutive months"). Considered.
+  Rejected. Picking numbers requires data we don't have, and the
+  metrics infrastructure to track them is itself overhead. Qualitative
+  signals are catchable by Marvin and don't require a measurement loop.
+- **Skip S5 entirely; let identity stay ambient.** Rejected. Ambient
+  identity drifts under AI generation: each session re-derives from
+  the surface text, and the derivations slowly diverge. Naming the
+  commitments and gating ADR changes through an `Identity impact` flag
+  is the minimum that arrests that drift, and it's cheap.
+- **Address S4 in the same ADR.** Rejected as scope creep. S4 needs
+  its own forcing function (probably the first time we mis-time a
+  capability against an ecosystem shift) and its own ADR. Doing both
+  in one document would dilute the S5 decision and pre-empt the S4
+  one.
+
+## Consequences
+
+### Positive
+
+- Governance overhead is matched to current scale. We are not paying
+  for unused machinery, and the upgrade path is identified so scale
+  changes do not require greenfield governance design.
+- Identity content becomes explicit — readable by AI sessions on every
+  task, and citable by ADRs. The 80% of P0 benefit (drift arrest,
+  shared vocabulary) is captured at tribal scale.
+- The `Identity impact` flag adds a small, durable signal to the ADR
+  process: changes that touch identity get flagged and rationalized,
+  changes that don't aren't burdened with extra ceremony.
+- Future governance upgrades inherit a known starting point. The
+  city-state PR is "promote the section to its own file"; the nation
+  PR is "add the amendment process to the file that already exists."
+  Each step is small.
+
+### Negative / trade-offs
+
+- Upgrade timing depends on Marvin's subjective judgment. Risk: the
+  upgrade lands later than optimal because the qualitative signal is
+  ambiguous or arrives slowly. The mitigation is periodic reflection
+  ("am I forgetting how I ruled?") rather than a metric.
+- Absence of quantitative triggers means "should have upgraded but
+  didn't" is only catchable via that periodic reflection. There is no
+  alarm.
+- The four identity commitments concentrate authorial risk: they were
+  settled in one prior discussion, and changing them carries a higher
+  bar than other decisions. That's intentional — identity *should* be
+  expensive to change — but it does mean a phrasing mistake is sticky.
+
+### Neutral
+
+- The `Identity impact` flag is the only process change. Everything
+  else (regular ADR mechanics, PR review, CI lints) continues as
+  before. No code change.
+- ADRs 0001–0004 are not retroactively flagged. The flag applies
+  going forward only.
+
+## Dev-process counterpart
+
+Per ADR 0002, every ADR declares the dev-process analog of the
+decision it records.
+
+This ADR's own governance weight — a single ADR plus a `CLAUDE.md`
+prose section, no separate file, no amendment cooldowns — is itself
+a sample of current S5 governance strength. When this ADR's form is
+no longer adequate (it needs to cross-reference five related ADRs;
+it grows subsections that should be their own documents; the
+`Identity impact` flag starts firing on most ADRs and a coarser
+mechanism is needed), that's one signal S5 governance needs to
+upgrade to city-state form.
+
+The same-defect-class rule (ADR 0002) applies: a recurring
+"two sessions interpreted the rule differently" incident is the
+S5 analog of a coordination-state-drift incident at the spine layer.
+When the dev-process pattern accumulates, the upgrade is structural,
+not procedural — exactly as it would be for a product subsystem.
+
+## Adoption checklist
+
+- [x] Add the "What makes Onsager Onsager" section to root `CLAUDE.md`,
+      immediately before `## Architecture`.
+- [x] Add a one-liner cross-link from `## Architecture` back up to the
+      identity section.
+- [x] Document the `Identity impact: yes/no` metadata field in
+      `docs/adr/README.md` ("How to add an ADR"), and add 0005 to the
+      index.
+- [x] This ADR exists with `Identity impact: yes` and is linked from
+      the `CLAUDE.md` identity section and the ADR index.
+
+## Out of scope
+
+- **A standalone `PRINCIPLES.md` file.** Explicit non-decision at
+  current scale; revisit when the city-state signal fires.
+- **Quantitative upgrade triggers.** Considered and rejected.
+- **Retroactive `Identity impact` flagging of ADRs 0001–0004.** Going
+  forward only.
+- **Modifying the four identity commitments themselves.** Settled by
+  the discussion that produced this ADR; phrasing-only nits welcome
+  via separate PR, substance changes require their own ADR with
+  `Identity impact: yes`.
+- **S4 (outside-and-future) layer.** Acknowledged as missing; deferred
+  to its own ADR when a forcing function appears.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,15 +15,34 @@ see [`../architecture.md`](../architecture.md).
 | [0002](0002-process-product-isomorphism.md) | Process ↔ product isomorphism as design discipline | Accepted (2026-04-19, amended 2026-05-01) |
 | [0003](0003-deliverable-and-registry-backed-kinds.md) | Deliverable as the workflow-run output; registry-backed artifact kinds | Accepted (2026-04-22) — v1 partially landed under #100 |
 | [0004](0004-tighten-the-seams.md) | Tighten the seams: HTTP at external boundaries, spine for everything internal | Accepted (2026-04-26, amended 2026-04-30) — all six levers landed (2026-04-30) |
+| [0005](0005-s5-governance-scales-with-scale.md) | S5 governance scales with scale | Accepted (2026-05-05) — `Identity impact: yes` |
 
 ## How to add an ADR
 
 1. Pick the next sequential number.
 2. Write `NNNN-short-slug.md` following the existing template:
-   Status / Date / Tracking issues / Context / Decision / Rejected alternatives /
-   Consequences / **Dev-process counterpart** (per ADR 0002) /
-   Adoption checklist / Out of scope.
+   Status / Date / **Identity impact** (per ADR 0005) / Tracking issues /
+   Context / Decision / Rejected alternatives / Consequences /
+   **Dev-process counterpart** (per ADR 0002) / Adoption checklist /
+   Out of scope.
 3. Link it from `CLAUDE.md` and from this index.
 4. If the ADR introduces an architectural invariant that should be enforced,
    open a follow-up spec for the lint or contract test that makes it
    machine-checkable (per ADR 0004's no-escape-hatch posture).
+
+## The `Identity impact` field
+
+Per [ADR 0005](0005-s5-governance-scales-with-scale.md), every new ADR
+declares whether it changes any of the four identity commitments named
+in root `CLAUDE.md` ("What makes Onsager Onsager"):
+
+- **`Identity impact: no`** (the common case) — the ADR records a
+  decision that operates within the existing identity commitments. No
+  extra rationale needed beyond the usual ADR sections.
+- **`Identity impact: yes`** — the ADR amends or extends one of the
+  four identity commitments, or establishes a new one. The ADR must
+  include explicit rationale for which commitment(s) change and why.
+  Identity changes are sticky by design and carry a higher review bar.
+
+The flag applies to ADRs from 0005 onward. ADRs 0001–0004 are not
+retroactively flagged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,8 +20,18 @@ see [`../architecture.md`](../architecture.md).
 ## How to add an ADR
 
 1. Pick the next sequential number.
-2. Write `NNNN-short-slug.md` following the existing template:
-   Status / Date / **Identity impact** (per ADR 0005) / Tracking issues /
+2. Write `NNNN-short-slug.md` following the existing template. Header
+   metadata block (in this order):
+   - `Status` — `Accepted` / `Proposed` / `Superseded`.
+   - `Date` — ISO date.
+   - `Identity impact` — `yes` or `no` (per ADR 0005; required for
+     ADRs from 0005 onward).
+   - `Tracking issues` — links to the spec and any sub-issues.
+   - `Supersedes` — prior ADR number, or `none`.
+   - `Superseded by` — `none` at creation; updated if a later ADR
+     replaces this one.
+
+   Body sections (in this order):
    Context / Decision / Rejected alternatives / Consequences /
    **Dev-process counterpart** (per ADR 0002) / Adoption checklist /
    Out of scope.
@@ -34,7 +44,10 @@ see [`../architecture.md`](../architecture.md).
 
 Per [ADR 0005](0005-s5-governance-scales-with-scale.md), every new ADR
 declares whether it changes any of the four identity commitments named
-in root `CLAUDE.md` ("What makes Onsager Onsager"):
+in root `CLAUDE.md` ("What makes Onsager Onsager"). The value is exactly
+`yes` or `no` — keep it mechanically scannable. Any rationale belongs
+in Context / Decision (or a one-sentence note immediately below the
+metadata block), not inside the field value.
 
 - **`Identity impact: no`** (the common case) — the ADR records a
   decision that operates within the existing identity commitments. No


### PR DESCRIPTION
## Summary

- Names the four identity commitments that have been ambient in `CLAUDE.md`
  and the ADRs (event-bus factory, artifacts as the unit of meaning, specs
  as ground truth, internal symmetry) in a new "What makes Onsager Onsager"
  section at the top of root `CLAUDE.md`.
- Adds an `Identity impact: yes/no` metadata field to the ADR convention so
  future changes to the four commitments are flagged and rationalized.
  Going forward only — ADRs 0001–0004 are not retroactively flagged.
- Records ADR 0005 (`Identity impact: yes`), the meta-rule that S5
  governance scales with operational scale: tribal form now (CLAUDE.md
  section + flag + Marvin's direct arbitration), city-state / nation
  forms sketched for later when qualitative signals fire.

Closes #249

## Why this shape

Per the prior VSM analysis, Onsager has S1–S3 mapped (S1=agent sessions,
S2=spine substrate, S3=Forge+Stiglab+Synodic, S3*=Ising). S5 substance
exists ambient in `CLAUDE.md` and the ADRs but isn't named as such, which
lets identity drift under AI generation. This PR makes S5 explicit at
tribal scale only — no separate `PRINCIPLES.md`, no quantitative upgrade
triggers, no amendment cooldowns. Those are city-state / nation
infrastructure and would decay unused at our current scale (1–5 agents,
<5 arbitrations/month).

## Out of scope

- Separate `PRINCIPLES.md` file — explicitly rejected at current scale;
  promote when the city-state signal fires.
- Quantitative upgrade triggers — considered and rejected; rely on
  qualitative signals via Marvin's judgment.
- Retroactive `Identity impact` flag on ADRs 0001–0004 — going forward
  only.
- Changes to the four identity commitments themselves — settled in the
  prior discussion; substance changes need their own ADR with
  `Identity impact: yes`.
- S4 (outside-and-future) layer — acknowledged as missing in ADR 0005's
  Context, deferred to its own ADR.

## Test plan

- [x] `cargo run -p xtask -- lint-seams` — clean.
- [x] `cargo run -p xtask -- check-api-contract` — clean.
- [x] `cargo run -p xtask -- check-events` — clean.
- [x] `cargo run -p xtask -- gen-event-docs --check` — up to date.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `docs/adr/README.md` index includes 0005 and documents the new
      `Identity impact` field.
- [x] ADR 0005 follows the same section ordering as ADRs 0001–0004 (with
      `Identity impact: yes` immediately after `Date`).
- [x] Identity section in `CLAUDE.md` reads as a coherent statement; the
      `## Architecture` section cross-links back to it.

Doc-only change; no Rust code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_016M5iQczAWHepoDC4Z7DFb7)_