### PR TITLE
feat(portal): move PATs stiglab → portal (#222 Slice 2b)

### DIFF
--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -72,17 +72,30 @@ first-class edge subsystem. The migration is staged:
   the same URLs through `routes::portal::proxy` (which now forwards
   `Set-Cookie` and `Location` so the OAuth dance round-trips
   unchanged) and keeps a cookie-only read against the spine-shared
-  `auth_sessions` table for its own `AuthUser` extractor. PAT
-  validation still lives in stiglab — Slice 2 moves it.
-- **Routes (follow-ups).** Slices 2/3/4: move
-  `/api/credentials/*`, `/api/pats/*`, `/api/workspaces/*`,
+  `auth_sessions` table for its own `AuthUser` extractor.
+- **Slice 2b — Personal Access Tokens (landed).** Portal owns
+  `GET/POST /api/pats` and `DELETE /api/pats/{id}`. The PAT
+  primitives — `PAT_TOKEN_NAMESPACE`, `generate_pat_token`,
+  `hash_pat_token`, `verify_pat`, `RequestPrincipal`, the
+  PAT-aware `AuthUser` Bearer-vs-cookie precedence — moved from
+  `stiglab/src/server/auth.rs` to `onsager-portal/src/auth.rs`.
+  `/api/auth/me` now reports `via: "pat" | "session"` based on the
+  request principal. The `user_pats` schema lives in
+  `crates/onsager-portal/migrations/005_user_pats.sql`. Stiglab
+  proxies `/api/pats*` through `routes::portal::proxy` and keeps
+  its own PAT machinery in `auth.rs` for the routes that still
+  accept PAT bearer auth (credentials in 2a, workspaces/projects
+  in 3, workflows in 4) — same database, separate connection
+  pool, portal is the only writer.
+- **Routes (follow-ups).** Slices 2a/3/4: move
+  `/api/credentials/*`, `/api/workspaces/*`,
   `/api/installations/*`, `/api/workflows/*`, and the preset
   registry into portal. Each route group lands atomically (portal
   handler live + stiglab handler deleted in the same PR).
 - **Schema split (follow-ups).** `workspaces` /
   `workspace_members` / `projects` move into
   `crates/onsager-spine/migrations/`; `user_credentials`,
-  `github_app_installations`, `user_pats` move into
+  `github_app_installations` move into
   `crates/onsager-portal/migrations/` next to the auth migrations.
   Atomic per-PR per Lever B.
 

--- a/crates/onsager-portal/migrations/005_user_pats.sql
+++ b/crates/onsager-portal/migrations/005_user_pats.sql
@@ -1,0 +1,43 @@
+-- Portal-owned schema: server-issued bearer tokens (Personal Access Tokens
+-- per issue #143) that authenticate non-browser callers as a specific user.
+--
+-- Spec #222 Slice 2b — moved from stiglab's inline `CREATE TABLE` block to
+-- portal. Portal mints, lists, and revokes PATs through `/api/pats*`; the
+-- AuthUser extractor on portal verifies presented tokens. Stiglab still
+-- reads this table from its `AnyPool` for its own `AuthUser` extractor —
+-- credentials/workspaces/projects/workflows still live behind the seam on
+-- stiglab and accept PAT bearer auth — until Slices 2a, 3, and 4 finish
+-- moving those routes. Same database, separate connection pool; portal is
+-- the only writer.
+--
+-- The full token is never stored: `token_hash` is the SHA-256 hex of the
+-- raw token, `token_prefix` is the first `PAT_PREFIX_LEN` characters for
+-- display + indexed lookup. `workspace_id` is the workspace this PAT is
+-- pinned to (mandatory since #163 — cross-workspace calls 403). `revoked_at`
+-- is a soft-delete: revoked rows stay for audit but fail verification.
+--
+-- `workspace_id` is intentionally TEXT without a foreign key to `workspaces`
+-- for the same reason `portal_webhook_secrets` skips the FK: the
+-- `workspaces` table currently lives in stiglab's runtime migrations
+-- (target: spine, per spec #222 Slice 3). Once workspaces move into the
+-- spine, the FK can be added in a follow-up migration.
+
+CREATE TABLE IF NOT EXISTS user_pats (
+    id                   TEXT PRIMARY KEY,
+    user_id              TEXT NOT NULL,
+    workspace_id         TEXT NOT NULL,
+    name                 TEXT NOT NULL,
+    token_prefix         TEXT NOT NULL,
+    token_hash           TEXT NOT NULL,
+    scopes               TEXT NOT NULL DEFAULT '["*"]',
+    expires_at           TEXT,
+    last_used_at         TEXT,
+    last_used_ip         TEXT,
+    last_used_user_agent TEXT,
+    created_at           TEXT NOT NULL,
+    revoked_at           TEXT,
+    UNIQUE (user_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_pats_user_id      ON user_pats (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_pats_token_prefix ON user_pats (token_prefix);

--- a/crates/onsager-portal/src/auth.rs
+++ b/crates/onsager-portal/src/auth.rs
@@ -1,22 +1,24 @@
-//! Auth primitives for portal-served `/api/auth/*` routes.
+//! Auth primitives for portal-served `/api/auth/*` and `/api/pats*` routes.
 //!
-//! Owns the `users`, `auth_sessions`, and `sso_exchange_codes` tables
-//! (portal migrations 002–004). Portal mints session cookies on the
-//! OAuth callback and the SSO finish path; downstream stiglab routes
-//! still validate the cookie out-of-band against the same tables —
-//! one DB, one writer (portal), readers wherever.
-//!
-//! Slice 5 of spec #222 introduces this module. Slice 2 will follow
-//! up with PAT verification + credential encryption (still in stiglab
-//! today).
+//! Owns the `users`, `auth_sessions`, `sso_exchange_codes`, and `user_pats`
+//! tables (portal migrations 002–005). Portal mints session cookies on the
+//! OAuth callback and the SSO finish path, and mints + verifies Personal
+//! Access Tokens. Stiglab's own `AuthUser` extractor still validates
+//! cookies and PATs out-of-band against the same tables — one DB, one
+//! writer (portal), readers wherever — until Slices 2a/3/4 of spec #222
+//! finish moving the dependent routes to portal.
 
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ring::digest;
 use ring::rand::{SecureRandom, SystemRandom};
 
 use crate::auth_db;
+use crate::pat_db;
 use crate::state::AppState;
 
 // ── GitHub OAuth (re-exports) ──
@@ -51,7 +53,173 @@ pub fn generate_state() -> String {
     hex::encode(bytes)
 }
 
+// ── Personal Access Tokens (issue #143) ──
+
+/// Token namespace prefix. Matches GitHub's `ghp_` style so secret scanners
+/// can recognize Onsager PATs in source-control / log scrapes.
+pub const PAT_TOKEN_NAMESPACE: &str = "ons_pat_";
+
+/// Length of the prefix stored in the DB for display + indexed lookup.
+/// `ons_pat_` (8 chars) + 4 chars of token entropy = 12 chars total.
+pub const PAT_PREFIX_LEN: usize = 12;
+
+/// Number of random bytes mixed into a PAT after the namespace prefix.
+const PAT_RANDOM_BYTES: usize = 32;
+
+/// Constant-time secret comparison. Both inputs are compared as raw bytes.
+/// Short-circuits only on length mismatch — the attacker controls whether
+/// a comparison is made at all, not how long it takes once started.
+fn secrets_equal(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// A freshly generated PAT, ready to be persisted (`hash`) and shown to the
+/// user exactly once (`token`).
+pub struct GeneratedPat {
+    /// The full token to hand to the user. Begins with `ons_pat_`.
+    pub token: String,
+    /// First [`PAT_PREFIX_LEN`] characters of `token`. Stored in the clear
+    /// for display + lookup.
+    pub prefix: String,
+    /// Hex-encoded SHA-256 of `token`. The only thing persisted to the DB
+    /// from the secret material.
+    pub hash: String,
+}
+
+/// Generate a fresh personal access token. The full token is `ons_pat_` plus
+/// 32 random url-safe bytes — about 256 bits of entropy after the namespace
+/// prefix. Only the hash is stored; the caller is responsible for showing
+/// `token` to the user exactly once.
+pub fn generate_pat_token() -> GeneratedPat {
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; PAT_RANDOM_BYTES];
+    rng.fill(&mut bytes).expect("rng failed to generate bytes");
+    let token = format!("{PAT_TOKEN_NAMESPACE}{}", URL_SAFE_NO_PAD.encode(bytes));
+    let prefix = pat_prefix(&token);
+    let hash = hash_pat_token(&token);
+    GeneratedPat {
+        token,
+        prefix,
+        hash,
+    }
+}
+
+/// Hex-encoded SHA-256 of the raw token. Used both at insert time and on
+/// every verification.
+pub fn hash_pat_token(token: &str) -> String {
+    let digest = digest::digest(&digest::SHA256, token.as_bytes());
+    hex::encode(digest.as_ref())
+}
+
+/// Return the lookup prefix for a token. Always [`PAT_PREFIX_LEN`] chars
+/// when the token is well-formed; for malformed (too-short) tokens returns
+/// the entire string so callers can compare without panicking.
+pub fn pat_prefix(token: &str) -> String {
+    if token.len() >= PAT_PREFIX_LEN {
+        token[..PAT_PREFIX_LEN].to_string()
+    } else {
+        token.to_string()
+    }
+}
+
+/// Outcome of verifying a PAT against the DB. The `Invalid` arms are split
+/// from `Ok` so the extractor can return the right `WWW-Authenticate` body
+/// without leaking which step failed. `UserPat` is boxed to keep the enum
+/// itself pointer-sized — most call sites match the small arms.
+#[derive(Debug)]
+pub enum PatVerifyOutcome {
+    Ok(Box<pat_db::UserPat>),
+    /// Prefix matched no row, or the hash didn't match any candidate row.
+    Unknown,
+    /// Row matched but is revoked or past its `expires_at`.
+    Revoked,
+    Expired,
+}
+
+/// Verify a presented PAT. Looks up candidate rows by `token_prefix`, then
+/// constant-time compares the SHA-256 hash against each candidate. The
+/// prefix is non-secret; the hash compare is the actual identity check.
+pub async fn verify_pat(
+    pool: &sqlx::postgres::PgPool,
+    presented_token: &str,
+) -> anyhow::Result<PatVerifyOutcome> {
+    if !presented_token.starts_with(PAT_TOKEN_NAMESPACE) {
+        return Ok(PatVerifyOutcome::Unknown);
+    }
+    let prefix = pat_prefix(presented_token);
+    let presented_hash = hash_pat_token(presented_token);
+    let candidates = pat_db::find_pats_by_prefix(pool, &prefix).await?;
+    if candidates.is_empty() {
+        return Ok(PatVerifyOutcome::Unknown);
+    }
+
+    let mut matched: Option<pat_db::UserPat> = None;
+    for (pat, stored_hash) in candidates {
+        if secrets_equal(&presented_hash, &stored_hash) {
+            matched = Some(pat);
+            // Don't break — keep iterating to keep the work uniform across
+            // collision and non-collision paths. The hash space makes >1
+            // match astronomically unlikely; the loop is still O(n) on the
+            // (non-secret) prefix bucket.
+        }
+    }
+
+    let Some(pat) = matched else {
+        return Ok(PatVerifyOutcome::Unknown);
+    };
+
+    if pat.revoked_at.is_some() {
+        return Ok(PatVerifyOutcome::Revoked);
+    }
+    if let Some(exp) = pat.expires_at {
+        if exp < chrono::Utc::now() {
+            return Ok(PatVerifyOutcome::Expired);
+        }
+    }
+    Ok(PatVerifyOutcome::Ok(Box::new(pat)))
+}
+
 // ── Auth Extractor ──
+
+/// Whether the request was authenticated via a browser session cookie or a
+/// PAT bearer token. Surfaced on [`AuthUser`] so destructive endpoints can
+/// gate behavior on the principal kind.
+#[derive(Debug, Clone)]
+pub enum RequestPrincipal {
+    /// Cookie-based session (the `stiglab_session` flow).
+    Session,
+    /// PAT-authenticated request. `pat_id` identifies the issuing token row;
+    /// `workspace_id` pins the request to that workspace — every PAT is
+    /// workspace-scoped post-#163, so this is mandatory at the type level.
+    Pat {
+        pat_id: String,
+        workspace_id: String,
+    },
+}
+
+impl RequestPrincipal {
+    pub fn is_pat(&self) -> bool {
+        matches!(self, RequestPrincipal::Pat { .. })
+    }
+
+    /// The workspace a PAT is pinned to. `None` for cookie/session
+    /// principals; PAT principals are always pinned.
+    pub fn pinned_workspace_id(&self) -> Option<&str> {
+        match self {
+            RequestPrincipal::Pat { workspace_id, .. } => Some(workspace_id.as_str()),
+            _ => None,
+        }
+    }
+}
 
 /// How the user behind a request was minted. The dashboard renders a
 /// persistent dev-mode banner when this is `Dev` (issue #193).
@@ -76,19 +244,43 @@ pub fn session_kind_for_github_id(github_id: i64) -> SessionKind {
     }
 }
 
-/// Authenticated user extracted from the `stiglab_session` cookie.
-///
-/// Portal's extractor is cookie-only — PAT bearer auth is still served
-/// by stiglab (it owns the `user_pats` table until Slice 2). Portal
-/// doesn't yet host any route that accepts a PAT, so the slim shape is
-/// sufficient.
+/// Authenticated user extracted from request cookies or a PAT Bearer token.
+/// Auth is always-on as of issue #193 — every request must resolve to a
+/// real `users` row. There is no synthetic principal.
 #[derive(Debug, Clone)]
 pub struct AuthUser {
     pub user_id: String,
     pub github_login: String,
     pub github_name: Option<String>,
     pub github_avatar_url: Option<String>,
+    pub principal: RequestPrincipal,
     pub session_kind: SessionKind,
+}
+
+/// Pull the bearer token (if any) out of the `Authorization` header.
+pub fn parse_bearer_token(parts: &Parts) -> Option<String> {
+    let v = parts
+        .headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = v.strip_prefix("Bearer ")?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+fn unauthorized_invalid_token() -> Response {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(
+            axum::http::header::WWW_AUTHENTICATE,
+            "Bearer error=\"invalid_token\"",
+        )
+        .body(axum::body::Body::from("invalid token"))
+        .unwrap()
 }
 
 impl FromRequestParts<AppState> for AuthUser {
@@ -98,6 +290,83 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
+        // 1) Try PAT Bearer token first. A valid PAT wins over any cookie
+        //    on the same request — cookie + Bearer normally doesn't happen
+        //    in practice, but a CLI smoke test of the dashboard shouldn't
+        //    silently fall through to the browser session.
+        if let Some(token) = parse_bearer_token(parts) {
+            if token.starts_with(PAT_TOKEN_NAMESPACE) {
+                match verify_pat(&state.pool, &token).await {
+                    Ok(PatVerifyOutcome::Ok(pat)) => {
+                        let user = match auth_db::get_user(&state.pool, &pat.user_id).await {
+                            Ok(Some(u)) => u,
+                            Ok(None) => {
+                                tracing::warn!(
+                                    pat_id = %pat.id,
+                                    "PAT references missing user — rejecting"
+                                );
+                                return Err(unauthorized_invalid_token());
+                            }
+                            Err(e) => {
+                                tracing::error!("PAT auth: failed to load user: {e}");
+                                return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                            }
+                        };
+
+                        // Best-effort touch — failure must not block the
+                        // request. Capture client metadata before the move.
+                        let pool = state.pool.clone();
+                        let pat_id = pat.id.clone();
+                        let ip = parts
+                            .headers
+                            .get("x-forwarded-for")
+                            .and_then(|v| v.to_str().ok())
+                            .and_then(|s| s.split(',').next())
+                            .map(|s| s.trim().to_string());
+                        let ua = parts
+                            .headers
+                            .get(axum::http::header::USER_AGENT)
+                            .and_then(|v| v.to_str().ok())
+                            .map(|s| s.to_string());
+                        tokio::spawn(async move {
+                            if let Err(e) =
+                                pat_db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref())
+                                    .await
+                            {
+                                tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
+                            }
+                        });
+
+                        let session_kind = session_kind_for_github_id(user.github_id);
+                        return Ok(AuthUser {
+                            user_id: user.id,
+                            github_login: user.github_login,
+                            github_name: user.github_name,
+                            github_avatar_url: user.github_avatar_url,
+                            principal: RequestPrincipal::Pat {
+                                pat_id: pat.id,
+                                workspace_id: pat.workspace_id,
+                            },
+                            session_kind,
+                        });
+                    }
+                    Ok(PatVerifyOutcome::Unknown)
+                    | Ok(PatVerifyOutcome::Revoked)
+                    | Ok(PatVerifyOutcome::Expired) => {
+                        return Err(unauthorized_invalid_token());
+                    }
+                    Err(e) => {
+                        tracing::error!("PAT verification failed: {e}");
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                    }
+                }
+            }
+            // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
+            // are owned by their dedicated routes — fall through so the
+            // cookie path still works for the dashboard.
+        }
+
+        // 2) Fall back to the session cookie.
         let session_id = parts
             .headers
             .get(axum::http::header::COOKIE)
@@ -117,6 +386,7 @@ impl FromRequestParts<AppState> for AuthUser {
                     github_login: auth_session.user.github_login,
                     github_name: auth_session.user.github_name,
                     github_avatar_url: auth_session.user.github_avatar_url,
+                    principal: RequestPrincipal::Session,
                     session_kind,
                 })
             }
@@ -211,5 +481,52 @@ mod tests {
             "\"github\""
         );
         assert_eq!(serde_json::to_string(&SessionKind::Dev).unwrap(), "\"dev\"");
+    }
+
+    #[test]
+    fn test_generate_pat_token_shape() {
+        let pat = generate_pat_token();
+        assert!(
+            pat.token.starts_with(PAT_TOKEN_NAMESPACE),
+            "token should start with the namespace prefix"
+        );
+        assert_eq!(pat.prefix.len(), PAT_PREFIX_LEN);
+        assert_eq!(pat.prefix, &pat.token[..PAT_PREFIX_LEN]);
+        // SHA-256 hex is 64 chars.
+        assert_eq!(pat.hash.len(), 64);
+        assert_eq!(pat.hash, hash_pat_token(&pat.token));
+    }
+
+    #[test]
+    fn test_generate_pat_token_uniqueness() {
+        let a = generate_pat_token();
+        let b = generate_pat_token();
+        assert_ne!(a.token, b.token);
+        assert_ne!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn test_hash_pat_token_deterministic() {
+        let token = "ons_pat_abc123";
+        assert_eq!(hash_pat_token(token), hash_pat_token(token));
+        assert_ne!(hash_pat_token(token), hash_pat_token("ons_pat_abc124"));
+    }
+
+    #[test]
+    fn test_pat_prefix_short_token_doesnt_panic() {
+        let s = pat_prefix("abc");
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn test_request_principal_helpers() {
+        assert!(!RequestPrincipal::Session.is_pat());
+        assert_eq!(RequestPrincipal::Session.pinned_workspace_id(), None);
+        let p = RequestPrincipal::Pat {
+            pat_id: "p1".into(),
+            workspace_id: "w1".into(),
+        };
+        assert!(p.is_pat());
+        assert_eq!(p.pinned_workspace_id(), Some("w1"));
     }
 }

--- a/crates/onsager-portal/src/handlers/auth.rs
+++ b/crates/onsager-portal/src/handlers/auth.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::auth::{
     self, exchange_code, generate_session_token, generate_state, get_github_user,
-    github_authorize_url, AuthUser,
+    github_authorize_url, AuthUser, RequestPrincipal,
 };
 use crate::auth_db::{self, User};
 use crate::config::Config;
@@ -506,7 +506,16 @@ pub async fn sso_finish(
 // ── /api/auth/me + logout ──
 
 /// GET /api/auth/me — Return current authenticated user.
+///
+/// `via` distinguishes a cookie-authenticated browser session from a PAT
+/// bearer call so dashboards can render a "you are signed in via PAT"
+/// affordance and CLI smoke tests can confirm their token is the
+/// principal in scope (not a stray browser cookie).
 pub async fn me(State(_state): State<AppState>, auth_user: AuthUser) -> impl IntoResponse {
+    let via = match auth_user.principal {
+        RequestPrincipal::Pat { .. } => "pat",
+        RequestPrincipal::Session => "session",
+    };
     Json(serde_json::json!({
         "user": {
             "id": auth_user.user_id,
@@ -515,7 +524,7 @@ pub async fn me(State(_state): State<AppState>, auth_user: AuthUser) -> impl Int
             "github_avatar_url": auth_user.github_avatar_url,
         },
         "session_kind": auth_user.session_kind,
-        "via": "session",
+        "via": via,
     }))
 }
 

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod auth;
 pub mod issues;
+pub mod pats;
 pub mod pull_request;
 pub mod spec_link;
 pub mod webhook;

--- a/crates/onsager-portal/src/handlers/pats.rs
+++ b/crates/onsager-portal/src/handlers/pats.rs
@@ -1,9 +1,16 @@
-//! Personal Access Token CRUD (issue #143).
+//! `/api/pats*` route handlers.
 //!
-//! Tokens are user-owned bearer credentials minted server-side, stored only
-//! as a SHA-256 hash, and revealed to the user exactly once on creation.
-//! Listing returns prefix-only metadata; the full token is unrecoverable
-//! after the create call returns.
+//! Personal Access Token CRUD (issue #143). Tokens are user-owned bearer
+//! credentials minted server-side, stored only as a SHA-256 hash, and
+//! revealed to the user exactly once on creation. Listing returns
+//! prefix-only metadata; the full token is unrecoverable after the create
+//! call returns.
+//!
+//! Spec #222 Slice 2b moved this surface from stiglab to portal so the
+//! external HTTP boundary is owned by the edge subsystem (clause 1 of the
+//! seam rule). Stiglab proxies `/api/pats*` to portal via
+//! `routes::portal::proxy` so the dashboard's API_BASE cutover (Slice 6)
+//! can land independently.
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -13,14 +20,14 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::server::auth::{generate_pat_token, AuthUser};
-use crate::server::db;
-use crate::server::state::AppState;
+use crate::auth::{generate_pat_token, AuthUser};
+use crate::pat_db::{self, UserPat};
+use crate::state::AppState;
 
 #[derive(Debug, Deserialize)]
 pub struct CreatePatBody {
     pub name: String,
-    /// Workspace the PAT is scoped to.  Every PAT is workspace-pinned
+    /// Workspace the PAT is scoped to. Every PAT is workspace-pinned
     /// post-#163; requests touching another workspace 403.
     pub workspace_id: String,
     /// Required by the API surface; the dashboard always sends one of the
@@ -29,14 +36,7 @@ pub struct CreatePatBody {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
-#[allow(clippy::result_large_err)]
-fn require_authenticated(auth_user: &AuthUser) -> Result<&str, Response> {
-    // Auth is always-on as of #193; the `AuthUser` extractor 401s
-    // unauthenticated requests before they reach this helper.
-    Ok(auth_user.user_id.as_str())
-}
-
-fn pat_summary(pat: &db::UserPat) -> serde_json::Value {
+fn pat_summary(pat: &UserPat) -> serde_json::Value {
     serde_json::json!({
         "id": pat.id,
         "name": pat.name,
@@ -51,13 +51,9 @@ fn pat_summary(pat: &db::UserPat) -> serde_json::Value {
     })
 }
 
-/// GET /api/pats — List the caller's PATs (no token material).
+/// GET /api/pats — list the caller's PATs (no token material).
 pub async fn list_pats(State(state): State<AppState>, auth_user: AuthUser) -> Response {
-    let user_id = match require_authenticated(&auth_user) {
-        Ok(id) => id.to_string(),
-        Err(r) => return r,
-    };
-    match db::list_user_pats(&state.db, &user_id).await {
+    match pat_db::list_user_pats(&state.pool, &auth_user.user_id).await {
         Ok(pats) => {
             let items: Vec<_> = pats.iter().map(pat_summary).collect();
             Json(serde_json::json!({ "pats": items })).into_response()
@@ -69,17 +65,14 @@ pub async fn list_pats(State(state): State<AppState>, auth_user: AuthUser) -> Re
     }
 }
 
-/// POST /api/pats — Mint a new PAT. The full token is returned exactly
+/// POST /api/pats — mint a new PAT. The full token is returned exactly
 /// once; subsequent reads show only the prefix.
 pub async fn create_pat(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Json(body): Json<CreatePatBody>,
 ) -> Response {
-    let user_id = match require_authenticated(&auth_user) {
-        Ok(id) => id.to_string(),
-        Err(r) => return r,
-    };
+    let user_id = auth_user.user_id.clone();
 
     let name = body.name.trim();
     if name.is_empty() {
@@ -127,7 +120,7 @@ pub async fn create_pat(
         )
             .into_response();
     }
-    match db::is_workspace_member(&state.db, workspace_id, &user_id).await {
+    match pat_db::is_workspace_member(&state.pool, workspace_id, &user_id).await {
         Ok(true) => {}
         Ok(false) => {
             return (
@@ -147,8 +140,8 @@ pub async fn create_pat(
     let generated = generate_pat_token();
     let id = Uuid::new_v4().to_string();
 
-    if let Err(e) = db::insert_user_pat(
-        &state.db,
+    if let Err(e) = pat_db::insert_user_pat(
+        &state.pool,
         &id,
         &user_id,
         workspace_id,
@@ -175,7 +168,7 @@ pub async fn create_pat(
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
 
-    let pat = db::UserPat {
+    let pat = UserPat {
         id: id.clone(),
         user_id: user_id.clone(),
         workspace_id: workspace_id.to_string(),
@@ -209,17 +202,13 @@ pub async fn create_pat(
     response
 }
 
-/// DELETE /api/pats/{id} — Soft-delete (revoke) a PAT.
+/// DELETE /api/pats/{id} — soft-delete (revoke) a PAT.
 pub async fn delete_pat(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(pat_id): Path<String>,
 ) -> Response {
-    let user_id = match require_authenticated(&auth_user) {
-        Ok(id) => id.to_string(),
-        Err(r) => return r,
-    };
-    match db::revoke_user_pat(&state.db, &user_id, &pat_id).await {
+    match pat_db::revoke_user_pat(&state.pool, &auth_user.user_id, &pat_id).await {
         Ok(true) => Json(serde_json::json!({ "ok": true })).into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -37,6 +37,7 @@ pub mod feedback;
 pub mod gate;
 pub mod handlers;
 pub mod migrate;
+pub mod pat_db;
 pub mod server;
 pub mod sso;
 pub mod state;

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -16,6 +16,11 @@
 //!   cookie sessions + cross-env SSO codes (#222 Slice 5). Stiglab still
 //!   reads from these tables for its `AuthUser` cookie extractor; portal
 //!   is the only writer.
+//! - `user_pats` — server-issued Personal Access Tokens (#143). Portal
+//!   owns mint/list/revoke via `/api/pats*` and verifies presented PATs
+//!   in its own `AuthUser` extractor (#222 Slice 2b). Stiglab still reads
+//!   this table for its `AuthUser` PAT path while non-portal routes
+//!   (credentials, workspaces, projects, workflows) accept PATs.
 //!
 //! Tables managed elsewhere (workspaces / projects / installations / events /
 //! events_ext / artifacts / vertical_lineage) are not touched here.
@@ -40,6 +45,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
     (
         "004_sso_exchange_codes",
         include_str!("../migrations/004_sso_exchange_codes.sql"),
+    ),
+    (
+        "005_user_pats",
+        include_str!("../migrations/005_user_pats.sql"),
     ),
 ];
 

--- a/crates/onsager-portal/src/pat_db.rs
+++ b/crates/onsager-portal/src/pat_db.rs
@@ -25,41 +25,45 @@ pub struct UserPat {
 }
 
 /// Column projection used by every SELECT below. Shared so the read path
-/// and the prefix-lookup path can't drift in column order.
+/// and the prefix-lookup path can't drift in column order — and the
+/// projection lines up with the field order on [`UserPatRow`] /
+/// [`UserPatWithHashRow`] so `query_as` populates by name, not by index.
 const PAT_FIELDS: &str = "id, user_id, workspace_id, name, token_prefix, expires_at, \
                           last_used_at, last_used_ip, last_used_user_agent, created_at, revoked_at";
 
-type PatRow = (
-    String,         // id
-    String,         // user_id
-    String,         // workspace_id
-    String,         // name
-    String,         // token_prefix
-    Option<String>, // expires_at
-    Option<String>, // last_used_at
-    Option<String>, // last_used_ip
-    Option<String>, // last_used_user_agent
-    String,         // created_at
-    Option<String>, // revoked_at
-);
+#[derive(sqlx::FromRow)]
+struct UserPatRow {
+    id: String,
+    user_id: String,
+    workspace_id: String,
+    name: String,
+    token_prefix: String,
+    expires_at: Option<String>,
+    last_used_at: Option<String>,
+    last_used_ip: Option<String>,
+    last_used_user_agent: Option<String>,
+    created_at: String,
+    revoked_at: Option<String>,
+}
 
-/// Same shape as [`PatRow`] with `token_hash` appended; the prefix-lookup
-/// path returns the hash alongside the row so the caller can constant-time
-/// compare without re-querying.
-type PatRowWithHash = (
-    String,
-    String,
-    String,
-    String,
-    String,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    String,
-    Option<String>,
-    String, // token_hash
-);
+/// Same shape as [`UserPatRow`] with `token_hash` appended — the
+/// prefix-lookup path returns the hash alongside the row so the caller
+/// can constant-time compare without re-querying.
+#[derive(sqlx::FromRow)]
+struct UserPatWithHashRow {
+    id: String,
+    user_id: String,
+    workspace_id: String,
+    name: String,
+    token_prefix: String,
+    expires_at: Option<String>,
+    last_used_at: Option<String>,
+    last_used_ip: Option<String>,
+    last_used_user_agent: Option<String>,
+    created_at: String,
+    revoked_at: Option<String>,
+    token_hash: String,
+}
 
 fn parse_optional_ts(v: Option<String>) -> anyhow::Result<Option<DateTime<Utc>>> {
     match v {
@@ -68,33 +72,24 @@ fn parse_optional_ts(v: Option<String>) -> anyhow::Result<Option<DateTime<Utc>>>
     }
 }
 
-fn row_to_pat(row: PatRow) -> anyhow::Result<UserPat> {
-    let (
-        id,
-        user_id,
-        workspace_id,
-        name,
-        token_prefix,
-        expires_at,
-        last_used_at,
-        last_used_ip,
-        last_used_user_agent,
-        created_at,
-        revoked_at,
-    ) = row;
-    Ok(UserPat {
-        id,
-        user_id,
-        workspace_id,
-        name,
-        token_prefix,
-        expires_at: parse_optional_ts(expires_at)?,
-        last_used_at: parse_optional_ts(last_used_at)?,
-        last_used_ip,
-        last_used_user_agent,
-        created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
-        revoked_at: parse_optional_ts(revoked_at)?,
-    })
+impl TryFrom<UserPatRow> for UserPat {
+    type Error = anyhow::Error;
+
+    fn try_from(row: UserPatRow) -> anyhow::Result<Self> {
+        Ok(UserPat {
+            id: row.id,
+            user_id: row.user_id,
+            workspace_id: row.workspace_id,
+            name: row.name,
+            token_prefix: row.token_prefix,
+            expires_at: parse_optional_ts(row.expires_at)?,
+            last_used_at: parse_optional_ts(row.last_used_at)?,
+            last_used_ip: row.last_used_ip,
+            last_used_user_agent: row.last_used_user_agent,
+            created_at: DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+            revoked_at: parse_optional_ts(row.revoked_at)?,
+        })
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -130,8 +125,11 @@ pub async fn insert_user_pat(
 pub async fn list_user_pats(pool: &PgPool, user_id: &str) -> anyhow::Result<Vec<UserPat>> {
     let q =
         format!("SELECT {PAT_FIELDS} FROM user_pats WHERE user_id = $1 ORDER BY created_at DESC");
-    let rows: Vec<PatRow> = sqlx::query_as(&q).bind(user_id).fetch_all(pool).await?;
-    rows.into_iter().map(row_to_pat).collect()
+    let rows = sqlx::query_as::<_, UserPatRow>(&q)
+        .bind(user_id)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
 }
 
 /// Look up candidate PATs by token prefix. The caller must verify the
@@ -142,14 +140,27 @@ pub async fn find_pats_by_prefix(
     token_prefix: &str,
 ) -> anyhow::Result<Vec<(UserPat, String)>> {
     let q = format!("SELECT {PAT_FIELDS}, token_hash FROM user_pats WHERE token_prefix = $1");
-    let rows: Vec<PatRowWithHash> = sqlx::query_as(&q)
+    let rows = sqlx::query_as::<_, UserPatWithHashRow>(&q)
         .bind(token_prefix)
         .fetch_all(pool)
         .await?;
     rows.into_iter()
         .map(|r| {
-            let hash = r.11.clone();
-            let pat = row_to_pat((r.0, r.1, r.2, r.3, r.4, r.5, r.6, r.7, r.8, r.9, r.10))?;
+            let hash = r.token_hash.clone();
+            let pat: UserPat = UserPatRow {
+                id: r.id,
+                user_id: r.user_id,
+                workspace_id: r.workspace_id,
+                name: r.name,
+                token_prefix: r.token_prefix,
+                expires_at: r.expires_at,
+                last_used_at: r.last_used_at,
+                last_used_ip: r.last_used_ip,
+                last_used_user_agent: r.last_used_user_agent,
+                created_at: r.created_at,
+                revoked_at: r.revoked_at,
+            }
+            .try_into()?;
             Ok((pat, hash))
         })
         .collect()

--- a/crates/onsager-portal/src/pat_db.rs
+++ b/crates/onsager-portal/src/pat_db.rs
@@ -1,0 +1,208 @@
+//! Postgres queries against the portal-owned `user_pats` table.
+//!
+//! Portal owns the table per spec #222 Slice 2b
+//! (`crates/onsager-portal/migrations/005_user_pats.sql`). Stiglab still
+//! reads it through its own `AnyPool` helpers (PAT verification in its
+//! `AuthUser` extractor) — same database, separate connection pool.
+//! Writes go through this module only.
+
+use chrono::{DateTime, Utc};
+use sqlx::postgres::PgPool;
+
+#[derive(Debug, Clone)]
+pub struct UserPat {
+    pub id: String,
+    pub user_id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub token_prefix: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub last_used_ip: Option<String>,
+    pub last_used_user_agent: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Column projection used by every SELECT below. Shared so the read path
+/// and the prefix-lookup path can't drift in column order.
+const PAT_FIELDS: &str = "id, user_id, workspace_id, name, token_prefix, expires_at, \
+                          last_used_at, last_used_ip, last_used_user_agent, created_at, revoked_at";
+
+type PatRow = (
+    String,         // id
+    String,         // user_id
+    String,         // workspace_id
+    String,         // name
+    String,         // token_prefix
+    Option<String>, // expires_at
+    Option<String>, // last_used_at
+    Option<String>, // last_used_ip
+    Option<String>, // last_used_user_agent
+    String,         // created_at
+    Option<String>, // revoked_at
+);
+
+/// Same shape as [`PatRow`] with `token_hash` appended; the prefix-lookup
+/// path returns the hash alongside the row so the caller can constant-time
+/// compare without re-querying.
+type PatRowWithHash = (
+    String,
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    String,
+    Option<String>,
+    String, // token_hash
+);
+
+fn parse_optional_ts(v: Option<String>) -> anyhow::Result<Option<DateTime<Utc>>> {
+    match v {
+        Some(s) => Ok(Some(DateTime::parse_from_rfc3339(&s)?.with_timezone(&Utc))),
+        None => Ok(None),
+    }
+}
+
+fn row_to_pat(row: PatRow) -> anyhow::Result<UserPat> {
+    let (
+        id,
+        user_id,
+        workspace_id,
+        name,
+        token_prefix,
+        expires_at,
+        last_used_at,
+        last_used_ip,
+        last_used_user_agent,
+        created_at,
+        revoked_at,
+    ) = row;
+    Ok(UserPat {
+        id,
+        user_id,
+        workspace_id,
+        name,
+        token_prefix,
+        expires_at: parse_optional_ts(expires_at)?,
+        last_used_at: parse_optional_ts(last_used_at)?,
+        last_used_ip,
+        last_used_user_agent,
+        created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
+        revoked_at: parse_optional_ts(revoked_at)?,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_user_pat(
+    pool: &PgPool,
+    id: &str,
+    user_id: &str,
+    workspace_id: &str,
+    name: &str,
+    token_prefix: &str,
+    token_hash: &str,
+    expires_at: Option<DateTime<Utc>>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO user_pats (id, user_id, workspace_id, name, token_prefix, token_hash, \
+                                scopes, expires_at, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+    )
+    .bind(id)
+    .bind(user_id)
+    .bind(workspace_id)
+    .bind(name)
+    .bind(token_prefix)
+    .bind(token_hash)
+    .bind("[\"*\"]")
+    .bind(expires_at.map(|d| d.to_rfc3339()))
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn list_user_pats(pool: &PgPool, user_id: &str) -> anyhow::Result<Vec<UserPat>> {
+    let q =
+        format!("SELECT {PAT_FIELDS} FROM user_pats WHERE user_id = $1 ORDER BY created_at DESC");
+    let rows: Vec<PatRow> = sqlx::query_as(&q).bind(user_id).fetch_all(pool).await?;
+    rows.into_iter().map(row_to_pat).collect()
+}
+
+/// Look up candidate PATs by token prefix. The caller must verify the
+/// `token_hash` against the presented token in constant time before
+/// accepting any row.
+pub async fn find_pats_by_prefix(
+    pool: &PgPool,
+    token_prefix: &str,
+) -> anyhow::Result<Vec<(UserPat, String)>> {
+    let q = format!("SELECT {PAT_FIELDS}, token_hash FROM user_pats WHERE token_prefix = $1");
+    let rows: Vec<PatRowWithHash> = sqlx::query_as(&q)
+        .bind(token_prefix)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter()
+        .map(|r| {
+            let hash = r.11.clone();
+            let pat = row_to_pat((r.0, r.1, r.2, r.3, r.4, r.5, r.6, r.7, r.8, r.9, r.10))?;
+            Ok((pat, hash))
+        })
+        .collect()
+}
+
+pub async fn revoke_user_pat(pool: &PgPool, user_id: &str, pat_id: &str) -> anyhow::Result<bool> {
+    let now = Utc::now().to_rfc3339();
+    let res = sqlx::query(
+        "UPDATE user_pats SET revoked_at = $1 \
+         WHERE id = $2 AND user_id = $3 AND revoked_at IS NULL",
+    )
+    .bind(&now)
+    .bind(pat_id)
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+pub async fn touch_user_pat(
+    pool: &PgPool,
+    pat_id: &str,
+    ip: Option<&str>,
+    user_agent: Option<&str>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "UPDATE user_pats SET last_used_at = $1, last_used_ip = $2, last_used_user_agent = $3 \
+         WHERE id = $4",
+    )
+    .bind(Utc::now().to_rfc3339())
+    .bind(ip)
+    .bind(user_agent)
+    .bind(pat_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Membership check used by the create-PAT handler. Workspaces still live
+/// in stiglab's runtime migrations until Slice 3 of spec #222 moves them
+/// into the spine; portal reads `workspace_members` via raw SQL against
+/// the same DB. Once workspaces move, this becomes a typed join.
+pub async fn is_workspace_member(
+    pool: &PgPool,
+    workspace_id: &str,
+    user_id: &str,
+) -> anyhow::Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT user_id FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
+    )
+    .bind(workspace_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.is_some())
+}

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 
 use crate::config::Config;
 use crate::gate::GateClient;
-use crate::handlers::{auth as auth_handlers, webhook};
+use crate::handlers::{auth as auth_handlers, pats as pat_handlers, webhook};
 use crate::state::AppState;
 
 /// Boot the webhook server. Blocks until the listener exits.
@@ -65,7 +65,16 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route("/api/auth/me", get(auth_handlers::me))
         .route("/api/auth/logout", post(auth_handlers::logout))
         .route("/api/auth/sso/redeem", post(auth_handlers::sso_redeem))
-        .route("/api/auth/sso/finish", get(auth_handlers::sso_finish));
+        .route("/api/auth/sso/finish", get(auth_handlers::sso_finish))
+        // Personal Access Tokens (#222 Slice 2b). Stiglab proxies
+        // `/api/pats*` here so dashboard fetches keep working pre–API_BASE
+        // cutover. Auth (cookie or PAT bearer) is enforced by the
+        // `AuthUser` extractor in each handler.
+        .route(
+            "/api/pats",
+            get(pat_handlers::list_pats).post(pat_handlers::create_pat),
+        )
+        .route("/api/pats/{id}", delete(pat_handlers::delete_pat));
 
     // Dev-login is debug-only — `cargo build --release` strips both the
     // route handler symbol and this registration so production deploys

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -27,8 +27,14 @@ What this means for stiglab specifically:
     `/api/auth/github/callback`, `/api/auth/me`, `/api/auth/logout`,
     `/api/auth/sso/redeem`, `/api/auth/sso/finish`,
     `/api/auth/dev-login` in debug builds) — Slice 5. Stiglab keeps
-    cookie validation (`AuthUser` extractor reads the shared
-    `auth_sessions` table) but no longer mints sessions.
+    cookie + PAT validation (`AuthUser` extractor reads the shared
+    `auth_sessions` and `user_pats` tables) but no longer mints
+    sessions or PATs.
+  - Personal Access Tokens (`GET/POST /api/pats`,
+    `DELETE /api/pats/{id}`) — Slice 2b. Portal mints/lists/revokes;
+    stiglab still verifies presented PATs in its own `AuthUser`
+    extractor for the credentials/workspaces/projects/workflows
+    routes that haven't moved yet.
 - **Forbidden HTTP surfaces.** Anything called from `forge`, `synodic`,
   or `ising`. **Lever C status (#148): no remaining violation** —
   `HttpStiglabDispatcher` and the `POST /api/shaping` route it

--- a/crates/stiglab/src/server/db.rs
+++ b/crates/stiglab/src/server/db.rs
@@ -179,6 +179,16 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     // issue #163 (renamed from the legacy `tenant_id`).  Cross-workspace
     // calls 403.  `revoked_at` is a soft-delete: revoked rows stay for audit
     // but fail verification.
+    //
+    // Spec #222 Slice 2b moved PAT mint/list/revoke to portal
+    // (`crates/onsager-portal/migrations/005_user_pats.sql`). Portal is the
+    // only writer; stiglab still reads this table from its `AuthUser`
+    // extractor for the credentials/workspaces/projects/workflows routes
+    // that haven't moved yet (Slices 2a/3/4). The DDL below stays
+    // idempotently here as a fallback so SQLite-backed unit tests build
+    // the schema without a portal binary in the loop, and on a fresh
+    // deploy whichever process migrates first wins (same-shape
+    // `CREATE TABLE IF NOT EXISTS` makes the loser a no-op).
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS user_pats (
             id TEXT PRIMARY KEY,

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -15,7 +15,7 @@ pub mod ws;
 pub use sqlx::AnyPool;
 
 use axum::http::{header, HeaderValue};
-use axum::routing::{any, delete, get, post, put};
+use axum::routing::{any, get, post, put};
 use axum::Router;
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
@@ -70,12 +70,13 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
             "/api/workspaces/{workspace_id}/credentials/{name}",
             put(routes::credentials::set_credential).delete(routes::credentials::delete_credential),
         )
-        // Personal Access Tokens (issue #143)
-        .route(
-            "/api/pats",
-            get(routes::pats::list_pats).post(routes::pats::create_pat),
-        )
-        .route("/api/pats/{id}", delete(routes::pats::delete_pat))
+        // Personal Access Tokens (issue #143). Spec #222 Slice 2b moved
+        // `/api/pats*` to portal; stiglab keeps the URLs as reverse
+        // proxies so the dashboard's API_BASE cutover (Slice 6) can land
+        // independently. Portal's `AuthUser` extractor honors both cookie
+        // and PAT bearer auth, so the proxy preserves full behavior.
+        .route("/api/pats", any(routes::portal::proxy))
+        .route("/api/pats/{id}", any(routes::portal::proxy))
         // Workspace routes (issue #59 — Phase 0; renamed from "tenant" →
         // "workspace" in issue #163).
         .route(

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -2,7 +2,6 @@ pub mod credentials;
 pub mod governance;
 pub mod health;
 pub mod nodes;
-pub mod pats;
 pub mod portal;
 pub mod projects;
 pub mod registry_events;

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -1,18 +1,23 @@
-//! Integration tests for Personal Access Tokens (issue #143).
+//! Integration tests for stiglab's PAT-aware `AuthUser` extractor and the
+//! credential / workspace-scope routes that still consume PAT bearer auth.
 //!
-//! Covers the contract surface most likely to break:
-//!   * the PAT extractor accepts the Bearer header end-to-end and prefers
-//!     it over the session cookie,
-//!   * revoked / expired PATs return 401 with the documented
-//!     `WWW-Authenticate` body and don't leak which arm failed,
-//!   * the destructive-credential guardrail (PUT-overwrite + DELETE) maps
-//!     to 403 `pat_destructive_blocked`,
+//! Spec #222 Slice 2b moved `/api/pats*` CRUD to portal — minting, listing,
+//! and revoking PATs is exercised on the portal side. The tests here cover
+//! the bits that remain stiglab-owned for the duration of Slices 2a / 3 / 4:
+//!
+//!   * stiglab's `verify_pat` DB primitive and `AuthUser` Bearer-vs-cookie
+//!     precedence (still hot because credentials/workspaces/projects/
+//!     workflows accept PAT bearer auth on stiglab),
+//!   * the destructive-credential guardrail (PUT-overwrite + DELETE) maps to
+//!     403 `pat_destructive_blocked`,
 //!   * workspace-scoped PATs reject calls to a different workspace, and
 //!   * `last_used_at` advances on a successful PAT auth.
 //!
-//! `/api/auth/me` shape coverage moved to portal in spec #222 Slice 5;
-//! the tests here exercise stiglab's `AuthUser` extractor against
-//! `/api/pats` instead, which is stiglab-owned.
+//! The auth-extractor tests pivot onto stiglab routes that survive the
+//! Slice 2b move: `/api/projects` (cross-workspace project listing,
+//! `AuthUser`-gated) and `/api/workspaces/{id}` (workspace get,
+//! `require_workspace_access`-gated). When credentials/workspaces move in
+//! later slices, these tests will follow them to portal-side coverage.
 
 use axum::body::Body;
 use axum::http::{header, Request, StatusCode};
@@ -86,12 +91,13 @@ async fn seed_workspace_with_member(pool: &AnyPool, user_id: &str, slug: &str) -
     workspace
 }
 
-/// Mint a PAT directly via the DB layer, bypassing `POST /api/pats`. Used
-/// to set up auth state before exercising other endpoints.
+/// Mint a PAT directly via the DB layer, bypassing `POST /api/pats` (which
+/// now lives on portal). Used to set up auth state before exercising other
+/// endpoints.
 ///
-/// PATs are workspace-scoped post-#163; when the caller doesn't already
-/// have a workspace in scope, pass `None` and `mint_pat` seeds a throwaway
-/// one for the user just so the row satisfies the NOT NULL constraint.
+/// PATs are workspace-scoped post-#163; when the caller doesn't already have
+/// a workspace in scope, pass `None` and `mint_pat` seeds a throwaway one
+/// for the user just so the row satisfies the NOT NULL constraint.
 async fn mint_pat(
     pool: &AnyPool,
     user_id: &str,
@@ -231,14 +237,12 @@ async fn verify_pat_reports_expired_separately_from_unknown() {
 
 // ── End-to-end PAT-authenticated requests ──
 //
-// Spec #222 Slice 5 moved `/api/auth/*` to portal, so the
-// `via: pat | session` shape assertions on `/api/auth/me` no longer
-// work against a stiglab-only `oneshot()` (the route is a proxy now —
-// portal isn't running in tests). The PAT auth path itself still lives
-// in stiglab's `AuthUser` extractor; the tests below exercise it
-// against `/api/pats`, which is stiglab-owned and `AuthUser`-gated.
-// Equivalent /api/auth/me coverage will follow on the portal side
-// when Slice 2 moves PAT validation to portal.
+// The PAT auth path lives in stiglab's `AuthUser` extractor as long as
+// non-portal routes (credentials, workspaces, projects, workflows) accept
+// PAT bearer auth. The tests below pivot onto `/api/projects` — a
+// cross-workspace, AuthUser-gated route stiglab still owns — to exercise
+// the extractor end-to-end without depending on `/api/pats` (now a portal
+// proxy).
 
 #[tokio::test]
 async fn revoked_pat_returns_401_with_invalid_token_challenge() {
@@ -250,7 +254,7 @@ async fn revoked_pat_returns_401_with_invalid_token_challenge() {
 
     let resp = app(state)
         .oneshot(
-            bearer(Request::builder().uri("/api/pats"), &token)
+            bearer(Request::builder().uri("/api/projects"), &token)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -278,7 +282,7 @@ async fn expired_pat_returns_401_with_invalid_token_challenge() {
 
     let resp = app(state)
         .oneshot(
-            bearer(Request::builder().uri("/api/pats"), &token)
+            bearer(Request::builder().uri("/api/projects"), &token)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -298,11 +302,17 @@ async fn pat_bearer_takes_precedence_over_cookie() {
     // A request that carries BOTH a valid PAT and a valid session cookie
     // should be authenticated as the PAT user (so that smoke-testing from
     // a CLI doesn't silently fall through to the browser session that
-    // happens to be in scope). `/api/pats` returns the principal's PATs;
-    // the only token belongs to `pat_user`, so the response shape proves
-    // the PAT principal won.
+    // happens to be in scope). The proof works because the PAT is pinned
+    // to `pat_workspace`; sending both auths to a different workspace's
+    // GET route must 403 with `pat_workspace_scope_mismatch`. If the
+    // cookie principal had won, the cookie user is a member of
+    // `cookie_workspace` so the same request would 200.
     let pool = test_pool().await;
+
     let pat_user = seed_user(&pool).await;
+    let pat_workspace = seed_workspace_with_member(&pool, &pat_user.id, "pat-ws").await;
+    let (_, pat_token) = mint_pat(&pool, &pat_user.id, Some(&pat_workspace.id), "ci", None).await;
+
     let cookie_user = User {
         id: Uuid::new_v4().to_string(),
         github_id: 999,
@@ -313,6 +323,7 @@ async fn pat_bearer_takes_precedence_over_cookie() {
         updated_at: Utc::now(),
     };
     db::upsert_user(&pool, &cookie_user).await.unwrap();
+    let cookie_workspace = seed_workspace_with_member(&pool, &cookie_user.id, "cookie-ws").await;
     let session_token = stiglab::server::auth::generate_session_token();
     db::create_auth_session(
         &pool,
@@ -322,13 +333,16 @@ async fn pat_bearer_takes_precedence_over_cookie() {
     )
     .await
     .unwrap();
-    let (_, pat_token) = mint_pat(&pool, &pat_user.id, None, "ci", None).await;
+
     let state = AppState::new(pool, auth_enabled_config(), None);
 
+    // Hit cookie_user's workspace with both auths. PAT precedence ⇒ 403
+    // (PAT is pinned to pat_workspace, request hits cookie_workspace).
+    // Cookie precedence would have been 200 (cookie_user is a member).
     let resp = app(state)
         .oneshot(
             Request::builder()
-                .uri("/api/pats")
+                .uri(format!("/api/workspaces/{}", cookie_workspace.id))
                 .header(header::AUTHORIZATION, format!("Bearer {pat_token}"))
                 .header(header::COOKIE, format!("stiglab_session={session_token}"))
                 .body(Body::empty())
@@ -336,307 +350,9 @@ async fn pat_bearer_takes_precedence_over_cookie() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let v = read_json(resp).await;
-    let pats = v["pats"].as_array().expect("pats array");
-    assert_eq!(pats.len(), 1);
-    assert_eq!(pats[0]["name"], "ci");
-}
-
-// ── PAT CRUD via /api/pats ──
-
-#[tokio::test]
-async fn create_pat_returns_token_once_then_listing_hides_it() {
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-create").await;
-    // Bootstrap auth via a session cookie so we can create a PAT.
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let state = AppState::new(pool, auth_enabled_config(), None);
-    let app_ = app(state);
-
-    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
-    let create = Request::builder()
-        .method("POST")
-        .uri("/api/pats")
-        .header(header::COOKIE, format!("stiglab_session={session_token}"))
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(
-            serde_json::json!({
-                "name": "ci",
-                "workspace_id": workspace.id,
-                "expires_at": exp,
-            })
-            .to_string(),
-        ))
-        .unwrap();
-    let resp = app_.clone().oneshot(create).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = read_json(resp).await;
-    let token = body["token"].as_str().unwrap().to_string();
-    assert!(token.starts_with("ons_pat_"));
-    let prefix = body["pat"]["token_prefix"].as_str().unwrap();
-    assert_eq!(prefix.len(), PAT_PREFIX_LEN);
-
-    // List — must NOT echo the secret token, only metadata + prefix.
-    let list = Request::builder()
-        .uri("/api/pats")
-        .header(header::COOKIE, format!("stiglab_session={session_token}"))
-        .body(Body::empty())
-        .unwrap();
-    let resp = app_.oneshot(list).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = read_json(resp).await;
-    let pats = body["pats"].as_array().unwrap();
-    assert_eq!(pats.len(), 1);
-    assert_eq!(pats[0]["token_prefix"].as_str().unwrap(), prefix);
-    assert!(pats[0].get("token").is_none());
-    assert!(pats[0].get("token_hash").is_none());
-}
-
-#[tokio::test]
-async fn create_pat_409s_on_duplicate_name() {
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-dup").await;
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let state = AppState::new(pool, auth_enabled_config(), None);
-    let app_ = app(state);
-
-    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
-    let workspace_id = workspace.id.clone();
-    let make = || {
-        Request::builder()
-            .method("POST")
-            .uri("/api/pats")
-            .header(header::COOKIE, format!("stiglab_session={session_token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(
-                serde_json::json!({
-                    "name": "ci",
-                    "workspace_id": workspace_id,
-                    "expires_at": exp,
-                })
-                .to_string(),
-            ))
-            .unwrap()
-    };
-    assert_eq!(
-        app_.clone().oneshot(make()).await.unwrap().status(),
-        StatusCode::OK
-    );
-    assert_eq!(
-        app_.oneshot(make()).await.unwrap().status(),
-        StatusCode::CONFLICT
-    );
-}
-
-#[tokio::test]
-async fn create_pat_rejects_empty_name() {
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-empty").await;
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let state = AppState::new(pool, auth_enabled_config(), None);
-
-    let exp = (Utc::now() + chrono::Duration::days(7)).to_rfc3339();
-    let resp = app(state)
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/pats")
-                .header(header::COOKIE, format!("stiglab_session={session_token}"))
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({
-                        "name": "  ",
-                        "workspace_id": workspace.id,
-                        "expires_at": exp,
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-}
-
-#[tokio::test]
-async fn create_pat_rejects_missing_expires_at() {
-    // v1 contract: an explicit expiry is required. `null` is reserved for
-    // a future "never expires" affordance and must not silently mint a
-    // long-lived token today.
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-noexp").await;
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let state = AppState::new(pool, auth_enabled_config(), None);
-
-    for body in [
-        serde_json::json!({
-            "name": "ci",
-            "workspace_id": workspace.id,
-            "expires_at": null,
-        }),
-        serde_json::json!({
-            "name": "ci",
-            "workspace_id": workspace.id,
-        }),
-    ] {
-        let resp = app(state.clone())
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/pats")
-                    .header(header::COOKIE, format!("stiglab_session={session_token}"))
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(body.to_string()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-}
-
-#[tokio::test]
-async fn create_pat_response_carries_no_store_cache_headers() {
-    // The body holds the only copy of the secret token — every
-    // intermediary must be told not to cache it.
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let workspace = seed_workspace_with_member(&pool, &user.id, "ws-headers").await;
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let state = AppState::new(pool, auth_enabled_config(), None);
-
-    let exp = (Utc::now() + chrono::Duration::days(30)).to_rfc3339();
-    let resp = app(state)
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/pats")
-                .header(header::COOKIE, format!("stiglab_session={session_token}"))
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({
-                        "name": "ci",
-                        "workspace_id": workspace.id,
-                        "expires_at": exp,
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(
-        resp.headers()
-            .get(header::CACHE_CONTROL)
-            .and_then(|v| v.to_str().ok()),
-        Some("no-store")
-    );
-    assert_eq!(
-        resp.headers().get("pragma").and_then(|v| v.to_str().ok()),
-        Some("no-cache")
-    );
-}
-
-#[tokio::test]
-async fn delete_pat_revokes_so_subsequent_use_401s() {
-    let pool = test_pool().await;
-    let user = seed_user(&pool).await;
-    let session_token = stiglab::server::auth::generate_session_token();
-    db::create_auth_session(
-        &pool,
-        &session_token,
-        &user.id,
-        Utc::now() + chrono::Duration::days(1),
-    )
-    .await
-    .unwrap();
-    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
-    let state = AppState::new(pool, auth_enabled_config(), None);
-    let app_ = app(state);
-
-    // Sanity: PAT works before revoke.
-    let pre = app_
-        .clone()
-        .oneshot(
-            bearer(Request::builder().uri("/api/pats"), &token)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(pre.status(), StatusCode::OK);
-
-    // Revoke via the API.
-    let revoke = app_
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("DELETE")
-                .uri(format!("/api/pats/{pat_id}"))
-                .header(header::COOKIE, format!("stiglab_session={session_token}"))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(revoke.status(), StatusCode::OK);
-
-    // After revoke: same Bearer token now 401s with invalid_token.
-    let post = app_
-        .oneshot(
-            bearer(Request::builder().uri("/api/pats"), &token)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(post.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(v["error"], "pat_workspace_scope_mismatch");
 }
 
 // ── Destructive-credential guardrail ──
@@ -774,7 +490,7 @@ async fn last_used_at_advances_after_pat_auth() {
         .oneshot(
             bearer(
                 Request::builder()
-                    .uri("/api/pats")
+                    .uri("/api/projects")
                     .header(header::USER_AGENT, "test-agent/1.0"),
                 &token,
             )


### PR DESCRIPTION
## Summary

Slice 2b of spec #222 — Personal Access Tokens move from stiglab to portal. Portal now owns `GET/POST /api/pats` and `DELETE /api/pats/{id}`, mints + verifies tokens, and surfaces `via: "pat" | "session"` on `/api/auth/me`.

The PAT primitives (`PAT_TOKEN_NAMESPACE`, `PAT_PREFIX_LEN`, `GeneratedPat`, `generate_pat_token`, `hash_pat_token`, `pat_prefix`, `verify_pat`, `PatVerifyOutcome`, `RequestPrincipal`, and the PAT-aware `AuthUser` Bearer-vs-cookie precedence) port from `stiglab/src/server/auth.rs` into `onsager-portal/src/auth.rs`. The `user_pats` schema lands in `crates/onsager-portal/migrations/005_user_pats.sql`, matching stiglab's inline DDL byte-for-byte (workspace-scoped, soft-delete via `revoked_at`, prefix-indexed lookup). Stiglab proxies `/api/pats*` via `routes::portal::proxy` so the dashboard's API_BASE cutover (Slice 6) can land independently.

## Why 2b before 2a

The original plan put credentials (Slice 2a) before PATs (Slice 2b). I flipped the order: stiglab's credentials routes accept PAT bearer auth (the destructive-credential guardrail in `routes/credentials.rs` checks `RequestPrincipal::Pat { .. }` and 403s overwrites/deletes), and CLI smoke tests rely on PATs to manage credentials programmatically. Moving credentials to portal first would have either broken PAT-based credential access or forced a portal→stiglab proxy hop just for auth, which inverts the seam.

## Scope notes

- **Stiglab keeps its PAT machinery for now.** Routes still on stiglab (credentials in 2a, workspaces/projects in 3, workflows in 4) accept PAT bearer auth; stiglab's `AuthUser` extractor still validates PATs against the same `user_pats` table. Same DB, separate connection pool, **portal is the only writer**. Stiglab's `auth.rs` PAT path retires when those routes finish moving (Slices 2a/3/4).
- **Idempotent fallback DDL.** Stiglab's inline `CREATE TABLE IF NOT EXISTS user_pats` stays so the SQLite-backed integration tests build the schema without portal in the loop, and on a fresh deploy whichever process migrates first wins. Mirrors the Slice 5 pattern for `users` / `auth_sessions` / `sso_exchange_codes`.
- **Comment on `db.rs` updated** to point at `crates/onsager-portal/migrations/005_user_pats.sql` as canonical.

## Tests

- `crates/stiglab/tests/pats.rs` retains 15 tests covering what stiglab still owns:
  - DB-level `verify_pat_*` (5).
  - Auth-extractor end-to-end coverage (revoked → 401, expired → 401, PAT-bearer-takes-precedence-over-cookie, `last_used_at` advances) — pivoted onto `/api/projects` and `/api/workspaces/{id}` (still stiglab routes, `AuthUser`-gated).
  - Destructive-credential guardrail (PUT-overwrite + DELETE → 403 `pat_destructive_blocked`; cookie session can still DELETE).
  - Workspace-scope guard (PAT pinned to workspace A → 403 on workspace B with `pat_workspace_scope_mismatch`).
- The `/api/pats` CRUD tests retire on the stiglab side (route is now a proxy and portal isn't running in stiglab's test harness). Restoring them on the portal side requires a Postgres-backed integration-test harness for portal — flagged as a follow-up; the unit tests in `auth.rs` cover the PAT primitives end-to-end.
- The `me_under_pat_reports_via_pat` / `me_under_session_reports_via_session_when_no_pat` tests dropped in Slice 5 stay pending the same Postgres harness; the `via` mapping is now wired in `handlers/auth.rs`.

## Pre-push

- `RUSTFLAGS="-D warnings" cargo build --workspace` ✅
- `RUSTFLAGS="-D warnings" cargo test --workspace --lib` ✅
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo run -p xtask --quiet -- lint-seams` ✅
- `cargo run -p xtask --quiet -- check-api-contract` ✅
- `cargo run -p xtask --quiet -- check-events` ✅
- `cargo test -p stiglab --test pats` — 15 passed ✅

## Test plan

- [ ] `just dev` starts portal on `:3002` and stiglab on `:3000`; `curl -X POST -H 'Content-Type: application/json' -b stiglab_session=... -d '{"name":"smoke","workspace_id":"...","expires_at":"..."}' http://localhost:3000/api/pats` returns `{token, pat}` with `Cache-Control: no-store` (proxied to portal).
- [ ] Same call direct to `http://localhost:3002/api/pats` returns the same shape.
- [ ] `curl -H 'Authorization: Bearer ons_pat_...' http://localhost:3002/api/auth/me` returns `via: "pat"`; same call with cookie returns `via: "session"`.
- [ ] Workspace-pinned PAT to a sibling workspace's `/api/workspaces/{id}` (proxied via stiglab) still 403s with `pat_workspace_scope_mismatch`.

Part of #222

https://claude.ai/code/session_01RuMh8TCJJJy2ttxJVUKkzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuMh8TCJJJy2ttxJVUKkzC)_