### PR TITLE
feat(portal): move /api/spine/* stiglab → portal (#259)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "uuid",
 ]
 

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -164,11 +164,21 @@ first-class edge subsystem. The migration is staged:
   and no longer depends on `onsager-registry`. First of the
   follow-up sub-issues that move the remaining stiglab dashboard
   surface to portal so #222 Slice 6 can drop the proxy.
+- **Spine API — #222 follow-up #259 (landed).** Portal owns the
+  seven dashboard-facing spine routes
+  (`GET /api/spine/events`, `GET/POST /api/spine/artifacts`,
+  `GET /api/spine/artifacts/:id`,
+  `POST /api/spine/artifacts/:id/{retry,abort,override-gate}`).
+  Reads run against `events_ext` / `artifacts`; writes either
+  `INSERT` an artifact row or `EventStore::append_ext` a single
+  event — no synodic side-effects, no GitHub side-effects. Stiglab
+  proxies the URLs through `routes::portal::proxy` and keeps
+  `SpineEmitter` for its own session-lifecycle emits.
 - **Routes (follow-ups).** Slice 6: dashboard `API_BASE` cutover
   to portal directly + delete the `routes::portal::proxy` entries
   in stiglab. Blocked on the remaining stiglab dashboard routes
-  (`/api/sessions/*`, `/api/spine/*`, `/api/governance/*`,
-  `/api/projects/{id}/issues|pulls|backfill|replay-trigger`)
+  (`/api/sessions/*` + `/api/tasks` + `/api/nodes`,
+  `/api/governance/*`, `/api/projects/{id}/issues|pulls|backfill|replay-trigger`)
   moving to portal — each one its own sub-issue under #222.
 
 While the migration is in flight, stiglab still hosts most of the

--- a/crates/onsager-portal/Cargo.toml
+++ b/crates/onsager-portal/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+ulid = { version = "1", features = ["serde"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod pull_request;
 pub mod registry_events;
 pub mod registry_triggers;
 pub mod spec_link;
+pub mod spine;
 pub mod webhook;
 pub mod workflow_kinds;
 pub mod workflows;

--- a/crates/onsager-portal/src/handlers/spine.rs
+++ b/crates/onsager-portal/src/handlers/spine.rs
@@ -1,20 +1,27 @@
-//! Spine API routes — exposes the shared event spine data to the dashboard.
+//! Spine read + write API for the dashboard.
 //!
-//! These endpoints read from the onsager-spine PostgreSQL tables (events_ext,
-//! artifacts) to surface factory-wide activity without requiring each subsystem
-//! to expose its own HTTP API.
+//! Spec #259 (sub-issue of #222) moved this from stiglab to portal so the
+//! dashboard's `API_BASE` cutover (#222 Slice 6) can eventually drop the
+//! `routes::portal::proxy` shim.
+//!
+//! Reads land directly against the spine `events_ext` and `artifacts`
+//! tables. Writes either insert into `artifacts` or emit a single
+//! event via `EventStore::append_ext` — no synodic side-effects, no
+//! GitHub side-effects. Stiglab's `SpineEmitter::emit_raw` wrapper
+//! stays in stiglab for the agent-runtime emits; portal calls
+//! `state.spine.append_ext` directly.
 
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use onsager_spine::EventMetadata;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
-use crate::server::auth::AuthUser;
-use crate::server::state::AppState;
-
-use super::require_workspace_access;
+use crate::auth::AuthUser;
+use crate::handlers::workspaces::require_workspace_access;
+use crate::state::AppState;
 
 #[derive(Debug, Deserialize)]
 pub struct EventsQuery {
@@ -102,11 +109,6 @@ pub struct RegisterArtifactRequest {
     pub working_dir: Option<String>,
 }
 
-/// POST /api/spine/artifacts/:id/retry — request re-shaping of an artifact.
-///
-/// Emits a `forge.retry_requested` event and bumps the artifact back to
-/// `in_progress` if it was stuck in `under_review`. Forge picks it up on
-/// the next tick.
 #[derive(Debug, Deserialize, Default)]
 pub struct RetryRequest {
     #[serde(default)]
@@ -115,10 +117,6 @@ pub struct RetryRequest {
     pub actor: Option<String>,
 }
 
-/// POST /api/spine/artifacts/:id/abort — archive an artifact.
-///
-/// Flips state to `archived` and emits `artifact.archived`. Irreversible;
-/// the dashboard asks for confirmation.
 #[derive(Debug, Deserialize, Default)]
 pub struct AbortRequest {
     #[serde(default)]
@@ -127,11 +125,6 @@ pub struct AbortRequest {
     pub actor: Option<String>,
 }
 
-/// POST /api/spine/artifacts/:id/override-gate — record a manual gate override.
-///
-/// Emits `synodic.escalation_resolved` with the chosen verdict so Forge's
-/// next tick honors it. This is the dashboard's counterpart to a human
-/// resolving an escalated gate.
 #[derive(Debug, Deserialize, Default)]
 pub struct OverrideGateRequest {
     /// `allow` (default) or `deny`.
@@ -143,11 +136,54 @@ pub struct OverrideGateRequest {
     pub actor: Option<String>,
 }
 
+/// Standard 400 body for the `?workspace=` requirement on every
+/// workspace-scoped list endpoint (#164).
+fn missing_workspace() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "workspace query parameter is required",
+            "detail": "every workspace-scoped list endpoint requires ?workspace=<id>",
+        })),
+    )
+        .into_response()
+}
+
+/// Emit a single spine event, swallowing errors with a warning — every
+/// caller in this module treats the emit as best-effort because the
+/// row mutation has already happened (or there is none).
+async fn emit(
+    state: &AppState,
+    workspace_id: &str,
+    stream_id: &str,
+    namespace: &str,
+    actor: &str,
+    event_type: &str,
+    data: serde_json::Value,
+) {
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+    };
+    if let Err(e) = state
+        .spine
+        .append_ext(
+            workspace_id,
+            stream_id,
+            namespace,
+            event_type,
+            data,
+            &metadata,
+            None,
+        )
+        .await
+    {
+        tracing::warn!("failed to emit {event_type} event: {e}");
+    }
+}
+
 /// GET /api/spine/events?workspace=W — query the events_ext table.
-///
-/// Filters event rows by `events_ext.workspace_id` (#183). The
-/// `?workspace=` query param is required (#164) — a missing value
-/// returns 400 so a caller can't silently scan every workspace's stream.
 pub async fn list_events(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -157,38 +193,13 @@ pub async fn list_events(
     if workspace_id.is_empty() {
         return missing_workspace();
     }
-    // Skip the membership check for the synthetic anonymous principal
-    // so auth-disabled dev mode keeps these endpoints usable. The
-    // `?workspace=` requirement still applies and the SQL still filters
-    // by it — anonymous just means no per-user gate.
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-            return r;
-        }
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, workspace_id).await {
+        return r;
     }
 
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
-
-    let pool = spine.pool();
+    let pool = state.spine.pool();
     let limit = params.limit.unwrap_or(50).min(500);
 
-    // `events_ext` stores the partition key in `namespace` and the actor inside
-    // `metadata`. The API surfaces them as `stream_type` / `actor` for clients,
-    // so we alias on the way out.
-    //
-    // Workspace scope is matched on the `workspace_id` column (#183 —
-    // promoted from `data->>'workspace_id'` to a real column with a
-    // backing index). Legacy and system events that have no tenant
-    // carry `'default'` and aren't returned to a tenant-scoped read.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
                 COALESCE(metadata->>'actor', '') AS actor, created_at \
@@ -205,9 +216,8 @@ pub async fn list_events(
         qb.push(" AND stream_id = ").push_bind(sid.to_string());
     }
     qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
-    let result = qb.build_query_as::<SpineEvent>().fetch_all(pool).await;
 
-    match result {
+    match qb.build_query_as::<SpineEvent>().fetch_all(pool).await {
         Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),
         Err(e) => {
             tracing::error!("spine events query failed: {e}");
@@ -220,21 +230,6 @@ pub async fn list_events(
     }
 }
 
-/// Standard 400 body for the `?workspace=` requirement on every
-/// workspace-scoped list endpoint (#164). Mirrors the helper in
-/// `routes/sessions.rs` — kept duplicated to avoid a fragile module
-/// dependency.
-fn missing_workspace() -> Response {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(serde_json::json!({
-            "error": "workspace query parameter is required",
-            "detail": "every workspace-scoped list endpoint requires ?workspace=<id>",
-        })),
-    )
-        .into_response()
-}
-
 /// Filters for `GET /api/spine/artifacts`.
 #[derive(Debug, Deserialize)]
 pub struct ListArtifactsQuery {
@@ -242,15 +237,11 @@ pub struct ListArtifactsQuery {
     pub workspace: String,
     /// Filter by `kind` discriminator (e.g. `pull_request`, `github_issue`).
     pub kind: Option<String>,
-    /// Filter by `metadata->>'project_id'`. Used by the dashboard `/issues`
-    /// inbox to scope to the workspace's project.
+    /// Filter by `metadata->>'project_id'`.
     pub project_id: Option<String>,
 }
 
 /// GET /api/spine/artifacts?workspace=W — list artifacts from the spine.
-///
-/// Filters by `workspace_id` (required). Optional `?kind=` and
-/// `?project_id=` further narrow the listing.
 pub async fn list_artifacts(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -260,33 +251,12 @@ pub async fn list_artifacts(
     if workspace_id.is_empty() {
         return missing_workspace();
     }
-    // Skip the membership check for the synthetic anonymous principal
-    // so auth-disabled dev mode keeps these endpoints usable. The
-    // `?workspace=` requirement still applies and the SQL still filters
-    // by it — anonymous just means no per-user gate.
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-            return r;
-        }
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, workspace_id).await {
+        return r;
     }
 
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
+    let pool = state.spine.pool();
 
-    let pool = spine.pool();
-
-    // The base query always filters by workspace_id (#162 added the
-    // column on the spine `artifacts` table).  Optional kind/project
-    // filters tack onto the same WHERE clause via QueryBuilder so a
-    // mis-set bind index can't shift between branches.
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
                 consumers, external_ref, created_at, updated_at, last_observed_at \
@@ -301,9 +271,8 @@ pub async fn list_artifacts(
             .push_bind(project_id.to_string());
     }
     qb.push(" ORDER BY updated_at DESC LIMIT 100");
-    let result = qb.build_query_as::<SpineArtifact>().fetch_all(pool).await;
 
-    match result {
+    match qb.build_query_as::<SpineArtifact>().fetch_all(pool).await {
         Ok(artifacts) => Json(serde_json::json!({ "artifacts": artifacts })).into_response(),
         Err(e) => {
             tracing::error!("spine artifacts query failed: {e}");
@@ -330,28 +299,11 @@ pub async fn register_artifact(
         )
             .into_response();
     }
-    // Skip the membership check for the synthetic anonymous principal
-    // so auth-disabled dev mode keeps these endpoints usable. The
-    // `?workspace=` requirement still applies and the SQL still filters
-    // by it — anonymous just means no per-user gate.
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, workspace_id).await {
-            return r;
-        }
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, workspace_id).await {
+        return r;
     }
 
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
-
-    let pool = spine.pool();
+    let pool = state.spine.pool();
     let artifact_id = format!("art_{}", ulid::Ulid::new());
 
     let result = sqlx::query(
@@ -362,39 +314,31 @@ pub async fn register_artifact(
     .bind(&req.kind)
     .bind(&req.name)
     .bind(&req.owner)
-    .bind("dashboard") // created_by
+    .bind("dashboard")
     .bind(workspace_id)
     .execute(pool)
     .await;
 
     match result {
         Ok(_) => {
-            // Emit a spine event for the registration.
-            if let Some(ref spine) = state.spine {
-                let data = serde_json::json!({
+            emit(
+                &state,
+                workspace_id,
+                &format!("forge:{artifact_id}"),
+                "forge",
+                "dashboard",
+                "artifact.registered",
+                serde_json::json!({
                     "artifact_id": artifact_id,
                     "kind": req.kind,
                     "name": req.name,
                     "owner": req.owner,
                     "description": req.description,
                     "working_dir": req.working_dir,
-                });
-                if let Err(e) = spine
-                    .emit_raw(
-                        workspace_id,
-                        &format!("forge:{artifact_id}"),
-                        "forge",
-                        "dashboard",
-                        "artifact.registered",
-                        &data,
-                    )
-                    .await
-                {
-                    tracing::warn!("failed to emit artifact.registered event: {e}");
-                }
-            }
+                }),
+            )
+            .await;
 
-            // Query back the inserted artifact.
             let artifact = sqlx::query_as::<_, SpineArtifact>(
                 "SELECT artifact_id AS id, kind, name, state, owner, current_version, consumers, \
                  external_ref, created_at, updated_at, last_observed_at \
@@ -439,22 +383,8 @@ pub async fn get_artifact(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Response {
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
+    let pool = state.spine.pool();
 
-    let pool = spine.pool();
-
-    // Resolve the artifact's workspace first so the membership check
-    // 404s before any further data is read; the artifact body itself
-    // is fetched separately to keep the row type a clean SpineArtifact.
     let workspace_id: String = match sqlx::query_scalar::<_, String>(
         "SELECT workspace_id FROM artifacts WHERE artifact_id = $1",
     )
@@ -483,17 +413,15 @@ pub async fn get_artifact(
     // 404 (not 403) on workspace mismatch via the shared helper —
     // rewrite the body to "artifact not found" so artifact IDs don't
     // leak via the workspace-not-found body.
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            if r.status() == StatusCode::NOT_FOUND {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "error": "artifact not found" })),
-                )
-                    .into_response();
-            }
-            return r;
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
         }
+        return r;
     }
 
     let artifact = sqlx::query_as::<_, SpineArtifact>(
@@ -524,7 +452,6 @@ pub async fn get_artifact(
         }
     };
 
-    // Fetch versions
     let versions = match sqlx::query_as::<_, ArtifactVersionRow>(
         "SELECT version, content_ref_uri, content_ref_checksum, change_summary, \
          created_by_session, parent_version, created_at \
@@ -545,7 +472,6 @@ pub async fn get_artifact(
         }
     };
 
-    // Fetch vertical lineage
     let lineage = match sqlx::query_as::<_, VerticalLineageRow>(
         "SELECT version, session_id, recorded_at \
          FROM vertical_lineage WHERE artifact_id = $1 ORDER BY version DESC",
@@ -565,11 +491,6 @@ pub async fn get_artifact(
         }
     };
 
-    // Fetch horizontal lineage — which other artifacts were used as
-    // inputs when shaping this one (artifact-model §4, e.g. PR
-    // `closes_issue` link). Empty for artifacts with no cross-kind
-    // references; we still surface the (possibly empty) field so the UI
-    // doesn't have to special-case undefined.
     let horizontal = match sqlx::query_as::<_, HorizontalLineageRow>(
         "SELECT source_artifact_id, source_version, role, recorded_at \
          FROM horizontal_lineage WHERE artifact_id = $1 \
@@ -590,7 +511,6 @@ pub async fn get_artifact(
         }
     };
 
-    // Fetch created_by from artifacts table
     let created_by: String =
         sqlx::query_scalar("SELECT created_by FROM artifacts WHERE artifact_id = $1")
             .bind(&id)
@@ -600,7 +520,6 @@ pub async fn get_artifact(
             .flatten()
             .unwrap_or_default();
 
-    // Fetch related spine events for the per-run DAG (issue #14 phase 3).
     let related_events = fetch_related_events(pool, &id).await.unwrap_or_else(|e| {
         tracing::warn!("failed to load related events for artifact {id}: {e}");
         Vec::new()
@@ -658,23 +577,9 @@ pub async fn retry_artifact(
     Path(id): Path<String>,
     Json(req): Json<RetryRequest>,
 ) -> Response {
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
+    let pool = state.spine.pool();
 
-    let pool = spine.pool();
-
-    // Resolve workspace + state in one round-trip; the membership check
-    // comes before any mutation so a non-member can't probe artifact
-    // state via the side-effect.
-    let row: Option<(String, String)> = match sqlx::query_as::<_, (String, String)>(
+    let row = match sqlx::query_as::<_, (String, String)>(
         "SELECT workspace_id, state FROM artifacts WHERE artifact_id = $1",
     )
     .bind(&id)
@@ -698,17 +603,15 @@ pub async fn retry_artifact(
         )
             .into_response();
     };
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            if r.status() == StatusCode::NOT_FOUND {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "error": "artifact not found" })),
-                )
-                    .into_response();
-            }
-            return r;
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
         }
+        return r;
     }
 
     if state_str == "archived" || state_str == "released" {
@@ -722,24 +625,20 @@ pub async fn retry_artifact(
     }
 
     let actor = req.actor.as_deref().unwrap_or("dashboard");
-    let data = serde_json::json!({
-        "artifact_id": id,
-        "reason": req.reason,
-        "previous_state": state_str,
-    });
-    if let Err(e) = spine
-        .emit_raw(
-            &workspace_id,
-            &format!("forge:{id}"),
-            "forge",
-            actor,
-            "forge.retry_requested",
-            &data,
-        )
-        .await
-    {
-        tracing::warn!("failed to emit forge.retry_requested event: {e}");
-    }
+    emit(
+        &state,
+        &workspace_id,
+        &format!("forge:{id}"),
+        "forge",
+        actor,
+        "forge.retry_requested",
+        serde_json::json!({
+            "artifact_id": id,
+            "reason": req.reason,
+            "previous_state": state_str,
+        }),
+    )
+    .await;
 
     (
         StatusCode::ACCEPTED,
@@ -758,20 +657,9 @@ pub async fn abort_artifact(
     Path(id): Path<String>,
     Json(req): Json<AbortRequest>,
 ) -> Response {
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
+    let pool = state.spine.pool();
 
-    let pool = spine.pool();
-
-    let row: Option<(String, String)> = match sqlx::query_as::<_, (String, String)>(
+    let row = match sqlx::query_as::<_, (String, String)>(
         "SELECT workspace_id, state FROM artifacts WHERE artifact_id = $1",
     )
     .bind(&id)
@@ -795,17 +683,15 @@ pub async fn abort_artifact(
         )
             .into_response();
     };
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            if r.status() == StatusCode::NOT_FOUND {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "error": "artifact not found" })),
-                )
-                    .into_response();
-            }
-            return r;
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
         }
+        return r;
     }
 
     if previous_state == "archived" {
@@ -822,7 +708,6 @@ pub async fn abort_artifact(
         .unwrap_or_else(|| "aborted via dashboard".to_string());
     let actor = req.actor.as_deref().unwrap_or("dashboard");
 
-    // Flip state to archived. The factory pipeline treats archived as terminal.
     if let Err(e) = sqlx::query(
         "UPDATE artifacts SET state = 'archived', updated_at = NOW() WHERE artifact_id = $1",
     )
@@ -838,24 +723,20 @@ pub async fn abort_artifact(
             .into_response();
     }
 
-    let data = serde_json::json!({
-        "artifact_id": id,
-        "reason": reason,
-        "previous_state": previous_state,
-    });
-    if let Err(e) = spine
-        .emit_raw(
-            &workspace_id,
-            &format!("forge:{id}"),
-            "forge",
-            actor,
-            "artifact.archived",
-            &data,
-        )
-        .await
-    {
-        tracing::warn!("failed to emit artifact.archived event: {e}");
-    }
+    emit(
+        &state,
+        &workspace_id,
+        &format!("forge:{id}"),
+        "forge",
+        actor,
+        "artifact.archived",
+        serde_json::json!({
+            "artifact_id": id,
+            "reason": reason,
+            "previous_state": previous_state,
+        }),
+    )
+    .await;
 
     (
         StatusCode::OK,
@@ -875,18 +756,7 @@ pub async fn override_gate(
     Path(id): Path<String>,
     Json(req): Json<OverrideGateRequest>,
 ) -> Response {
-    let spine = match &state.spine {
-        Some(s) => s,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({ "error": "spine not connected" })),
-            )
-                .into_response()
-        }
-    };
-
-    let pool = spine.pool();
+    let pool = state.spine.pool();
 
     let workspace_id: String = match sqlx::query_scalar::<_, String>(
         "SELECT workspace_id FROM artifacts WHERE artifact_id = $1",
@@ -912,17 +782,15 @@ pub async fn override_gate(
                 .into_response();
         }
     };
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.db, &auth_user, &workspace_id).await {
-            if r.status() == StatusCode::NOT_FOUND {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "error": "artifact not found" })),
-                )
-                    .into_response();
-            }
-            return r;
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
+        if r.status() == StatusCode::NOT_FOUND {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "artifact not found" })),
+            )
+                .into_response();
         }
+        return r;
     }
 
     let verdict = req.verdict.as_deref().unwrap_or("allow").to_lowercase();
@@ -943,28 +811,24 @@ pub async fn override_gate(
         .unwrap_or_else(|| format!("manual {verdict} via dashboard"));
     let escalation_id = format!("esc_{}", ulid::Ulid::new());
 
-    let data = serde_json::json!({
-        "escalation_id": escalation_id,
-        "artifact_id": id,
-        "resolution": {
-            "verdict": verdict,
-            "resolved_by": actor,
-            "reason": reason,
-        },
-    });
-    if let Err(e) = spine
-        .emit_raw(
-            &workspace_id,
-            &format!("forge:{id}"),
-            "synodic",
-            actor,
-            "synodic.escalation_resolved",
-            &data,
-        )
-        .await
-    {
-        tracing::warn!("failed to emit synodic.escalation_resolved event: {e}");
-    }
+    emit(
+        &state,
+        &workspace_id,
+        &format!("forge:{id}"),
+        "synodic",
+        actor,
+        "synodic.escalation_resolved",
+        serde_json::json!({
+            "escalation_id": escalation_id,
+            "artifact_id": id,
+            "resolution": {
+                "verdict": verdict,
+                "resolved_by": actor,
+                "reason": reason,
+            },
+        }),
+    )
+    .await;
 
     (
         StatusCode::OK,

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -11,8 +11,8 @@ use crate::handlers::{
     auth as auth_handlers, credentials as credential_handlers, github_app as github_app_handlers,
     installations as installation_handlers, pats as pat_handlers, projects as project_handlers,
     registry_events as registry_event_handlers, registry_triggers as registry_trigger_handlers,
-    webhook, workflow_kinds as workflow_kind_handlers, workflows as workflow_handlers,
-    workspaces as workspace_handlers,
+    spine as spine_handlers, webhook, workflow_kinds as workflow_kind_handlers,
+    workflows as workflow_handlers, workspaces as workspace_handlers,
 };
 use crate::state::AppState;
 
@@ -201,6 +201,33 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/registry/triggers",
             get(registry_trigger_handlers::list_triggers),
+        )
+        // Spine API (#222 follow-up #259). Reads `events_ext` and
+        // `artifacts` directly; writes either insert into `artifacts`
+        // or emit a single event via `EventStore::append_ext`. Stiglab
+        // proxies the URLs through `routes::portal::proxy` so the
+        // dashboard's API_BASE cutover (#222 Slice 6) can land
+        // independently.
+        .route("/api/spine/events", get(spine_handlers::list_events))
+        .route(
+            "/api/spine/artifacts",
+            get(spine_handlers::list_artifacts).post(spine_handlers::register_artifact),
+        )
+        .route(
+            "/api/spine/artifacts/{id}",
+            get(spine_handlers::get_artifact),
+        )
+        .route(
+            "/api/spine/artifacts/{id}/retry",
+            post(spine_handlers::retry_artifact),
+        )
+        .route(
+            "/api/spine/artifacts/{id}/abort",
+            post(spine_handlers::abort_artifact),
+        )
+        .route(
+            "/api/spine/artifacts/{id}/override-gate",
+            post(spine_handlers::override_gate),
         );
 
     // Dev-login is debug-only — `cargo build --release` strips both the

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -68,6 +68,17 @@ What this means for stiglab specifically:
     `TRIGGERS`); stiglab proxies the URLs through
     `routes::portal::proxy` so dashboard fetches keep working pre–
     API_BASE cutover. Stiglab no longer depends on `onsager-registry`.
+  - Spine reads + writes (`GET /api/spine/events`,
+    `GET/POST /api/spine/artifacts`, `GET /api/spine/artifacts/:id`,
+    `POST /api/spine/artifacts/:id/{retry,abort,override-gate}`) —
+    #222 follow-up #259. Portal owns the dashboard-facing reads
+    (against `events_ext` / `artifacts`) and the single-event emits
+    (via `EventStore::append_ext`). Stiglab still keeps
+    `SpineEmitter` for the agent-runtime emits
+    (`emit_session_started/completed/failed`,
+    `emit_shaping_result_ready`) — those are session-lifecycle, not
+    dashboard-facing — and still uses the spine pool for in-process
+    reads (`routes::projects::replay_issue_trigger`).
   - Workflow CRUD + GitHub side-effects
     (`GET/POST /api/workflows`, `GET/PATCH/DELETE /api/workflows/:id`,
     `GET /api/workflows/:id/runs`, `GET /api/workflow/kinds`) — Slice 4.

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -192,27 +192,30 @@ pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
         // manifest of every `TriggerKind` variant — read by the
         // dashboard's `<TriggerKindPicker>`.
         .route("/api/registry/triggers", any(routes::portal::proxy))
-        // Spine API — exposes shared event spine data to the dashboard
-        .route("/api/spine/events", get(routes::spine::list_events))
-        .route(
-            "/api/spine/artifacts",
-            get(routes::spine::list_artifacts).post(routes::spine::register_artifact),
-        )
-        .route(
-            "/api/spine/artifacts/{id}",
-            get(routes::spine::get_artifact),
-        )
+        // Spine API (#222 follow-up #259). Portal owns the seven
+        // `/api/spine/*` routes; stiglab proxies them through
+        // `routes::portal::proxy` so dashboard fetches keep working
+        // pre–API_BASE cutover (#222 Slice 6). Reads land directly
+        // against `events_ext` / `artifacts`; writes emit via
+        // `EventStore::append_ext`. Stiglab still uses the spine pool
+        // for its own in-process needs (`SpineEmitter` for session
+        // lifecycle emits, `routes::projects::replay_issue_trigger`
+        // reads) — same database, separate connection pool, portal is
+        // the only HTTP writer.
+        .route("/api/spine/events", any(routes::portal::proxy))
+        .route("/api/spine/artifacts", any(routes::portal::proxy))
+        .route("/api/spine/artifacts/{id}", any(routes::portal::proxy))
         .route(
             "/api/spine/artifacts/{id}/retry",
-            post(routes::spine::retry_artifact),
+            any(routes::portal::proxy),
         )
         .route(
             "/api/spine/artifacts/{id}/abort",
-            post(routes::spine::abort_artifact),
+            any(routes::portal::proxy),
         )
         .route(
             "/api/spine/artifacts/{id}/override-gate",
-            post(routes::spine::override_gate),
+            any(routes::portal::proxy),
         );
 
     // Dev-login (issue #193) lives on portal post-#222 Slice 5; the

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -5,7 +5,6 @@ pub mod portal;
 pub mod projects;
 pub mod sessions;
 pub mod shaping;
-pub mod spine;
 pub mod tasks;
 
 use axum::http::StatusCode;


### PR DESCRIPTION
Closes #259. Part of #222.

## Summary

Second of the follow-up sub-issues that move the remaining stiglab dashboard surface to portal so #222 Slice 6 (`API_BASE` cutover + delete `routes::portal::proxy`) can land cleanly. The seven `/api/spine/*` routes are the next-cheapest mechanical move after the registry manifests (#257): all handlers either read from spine tables or emit a single spine event — no synodic side-effects, no GitHub side-effects, no in-process session execution.

- `crates/onsager-portal/src/handlers/spine.rs`: ports the seven handlers (`list_events`, `list_artifacts`, `register_artifact`, `get_artifact`, `retry_artifact`, `abort_artifact`, `override_gate`). Drops stiglab's `auth_user.user_id == "anonymous"` bypass (portal auth is always-on per #193). Drops the `state.spine` Option-unwrap (portal's `EventStore` is non-Option). Replaces `SpineEmitter::emit_raw` calls with `EventStore::append_ext` directly via a small `emit(...)` helper. Reuses portal's `handlers::workspaces::require_workspace_access` for the 404-not-403 membership + PAT-scope guardrail.
- `crates/onsager-portal/src/server.rs`: register the seven routes next to the `/api/registry/*` block landed in #257.
- `crates/onsager-portal/Cargo.toml`: add `ulid` dep (used for new `art_*` and `esc_*` IDs minted by the handlers).
- `crates/stiglab/src/server/mod.rs`: replace the seven `get(...)`/`post(...)` route entries with `any(routes::portal::proxy)`. Delete `pub mod spine;` from `routes/mod.rs`. Delete the file.
- Stiglab's `SpineEmitter` stays — it's used by the agent-runtime (`emit_session_started/completed/failed`, `emit_shaping_result_ready`), which is session-lifecycle, not dashboard-facing. Same database, separate connection pool.
- `CLAUDE.md` updates on both subsystems noting the move and the remaining Slice 6 blockers still on stiglab.

## Test plan

- [x] `cargo build -p stiglab -p onsager-portal` clean.
- [x] `cargo test -p onsager-portal --lib` — 113 passed.
- [x] `cargo test -p stiglab --lib` — 52 passed.
- [x] `cargo clippy -p stiglab -p onsager-portal --all-targets -- -D warnings` clean.
- [x] `xtask lint-seams`, `xtask check-events`, `xtask check-api-contract` clean.
- [ ] Manual: `just dev`, then verify each of the seven URLs answers identically against `localhost:3000` (proxied) and `localhost:3002` (direct).

https://claude.ai/code/session_01N9tascLveRtBHEgtRfBi8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9tascLveRtBHEgtRfBi8C)_