### PR TITLE
fix(stiglab): proxy /api/* to portal (fixes dev-login + GitHub login in production)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,7 @@ dependencies = [
  "onsager-github",
  "onsager-spine",
  "rand 0.8.5",
+ "reqwest",
  "ring",
  "serde",
  "serde_json",

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -42,6 +42,7 @@ ring = { workspace = true }
 hex = { workspace = true }
 axum-extra = { workspace = true }
 jsonwebtoken = { workspace = true }
+reqwest = { workspace = true }
 
 # From stiglab-agent
 tokio-tungstenite = { workspace = true }

--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -49,10 +49,13 @@ impl ServerConfig {
         let internal_dispatch_token = env::var("STIGLAB_INTERNAL_DISPATCH_TOKEN")
             .ok()
             .filter(|s| !s.is_empty());
-        let portal_url = env::var("PORTAL_URL").unwrap_or_else(|_| {
-            let portal_port = env::var("PORTAL_PORT").unwrap_or_else(|_| "3002".to_string());
-            format!("http://127.0.0.1:{portal_port}")
-        });
+        let portal_url = env::var("PORTAL_URL")
+            .unwrap_or_else(|_| {
+                let portal_port = env::var("PORTAL_PORT").unwrap_or_else(|_| "3002".to_string());
+                format!("http://127.0.0.1:{portal_port}")
+            })
+            .trim_end_matches('/')
+            .to_string();
 
         ServerConfig {
             host,

--- a/crates/stiglab/src/server/config.rs
+++ b/crates/stiglab/src/server/config.rs
@@ -25,6 +25,11 @@ pub struct ServerConfig {
     /// Goes away with the seam (Lever C, spec #131 / #148) once
     /// shaping moves to spine events.
     pub internal_dispatch_token: Option<String>,
+    /// URL of the onsager-portal process (e.g. `http://127.0.0.1:3002`).
+    /// All `/api/*` traffic not handled by stiglab itself is reverse-proxied
+    /// here. Reads `PORTAL_URL`; falls back to `http://127.0.0.1:$PORTAL_PORT`
+    /// (default port 3002).
+    pub portal_url: String,
 }
 
 impl ServerConfig {
@@ -44,6 +49,10 @@ impl ServerConfig {
         let internal_dispatch_token = env::var("STIGLAB_INTERNAL_DISPATCH_TOKEN")
             .ok()
             .filter(|s| !s.is_empty());
+        let portal_url = env::var("PORTAL_URL").unwrap_or_else(|_| {
+            let portal_port = env::var("PORTAL_PORT").unwrap_or_else(|_| "3002".to_string());
+            format!("http://127.0.0.1:{portal_port}")
+        });
 
         ServerConfig {
             host,
@@ -54,6 +63,7 @@ impl ServerConfig {
             credential_key,
             public_url,
             internal_dispatch_token,
+            portal_url,
         }
     }
 }

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -14,7 +14,7 @@ pub mod ws;
 pub use sqlx::AnyPool;
 
 use axum::http::{header, HeaderValue};
-use axum::routing::get;
+use axum::routing::{any, get};
 use axum::Router;
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
@@ -32,9 +32,15 @@ use state::AppState;
 /// dev, nginx in prod) so the dashboard's same-origin fetches land on
 /// portal without any per-environment URL configuration.
 pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
+    // `/api/health` and `/agent/ws` are the two routes stiglab owns
+    // post-#222 Slice 6. The catch-all forwards everything else under
+    // `/api/` to onsager-portal (loopback:PORTAL_PORT). Exact routes
+    // take priority over the wildcard in axum, so `/api/health` is
+    // never forwarded.
     let api_routes = Router::new()
         .route("/api/health", get(routes::health::health))
-        .route("/agent/ws", get(ws::agent::agent_ws_handler));
+        .route("/agent/ws", get(ws::agent::agent_ws_handler))
+        .route("/api/{*path}", any(routes::portal::proxy));
 
     // Configure CORS
     let cors = if let Some(ref origin) = config.cors_origin {

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod health;
+pub mod portal;
 pub mod shaping;
 
 use axum::http::StatusCode;

--- a/crates/stiglab/src/server/routes/portal.rs
+++ b/crates/stiglab/src/server/routes/portal.rs
@@ -15,11 +15,7 @@ use axum::response::{IntoResponse, Response};
 use crate::server::state::AppState;
 
 pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
-    let path_and_query = req
-        .uri()
-        .path_and_query()
-        .map(|p| p.as_str())
-        .unwrap_or("");
+    let path_and_query = req.uri().path_and_query().map(|p| p.as_str()).unwrap_or("");
     let target = format!("{}{}", state.config.portal_url, path_and_query);
 
     let method = match req.method().as_str().parse::<reqwest::Method>() {
@@ -32,9 +28,19 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
     let mut builder = state.http_client.request(method, &target);
 
     for (name, value) in req.headers() {
-        // Drop hop-by-hop headers that must not be forwarded.
+        // Drop hop-by-hop headers (RFC 7230 §6.1) that must not be forwarded.
         let n = name.as_str();
-        if n == "host" || n == "connection" || n == "transfer-encoding" || n == "te" {
+        if matches!(
+            n,
+            "host"
+                | "connection"
+                | "keep-alive"
+                | "proxy-connection"
+                | "transfer-encoding"
+                | "te"
+                | "trailer"
+                | "upgrade"
+        ) {
             continue;
         }
         builder = builder.header(name, value);
@@ -61,7 +67,13 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
                 }
                 response_builder = response_builder.header(name, value.as_bytes());
             }
-            let body_bytes = resp.bytes().await.unwrap_or_default();
+            let body_bytes = match resp.bytes().await {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(error = %e, %target, "portal proxy: failed to read response body");
+                    return StatusCode::BAD_GATEWAY.into_response();
+                }
+            };
             response_builder
                 .body(Body::from(body_bytes))
                 .unwrap_or_else(|_| StatusCode::BAD_GATEWAY.into_response())

--- a/crates/stiglab/src/server/routes/portal.rs
+++ b/crates/stiglab/src/server/routes/portal.rs
@@ -1,0 +1,74 @@
+//! Catch-all reverse proxy: forwards `/api/*` to onsager-portal.
+//!
+//! Post-#222 Slice 6 stiglab owns only `/api/health` and `/agent/ws`.
+//! Everything else under `/api/` is handled by portal. In dev, Caddy
+//! routes those requests directly to portal; in the Railway single-
+//! container deployment stiglab is the only process reachable from
+//! outside, so this handler forwards the request over the loopback to
+//! portal at `config.portal_url` (default `http://127.0.0.1:3002`).
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::server::state::AppState;
+
+pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(|p| p.as_str())
+        .unwrap_or("");
+    let target = format!("{}{}", state.config.portal_url, path_and_query);
+
+    let method = match req.method().as_str().parse::<reqwest::Method>() {
+        Ok(m) => m,
+        Err(_) => {
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
+
+    let mut builder = state.http_client.request(method, &target);
+
+    for (name, value) in req.headers() {
+        // Drop hop-by-hop headers that must not be forwarded.
+        let n = name.as_str();
+        if n == "host" || n == "connection" || n == "transfer-encoding" || n == "te" {
+            continue;
+        }
+        builder = builder.header(name, value);
+    }
+
+    let body = match axum::body::to_bytes(req.into_body(), 16 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, "portal proxy: failed to read request body");
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
+    builder = builder.body(body);
+
+    match builder.send().await {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+            let mut response_builder = axum::http::Response::builder().status(status);
+            for (name, value) in resp.headers() {
+                // Drop transfer-encoding — reqwest reassembles chunked responses.
+                if name.as_str() == "transfer-encoding" {
+                    continue;
+                }
+                response_builder = response_builder.header(name, value.as_bytes());
+            }
+            let body_bytes = resp.bytes().await.unwrap_or_default();
+            response_builder
+                .body(Body::from(body_bytes))
+                .unwrap_or_else(|_| StatusCode::BAD_GATEWAY.into_response())
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, %target, "portal proxy: upstream request failed");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}

--- a/crates/stiglab/src/server/state.rs
+++ b/crates/stiglab/src/server/state.rs
@@ -33,7 +33,10 @@ impl AppState {
             agents: Arc::new(RwLock::new(HashMap::new())),
             config,
             spine,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::ClientBuilder::new()
+                .timeout(std::time::Duration::from_secs(60))
+                .build()
+                .expect("failed to build reqwest client"),
         }
     }
 }

--- a/crates/stiglab/src/server/state.rs
+++ b/crates/stiglab/src/server/state.rs
@@ -23,6 +23,7 @@ pub struct AppState {
     pub agents: Arc<RwLock<HashMap<String, AgentConnection>>>,
     pub config: ServerConfig,
     pub spine: Option<SpineEmitter>,
+    pub http_client: reqwest::Client,
 }
 
 impl AppState {
@@ -32,6 +33,7 @@ impl AppState {
             agents: Arc::new(RwLock::new(HashMap::new())),
             config,
             spine,
+            http_client: reqwest::Client::new(),
         }
     }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -10,11 +10,9 @@
 #   forge           | Workflow orchestrator (spine consumer)    | 3003 (internal)
 #   PostgreSQL      | Shared event spine (Railway plugin)       | 5432
 #
-# Stiglab is the front door — it serves the dashboard, its own API, and
-# reverse-proxies /api/governance/* to synodic on localhost:3001 and
-# /webhooks/github to onsager-portal on localhost:3002. The portal runs its
-# own migrations (factory_tasks, pr_gate_verdicts, pr_branch_links) at
-# startup.
+# Stiglab is the front door — it serves the dashboard, owns /api/health
+# and /agent/ws, and reverse-proxies all other /api/* traffic to portal
+# on localhost:3002. Portal runs its own migrations at startup.
 #
 # Quick start:
 #   1. Create a Railway project and connect this repo


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Slice 6 of #222 stripped per-route proxies from stiglab expecting an edge proxy (Caddy/nginx) to route `/api/*` to portal. The Railway single-container deployment has no such proxy — stiglab is the only process reachable from the internet.
- Every `/api/*` request not handled by stiglab fell through to the SPA fallback (`ServeFile` returning `index.html`), causing three production failures:
  1. **Dev-login shown on app.onsager.ai**: `GET /api/auth/dev-login` returned 200 (HTML), so the probe (`status !== 404`) enabled the button on production.
  2. **Dev-login 405**: `POST /api/auth/dev-login` hit the static-file service which rejects non-GET methods.
  3. **GitHub login broken**: `GET /api/auth/github` returned 200 HTML instead of a 302 redirect to GitHub OAuth.

Fix: add a catch-all `any("/api/{*path}")` handler in stiglab that reverse-proxies to portal at `PORTAL_URL` (default `http://127.0.0.1:3002`). The two routes stiglab still owns (`/api/health`, `/agent/ws`) take priority as exact matches.

Part of #222

## Test plan

- [ ] Deploy to a preview environment and confirm `GET /app.onsager.ai/` shows only the GitHub login button (no Dev Login section)
- [ ] Confirm GitHub OAuth sign-in redirects to GitHub correctly
- [ ] Confirm `/api/health` still returns `{"status":"ok"}` (not proxied to portal)
- [ ] Confirm `/agent/ws` WebSocket still connects

https://claude.ai/code/session_01Nqn7DUANrfkzdDmo6qqzAy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqn7DUANrfkzdDmo6qqzAy)_