### PR TITLE
portal: enable dev-login on Railway preview envs; fix stiglab /api/health seam violation

### DIFF
--- a/apps/dashboard/src/lib/api/sessions.ts
+++ b/apps/dashboard/src/lib/api/sessions.ts
@@ -31,6 +31,8 @@ export const sessions = {
       '/auth/dev-login',
       { method: 'POST' },
     ),
+  authProviders: () =>
+    request<{ github: boolean; dev: boolean }>('/auth/providers'),
   // Session spend view (issue #39). Reads recent `stiglab.session_completed`
   // events and unpacks the typed `token_usage` payload client-side so we
   // don't have to spin up a dedicated pricing/accounting endpoint just to

--- a/apps/dashboard/src/pages/LoginPage.tsx
+++ b/apps/dashboard/src/pages/LoginPage.tsx
@@ -8,30 +8,28 @@ import { api, ApiError } from "@/lib/api"
 /**
  * Login screen.
  *
- * Renders the GitHub OAuth entry-point unconditionally. The "Dev Login"
- * button is conditional: we probe `/api/auth/dev-login` with a HEAD-style
- * request and only render the button when the route exists, which is the
- * case in `cargo build` (debug) but not `cargo build --release`. Issue
- * #193 — anonymous mode was deleted; dev-login replaces it as the
- * SSO-free path for local development.
+ * Which buttons to render is driven by GET /api/auth/providers, which
+ * returns {github: bool, dev: bool}. GitHub is suppressed on Railway
+ * preview environments (dev-login is the intended path there); dev-login
+ * is suppressed on production release builds.
  */
 export function LoginPage() {
+  const [githubAvailable, setGithubAvailable] = useState(true)
   const [devAvailable, setDevAvailable] = useState(false)
   const [devLoggingIn, setDevLoggingIn] = useState(false)
   const [devError, setDevError] = useState<string | null>(null)
 
-  // Detect whether the server has the dev-login route. A bare GET is
-  // enough — debug builds reply 405 (route registered, wrong method);
-  // release builds reply 404 (route absent). Any non-404 means present.
   useEffect(() => {
     let cancelled = false
-    fetch("/api/auth/dev-login", { method: "GET" })
-      .then((r) => {
-        if (!cancelled) setDevAvailable(r.status !== 404)
+    api.authProviders()
+      .then((p) => {
+        if (!cancelled) {
+          setGithubAvailable(p.github)
+          setDevAvailable(p.dev)
+        }
       })
       .catch(() => {
-        // Network failure — leave the button hidden rather than
-        // letting a backend outage suggest dev-login is available.
+        // Network failure — leave defaults (github=true, dev=false).
       })
     return () => {
       cancelled = true
@@ -69,15 +67,17 @@ export function LoginPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
-          <a
-            href="/api/auth/github"
-            className={buttonVariants({ size: "lg", className: "w-full" })}
-          >
-            <svg className="mr-2 h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
-            Sign in with GitHub
-          </a>
+          {githubAvailable && (
+            <a
+              href="/api/auth/github"
+              className={buttonVariants({ size: "lg", className: "w-full" })}
+            >
+              <svg className="mr-2 h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              Sign in with GitHub
+            </a>
+          )}
           {devAvailable && (
             <>
               <div className="relative my-1 flex items-center">
@@ -104,8 +104,7 @@ export function LoginPage() {
                 </p>
               )}
               <p className="text-center text-[11px] text-muted-foreground">
-                Available in debug builds only. Build with{" "}
-                <span className="font-mono">--release</span> to disable.
+                Bypass GitHub OAuth — for local dev and preview environments.
               </p>
             </>
           )}

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -49,8 +49,9 @@ pub struct Config {
 
 impl Config {
     /// Classify the process's role in the SSO flow. `None` means no GitHub
-    /// OAuth is configured — the only path to authentication is dev-login
-    /// (debug builds, or release builds with `DEV_LOGIN_ENABLED=true`).
+    /// OAuth is configured. The only remaining login path is then dev-login
+    /// (debug builds, or release builds with `DEV_LOGIN_ENABLED=true`); if
+    /// neither applies, there is no login path at all.
     pub fn sso_mode(&self) -> Option<crate::sso::SsoMode> {
         let has_github = self.github_client_id.is_some() && self.github_client_secret.is_some();
         let has_owner_secrets =
@@ -98,6 +99,14 @@ impl Config {
             panic!(
                 "invalid SSO config: SSO_AUTH_DOMAIN is set but SSO_EXCHANGE_SECRET is \
                  not — the relying party cannot authenticate to the owner"
+            );
+        }
+
+        if self.dev_login_enabled && has_github {
+            panic!(
+                "invalid config: DEV_LOGIN_ENABLED is set but GITHUB_CLIENT_ID/SECRET \
+                 are also configured — dev-login is redundant when real OAuth is available \
+                 and enabling both is likely a misconfiguration"
             );
         }
     }
@@ -231,5 +240,26 @@ mod tests {
             ..base_config()
         };
         c.assert_sso_consistent();
+    }
+
+    #[test]
+    #[should_panic(expected = "DEV_LOGIN_ENABLED")]
+    fn assert_panics_when_dev_login_and_github_oauth_both_set() {
+        let c = Config {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            dev_login_enabled: true,
+            ..base_config()
+        };
+        c.assert_sso_consistent();
+    }
+
+    #[test]
+    fn dev_login_without_github_oauth_is_valid() {
+        let c = Config {
+            dev_login_enabled: true,
+            ..base_config()
+        };
+        c.assert_sso_consistent(); // must not panic
     }
 }

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -101,14 +101,6 @@ impl Config {
                  not — the relying party cannot authenticate to the owner"
             );
         }
-
-        if self.dev_login_enabled && has_github {
-            panic!(
-                "invalid config: DEV_LOGIN_ENABLED is set but GITHUB_CLIENT_ID/SECRET \
-                 are also configured — dev-login is redundant when real OAuth is available \
-                 and enabling both is likely a misconfiguration"
-            );
-        }
     }
 }
 
@@ -242,24 +234,4 @@ mod tests {
         c.assert_sso_consistent();
     }
 
-    #[test]
-    #[should_panic(expected = "DEV_LOGIN_ENABLED")]
-    fn assert_panics_when_dev_login_and_github_oauth_both_set() {
-        let c = Config {
-            github_client_id: Some("id".into()),
-            github_client_secret: Some("secret".into()),
-            dev_login_enabled: true,
-            ..base_config()
-        };
-        c.assert_sso_consistent();
-    }
-
-    #[test]
-    fn dev_login_without_github_oauth_is_valid() {
-        let c = Config {
-            dev_login_enabled: true,
-            ..base_config()
-        };
-        c.assert_sso_consistent(); // must not panic
-    }
 }

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -41,12 +41,16 @@ pub struct Config {
     /// Cross-environment SSO — relying side. When set, `/api/auth/github`
     /// redirects here instead of talking to GitHub directly.
     pub sso_auth_domain: Option<String>,
+    /// Enable the `/api/auth/dev-login` route in release builds. Always
+    /// enabled in debug builds. Set `DEV_LOGIN_ENABLED=true` on Railway
+    /// preview environments that need a login path without GitHub OAuth.
+    pub dev_login_enabled: bool,
 }
 
 impl Config {
     /// Classify the process's role in the SSO flow. `None` means no GitHub
     /// OAuth is configured — the only path to authentication is dev-login
-    /// (debug builds only).
+    /// (debug builds, or release builds with `DEV_LOGIN_ENABLED=true`).
     pub fn sso_mode(&self) -> Option<crate::sso::SsoMode> {
         let has_github = self.github_client_id.is_some() && self.github_client_secret.is_some();
         let has_owner_secrets =
@@ -117,6 +121,7 @@ mod tests {
             sso_exchange_secret: None,
             sso_return_host_allowlist: Vec::new(),
             sso_auth_domain: None,
+            dev_login_enabled: false,
         }
     }
 

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -233,5 +233,4 @@ mod tests {
         };
         c.assert_sso_consistent();
     }
-
 }

--- a/crates/onsager-portal/src/dev_auth.rs
+++ b/crates/onsager-portal/src/dev_auth.rs
@@ -1,10 +1,9 @@
-//! Dev-login mode (issue #193). Local-dev-only replacement for the
-//! removed anonymous-mode branch.
+//! Dev-login mode (issue #193). Replaces the removed anonymous-mode branch.
 //!
-//! The whole module is `#[cfg(debug_assertions)]`-gated. Release builds
-//! (`cargo build --release`) physically do not contain the seeder or the
-//! `/api/auth/dev-login` route, so a misconfigured production deploy
-//! cannot serve dev-login regardless of env-var manipulation.
+//! Enabled in two ways:
+//! - **Debug builds** (`cargo build`): always available.
+//! - **Release builds** with `DEV_LOGIN_ENABLED=true`: opt-in for Railway
+//!   preview environments that need a login path without GitHub OAuth.
 //!
 //! Two pieces:
 //! - [`seed_dev_user_and_workspace`] is called once at server boot. It
@@ -25,8 +24,6 @@
 //! runtime migrations until Slice 3 of spec #222 moves them into the
 //! spine. Portal writes to those tables via raw SQL — same DB, same
 //! shape, no shared crate needed.
-
-#![cfg(debug_assertions)]
 
 use axum::extract::State;
 use axum::http::{header, StatusCode};

--- a/crates/onsager-portal/src/handlers/auth.rs
+++ b/crates/onsager-portal/src/handlers/auth.rs
@@ -528,6 +528,24 @@ pub async fn me(State(_state): State<AppState>, auth_user: AuthUser) -> impl Int
     }))
 }
 
+/// GET /api/auth/providers — Which login methods are available.
+///
+/// Returns `{"github": bool, "dev": bool}`. Used by the LoginPage to decide
+/// which buttons to render. GitHub is suppressed on Railway preview
+/// environments (where dev-login is the intended path) so the login screen
+/// stays simple for reviewers. Specifically: GitHub is disabled when
+/// dev-login is explicitly enabled in a release build (i.e. not a local
+/// debug session) — production never sets dev_login_enabled so its GitHub
+/// button always appears.
+pub async fn providers(State(state): State<AppState>) -> impl IntoResponse {
+    let cfg = &state.config;
+    let dev = cfg!(debug_assertions) || cfg.dev_login_enabled;
+    // Suppress GitHub on release builds with dev-login enabled (Railway preview).
+    // Debug builds keep GitHub available so local OAuth testing still works.
+    let github = cfg.sso_mode().is_some() && !(cfg.dev_login_enabled && !cfg!(debug_assertions));
+    Json(serde_json::json!({ "github": github, "dev": dev }))
+}
+
 /// POST /api/auth/logout — Delete auth session and clear cookie
 pub async fn logout(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let cookie_header = headers

--- a/crates/onsager-portal/src/handlers/auth.rs
+++ b/crates/onsager-portal/src/handlers/auth.rs
@@ -542,7 +542,7 @@ pub async fn providers(State(state): State<AppState>) -> impl IntoResponse {
     let dev = cfg!(debug_assertions) || cfg.dev_login_enabled;
     // Suppress GitHub on release builds with dev-login enabled (Railway preview).
     // Debug builds keep GitHub available so local OAuth testing still works.
-    let github = cfg.sso_mode().is_some() && !(cfg.dev_login_enabled && !cfg!(debug_assertions));
+    let github = cfg.sso_mode().is_some() && (!cfg.dev_login_enabled || cfg!(debug_assertions));
     Json(serde_json::json!({ "github": github, "dev": dev }))
 }
 

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -33,7 +33,6 @@ pub mod config;
 pub mod core;
 pub mod credential_db;
 pub mod db;
-#[cfg(debug_assertions)]
 pub mod dev_auth;
 pub mod feedback;
 pub mod gate;

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -62,9 +62,9 @@ enum Command {
         /// redirects here instead of talking to GitHub directly.
         #[arg(long, env = "SSO_AUTH_DOMAIN")]
         sso_auth_domain: Option<String>,
-        /// Enable dev-login in release builds. Automatically true when
-        /// `ONSAGER_PREVIEW=true` (set on all Railway preview environments
-        /// by railway.toml). Can also be forced with `DEV_LOGIN_ENABLED=true`.
+        /// Enable dev-login in release builds. Automatically true on Railway
+        /// preview environments (detected via RAILWAY_ENVIRONMENT_NAME).
+        /// Use this flag for explicit opt-in outside Railway.
         #[arg(long, env = "DEV_LOGIN_ENABLED", default_value_t = false)]
         dev_login_enabled: bool,
     },
@@ -117,9 +117,17 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 .as_deref()
                 .map(onsager_portal::sso::parse_host_allowlist)
                 .unwrap_or_default();
-            // ONSAGER_PREVIEW=true is already set on all Railway preview
-            // environments via railway.toml [environments.preview.variables].
-            let is_preview = std::env::var("ONSAGER_PREVIEW").as_deref() == Ok("true");
+            // Auto-detect Railway preview environments from the always-injected
+            // RAILWAY_ENVIRONMENT_NAME (e.g. "onsager-pr-267"). Railway only
+            // seeds [environments.preview.variables] at creation time, so we
+            // can't rely on ONSAGER_PREVIEW being present on existing envs.
+            // Fall back to ONSAGER_PREVIEW for safety, and DEV_LOGIN_ENABLED
+            // for explicit opt-in outside Railway.
+            let is_railway_preview = std::env::var("RAILWAY_ENVIRONMENT_NAME")
+                .ok()
+                .map(|n| n.to_lowercase().contains("pr-"))
+                .unwrap_or(false)
+                || std::env::var("ONSAGER_PREVIEW").as_deref() == Ok("true");
             let cfg = onsager_portal::config::Config {
                 bind: bind.clone(),
                 database_url,
@@ -137,7 +145,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 sso_auth_domain: sso_auth_domain
                     .filter(|s| !s.is_empty())
                     .map(|s| s.trim_end_matches('/').to_string()),
-                dev_login_enabled: dev_login_enabled || is_preview,
+                dev_login_enabled: dev_login_enabled || is_railway_preview,
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -62,8 +62,9 @@ enum Command {
         /// redirects here instead of talking to GitHub directly.
         #[arg(long, env = "SSO_AUTH_DOMAIN")]
         sso_auth_domain: Option<String>,
-        /// Enable dev-login in release builds. Set `DEV_LOGIN_ENABLED=true`
-        /// on Railway preview environments that need login without GitHub OAuth.
+        /// Enable dev-login in release builds. Automatically true when
+        /// `ONSAGER_PREVIEW=true` (set on all Railway preview environments
+        /// by railway.toml). Can also be forced with `DEV_LOGIN_ENABLED=true`.
         #[arg(long, env = "DEV_LOGIN_ENABLED", default_value_t = false)]
         dev_login_enabled: bool,
     },
@@ -116,6 +117,9 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 .as_deref()
                 .map(onsager_portal::sso::parse_host_allowlist)
                 .unwrap_or_default();
+            // ONSAGER_PREVIEW=true is already set on all Railway preview
+            // environments via railway.toml [environments.preview.variables].
+            let is_preview = std::env::var("ONSAGER_PREVIEW").as_deref() == Ok("true");
             let cfg = onsager_portal::config::Config {
                 bind: bind.clone(),
                 database_url,
@@ -133,7 +137,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 sso_auth_domain: sso_auth_domain
                     .filter(|s| !s.is_empty())
                     .map(|s| s.trim_end_matches('/').to_string()),
-                dev_login_enabled,
+                dev_login_enabled: dev_login_enabled || is_preview,
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -62,6 +62,10 @@ enum Command {
         /// redirects here instead of talking to GitHub directly.
         #[arg(long, env = "SSO_AUTH_DOMAIN")]
         sso_auth_domain: Option<String>,
+        /// Enable dev-login in release builds. Set `DEV_LOGIN_ENABLED=true`
+        /// on Railway preview environments that need login without GitHub OAuth.
+        #[arg(long, env = "DEV_LOGIN_ENABLED", default_value_t = false)]
+        dev_login_enabled: bool,
     },
     /// Backfill issues + PRs for an existing project.
     Backfill {
@@ -106,6 +110,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             sso_exchange_secret,
             sso_return_host_allowlist,
             sso_auth_domain,
+            dev_login_enabled,
         } => {
             let allowlist = sso_return_host_allowlist
                 .as_deref()
@@ -128,6 +133,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 sso_auth_domain: sso_auth_domain
                     .filter(|s| !s.is_empty())
                     .map(|s| s.trim_end_matches('/').to_string()),
+                dev_login_enabled,
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -34,16 +34,17 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         tracing::warn!(error = %e, "github adapter registration skipped");
     }
 
-    // Seed the dev user / workspace in debug builds so the dev-login
-    // button works on a fresh DB. Stiglab's `workspaces` /
-    // `workspace_members` tables must already exist; in `just dev` the
-    // boot order is portal→stiglab so portal doesn't see them on a cold
-    // start. Best-effort: if the tables aren't there yet, log and
-    // continue — stiglab's first migration run will create them, and
-    // the next portal start will seed.
-    #[cfg(debug_assertions)]
-    if let Err(e) = crate::dev_auth::seed_dev_user_and_workspace(&pool).await {
-        tracing::warn!(error = %e, "portal dev-login seeder skipped (workspaces table missing?)");
+    // Seed the dev user / workspace when dev-login is active (always in
+    // debug builds, or release builds with DEV_LOGIN_ENABLED=true).
+    // Stiglab's `workspaces` / `workspace_members` tables must already
+    // exist; in `just dev` the boot order is portal→stiglab so portal
+    // doesn't see them on a cold start. Best-effort: if the tables
+    // aren't there yet, log and continue — stiglab's first migration run
+    // will create them, and the next portal start will seed.
+    if cfg!(debug_assertions) || config.dev_login_enabled {
+        if let Err(e) = crate::dev_auth::seed_dev_user_and_workspace(&pool).await {
+            tracing::warn!(error = %e, "portal dev-login seeder skipped (workspaces table missing?)");
+        }
     }
 
     let gate = Arc::new(GateClient::new(config.synodic_url.clone()));
@@ -292,11 +293,14 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route("/api/nodes", get(node_handlers::list_nodes))
         .route("/api/tasks", post(task_handlers::create_task));
 
-    // Dev-login is debug-only — `cargo build --release` strips both the
-    // route handler symbol and this registration so production deploys
-    // physically cannot serve it regardless of env-var manipulation.
-    #[cfg(debug_assertions)]
-    let app = app.route("/api/auth/dev-login", post(crate::dev_auth::dev_login));
+    // Dev-login: always in debug builds; in release only when
+    // DEV_LOGIN_ENABLED=true (Railway preview environments).
+    // Production omits the env var so the route is never registered.
+    let app = if cfg!(debug_assertions) || config.dev_login_enabled {
+        app.route("/api/auth/dev-login", post(crate::dev_auth::dev_login))
+    } else {
+        app
+    };
 
     let app = app.with_state(state);
 

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -76,6 +76,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             get(auth_handlers::github_callback),
         )
         .route("/api/auth/me", get(auth_handlers::me))
+        .route("/api/auth/providers", get(auth_handlers::providers))
         .route("/api/auth/logout", post(auth_handlers::logout))
         .route("/api/auth/sso/redeem", post(auth_handlers::sso_redeem))
         .route("/api/auth/sso/finish", get(auth_handlers::sso_finish))

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -26,19 +26,11 @@ use tower_http::trace::TraceLayer;
 use config::ServerConfig;
 use state::AppState;
 
-/// Build the Axum router. Post-#222 Slice 6, stiglab owns only two routes:
-/// `/api/health` (liveness probe) and `/agent/ws` (agent WebSocket).
-/// All `/api/*` traffic is routed to portal by the edge proxy (Caddy in
-/// dev, nginx in prod) so the dashboard's same-origin fetches land on
-/// portal without any per-environment URL configuration.
+/// Build the Axum router. Post-#222 Slice 6, stiglab owns only one route:
+/// `/agent/ws` (agent WebSocket). All `/api/*` traffic is forwarded to
+/// portal by the catch-all proxy (including `/api/health`).
 pub fn build_router(state: AppState, config: &ServerConfig) -> Router {
-    // `/api/health` and `/agent/ws` are the two routes stiglab owns
-    // post-#222 Slice 6. The catch-all forwards everything else under
-    // `/api/` to onsager-portal (loopback:PORTAL_PORT). Exact routes
-    // take priority over the wildcard in axum, so `/api/health` is
-    // never forwarded.
     let api_routes = Router::new()
-        .route("/api/health", get(routes::health::health))
         .route("/agent/ws", get(ws::agent::agent_ws_handler))
         .route("/api/{*path}", any(routes::portal::proxy));
 

--- a/crates/stiglab/src/server/routes/health.rs
+++ b/crates/stiglab/src/server/routes/health.rs
@@ -1,9 +1,0 @@
-use axum::response::IntoResponse;
-use axum::Json;
-
-pub async fn health() -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "ok",
-        "version": env!("CARGO_PKG_VERSION"),
-    }))
-}

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -1,4 +1,3 @@
-pub mod health;
 pub mod portal;
 pub mod shaping;
 

--- a/crates/stiglab/src/server/routes/portal.rs
+++ b/crates/stiglab/src/server/routes/portal.rs
@@ -1,6 +1,6 @@
 //! Catch-all reverse proxy: forwards `/api/*` to onsager-portal.
 //!
-//! Post-#222 Slice 6 stiglab owns only `/api/health` and `/agent/ws`.
+//! Post-#222 Slice 6 stiglab owns only `/agent/ws`.
 //! Everything else under `/api/` is handled by portal. In dev, Caddy
 //! routes those requests directly to portal; in the Railway single-
 //! container deployment stiglab is the only process reachable from

--- a/railway.toml
+++ b/railway.toml
@@ -73,6 +73,9 @@ numReplicas = 1
 #                               split, etc.).
 #   GITHUB_CLIENT_ID          — GitHub OAuth app client ID
 #   GITHUB_CLIENT_SECRET      — GitHub OAuth app client secret
+#   DEV_LOGIN_ENABLED         — set to `true` on preview environments to
+#                               enable the /api/auth/dev-login bypass.
+#                               Must NOT be set on production (app.onsager.ai).
 #
 # Cross-environment SSO (owner side — prod only):
 #   The preview environments piggy-back off prod's GitHub OAuth app via a

--- a/railway.toml
+++ b/railway.toml
@@ -180,3 +180,6 @@ STIGLAB_TRUST_FORWARDED_HEADERS = "1"
 # present, to catch config confusion early.
 SSO_AUTH_DOMAIN = "${{SSO_AUTH_DOMAIN}}"
 SSO_EXCHANGE_SECRET = "${{SSO_EXCHANGE_SECRET}}"
+# Preview envs have no GitHub OAuth creds, so dev-login is the only
+# login path. Automatically enabled here; must NOT be added to prod.
+DEV_LOGIN_ENABLED = "true"

--- a/railway.toml
+++ b/railway.toml
@@ -73,8 +73,9 @@ numReplicas = 1
 #                               split, etc.).
 #   GITHUB_CLIENT_ID          — GitHub OAuth app client ID
 #   GITHUB_CLIENT_SECRET      — GitHub OAuth app client secret
-#   DEV_LOGIN_ENABLED         — set to `true` on preview environments to
-#                               enable the /api/auth/dev-login bypass.
+#   DEV_LOGIN_ENABLED         — explicit opt-in for dev-login in release builds.
+#                               Not needed on preview environments — those are
+#                               detected automatically via ONSAGER_PREVIEW=true.
 #                               Must NOT be set on production (app.onsager.ai).
 #
 # Cross-environment SSO (owner side — prod only):
@@ -180,6 +181,3 @@ STIGLAB_TRUST_FORWARDED_HEADERS = "1"
 # present, to catch config confusion early.
 SSO_AUTH_DOMAIN = "${{SSO_AUTH_DOMAIN}}"
 SSO_EXCHANGE_SECRET = "${{SSO_EXCHANGE_SECRET}}"
-# Preview envs have no GitHub OAuth creds, so dev-login is the only
-# login path. Automatically enabled here; must NOT be added to prod.
-DEV_LOGIN_ENABLED = "true"

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -693,10 +693,10 @@ mod tests {
         let root = workspace_root();
         let stiglab =
             parse_rust_routes(&root.join("crates/stiglab/src/server/mod.rs"), "stiglab").unwrap();
-        // Post-#222 Slice 6 stiglab owns only /api/health + /agent/ws.
-        assert!(stiglab.len() >= 2, "stiglab routes: {}", stiglab.len());
+        // Post-#222 Slice 6 stiglab owns only /agent/ws; /api/* goes to portal.
+        assert!(stiglab.len() >= 1, "stiglab routes: {}", stiglab.len());
         let stiglab_paths: Vec<_> = stiglab.iter().map(|r| r.path.as_str()).collect();
-        assert!(stiglab_paths.contains(&"/api/health"));
+        assert!(stiglab_paths.contains(&"/agent/ws"));
 
         let portal =
             parse_rust_routes(&root.join("crates/onsager-portal/src/server.rs"), "portal").unwrap();

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -694,7 +694,7 @@ mod tests {
         let stiglab =
             parse_rust_routes(&root.join("crates/stiglab/src/server/mod.rs"), "stiglab").unwrap();
         // Post-#222 Slice 6 stiglab owns only /agent/ws; /api/* goes to portal.
-        assert!(stiglab.len() >= 1, "stiglab routes: {}", stiglab.len());
+        assert!(!stiglab.is_empty(), "stiglab routes: {}", stiglab.len());
         let stiglab_paths: Vec<_> = stiglab.iter().map(|r| r.path.as_str()).collect();
         assert!(stiglab_paths.contains(&"/agent/ws"));
 


### PR DESCRIPTION
## Summary

**Dev-login on Railway preview environments (no manual config per PR):**
- Removes the compile-time `#[cfg(debug_assertions)]` gate from `dev_auth.rs` / `lib.rs` so the module compiles in release builds.
- Adds `dev_login_enabled: bool` to `Config`, auto-set when `RAILWAY_ENVIRONMENT_NAME` contains `"pr-"` (always injected by Railway) or `ONSAGER_PREVIEW=true`. No per-PR env var setup needed.
- Replaces `#[cfg(debug_assertions)]` blocks in `server.rs` with `if cfg!(debug_assertions) || config.dev_login_enabled`.
- Adds `GET /api/auth/providers` endpoint returning `{github: bool, dev: bool}` — Railway preview returns `{github: false, dev: true}`, production returns `{github: true, dev: false}`.
- `LoginPage` uses `api.authProviders()` instead of a probe hack to decide which buttons to show.

**Seam rule fix — remove `/api/health` from stiglab:**
- `stiglab/src/server/mod.rs` was registering `/api/health` directly, bypassing the catch-all proxy and violating the seam rule (only portal owns `/api/*`). Portal already serves `GET /api/health`.
- Deleted `routes/health.rs`, removed the route registration and module declaration.

Closes #266

https://claude.ai/code/session_01JRx7XTWHpdpHN8isdcHeFo