### PR TITLE
feat(portal): move workspaces+members+projects stiglab → portal (#222 Slice 3a)

### DIFF
--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -112,8 +112,10 @@ first-class edge subsystem. The migration is staged:
   `onsager-portal/src/handlers/{workspaces,projects}.rs`. The
   `workspaces` / `workspace_members` / `projects` schema moved
   into `crates/onsager-spine/migrations/020_workspaces_to_spine.sql`
-  (cross-cutting — `artifacts.workspace_id` already FKs into
-  `workspaces`). Stiglab proxies the URLs through
+  (cross-cutting — `artifacts.workspace_id` joins back to
+  `workspaces.id` at the app layer; no FK constraint declared, in
+  keeping with the rest of the stiglab/spine schema). Stiglab
+  proxies the URLs through
   `routes::portal::proxy` and keeps its own `db::*` reads
   (`is_workspace_member`, `get_project`, `list_workspaces_for_user`,
   etc.) for the in-process needs of `tasks.rs` / `sessions.rs` and

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -101,15 +101,33 @@ first-class edge subsystem. The migration is staged:
   decrypt-and-launch path used by `tasks.rs`/`workflows.rs` —
   same database, separate connection pool, portal is the only
   writer.
-- **Routes (follow-ups).** Slices 3/4: move `/api/workspaces/*`,
-  `/api/installations/*`, `/api/workflows/*`, and the preset
-  registry into portal. Each route group lands atomically (portal
-  handler live + stiglab handler deleted in the same PR).
-- **Schema split (follow-ups).** `workspaces` /
-  `workspace_members` / `projects` move into
-  `crates/onsager-spine/migrations/`; `github_app_installations`
-  move into `crates/onsager-portal/migrations/` next to the auth
-  migrations. Atomic per-PR per Lever B.
+- **Slice 3a — workspace/member/project CRUD (landed).** Portal
+  owns `GET/POST /api/workspaces`, `GET /api/workspaces/:id`,
+  `GET /api/workspaces/:id/members`,
+  `GET/POST /api/workspaces/:id/projects`, `GET /api/projects`,
+  and `GET/DELETE /api/projects/:id`. Domain types
+  (`Workspace`, `WorkspaceMember`, `WorkspaceMemberWithUser`,
+  `Project`) live in `onsager-portal/src/core.rs`; CRUD in
+  `onsager-portal/src/workspace_db.rs`; routes in
+  `onsager-portal/src/handlers/{workspaces,projects}.rs`. The
+  `workspaces` / `workspace_members` / `projects` schema moved
+  into `crates/onsager-spine/migrations/020_workspaces_to_spine.sql`
+  (cross-cutting — `artifacts.workspace_id` already FKs into
+  `workspaces`). Stiglab proxies the URLs through
+  `routes::portal::proxy` and keeps its own `db::*` reads
+  (`is_workspace_member`, `get_project`, `list_workspaces_for_user`,
+  etc.) for the in-process needs of `tasks.rs` / `sessions.rs` and
+  the workflow runtime — same database, separate connection pool,
+  portal is the only writer. The PAT-pinned-workspace 403 guardrail
+  follows the routes.
+- **Routes (follow-ups).** Slices 3b/4: move
+  `/api/workspaces/:id/github-installations*`,
+  `/api/github-app/*`, `/api/workflows/*`, and the preset registry
+  into portal. Each route group lands atomically (portal handler
+  live + stiglab handler deleted in the same PR).
+- **Schema split (follow-ups).** `github_app_installations` moves
+  into `crates/onsager-portal/migrations/` (Slice 3b) next to the
+  auth migrations. Atomic per-PR per Lever B.
 
 While the migration is in flight, stiglab still hosts most of the
 external HTTP surface — that is the drift #222 closes, not a pattern

--- a/crates/onsager-portal/src/core.rs
+++ b/crates/onsager-portal/src/core.rs
@@ -1,0 +1,59 @@
+//! Domain types for the portal-owned external surface.
+//!
+//! Spec #222 Slice 3a moved workspace / membership / project CRUD from
+//! stiglab to portal. The corresponding domain types move with them so
+//! portal's handlers don't import from stiglab (forbidden by the seam
+//! rule). Stiglab keeps its own copies under `crates/stiglab/src/core/`
+//! for the in-process needs of session orchestration; the wire shape is
+//! identical so the dashboard's existing payload contract is preserved.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// An Onsager-native workspace identity. Owns membership, GitHub
+/// installations, and projects. Identity is owned by Onsager (not borrowed
+/// from any external provider), so future source providers can hang off
+/// the same workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workspace {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Many-to-many join between users and workspaces. v1 has no `role`
+/// column — every member has equal access.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceMember {
+    pub workspace_id: String,
+    pub user_id: String,
+    pub joined_at: DateTime<Utc>,
+}
+
+/// `WorkspaceMember` enriched with the member's GitHub profile so the
+/// dashboard can render `@login` + avatar instead of an opaque user UUID.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceMemberWithUser {
+    pub workspace_id: String,
+    pub user_id: String,
+    pub joined_at: DateTime<Utc>,
+    pub github_login: Option<String>,
+    pub github_name: Option<String>,
+    pub github_avatar_url: Option<String>,
+}
+
+/// A repo linked to both a workspace and a specific GitHub App
+/// installation. Opt-in per repo: installing the App on an org does not
+/// auto-mirror all of that org's repos; the user explicitly adds each one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: String,
+    pub workspace_id: String,
+    pub github_app_installation_id: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub default_branch: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -5,6 +5,8 @@ pub mod auth;
 pub mod credentials;
 pub mod issues;
 pub mod pats;
+pub mod projects;
 pub mod pull_request;
 pub mod spec_link;
 pub mod webhook;
+pub mod workspaces;

--- a/crates/onsager-portal/src/handlers/projects.rs
+++ b/crates/onsager-portal/src/handlers/projects.rs
@@ -174,13 +174,20 @@ pub async fn list_projects(
 
 /// GET /api/projects — List every project the current user can access,
 /// across all their workspaces. Powers the cross-workspace project
-/// selector in `CreateSessionSheet`.
+/// selector in `CreateSessionSheet`. PAT-pinned principals see only
+/// projects in their pinned workspace.
 pub async fn list_all_projects_for_user(
     State(state): State<AppState>,
     auth_user: AuthUser,
 ) -> Response {
+    let pinned = auth_user.principal.pinned_workspace_id();
     match workspace_db::list_projects_for_user(&state.pool, &auth_user.user_id).await {
-        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
+        Ok(mut projects) => {
+            if let Some(p) = pinned {
+                projects.retain(|proj| proj.workspace_id == p);
+            }
+            Json(serde_json::json!({ "projects": projects })).into_response()
+        }
         Err(e) => {
             tracing::error!("failed to list projects: {e}");
             (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
@@ -189,7 +196,9 @@ pub async fn list_all_projects_for_user(
 }
 
 /// GET /api/projects/:id — Fetch a project by ID. 404 for users who are
-/// not members of the owning workspace.
+/// not members of the owning workspace, and **404 (not 403) for PATs
+/// pinned to a different workspace** — the existence-vs-scope leak
+/// would otherwise let a PAT enumerate project IDs across workspaces.
 pub async fn get_project(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -203,6 +212,11 @@ pub async fn get_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
     };
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
+        if pinned != project.workspace_id {
+            return not_found("project not found");
+        }
+    }
     if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
         return r;
     }
@@ -211,7 +225,8 @@ pub async fn get_project(
 
 /// DELETE /api/projects/:id — Delete a project. Blocks with a clear
 /// error when any attached session is not in a terminal state (no
-/// cascade, no soft-delete in v1).
+/// cascade, no soft-delete in v1). Same 404-not-403 PAT scope policy
+/// as `get_project`.
 pub async fn delete_project(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -225,6 +240,11 @@ pub async fn delete_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
     };
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
+        if pinned != project.workspace_id {
+            return not_found("project not found");
+        }
+    }
     if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
         return r;
     }

--- a/crates/onsager-portal/src/handlers/projects.rs
+++ b/crates/onsager-portal/src/handlers/projects.rs
@@ -1,0 +1,261 @@
+//! Project CRUD (spec #222 Slice 3a — moved from stiglab).
+//!
+//! These routes link a workspace to a `(repo_owner, repo_name)` pair.
+//! Membership is checked via `super::workspaces::require_workspace_access`
+//! (404 not 403 for non-members; PAT scope guardrail).
+//!
+//! Project deletion blocks with a clear error when live sessions
+//! reference the project; there is no cascade and no soft-delete in v1.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use onsager_github::api::app as gh_app;
+use serde::Deserialize;
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+use crate::auth::AuthUser;
+use crate::core::Project;
+use crate::handlers::workspaces::require_workspace_access;
+use crate::state::AppState;
+use crate::workspace_db;
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+/// Mint a per-installation token from the row UUID. Returns `None` when
+/// the App is not configured or the installation row is missing — the
+/// caller falls back to a default.
+async fn installation_token_for(
+    pool: &PgPool,
+    install_row_id: &str,
+) -> anyhow::Result<Option<gh_app::InstallationToken>> {
+    let Some(cfg) = gh_app::AppConfig::from_env() else {
+        return Ok(None);
+    };
+    let Some(lookup) = workspace_db::get_installation_lookup(pool, install_row_id).await? else {
+        return Ok(None);
+    };
+    let jwt = gh_app::mint_app_jwt(&cfg)?;
+    let token = gh_app::mint_installation_token(&jwt, lookup.install_id).await?;
+    Ok(Some(token))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddProjectBody {
+    pub github_app_installation_id: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    /// Optional. If absent we try the GitHub API (when the App is
+    /// configured) and fall back to `"main"` on any failure.
+    pub default_branch: Option<String>,
+}
+
+/// POST /api/workspaces/:id/projects — Add a project (opt-in per repo;
+/// no auto-mirroring).
+pub async fn add_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
+    Json(body): Json<AddProjectBody>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        return r;
+    }
+
+    // Validate the installation belongs to this workspace.
+    match workspace_db::get_installation_lookup(&state.pool, &body.github_app_installation_id).await
+    {
+        Ok(Some(l)) if l.workspace_id == workspace_id => {}
+        Ok(_) => return not_found("installation not found"),
+        Err(e) => {
+            tracing::error!("failed to get installation: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+    }
+
+    let repo_owner = body.repo_owner.trim();
+    let repo_name = body.repo_name.trim();
+    if repo_owner.is_empty() || repo_name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "repo_owner and repo_name are required" })),
+        )
+            .into_response();
+    }
+
+    // If the caller supplied a branch, trust it. Otherwise try the
+    // GitHub API (when the App is configured), then fall back to
+    // "main" on any failure — onboarding must never block on a
+    // network hiccup.
+    let supplied = body
+        .default_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let default_branch = match supplied {
+        Some(b) => b,
+        None => match installation_token_for(&state.pool, &body.github_app_installation_id).await {
+            Ok(Some(token)) => match gh_app::get_repo_default_branch(
+                &token,
+                repo_owner,
+                repo_name,
+            )
+            .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(
+                        "default_branch inference failed for {repo_owner}/{repo_name}: {e}"
+                    );
+                    "main".to_string()
+                }
+            },
+            Ok(None) => "main".to_string(),
+            Err(e) => {
+                tracing::warn!(
+                    "installation token lookup failed for default_branch inference on {repo_owner}/{repo_name}: {e}"
+                );
+                "main".to_string()
+            }
+        },
+    };
+
+    let project = Project {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.clone(),
+        github_app_installation_id: body.github_app_installation_id.clone(),
+        repo_owner: repo_owner.to_string(),
+        repo_name: repo_name.to_string(),
+        default_branch,
+        created_at: Utc::now(),
+    };
+
+    if let Err(e) = workspace_db::insert_project(&state.pool, &project).await {
+        tracing::error!("failed to insert project: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed to add project (repo may already be onboarded)"
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "project": project })),
+    )
+        .into_response()
+}
+
+/// GET /api/workspaces/:id/projects — List projects in a workspace.
+pub async fn list_projects(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        return r;
+    }
+    match workspace_db::list_projects_for_workspace(&state.pool, &workspace_id).await {
+        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list projects: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}
+
+/// GET /api/projects — List every project the current user can access,
+/// across all their workspaces. Powers the cross-workspace project
+/// selector in `CreateSessionSheet`.
+pub async fn list_all_projects_for_user(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Response {
+    match workspace_db::list_projects_for_user(&state.pool, &auth_user.user_id).await {
+        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list projects: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}
+
+/// GET /api/projects/:id — Fetch a project by ID. 404 for users who are
+/// not members of the owning workspace.
+pub async fn get_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+) -> Response {
+    let project = match workspace_db::get_project(&state.pool, &project_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return not_found("project not found"),
+        Err(e) => {
+            tracing::error!("failed to get project: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
+        return r;
+    }
+    Json(serde_json::json!({ "project": project })).into_response()
+}
+
+/// DELETE /api/projects/:id — Delete a project. Blocks with a clear
+/// error when any attached session is not in a terminal state (no
+/// cascade, no soft-delete in v1).
+pub async fn delete_project(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(project_id): Path<String>,
+) -> Response {
+    let project = match workspace_db::get_project(&state.pool, &project_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return not_found("project not found"),
+        Err(e) => {
+            tracing::error!("failed to get project: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
+        return r;
+    }
+
+    match workspace_db::count_live_sessions_for_project(&state.pool, &project_id).await {
+        Ok(n) if n > 0 => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "cannot delete project: {n} live session(s) still reference it. \
+                         Wait for them to finish or abort them first."
+                    )
+                })),
+            )
+                .into_response();
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!("failed to count live sessions: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+        }
+    }
+
+    if let Err(e) = workspace_db::delete_project(&state.pool, &project_id).await {
+        tracing::error!("failed to delete project: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
+    }
+    Json(serde_json::json!({ "ok": true })).into_response()
+}

--- a/crates/onsager-portal/src/handlers/projects.rs
+++ b/crates/onsager-portal/src/handlers/projects.rs
@@ -105,21 +105,17 @@ pub async fn add_project(
     let default_branch = match supplied {
         Some(b) => b,
         None => match installation_token_for(&state.pool, &body.github_app_installation_id).await {
-            Ok(Some(token)) => match gh_app::get_repo_default_branch(
-                &token,
-                repo_owner,
-                repo_name,
-            )
-            .await
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::warn!(
-                        "default_branch inference failed for {repo_owner}/{repo_name}: {e}"
-                    );
-                    "main".to_string()
+            Ok(Some(token)) => {
+                match gh_app::get_repo_default_branch(&token, repo_owner, repo_name).await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!(
+                            "default_branch inference failed for {repo_owner}/{repo_name}: {e}"
+                        );
+                        "main".to_string()
+                    }
                 }
-            },
+            }
             Ok(None) => "main".to_string(),
             Err(e) => {
                 tracing::warn!(

--- a/crates/onsager-portal/src/handlers/workspaces.rs
+++ b/crates/onsager-portal/src/handlers/workspaces.rs
@@ -1,0 +1,186 @@
+//! Workspace + member CRUD (spec #222 Slice 3a — moved from stiglab).
+//!
+//! These routes funnel through `require_workspace_access` for the
+//! 404-not-403 membership check and the PAT-scope guardrail (matching
+//! GitHub's private-resource pattern — non-members can't enumerate
+//! workspaces via 403 vs 404 differentiation).
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use serde::Deserialize;
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+use crate::auth::AuthUser;
+use crate::core::{Workspace, WorkspaceMember};
+use crate::state::AppState;
+use crate::workspace_db;
+
+/// Authorize an `AuthUser` against a target workspace. Two checks, in
+/// order:
+///
+/// 1. **PAT scope (403 on mismatch).** If the principal is a PAT pinned
+///    to a workspace, the request must target that exact workspace.
+/// 2. **Membership (404 on miss).** Otherwise the caller must be a
+///    member of the workspace; non-members get a flat 404 to avoid
+///    leaking workspace existence.
+pub(crate) async fn require_workspace_access(
+    pool: &PgPool,
+    auth_user: &AuthUser,
+    workspace_id: &str,
+) -> Result<(), Response> {
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
+        if pinned != workspace_id {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": "pat_workspace_scope_mismatch",
+                    "detail": "PAT is pinned to a different workspace",
+                })),
+            )
+                .into_response());
+        }
+    }
+    match workspace_db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "workspace not found" })),
+        )
+            .into_response()),
+        Err(e) => {
+            tracing::error!("failed to check workspace membership: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+    }
+}
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateWorkspaceBody {
+    pub slug: String,
+    pub name: String,
+}
+
+/// POST /api/workspaces — Create a workspace. Creator is auto-inserted
+/// as a member (no role column in v1).
+pub async fn create_workspace(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(body): Json<CreateWorkspaceBody>,
+) -> Response {
+    let user_id = auth_user.user_id.clone();
+
+    let slug = body.slug.trim();
+    let name = body.name.trim();
+    if slug.is_empty() || name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "slug and name are required" })),
+        )
+            .into_response();
+    }
+    if !slug
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "slug must be lowercase alphanumeric with hyphens"
+            })),
+        )
+            .into_response();
+    }
+
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: Uuid::new_v4().to_string(),
+        slug: slug.to_string(),
+        name: name.to_string(),
+        created_by: user_id.clone(),
+        created_at: now,
+    };
+    let member = WorkspaceMember {
+        workspace_id: workspace.id.clone(),
+        user_id: user_id.clone(),
+        joined_at: now,
+    };
+
+    if let Err(e) =
+        workspace_db::insert_workspace_with_creator(&state.pool, &workspace, &member).await
+    {
+        tracing::error!("failed to insert workspace + creator-member: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed to create workspace (slug may already exist)"
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "workspace": workspace })),
+    )
+        .into_response()
+}
+
+/// GET /api/workspaces — List workspaces the current user belongs to.
+pub async fn list_workspaces(State(state): State<AppState>, auth_user: AuthUser) -> Response {
+    match workspace_db::list_workspaces_for_user(&state.pool, &auth_user.user_id).await {
+        Ok(workspaces) => Json(serde_json::json!({ "workspaces": workspaces })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list workspaces: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}
+
+/// GET /api/workspaces/:id — Fetch a workspace. 404 for non-members.
+pub async fn get_workspace(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        return r;
+    }
+    match workspace_db::get_workspace(&state.pool, &workspace_id).await {
+        Ok(Some(w)) => Json(serde_json::json!({ "workspace": w })).into_response(),
+        Ok(None) => not_found("workspace not found"),
+        Err(e) => {
+            tracing::error!("failed to get workspace: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}
+
+/// GET /api/workspaces/:id/members — List members (read-only in v1).
+pub async fn list_members(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        return r;
+    }
+    match workspace_db::list_workspace_members_with_users(&state.pool, &workspace_id).await {
+        Ok(members) => Json(serde_json::json!({ "members": members })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to list members: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()
+        }
+    }
+}

--- a/crates/onsager-portal/src/handlers/workspaces.rs
+++ b/crates/onsager-portal/src/handlers/workspaces.rs
@@ -138,9 +138,20 @@ pub async fn create_workspace(
 }
 
 /// GET /api/workspaces — List workspaces the current user belongs to.
+///
+/// PATs are workspace-scoped post-#163: a PAT pinned to a workspace
+/// must not enumerate other workspaces its user happens to belong to.
+/// When the principal is a pinned PAT, the response is filtered to the
+/// pinned workspace (returning `[]` if the user is not a member).
 pub async fn list_workspaces(State(state): State<AppState>, auth_user: AuthUser) -> Response {
+    let pinned = auth_user.principal.pinned_workspace_id();
     match workspace_db::list_workspaces_for_user(&state.pool, &auth_user.user_id).await {
-        Ok(workspaces) => Json(serde_json::json!({ "workspaces": workspaces })).into_response(),
+        Ok(mut workspaces) => {
+            if let Some(p) = pinned {
+                workspaces.retain(|w| w.id == p);
+            }
+            Json(serde_json::json!({ "workspaces": workspaces })).into_response()
+        }
         Err(e) => {
             tracing::error!("failed to list workspaces: {e}");
             (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response()

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -30,6 +30,7 @@ pub mod auth;
 pub mod auth_db;
 pub mod backfill;
 pub mod config;
+pub mod core;
 pub mod credential_db;
 pub mod db;
 #[cfg(debug_assertions)]
@@ -42,3 +43,4 @@ pub mod pat_db;
 pub mod server;
 pub mod sso;
 pub mod state;
+pub mod workspace_db;

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -8,7 +8,8 @@ use axum::Router;
 use crate::config::Config;
 use crate::gate::GateClient;
 use crate::handlers::{
-    auth as auth_handlers, credentials as credential_handlers, pats as pat_handlers, webhook,
+    auth as auth_handlers, credentials as credential_handlers, pats as pat_handlers,
+    projects as project_handlers, webhook, workspaces as workspace_handlers,
 };
 use crate::state::AppState;
 
@@ -90,6 +91,36 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/workspaces/{workspace_id}/credentials/{name}",
             put(credential_handlers::set_credential).delete(credential_handlers::delete_credential),
+        )
+        // Workspace + member + project CRUD (#222 Slice 3a). Stiglab
+        // proxies these URLs through `routes::portal::proxy` so the
+        // dashboard's API_BASE cutover (Slice 6) can land independently.
+        // Auth (cookie or PAT bearer) is enforced by the `AuthUser`
+        // extractor; PAT-pinned principals are 403'd against
+        // mismatched workspace IDs by `require_workspace_access`.
+        .route(
+            "/api/workspaces",
+            get(workspace_handlers::list_workspaces).post(workspace_handlers::create_workspace),
+        )
+        .route(
+            "/api/workspaces/{workspace_id}",
+            get(workspace_handlers::get_workspace),
+        )
+        .route(
+            "/api/workspaces/{workspace_id}/members",
+            get(workspace_handlers::list_members),
+        )
+        .route(
+            "/api/workspaces/{workspace_id}/projects",
+            get(project_handlers::list_projects).post(project_handlers::add_project),
+        )
+        .route(
+            "/api/projects",
+            get(project_handlers::list_all_projects_for_user),
+        )
+        .route(
+            "/api/projects/{project_id}",
+            get(project_handlers::get_project).delete(project_handlers::delete_project),
         );
 
     // Dev-login is debug-only — `cargo build --release` strips both the

--- a/crates/onsager-portal/src/workspace_db.rs
+++ b/crates/onsager-portal/src/workspace_db.rs
@@ -1,0 +1,294 @@
+//! Workspace / member / project CRUD against the spine-owned tables
+//! (`crates/onsager-spine/migrations/020_workspaces_to_spine.sql`).
+//!
+//! Spec #222 Slice 3a moved the routes from stiglab → portal; the
+//! supporting DB functions move with them. Stiglab still reads the same
+//! tables from the same Postgres instance (separate connection pool) for
+//! its in-process session/task workflow needs, but **portal is the only
+//! writer**.
+
+use chrono::{DateTime, Utc};
+use sqlx::postgres::PgPool;
+
+use crate::core::{Project, Workspace, WorkspaceMember, WorkspaceMemberWithUser};
+
+#[derive(sqlx::FromRow)]
+struct WorkspaceRow {
+    id: String,
+    slug: String,
+    name: String,
+    created_by: String,
+    created_at: String,
+}
+
+impl TryFrom<WorkspaceRow> for Workspace {
+    type Error = anyhow::Error;
+
+    fn try_from(row: WorkspaceRow) -> anyhow::Result<Self> {
+        Ok(Workspace {
+            id: row.id,
+            slug: row.slug,
+            name: row.name,
+            created_by: row.created_by,
+            created_at: DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct WorkspaceMemberWithUserRow {
+    workspace_id: String,
+    user_id: String,
+    joined_at: String,
+    github_login: Option<String>,
+    github_name: Option<String>,
+    github_avatar_url: Option<String>,
+}
+
+impl TryFrom<WorkspaceMemberWithUserRow> for WorkspaceMemberWithUser {
+    type Error = anyhow::Error;
+
+    fn try_from(row: WorkspaceMemberWithUserRow) -> anyhow::Result<Self> {
+        Ok(WorkspaceMemberWithUser {
+            workspace_id: row.workspace_id,
+            user_id: row.user_id,
+            joined_at: DateTime::parse_from_rfc3339(&row.joined_at)?.with_timezone(&Utc),
+            github_login: row.github_login,
+            github_name: row.github_name,
+            github_avatar_url: row.github_avatar_url,
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct ProjectRow {
+    id: String,
+    workspace_id: String,
+    github_app_installation_id: String,
+    repo_owner: String,
+    repo_name: String,
+    default_branch: String,
+    created_at: String,
+}
+
+impl TryFrom<ProjectRow> for Project {
+    type Error = anyhow::Error;
+
+    fn try_from(row: ProjectRow) -> anyhow::Result<Self> {
+        Ok(Project {
+            id: row.id,
+            workspace_id: row.workspace_id,
+            github_app_installation_id: row.github_app_installation_id,
+            repo_owner: row.repo_owner,
+            repo_name: row.repo_name,
+            default_branch: row.default_branch,
+            created_at: DateTime::parse_from_rfc3339(&row.created_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+/// Atomically insert a workspace and its creator-as-member row. Either
+/// both rows land or neither — prevents a failed `workspace_members`
+/// insert from leaving an orphan workspace that permanently consumes
+/// its slug.
+pub async fn insert_workspace_with_creator(
+    pool: &PgPool,
+    workspace: &Workspace,
+    member: &WorkspaceMember,
+) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO workspaces (id, slug, name, created_by, created_at) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(&workspace.id)
+    .bind(&workspace.slug)
+    .bind(&workspace.name)
+    .bind(&workspace.created_by)
+    .bind(workspace.created_at.to_rfc3339())
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO workspace_members (workspace_id, user_id, joined_at) VALUES ($1, $2, $3)",
+    )
+    .bind(&member.workspace_id)
+    .bind(&member.user_id)
+    .bind(member.joined_at.to_rfc3339())
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+pub async fn get_workspace(pool: &PgPool, workspace_id: &str) -> anyhow::Result<Option<Workspace>> {
+    let row = sqlx::query_as::<_, WorkspaceRow>(
+        "SELECT id, slug, name, created_by, created_at FROM workspaces WHERE id = $1",
+    )
+    .bind(workspace_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn list_workspaces_for_user(
+    pool: &PgPool,
+    user_id: &str,
+) -> anyhow::Result<Vec<Workspace>> {
+    let rows = sqlx::query_as::<_, WorkspaceRow>(
+        "SELECT w.id, w.slug, w.name, w.created_by, w.created_at \
+         FROM workspaces w \
+         JOIN workspace_members m ON w.id = m.workspace_id \
+         WHERE m.user_id = $1 \
+         ORDER BY w.created_at ASC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn is_workspace_member(
+    pool: &PgPool,
+    workspace_id: &str,
+    user_id: &str,
+) -> anyhow::Result<bool> {
+    let row = sqlx::query_scalar::<_, String>(
+        "SELECT user_id FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
+    )
+    .bind(workspace_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.is_some())
+}
+
+pub async fn list_workspace_members_with_users(
+    pool: &PgPool,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<WorkspaceMemberWithUser>> {
+    let rows = sqlx::query_as::<_, WorkspaceMemberWithUserRow>(
+        "SELECT m.workspace_id, m.user_id, m.joined_at, \
+                u.github_login, u.github_name, u.github_avatar_url \
+         FROM workspace_members m \
+         LEFT JOIN users u ON u.id = m.user_id \
+         WHERE m.workspace_id = $1 \
+         ORDER BY m.joined_at ASC",
+    )
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+/// Read shape the workspace route handlers need to validate that an
+/// installation belongs to a workspace and to mint an installation
+/// token. Slice 3b moves the `github_app_installations` table into
+/// portal's migrations directory; until then portal reads the same
+/// table stiglab's runtime migrations created.
+pub struct InstallationLookup {
+    pub workspace_id: String,
+    pub install_id: i64,
+}
+
+pub async fn get_installation_lookup(
+    pool: &PgPool,
+    install_row_id: &str,
+) -> anyhow::Result<Option<InstallationLookup>> {
+    let row: Option<(String, i64)> = sqlx::query_as(
+        "SELECT workspace_id, install_id FROM github_app_installations WHERE id = $1",
+    )
+    .bind(install_row_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(w, i)| InstallationLookup {
+        workspace_id: w,
+        install_id: i,
+    }))
+}
+
+pub async fn insert_project(pool: &PgPool, project: &Project) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO projects (id, workspace_id, github_app_installation_id, repo_owner, \
+                               repo_name, default_branch, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(&project.id)
+    .bind(&project.workspace_id)
+    .bind(&project.github_app_installation_id)
+    .bind(&project.repo_owner)
+    .bind(&project.repo_name)
+    .bind(&project.default_branch)
+    .bind(project.created_at.to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Option<Project>> {
+    let row = sqlx::query_as::<_, ProjectRow>(
+        "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
+                default_branch, created_at \
+         FROM projects WHERE id = $1",
+    )
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|r| r.try_into()).transpose()
+}
+
+pub async fn list_projects_for_workspace(
+    pool: &PgPool,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
+                default_branch, created_at \
+         FROM projects WHERE workspace_id = $1 ORDER BY created_at ASC",
+    )
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn list_projects_for_user(pool: &PgPool, user_id: &str) -> anyhow::Result<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        "SELECT p.id, p.workspace_id, p.github_app_installation_id, p.repo_owner, p.repo_name, \
+                p.default_branch, p.created_at \
+         FROM projects p \
+         JOIN workspace_members m ON p.workspace_id = m.workspace_id \
+         WHERE m.user_id = $1 \
+         ORDER BY p.created_at ASC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(|r| r.try_into()).collect()
+}
+
+pub async fn delete_project(pool: &PgPool, project_id: &str) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM projects WHERE id = $1")
+        .bind(project_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Count sessions attached to a project that are not in a terminal
+/// state. Used to block project deletion while live sessions reference
+/// it (no cascade, no soft-delete in v1). Reads stiglab's `sessions`
+/// table from the same Postgres instance — the table is stiglab-owned
+/// but the column is shared.
+pub async fn count_live_sessions_for_project(
+    pool: &PgPool,
+    project_id: &str,
+) -> anyhow::Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sessions \
+         WHERE project_id = $1 AND state NOT IN ('done', 'failed')",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}

--- a/crates/onsager-spine/migrations/020_workspaces_to_spine.sql
+++ b/crates/onsager-spine/migrations/020_workspaces_to_spine.sql
@@ -1,13 +1,15 @@
 -- Onsager #222 Slice 3a: workspaces / workspace_members / projects move
 -- into the spine.
 --
--- These three tables are cross-cutting — `artifacts.workspace_id` already
--- FKs into `workspaces`, every subsystem that joins agent-session work to
--- a tenant boundary needs `workspace_members` for membership checks, and
--- `projects` is the (workspace, repo) pair that webhook ingestion and
--- workflow CRUD both index on. Per Lever B, the schema lives where the
--- data is canonical — in the spine — rather than in the subsystem that
--- happens to own a CRUD route over it.
+-- These three tables are cross-cutting — `artifacts.workspace_id` joins
+-- to `workspaces.id` (no FK constraint declared, in keeping with the
+-- rest of stiglab/spine schema; app-layer enforcement only), every
+-- subsystem that joins agent-session work to a tenant boundary needs
+-- `workspace_members` for membership checks, and `projects` is the
+-- (workspace, repo) pair that webhook ingestion and workflow CRUD both
+-- index on. Per Lever B, the schema lives where the data is canonical
+-- — in the spine — rather than in the subsystem that happens to own a
+-- CRUD route over it.
 --
 -- Slice 2a's pattern: portal becomes the only writer to these tables;
 -- stiglab keeps its own `db::*` reads (same database, separate connection

--- a/crates/onsager-spine/migrations/020_workspaces_to_spine.sql
+++ b/crates/onsager-spine/migrations/020_workspaces_to_spine.sql
@@ -1,0 +1,54 @@
+-- Onsager #222 Slice 3a: workspaces / workspace_members / projects move
+-- into the spine.
+--
+-- These three tables are cross-cutting — `artifacts.workspace_id` already
+-- FKs into `workspaces`, every subsystem that joins agent-session work to
+-- a tenant boundary needs `workspace_members` for membership checks, and
+-- `projects` is the (workspace, repo) pair that webhook ingestion and
+-- workflow CRUD both index on. Per Lever B, the schema lives where the
+-- data is canonical — in the spine — rather than in the subsystem that
+-- happens to own a CRUD route over it.
+--
+-- Slice 2a's pattern: portal becomes the only writer to these tables;
+-- stiglab keeps its own `db::*` reads (same database, separate connection
+-- pool) for the in-process needs of `tasks.rs` / `sessions.rs` / the
+-- workflow runtime. Stiglab also keeps idempotent `CREATE TABLE IF NOT
+-- EXISTS` fallbacks in `server/db.rs::run_migrations` so SQLite-backed
+-- integration tests build the schema without a portal binary in the loop,
+-- and so a fresh deploy's first migrator wins.
+--
+-- Slice 3b moves `github_app_installations` to portal's migrations
+-- directory. This migration leaves that table in stiglab's runtime path
+-- until 3b lands.
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspace_members (
+    workspace_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    joined_at TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_members_user_id
+    ON workspace_members (user_id);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    github_app_installation_id TEXT NOT NULL,
+    repo_owner TEXT NOT NULL,
+    repo_name TEXT NOT NULL,
+    default_branch TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(workspace_id, repo_owner, repo_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_workspace_id
+    ON projects (workspace_id);

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -42,6 +42,20 @@ What this means for stiglab specifically:
     stiglab still owns the in-process decrypt-and-launch path used
     when spawning agent sessions (`decrypt_credential` in
     `tasks.rs`/`workflows.rs`).
+  - Workspace + member + project CRUD (`GET/POST /api/workspaces`,
+    `GET /api/workspaces/:id`, `GET /api/workspaces/:id/members`,
+    `GET/POST /api/workspaces/:id/projects`, `GET /api/projects`,
+    `GET/DELETE /api/projects/:id`) — Slice 3a. Portal is the only
+    writer; the `workspaces` / `workspace_members` / `projects`
+    schema lives in `crates/onsager-spine/migrations/020_workspaces_to_spine.sql`
+    post-Slice 3a. Stiglab still reads the same Postgres tables for
+    the in-process session/task/workflow lookups (`db::is_workspace_member`,
+    `db::get_project`, `db::list_workspaces_for_user`, etc.) — same
+    database, separate connection pool.
+  - GitHub App install + per-workspace installation routes
+    (`/api/workspaces/:id/github-installations*`,
+    `/api/github-app/*`) — Slice 3b pending. Stiglab still owns
+    these and the `github_app_installations` table.
 - **Forbidden HTTP surfaces.** Anything called from `forge`, `synodic`,
   or `ising`. **Lever C status (#148): no remaining violation** —
   `HttpStiglabDispatcher` and the `POST /api/shaping` route it

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -82,20 +82,25 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         // and PAT bearer auth, so the proxy preserves full behavior.
         .route("/api/pats", any(routes::portal::proxy))
         .route("/api/pats/{id}", any(routes::portal::proxy))
-        // Workspace routes (issue #59 — Phase 0; renamed from "tenant" →
-        // "workspace" in issue #163).
-        .route(
-            "/api/workspaces",
-            get(routes::workspaces::list_workspaces).post(routes::workspaces::create_workspace),
-        )
-        .route(
-            "/api/workspaces/{id}",
-            get(routes::workspaces::get_workspace),
-        )
-        .route(
-            "/api/workspaces/{id}/members",
-            get(routes::workspaces::list_members),
-        )
+        // Workspace + member + project CRUD (#222 Slice 3a). Portal owns
+        // these routes; stiglab proxies them so dashboard fetches keep
+        // working pre–API_BASE cutover (Slice 6). Schema for
+        // `workspaces` / `workspace_members` / `projects` lives in the
+        // spine migration (`020_workspaces_to_spine.sql`); stiglab
+        // still reads the same Postgres tables for the in-process
+        // session/task lookups (`db::is_workspace_member`,
+        // `db::get_project`, etc.) — same database, separate
+        // connection pool, portal is the only writer.
+        .route("/api/workspaces", any(routes::portal::proxy))
+        .route("/api/workspaces/{id}", any(routes::portal::proxy))
+        .route("/api/workspaces/{id}/members", any(routes::portal::proxy))
+        .route("/api/workspaces/{id}/projects", any(routes::portal::proxy))
+        .route("/api/projects", any(routes::portal::proxy))
+        .route("/api/projects/{id}", any(routes::portal::proxy))
+        // GitHub App installation + install-flow routes (Slice 3b
+        // pending). Stiglab still owns these — they live alongside the
+        // workspace routes above and read/write `github_app_installations`
+        // which moves to portal in 3b.
         .route(
             "/api/workspaces/{id}/github-installations",
             get(routes::workspaces::list_installations)
@@ -124,18 +129,6 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         .route(
             "/api/github-app/callback",
             get(routes::workspaces::github_app_install_callback),
-        )
-        .route(
-            "/api/workspaces/{id}/projects",
-            get(routes::workspaces::list_projects).post(routes::workspaces::add_project),
-        )
-        .route(
-            "/api/projects",
-            get(routes::workspaces::list_all_projects_for_user),
-        )
-        .route(
-            "/api/projects/{id}",
-            get(routes::workspaces::get_project).delete(routes::workspaces::delete_project),
         )
         // Live-data hydration for reference-only artifacts (#170 / #167 / #171).
         // The dashboard joins skeleton rows from `/api/spine/artifacts?kind=...`

--- a/crates/stiglab/src/server/routes/tasks.rs
+++ b/crates/stiglab/src/server/routes/tasks.rs
@@ -140,7 +140,7 @@ pub async fn create_task(
                     .into_response();
             }
         }
-        if let Err(r) = crate::server::routes::workspaces::assert_workspace_member(
+        if let Err(r) = crate::server::routes::require_workspace_access(
             &state.db,
             &auth_user,
             &project.workspace_id,

--- a/crates/stiglab/src/server/routes/workspaces.rs
+++ b/crates/stiglab/src/server/routes/workspaces.rs
@@ -1,15 +1,16 @@
-//! Workspace, membership, GitHub App installation, and project CRUD
-//! routes (issue #59 — Phase 0; renamed from "tenant" → "workspace" in
-//! issue #163).
+//! GitHub App installation + install-flow routes (slice 3b of spec
+//! #222 still pending).
 //!
-//! All workspace-scoped endpoints go through
+//! Workspace, membership, and project CRUD moved to portal in Slice 3a
+//! (PR #222 Slice 3a) — see `crates/onsager-portal/src/handlers/{workspaces,projects}.rs`.
+//! Stiglab proxies the moved URLs through `routes::portal::proxy` until
+//! the dashboard's API_BASE cutover (Slice 6) lands.
+//!
+//! All workspace-scoped endpoints in this module go through
 //! [`super::require_workspace_access`] which returns **404 (not 403)** for
 //! non-members. Matching GitHub's private-resource behaviour means the
 //! workspace-enumeration surface stays private — no invite-acceptance UI
 //! needed for v1.
-//!
-//! Project deletion blocks with a clear error when live sessions reference
-//! the project; there is no cascade and no soft-delete in v1.
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -20,17 +21,11 @@ use serde::Deserialize;
 use sqlx::AnyPool;
 use uuid::Uuid;
 
-use crate::core::{GitHubAccountType, GitHubAppInstallation, Project, Workspace, WorkspaceMember};
+use crate::core::{GitHubAccountType, GitHubAppInstallation};
 use crate::server::auth::{encrypt_credential, AuthUser};
 use crate::server::db;
 use crate::server::github_app;
 use crate::server::state::AppState;
-
-// ── Auth helper ──
-//
-// The shared workspace authorization gate lives at
-// `super::require_workspace_access` (see `routes/mod.rs`); every
-// workspace-scoped endpoint in this module funnels through it.
 
 use super::require_workspace_access;
 
@@ -45,148 +40,8 @@ fn not_found(msg: &str) -> Response {
 #[allow(clippy::result_large_err)]
 fn require_auth_user(auth_user: &AuthUser) -> Result<&str, Response> {
     // Auth is always-on as of #193; the `AuthUser` extractor 401s
-    // unauthenticated requests before they reach this helper. The
-    // wrapper stays as the canonical place to return the user-id —
-    // callers don't have to thread `auth_user.user_id.as_str()`
-    // by hand and the helper signature is stable for any future
-    // checks (suspension, etc.) that need to short-circuit here.
+    // unauthenticated requests before they reach this helper.
     Ok(auth_user.user_id.as_str())
-}
-
-// ── Workspace CRUD ──
-
-#[derive(Debug, Deserialize)]
-pub struct CreateWorkspaceBody {
-    pub slug: String,
-    pub name: String,
-}
-
-/// POST /api/workspaces — Create a workspace. Creator is auto-inserted as
-/// a member (no role column in v1).
-pub async fn create_workspace(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Json(body): Json<CreateWorkspaceBody>,
-) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id.to_string(),
-        Err(r) => return r,
-    };
-
-    let slug = body.slug.trim();
-    let name = body.name.trim();
-    if slug.is_empty() || name.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "slug and name are required" })),
-        )
-            .into_response();
-    }
-    if !slug
-        .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "slug must be lowercase alphanumeric with hyphens"
-            })),
-        )
-            .into_response();
-    }
-
-    let now = Utc::now();
-    let workspace = Workspace {
-        id: Uuid::new_v4().to_string(),
-        slug: slug.to_string(),
-        name: name.to_string(),
-        created_by: user_id.clone(),
-        created_at: now,
-    };
-    let member = WorkspaceMember {
-        workspace_id: workspace.id.clone(),
-        user_id: user_id.clone(),
-        joined_at: now,
-    };
-
-    // Transactional so a failed member insert can't leave an orphan
-    // workspace row that permanently consumes the slug.
-    if let Err(e) = db::insert_workspace_with_creator(&state.db, &workspace, &member).await {
-        tracing::error!("failed to insert workspace + creator-member: {e}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": "failed to create workspace (slug may already exist)"
-            })),
-        )
-            .into_response();
-    }
-
-    (
-        StatusCode::CREATED,
-        Json(serde_json::json!({ "workspace": workspace })),
-    )
-        .into_response()
-}
-
-/// GET /api/workspaces — List workspaces the current user belongs to.
-pub async fn list_workspaces(State(state): State<AppState>, auth_user: AuthUser) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    match db::list_workspaces_for_user(&state.db, user_id).await {
-        Ok(workspaces) => Json(serde_json::json!({ "workspaces": workspaces })).into_response(),
-        Err(e) => {
-            tracing::error!("failed to list workspaces: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    }
-}
-
-/// GET /api/workspaces/:id — Fetch a workspace. 404 for non-members.
-pub async fn get_workspace(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(workspace_id): Path<String>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        return r;
-    }
-    match db::get_workspace(&state.db, &workspace_id).await {
-        Ok(Some(w)) => Json(serde_json::json!({ "workspace": w })).into_response(),
-        Ok(None) => not_found("workspace not found"),
-        Err(e) => {
-            tracing::error!("failed to get workspace: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    }
-}
-
-/// GET /api/workspaces/:id/members — List members (read-only in v1).
-pub async fn list_members(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(workspace_id): Path<String>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        return r;
-    }
-    match db::list_workspace_members_with_users(&state.db, &workspace_id).await {
-        Ok(members) => Json(serde_json::json!({ "members": members })).into_response(),
-        Err(e) => {
-            tracing::error!("failed to list members: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    }
 }
 
 // ── GitHub App installations ──
@@ -361,246 +216,6 @@ pub async fn delete_installation(
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
     Json(serde_json::json!({ "ok": true })).into_response()
-}
-
-// ── Projects ──
-
-#[derive(Debug, Deserialize)]
-pub struct AddProjectBody {
-    pub github_app_installation_id: String,
-    pub repo_owner: String,
-    pub repo_name: String,
-    /// Optional. Inferring from GitHub at create-time requires an
-    /// installation access token the Phase 0 stub can't mint; callers may
-    /// supply a branch or let the server fall back to `"main"`.
-    pub default_branch: Option<String>,
-}
-
-/// POST /api/workspaces/:id/projects — Add a project (opt-in per repo;
-/// no auto-mirroring).
-pub async fn add_project(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(workspace_id): Path<String>,
-    Json(body): Json<AddProjectBody>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        return r;
-    }
-
-    // Validate the installation belongs to this workspace.
-    match db::get_github_app_installation(&state.db, &body.github_app_installation_id).await {
-        Ok(Some(inst)) if inst.workspace_id == workspace_id => {}
-        Ok(_) => return not_found("installation not found"),
-        Err(e) => {
-            tracing::error!("failed to get installation: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    }
-
-    let repo_owner = body.repo_owner.trim();
-    let repo_name = body.repo_name.trim();
-    if repo_owner.is_empty() || repo_name.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "repo_owner and repo_name are required" })),
-        )
-            .into_response();
-    }
-
-    // If the caller supplied a branch, trust it. Otherwise try the GitHub
-    // API (when the App is configured), then fall back to "main" on any
-    // failure — onboarding must never block on a network hiccup.
-    let supplied = body
-        .default_branch
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let default_branch = match supplied {
-        Some(b) => b,
-        None => match installation_token_for(&state.db, &body.github_app_installation_id).await {
-            Ok(Some(token)) => {
-                match github_app::get_repo_default_branch(&token, repo_owner, repo_name).await {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::warn!(
-                            "default_branch inference failed for {repo_owner}/{repo_name}: {e}"
-                        );
-                        "main".to_string()
-                    }
-                }
-            }
-            Ok(None) => "main".to_string(),
-            Err(e) => {
-                tracing::warn!(
-                    "installation token lookup failed for default_branch inference on {repo_owner}/{repo_name}: {e}"
-                );
-                "main".to_string()
-            }
-        },
-    };
-
-    let project = Project {
-        id: Uuid::new_v4().to_string(),
-        workspace_id: workspace_id.clone(),
-        github_app_installation_id: body.github_app_installation_id.clone(),
-        repo_owner: repo_owner.to_string(),
-        repo_name: repo_name.to_string(),
-        default_branch,
-        created_at: Utc::now(),
-    };
-
-    if let Err(e) = db::insert_project(&state.db, &project).await {
-        tracing::error!("failed to insert project: {e}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": "failed to add project (repo may already be onboarded)"
-            })),
-        )
-            .into_response();
-    }
-
-    (
-        StatusCode::CREATED,
-        Json(serde_json::json!({ "project": project })),
-    )
-        .into_response()
-}
-
-/// GET /api/workspaces/:id/projects — List projects in a workspace.
-pub async fn list_projects(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(workspace_id): Path<String>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-        return r;
-    }
-    match db::list_projects_for_workspace(&state.db, &workspace_id).await {
-        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
-        Err(e) => {
-            tracing::error!("failed to list projects: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    }
-}
-
-/// GET /api/projects — List every project the current user can access,
-/// across all their workspaces. Powers the cross-workspace project
-/// selector in `CreateSessionSheet`.
-pub async fn list_all_projects_for_user(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-) -> Response {
-    let user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    match db::list_projects_for_user(&state.db, user_id).await {
-        Ok(projects) => Json(serde_json::json!({ "projects": projects })).into_response(),
-        Err(e) => {
-            tracing::error!("failed to list projects: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    }
-}
-
-/// GET /api/projects/:id — Fetch a project by ID. 404 for users who are
-/// not members of the owning workspace.
-pub async fn get_project(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(project_id): Path<String>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    let project = match db::get_project(&state.db, &project_id).await {
-        Ok(Some(p)) => p,
-        Ok(None) => return not_found("project not found"),
-        Err(e) => {
-            tracing::error!("failed to get project: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &project.workspace_id).await {
-        return r;
-    }
-    Json(serde_json::json!({ "project": project })).into_response()
-}
-
-/// DELETE /api/projects/:id — Delete a project. Blocks with a clear
-/// error when any attached session is not in a terminal state (no
-/// cascade, no soft-delete in v1).
-pub async fn delete_project(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Path(project_id): Path<String>,
-) -> Response {
-    let _user_id = match require_auth_user(&auth_user) {
-        Ok(id) => id,
-        Err(r) => return r,
-    };
-    let project = match db::get_project(&state.db, &project_id).await {
-        Ok(Some(p)) => p,
-        Ok(None) => return not_found("project not found"),
-        Err(e) => {
-            tracing::error!("failed to get project: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    };
-    if let Err(r) = require_workspace_access(&state.db, &auth_user, &project.workspace_id).await {
-        return r;
-    }
-
-    match db::count_live_sessions_for_project(&state.db, &project_id).await {
-        Ok(n) if n > 0 => {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({
-                    "error": format!(
-                        "cannot delete project: {n} live session(s) still reference it. \
-                         Wait for them to finish or abort them first."
-                    )
-                })),
-            )
-                .into_response();
-        }
-        Ok(_) => {}
-        Err(e) => {
-            tracing::error!("failed to count live sessions: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    }
-
-    if let Err(e) = db::delete_project(&state.db, &project_id).await {
-        tracing::error!("failed to delete project: {e}");
-        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-    }
-    Json(serde_json::json!({ "ok": true })).into_response()
-}
-
-/// Public helper re-exported so `routes::tasks` can reuse the same 404
-/// semantics (and PAT scope check) when creating a session scoped to a
-/// project.
-#[allow(clippy::result_large_err)]
-pub async fn assert_workspace_member(
-    pool: &AnyPool,
-    auth_user: &AuthUser,
-    workspace_id: &str,
-) -> Result<(), Response> {
-    require_workspace_access(pool, auth_user, workspace_id).await
 }
 
 // ── Accessible-repos picker + GitHub App install flow ──

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -14,10 +14,11 @@
 //!   * `last_used_at` advances on a successful PAT auth.
 //!
 //! The auth-extractor tests pivot onto stiglab routes that survive the
-//! Slice 2b move: `/api/projects` (cross-workspace project listing,
-//! `AuthUser`-gated) and `/api/workspaces/{id}` (workspace get,
-//! `require_workspace_access`-gated). When credentials/workspaces move in
-//! later slices, these tests will follow them to portal-side coverage.
+//! Slice 3a move: `/api/sessions?workspace={id}` (workspace-scoped list,
+//! `AuthUser`-gated and `require_workspace_access`-gated). Earlier slices
+//! used `/api/projects` and `/api/workspaces/{id}`; those are reverse
+//! proxies to portal as of #222 Slice 3a, so route-level tests against
+//! them require a Postgres-backed portal harness that doesn't exist yet.
 
 use axum::body::Body;
 use axum::http::{header, Request, StatusCode};
@@ -238,25 +239,29 @@ async fn verify_pat_reports_expired_separately_from_unknown() {
 // ── End-to-end PAT-authenticated requests ──
 //
 // The PAT auth path lives in stiglab's `AuthUser` extractor as long as
-// non-portal routes (credentials, workspaces, projects, workflows) accept
-// PAT bearer auth. The tests below pivot onto `/api/projects` — a
-// cross-workspace, AuthUser-gated route stiglab still owns — to exercise
-// the extractor end-to-end without depending on `/api/pats` (now a portal
-// proxy).
+// non-portal routes (workflows, sessions, nodes) accept PAT bearer auth.
+// The tests below pivot onto `/api/sessions?workspace={id}` — a
+// workspace-scoped list endpoint stiglab still owns post-Slice 3a — to
+// exercise the extractor end-to-end without depending on `/api/projects`
+// or `/api/workspaces/{id}` (both now portal proxies).
 
 #[tokio::test]
 async fn revoked_pat_returns_401_with_invalid_token_challenge() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
-    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "rvk").await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     db::revoke_user_pat(&pool, &user.id, &pat_id).await.unwrap();
     let state = AppState::new(pool, auth_enabled_config(), None);
 
     let resp = app(state)
         .oneshot(
-            bearer(Request::builder().uri("/api/projects"), &token)
-                .body(Body::empty())
-                .unwrap(),
+            bearer(
+                Request::builder().uri(format!("/api/sessions?workspace={}", workspace.id)),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
         )
         .await
         .unwrap();
@@ -276,15 +281,19 @@ async fn revoked_pat_returns_401_with_invalid_token_challenge() {
 async fn expired_pat_returns_401_with_invalid_token_challenge() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "exp").await;
     let past = Utc::now() - chrono::Duration::seconds(60);
-    let (_, token) = mint_pat(&pool, &user.id, None, "ci", Some(past)).await;
+    let (_, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", Some(past)).await;
     let state = AppState::new(pool, auth_enabled_config(), None);
 
     let resp = app(state)
         .oneshot(
-            bearer(Request::builder().uri("/api/projects"), &token)
-                .body(Body::empty())
-                .unwrap(),
+            bearer(
+                Request::builder().uri(format!("/api/sessions?workspace={}", workspace.id)),
+                &token,
+            )
+            .body(Body::empty())
+            .unwrap(),
         )
         .await
         .unwrap();
@@ -342,7 +351,7 @@ async fn pat_bearer_takes_precedence_over_cookie() {
     let resp = app(state)
         .oneshot(
             Request::builder()
-                .uri(format!("/api/workspaces/{}", cookie_workspace.id))
+                .uri(format!("/api/sessions?workspace={}", cookie_workspace.id))
                 .header(header::AUTHORIZATION, format!("Bearer {pat_token}"))
                 .header(header::COOKIE, format!("stiglab_session={session_token}"))
                 .body(Body::empty())
@@ -370,7 +379,8 @@ async fn pat_bearer_takes_precedence_over_cookie() {
 async fn last_used_at_advances_after_pat_auth() {
     let pool = test_pool().await;
     let user = seed_user(&pool).await;
-    let (pat_id, token) = mint_pat(&pool, &user.id, None, "ci", None).await;
+    let workspace = seed_workspace_with_member(&pool, &user.id, "lua").await;
+    let (pat_id, token) = mint_pat(&pool, &user.id, Some(&workspace.id), "ci", None).await;
     // Sanity: brand-new PAT has no last_used_at.
     {
         let pats = db::list_user_pats(&pool, &user.id).await.unwrap();
@@ -384,7 +394,7 @@ async fn last_used_at_advances_after_pat_auth() {
         .oneshot(
             bearer(
                 Request::builder()
-                    .uri("/api/projects")
+                    .uri(format!("/api/sessions?workspace={}", workspace.id))
                     .header(header::USER_AGENT, "test-agent/1.0"),
                 &token,
             )
@@ -424,7 +434,7 @@ async fn workspace_scoped_pat_can_read_its_own_workspace() {
     let resp = app(state)
         .oneshot(
             bearer(
-                Request::builder().uri(format!("/api/workspaces/{}", workspace.id)),
+                Request::builder().uri(format!("/api/sessions?workspace={}", workspace.id)),
                 &token,
             )
             .body(Body::empty())
@@ -434,7 +444,7 @@ async fn workspace_scoped_pat_can_read_its_own_workspace() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = read_json(resp).await;
-    assert_eq!(v["workspace"]["id"], workspace.id);
+    assert!(v["sessions"].is_array(), "expected sessions array");
 }
 
 #[tokio::test]
@@ -449,7 +459,7 @@ async fn workspace_scoped_pat_rejects_other_workspace() {
     let resp = app(state)
         .oneshot(
             bearer(
-                Request::builder().uri(format!("/api/workspaces/{}", workspace_b.id)),
+                Request::builder().uri(format!("/api/sessions?workspace={}", workspace_b.id)),
                 &token,
             )
             .body(Body::empty())


### PR DESCRIPTION
## Summary

Slice 3a of spec #222 — workspace, member, and project CRUD moves from stiglab to portal. Mirrors the Slice 2a (PR #253) and Slice 5/2b (PRs #251/#252) landing pattern.

**Portal owns:**
- `GET/POST /api/workspaces`
- `GET /api/workspaces/:id`
- `GET /api/workspaces/:id/members`
- `GET/POST /api/workspaces/:id/projects`
- `GET /api/projects`
- `GET/DELETE /api/projects/:id`

Domain types (`Workspace`, `WorkspaceMember`, `WorkspaceMemberWithUser`, `Project`) live in `onsager-portal/src/core.rs`. CRUD lives in `onsager-portal/src/workspace_db.rs`. Route handlers live in `onsager-portal/src/handlers/{workspaces,projects}.rs`. The PAT-pinned-workspace 403 guardrail follows the routes.

**Schema split** — `workspaces` / `workspace_members` / `projects` move into `crates/onsager-spine/migrations/020_workspaces_to_spine.sql` (cross-cutting — `artifacts.workspace_id` already FKs into `workspaces`). Stiglab keeps its idempotent `CREATE TABLE IF NOT EXISTS` fallback in `server/db.rs::run_migrations` so SQLite-backed integration tests build the schema without portal in the loop, and so a fresh deploy's first migrator wins.

**Stiglab proxies** the moved URLs through `routes::portal::proxy` so the dashboard's `API_BASE` cutover (Slice 6) can land independently. Stiglab keeps its own `db::*` reads (`is_workspace_member`, `get_project`, `list_workspaces_for_user`, etc.) for the in-process needs of `tasks.rs`/`sessions.rs`/the workflow runtime — same database, separate connection pool, **portal is the only writer**. `tasks.rs`'s project-scope membership check now calls `require_workspace_access` directly instead of the `assert_workspace_member` re-export.

## Scope note: pending slices 3b, 4, 6

This PR ships **Slice 3a only**. Per the spec's per-slice landing pattern (item 2: *"In one PR: portal handler live + portal-side migration (if any) + stiglab proxy entry + stiglab handler deletion. No half-state."*) and given their size, the remaining slices are follow-up branches:

- **Slice 3b**: GitHub App install + per-installation routes (`/api/workspaces/:id/github-installations*`, `/api/github-app/*`); `github_app_installations` table → `crates/onsager-portal/migrations/`. Stiglab still owns these in this PR.
- **Slice 4**: workflows.rs (1144 LOC) + workflow_activation.rs (1190 LOC) decomposition; new spine event types `workflow.activate_requested` / `workflow.deactivate_requested`; stiglab listener.
- **Slice 6**: dashboard `API_BASE` cutover; delete `routes::portal::proxy`. Lands after 3b + 4.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — 0 failures
- [x] `cargo run -q -p xtask -- lint-seams` — clean (2 pre-existing exemptions)
- [x] `cargo run -q -p xtask -- check-events` — clean (75 events)
- [x] `cargo run -q -p xtask -- check-api-contract` — clean (59 backend routes, 60 dashboard calls)
- [ ] Manual: dashboard against portal via stiglab proxy — workspace/project create/list/delete works end-to-end.
- [ ] Manual: PAT-pinned principal gets 403 against mismatched workspace ID.

Part of #222

https://claude.ai/code/session_01XTt7ojBKRhbWxJeAXPbhxC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTt7ojBKRhbWxJeAXPbhxC)_