### PR TITLE
feat(portal): move /api/registry/* stiglab → portal (#257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,6 @@ dependencies = [
  "jsonwebtoken",
  "onsager-artifact",
  "onsager-github",
- "onsager-registry",
  "onsager-spine",
  "rand 0.8.5",
  "reqwest",

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -156,9 +156,20 @@ first-class edge subsystem. The migration is staged:
   database, separate connection pool. The activation hooks still
   read `installation_db::get_install_webhook_secret_cipher` for
   per-install webhook signature secrets.
+- **Registry manifests — #222 follow-up #257 (landed).**
+  Portal owns `GET /api/registry/events` and
+  `GET /api/registry/triggers`. Pure static reads of
+  `onsager_registry::EVENTS` / `TRIGGERS`; no auth, no DB, no spine
+  writes. Stiglab proxies the URLs through `routes::portal::proxy`
+  and no longer depends on `onsager-registry`. First of the
+  follow-up sub-issues that move the remaining stiglab dashboard
+  surface to portal so #222 Slice 6 can drop the proxy.
 - **Routes (follow-ups).** Slice 6: dashboard `API_BASE` cutover
   to portal directly + delete the `routes::portal::proxy` entries
-  in stiglab.
+  in stiglab. Blocked on the remaining stiglab dashboard routes
+  (`/api/sessions/*`, `/api/spine/*`, `/api/governance/*`,
+  `/api/projects/{id}/issues|pulls|backfill|replay-trigger`)
+  moving to portal — each one its own sub-issue under #222.
 
 While the migration is in flight, stiglab still hosts most of the
 external HTTP surface — that is the drift #222 closes, not a pattern

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -9,6 +9,8 @@ pub mod issues;
 pub mod pats;
 pub mod projects;
 pub mod pull_request;
+pub mod registry_events;
+pub mod registry_triggers;
 pub mod spec_link;
 pub mod webhook;
 pub mod workflow_kinds;

--- a/crates/onsager-portal/src/handlers/registry_events.rs
+++ b/crates/onsager-portal/src/handlers/registry_events.rs
@@ -8,6 +8,10 @@
 //!
 //! Public by design (matches `workflow_kinds`): the manifest is part of
 //! the architecture documentation, not user data.
+//!
+//! Spec #257 (sub-issue of #222) moved this route from stiglab to
+//! portal so the dashboard's `API_BASE` cutover (#222 Slice 6) can
+//! eventually drop the `routes::portal::proxy` shim.
 
 use axum::response::{IntoResponse, Response};
 use axum::Json;

--- a/crates/onsager-portal/src/handlers/registry_triggers.rs
+++ b/crates/onsager-portal/src/handlers/registry_triggers.rs
@@ -8,6 +8,10 @@
 //!
 //! Public by design (matches `registry_events`): the manifest is part of
 //! the architecture documentation, not user data.
+//!
+//! Spec #257 (sub-issue of #222) moved this route from stiglab to
+//! portal so the dashboard's `API_BASE` cutover (#222 Slice 6) can
+//! eventually drop the `routes::portal::proxy` shim.
 
 use axum::response::{IntoResponse, Response};
 use axum::Json;

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -10,6 +10,7 @@ use crate::gate::GateClient;
 use crate::handlers::{
     auth as auth_handlers, credentials as credential_handlers, github_app as github_app_handlers,
     installations as installation_handlers, pats as pat_handlers, projects as project_handlers,
+    registry_events as registry_event_handlers, registry_triggers as registry_trigger_handlers,
     webhook, workflow_kinds as workflow_kind_handlers, workflows as workflow_handlers,
     workspaces as workspace_handlers,
 };
@@ -183,6 +184,23 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/workflow/kinds",
             get(workflow_kind_handlers::list_workflow_kinds),
+        )
+        // Event-type registry manifest (#222 follow-up #257). Static,
+        // human-reviewed manifest of every `FactoryEventKind` variant —
+        // which subsystems produce/consume it. Stiglab proxies the URL
+        // through `routes::portal::proxy` so the dashboard's API_BASE
+        // cutover (#222 Slice 6) can land independently.
+        .route(
+            "/api/registry/events",
+            get(registry_event_handlers::list_events),
+        )
+        // Trigger-kind registry manifest (#222 follow-up #257). Static,
+        // human-reviewed manifest of every `TriggerKind` variant — read
+        // by the dashboard's `<TriggerKindPicker>`. Same proxy shape
+        // as `/api/registry/events` above.
+        .route(
+            "/api/registry/triggers",
+            get(registry_trigger_handlers::list_triggers),
         );
 
     // Dev-login is debug-only — `cargo build --release` strips both the

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -62,6 +62,12 @@ What this means for stiglab specifically:
     (`db::get_github_app_installation`,
     `db::get_install_webhook_secret_cipher`) — same database,
     separate connection pool.
+  - Registry manifests (`GET /api/registry/events`,
+    `GET /api/registry/triggers`) — #222 follow-up #257. Portal owns
+    the static manifest reads (`onsager_registry::EVENTS` /
+    `TRIGGERS`); stiglab proxies the URLs through
+    `routes::portal::proxy` so dashboard fetches keep working pre–
+    API_BASE cutover. Stiglab no longer depends on `onsager-registry`.
   - Workflow CRUD + GitHub side-effects
     (`GET/POST /api/workflows`, `GET/PATCH/DELETE /api/workflows/:id`,
     `GET /api/workflows/:id/runs`, `GET /api/workflow/kinds`) — Slice 4.

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 [dependencies]
 onsager-artifact = { path = "../onsager-artifact" }
 onsager-github = { path = "../onsager-github" }
-onsager-registry = { path = "../onsager-registry" }
 onsager-spine = { path = "../onsager-spine" }
 
 # From stiglab-core

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -181,21 +181,17 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         // Workflow artifact-kind catalog (issue #102 / #222 Slice 4) —
         // public registry pass-through; portal owns the route now.
         .route("/api/workflow/kinds", any(routes::portal::proxy))
-        // Event-type registry manifest (spec #131 Lever E / #150).
-        // Static, human-reviewed manifest of every FactoryEventKind
-        // variant — which subsystems produce it and which consume it.
-        .route(
-            "/api/registry/events",
-            get(routes::registry_events::list_events),
-        )
-        // Trigger-kind registry manifest (spec #237 / parent #236).
-        // Static, human-reviewed manifest of every TriggerKind variant —
-        // its producer subsystem, category, and UI form shape. Read by
-        // the dashboard's `<TriggerKindPicker>`.
-        .route(
-            "/api/registry/triggers",
-            get(routes::registry_triggers::list_triggers),
-        )
+        // Event-type registry manifest (#222 follow-up #257). Portal
+        // owns this; stiglab proxies the URL through `routes::portal::proxy`
+        // so dashboard fetches keep working pre–API_BASE cutover (#222
+        // Slice 6). Static, human-reviewed manifest of every
+        // `FactoryEventKind` variant — which subsystems produce/consume it.
+        .route("/api/registry/events", any(routes::portal::proxy))
+        // Trigger-kind registry manifest (#222 follow-up #257). Same
+        // proxy shape as `/api/registry/events`. Static, human-reviewed
+        // manifest of every `TriggerKind` variant — read by the
+        // dashboard's `<TriggerKindPicker>`.
+        .route("/api/registry/triggers", any(routes::portal::proxy))
         // Spine API — exposes shared event spine data to the dashboard
         .route("/api/spine/events", get(routes::spine::list_events))
         .route(

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -3,8 +3,6 @@ pub mod health;
 pub mod nodes;
 pub mod portal;
 pub mod projects;
-pub mod registry_events;
-pub mod registry_triggers;
 pub mod sessions;
 pub mod shaping;
 pub mod spine;


### PR DESCRIPTION
Closes #257. Part of #222.

## Summary

First follow-up sub-issue under #222 that moves a piece of the remaining stiglab dashboard surface onto portal so #222 Slice 6 (`API_BASE` cutover + drop the `routes::portal::proxy` shim) can eventually land cleanly. `/api/registry/events` and `/api/registry/triggers` are the smallest, lowest-risk move — pure static reads of `onsager_registry::EVENTS` / `TRIGGERS`, no auth, no DB, no spine writes — used here to validate the relocation pattern before tackling sessions / spine / governance / project hydration.

- `crates/onsager-portal/src/handlers/registry_events.rs`, `registry_triggers.rs`: copied verbatim from stiglab. Register `GET /api/registry/events` and `GET /api/registry/triggers` in `server.rs` next to the existing `/api/workflow/kinds`.
- `crates/stiglab/src/server/mod.rs`: replace the two `get(...)` route entries with `any(routes::portal::proxy)` — same shape used by every prior #222 slice. Delete the now-empty handler modules from `routes/mod.rs` and the source files. Drop the now-unused `onsager-registry` dep from `crates/stiglab/Cargo.toml`.
- `CLAUDE.md` updates on both subsystems noting the move and the Slice 6 blockers still on stiglab.

## Test plan

- [x] `cargo build -p stiglab -p onsager-portal` clean.
- [x] `cargo test -p onsager-portal --lib` — 113 passed (relocated handler tests included, shape + known-kind assertions copied verbatim).
- [x] `cargo test -p stiglab --lib` — 52 passed.
- [x] `cargo clippy -p stiglab -p onsager-portal --all-targets -- -D warnings` clean.
- [x] `xtask lint-seams`, `xtask check-events`, `xtask check-api-contract` clean.
- [ ] Manual: `just dev`, then verify `curl localhost:3000/api/registry/events | jq '.events | length'` matches `curl localhost:3002/api/registry/events | jq '.events | length'`. Same for `/api/registry/triggers`.

https://claude.ai/code/session_01N9tascLveRtBHEgtRfBi8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9tascLveRtBHEgtRfBi8C)_