### PR TITLE
docs(skills): stop hard-wrapping prose in spec issue bodies

### DIFF
--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -96,7 +96,7 @@ If a related spec issue already exists, reference it — don't duplicate.
 
 Read [references/spec-format.md](references/spec-format.md) for the section-by-section format guide.
 
-**Don't hard-wrap prose paragraphs.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph becomes a `<br>`, producing visible mid-sentence line breaks. Source files in this repo wrap at ~70 columns; **issue bodies must not**. Each prose paragraph is one long line, separated from the next by a blank line. Lists, tables, fenced code blocks, blockquotes, and heading lines are unaffected — wrap those normally.
+**Don't hard-wrap prose paragraphs.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph becomes a `<br>`, producing visible mid-sentence line breaks. Source files in this repo wrap at ~70 columns; **issue bodies must not**. Each prose paragraph is one long line, separated from the next by a blank line. Lists, tables, fenced code blocks, and blockquotes are unaffected — wrap those normally. Headings are always a single line (markdown requires it).
 
 Draft the issue body using the lean-spec structure:
 

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -96,7 +96,7 @@ If a related spec issue already exists, reference it — don't duplicate.
 
 Read [references/spec-format.md](references/spec-format.md) for the section-by-section format guide.
 
-**Don't hard-wrap prose paragraphs.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph becomes a `<br>`, producing visible mid-sentence line breaks. Source files in this repo wrap at ~70 columns; **issue bodies must not**. Each prose paragraph is one long line, separated from the next by a blank line. Lists, tables, fenced code blocks, and blockquotes are unaffected — wrap those normally. Headings are always a single line (markdown requires it).
+**Don't hard-wrap prose, list items, or blockquote lines.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph, list item, or blockquote becomes a `<br>`, producing visible mid-sentence breaks. Source files in this repo wrap at ~70 columns; **issue bodies must not**. Each paragraph, list item, and blockquote line is a single long line; only blank lines separate paragraphs, and each new bullet/quote line starts on its own line. Fenced code blocks and tables preserve formatting and are unaffected. Headings are single-line by markdown's own rules.
 
 Draft the issue body using the lean-spec structure:
 
@@ -155,7 +155,7 @@ Add an **Alignment** section to the issue body (this extends lean-spec for human
 Before creating the issue, self-check:
 
 - [ ] Body is under ~2000 tokens (context economy)
-- [ ] Prose paragraphs are not hard-wrapped (one long line per paragraph, blank line between paragraphs)
+- [ ] Prose paragraphs, list items, and blockquote lines are not hard-wrapped (each is one long line; blank line between paragraphs, new bullet/quote line on its own)
 - [ ] Overview explains *why*, not just *what*
 - [ ] Design captures intent, not implementation details
 - [ ] Plan items are concrete and independently verifiable

--- a/.claude/skills/issue-spec/SKILL.md
+++ b/.claude/skills/issue-spec/SKILL.md
@@ -96,6 +96,8 @@ If a related spec issue already exists, reference it — don't duplicate.
 
 Read [references/spec-format.md](references/spec-format.md) for the section-by-section format guide.
 
+**Don't hard-wrap prose paragraphs.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph becomes a `<br>`, producing visible mid-sentence line breaks. Source files in this repo wrap at ~70 columns; **issue bodies must not**. Each prose paragraph is one long line, separated from the next by a blank line. Lists, tables, fenced code blocks, blockquotes, and heading lines are unaffected — wrap those normally.
+
 Draft the issue body using the lean-spec structure:
 
 ```markdown
@@ -153,6 +155,7 @@ Add an **Alignment** section to the issue body (this extends lean-spec for human
 Before creating the issue, self-check:
 
 - [ ] Body is under ~2000 tokens (context economy)
+- [ ] Prose paragraphs are not hard-wrapped (one long line per paragraph, blank line between paragraphs)
 - [ ] Overview explains *why*, not just *what*
 - [ ] Design captures intent, not implementation details
 - [ ] Plan items are concrete and independently verifiable

--- a/.claude/skills/issue-spec/references/spec-format.md
+++ b/.claude/skills/issue-spec/references/spec-format.md
@@ -76,7 +76,7 @@ The `draft → planned` transition is the **human-AI alignment gate**. Only a hu
 
 **Purpose**: Why does this work matter? What problem does it solve?
 
-**Good overview** (note: prose paragraphs are *not* hard-wrapped — GitHub renders single newlines as `<br>` in issue bodies):
+**Good overview** (note: prose, list items, and blockquote lines are *not* hard-wrapped — GitHub renders single newlines as `<br>` in issue bodies; see SKILL.md step 2):
 ```markdown
 ## Overview
 

--- a/.claude/skills/issue-spec/references/spec-format.md
+++ b/.claude/skills/issue-spec/references/spec-format.md
@@ -76,14 +76,11 @@ The `draft → planned` transition is the **human-AI alignment gate**. Only a hu
 
 **Purpose**: Why does this work matter? What problem does it solve?
 
-**Good overview:**
+**Good overview** (note: prose paragraphs are *not* hard-wrapped — GitHub renders single newlines as `<br>` in issue bodies):
 ```markdown
 ## Overview
 
-Sessions in `WAITING_INPUT` state can hang indefinitely if the user
-disconnects. This wastes agent capacity and leaves stale sessions in
-the dashboard. We need a configurable timeout that transitions idle
-sessions to `FAILED` after a period of inactivity.
+Sessions in `WAITING_INPUT` state can hang indefinitely if the user disconnects. This wastes agent capacity and leaves stale sessions in the dashboard. We need a configurable timeout that transitions idle sessions to `FAILED` after a period of inactivity.
 ```
 
 **Bad overview:**
@@ -108,14 +105,12 @@ The bad version says *what* but not *why*. The AI has no context to make tradeof
 ```markdown
 ## Design
 
-Each session gets an inactivity timer that resets on any WebSocket
-message. When the timer expires:
+Each session gets an inactivity timer that resets on any WebSocket message. When the timer expires:
 1. Emit a `SessionTimeoutWarning` event 5 minutes before deadline
 2. Transition state to `Failed` with reason `session_timeout`
 3. Preserve all session output collected before timeout
 
-The timeout duration is server-configurable via environment variable.
-Per-session overrides are out of scope for now.
+The timeout duration is server-configurable via environment variable. Per-session overrides are out of scope for now.
 ```
 
 **Guidelines:**
@@ -209,10 +204,8 @@ Per-session overrides are out of scope for now.
 ```markdown
 ## Notes
 
-- Considered per-session timeout overrides via API, but deferred to keep
-  scope small. Can add in a follow-up spec.
-- The timeout timer approach uses `tokio::time::sleep` per session.
-  At 100+ concurrent sessions this may need optimization (timer wheel).
+- Considered per-session timeout overrides via API, but deferred to keep scope small. Can add in a follow-up spec.
+- The timeout timer approach uses `tokio::time::sleep` per session. At 100+ concurrent sessions this may need optimization (timer wheel).
 - Related: #23 (session state machine), #31 (node heartbeat)
 ```
 


### PR DESCRIPTION
## Summary

GitHub renders issue/comment bodies with `breaks: true` — every newline inside a paragraph becomes a `<br>`. This repo's source files (skills, docs, code) wrap at ~70 columns, and that habit was bleeding into spec issue bodies, so recent specs render with visible mid-sentence line breaks.

The `issue-spec` skill never said "don't do that," and the worked Overview / Design / Notes examples in `references/spec-format.md` were themselves hard-wrapped, teaching the wrong shape.

This PR:

- Adds an explicit "don't hard-wrap prose paragraphs" callout in step 2 (Design) of the `issue-spec` SKILL, with the rule and the exceptions (lists, tables, code blocks, blockquotes, headings).
- Adds a matching item to the step 4 (Validate) self-check.
- Unwraps the worked Overview, Design, and Notes examples in `references/spec-format.md` so they demonstrate the right shape.

No behavior change in code. Doc-only fix to skill guidance — labeling `trivial`.

## Test plan

- [ ] Skill SKILL.md renders the new callout in step 2 and the new self-check item in step 4.
- [ ] `references/spec-format.md` Overview / Design / Notes examples show long-line paragraphs separated by blank lines, no internal hard wraps.
- [ ] Future spec issues drafted by an AI following this skill have no mid-sentence line breaks on the rendered GitHub issue page.

https://claude.ai/code/session_016gFQU2UmbH7XjsB4GD8TJU

---
_Generated by [Claude Code](https://claude.ai/code/session_016gFQU2UmbH7XjsB4GD8TJU)_