### PR TITLE
feat(triggers): finish #236 — external-request + manual portal surface

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/WorkflowActions.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowActions.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
-import { MoreHorizontal, Pause, Play, Trash2 } from "lucide-react"
+import { MoreHorizontal, Pause, Play, Rocket, Trash2 } from "lucide-react"
 import { api, type Workflow } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import {
@@ -49,6 +49,18 @@ export function WorkflowActions({
   const [confirming, setConfirming] = useState(false)
 
   const isActive = workflow.status === "active"
+  const isManualTrigger = workflow.trigger.kind_tag === "manual"
+  const manualName = workflow.trigger.manual_name ?? ""
+
+  const fireManual = useMutation({
+    mutationFn: () => api.fireManualTrigger(workflow.id, manualName),
+    onSuccess: () => {
+      // The trigger.fired event lands within ~50ms; refresh runs so
+      // the new artifact appears without waiting for the 5s poll.
+      queryClient.invalidateQueries({ queryKey: ["workflow-runs", workflow.id] })
+      queryClient.invalidateQueries({ queryKey: ["spine-events"] })
+    },
+  })
 
   const toggle = useMutation({
     mutationFn: (active: boolean) => api.setWorkflowActive(workflow.id, active),
@@ -91,6 +103,15 @@ export function WorkflowActions({
           <MoreHorizontal className="h-5 w-5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
+          {isManualTrigger && isActive && (
+            <DropdownMenuItem
+              disabled={fireManual.isPending}
+              onClick={() => fireManual.mutate()}
+            >
+              <Rocket className="mr-2 h-4 w-4" />
+              {fireManual.isPending ? "Firing…" : "Run now"}
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             disabled={toggle.isPending}
             onClick={() => toggle.mutate(!isActive)}
@@ -112,6 +133,18 @@ export function WorkflowActions({
         className="flex flex-wrap items-center gap-2"
         data-testid="workflow-actions"
       >
+        {isManualTrigger && isActive && (
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            disabled={fireManual.isPending}
+            onClick={() => fireManual.mutate()}
+          >
+            <Rocket className="h-4 w-4" />
+            {fireManual.isPending ? "Firing…" : "Run now"}
+          </Button>
+        )}
         <Button
           type="button"
           variant={isActive ? "outline" : "default"}
@@ -136,6 +169,13 @@ export function WorkflowActions({
             {toggle.error instanceof Error
               ? toggle.error.message
               : "Failed to update workflow"}
+          </p>
+        )}
+        {fireManual.isError && (
+          <p className="w-full text-xs text-destructive">
+            {fireManual.error instanceof Error
+              ? fireManual.error.message
+              : "Run now failed"}
           </p>
         )}
       </div>

--- a/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/factory/workflows/workflow-draft.ts
@@ -173,6 +173,8 @@ export function draftToRequestTrigger(t: WorkflowTriggerDraft): WorkflowTrigger 
     repo_owner: t.repo_owner,
     repo_name: t.repo_name,
     label: t.label,
+    kind_tag: "github_issue_webhook",
+    manual_name: "",
   }
 }
 

--- a/apps/dashboard/src/lib/api/types.ts
+++ b/apps/dashboard/src/lib/api/types.ts
@@ -390,6 +390,15 @@ export interface WorkflowTrigger {
   repo_owner: string;
   repo_name: string;
   label: string;
+  /// Snake-case wire `kind_tag` from the registry manifest (e.g.
+  /// `'github_issue_webhook'`, `'manual'`). Set on every workflow,
+  /// regardless of the UI-side discriminant; the `<RunNowButton>`
+  /// keys off this rather than the legacy `kind` field so it can
+  /// render for `'manual'` workflows without a UI-side variant.
+  kind_tag: string;
+  /// Manual-trigger name when `kind_tag === 'manual'`. Empty for
+  /// other kinds.
+  manual_name?: string;
 }
 
 export type WorkflowGateKind =
@@ -444,7 +453,19 @@ export interface EventManifestEntry {
 // `onsager_registry::TriggerDefinition`; keep in sync with the Rust
 // struct.
 export type TriggerCategory = 'event' | 'schedule' | 'request' | 'manual';
-export type TriggerUiKind = 'webhook';
+export type TriggerUiKind =
+  | 'webhook'
+  | 'github_pull_request_closed'
+  | 'github_workflow_run_completed'
+  | 'telegram_webhook'
+  | 'cron'
+  | 'delay'
+  | 'interval'
+  | 'spine_event'
+  | 'pg_notify'
+  | 'outbox'
+  | 'manual'
+  | 'replay';
 
 export interface TriggerManifestEntry {
   kind_tag: string;

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -19,6 +19,11 @@ interface BackendTrigger {
   kind: string;
   repo?: string;
   label?: string;
+  // Manual / replay variants — `name` for `manual`, `source_event_id`
+  // for `replay`. Other variants carry their own per-kind fields the
+  // UI doesn't currently render.
+  name?: string;
+  [extra: string]: unknown;
 }
 
 interface BackendWorkflow {
@@ -112,6 +117,8 @@ function workflowFromBackend(
       repo_owner: repoOwner,
       repo_name: repoName,
       label: w.trigger.label ?? '',
+      kind_tag: w.trigger.kind ?? '',
+      manual_name: typeof w.trigger.name === 'string' ? w.trigger.name : '',
     },
     stages: stages.map(stageFromBackend),
     created_at: w.created_at,
@@ -189,6 +196,39 @@ export const workflows = {
   getWorkflowRuns: (id: string, limit = 20) =>
     request<{ runs: WorkflowRun[] }>(
       `/workflows/${encodeURIComponent(id)}/runs?limit=${limit}`,
+    ),
+  // Manual / replay trigger fires (#241 — Category 4 of the trigger
+  // taxonomy umbrella #236). Both endpoints emit a `trigger.fired`
+  // spine event the workflow runtime consumes, plus a
+  // `workflow.manual_triggered` audit record.
+  fireManualTrigger: (
+    workflowId: string,
+    name: string,
+    payload?: Record<string, unknown>,
+  ) =>
+    request<{
+      workflow_id: string;
+      trigger_kind: 'manual';
+      name: string;
+      trigger_event_id: number;
+      actor: string;
+    }>(
+      `/workflows/${encodeURIComponent(workflowId)}/triggers/manual/${encodeURIComponent(name)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload === undefined ? {} : { payload }),
+      },
+    ),
+  replayTrigger: (workflowId: string, sourceEventId: number) =>
+    request<{
+      workflow_id: string;
+      trigger_kind: 'replay';
+      source_event_id: number;
+      trigger_event_id: number;
+      actor: string;
+    }>(
+      `/workflows/${encodeURIComponent(workflowId)}/triggers/replay/${sourceEventId}`,
+      { method: 'POST' },
     ),
   // Registry-backed workflow artifact kinds (issue #102). Poll-on-load; the
   // dashboard caches the result for the session. Falls back to the static

--- a/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
@@ -95,6 +95,8 @@ describe("workflow-draft serialization", () => {
       repo_owner: "onsager-ai",
       repo_name: "onsager",
       label: "factory",
+      kind_tag: "github_issue_webhook",
+      manual_name: "",
     })
   })
 

--- a/crates/forge/src/core/workflow.rs
+++ b/crates/forge/src/core/workflow.rs
@@ -148,6 +148,9 @@ impl Workflow {
     pub fn trigger_artifact_kind(&self) -> &'static str {
         match self.trigger {
             TriggerKind::GithubIssueWebhook { .. } => "github-issue",
+            TriggerKind::GithubPullRequestClosed { .. } => "github-pull-request",
+            TriggerKind::GithubWorkflowRunCompleted { .. } => "github-workflow-run",
+            TriggerKind::TelegramWebhook { .. } => "telegram-update",
             TriggerKind::Cron { .. } | TriggerKind::Delay { .. } | TriggerKind::Interval { .. } => {
                 "scheduled-tick"
             }

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -45,6 +45,12 @@ pub struct Config {
     /// enabled in debug builds. Set `DEV_LOGIN_ENABLED=true` on Railway
     /// preview environments that need a login path without GitHub OAuth.
     pub dev_login_enabled: bool,
+    /// Shared secret echoed back by Telegram in the
+    /// `X-Telegram-Bot-Api-Secret-Token` header on every webhook
+    /// delivery. When `None` the `/webhooks/telegram` route returns
+    /// `503` — the trigger kind is registered but the receiver is
+    /// disabled. Set via `TELEGRAM_WEBHOOK_SECRET` (#240).
+    pub telegram_webhook_secret: Option<String>,
 }
 
 impl Config {
@@ -123,6 +129,7 @@ mod tests {
             sso_return_host_allowlist: Vec::new(),
             sso_auth_domain: None,
             dev_login_enabled: false,
+            telegram_webhook_secret: None,
         }
     }
 

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -18,6 +18,8 @@ pub mod sessions;
 pub mod spec_link;
 pub mod spine;
 pub mod tasks;
+pub mod telegram_webhook;
+pub mod triggers;
 pub mod webhook;
 pub mod workflow_kinds;
 pub mod workflows;

--- a/crates/onsager-portal/src/handlers/telegram_webhook.rs
+++ b/crates/onsager-portal/src/handlers/telegram_webhook.rs
@@ -1,0 +1,192 @@
+//! Telegram bot webhook receiver (#240 — Category 3 of the trigger
+//! taxonomy umbrella #236).
+//!
+//! Telegram tells the bot's webhook URL apart from any other request by
+//! the `X-Telegram-Bot-Api-Secret-Token` header it sets at
+//! `setWebhook` time. We compare that against `TELEGRAM_WEBHOOK_SECRET`
+//! (configured at portal boot) using a constant-time comparison; a
+//! missing or wrong header returns `401`.
+//!
+//! On a verified update we look up every active `TelegramWebhook`
+//! workflow whose `bot_username` + `chat_id_allowlist` + optional
+//! `command_prefix` match the incoming update, and emit one
+//! `workflow.trigger_fired` event per match. Per-bot per-workspace
+//! secret storage is a v2 follow-up — v1 ships with a single global
+//! secret because the factory's first Telegram bot is operator-grade.
+
+use std::collections::HashSet;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use onsager_spine::{EventMetadata, TriggerKind};
+use serde_json::Value;
+
+use crate::state::AppState;
+
+/// Header Telegram echoes back from `setWebhook`.
+const HDR_SECRET: &str = "x-telegram-bot-api-secret-token";
+
+/// `POST /webhooks/telegram` — Telegram bot webhook entry point.
+pub async fn handle(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Some(expected) = state.config.telegram_webhook_secret.clone() else {
+        // No secret configured ⇒ Telegram routing is disabled. We return
+        // 503 so a misconfigured webhook URL surfaces in Telegram's
+        // delivery dashboard rather than silently accepting payloads.
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "telegram_webhook_disabled" })),
+        )
+            .into_response();
+    };
+
+    let supplied = headers
+        .get(HDR_SECRET)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    if !constant_time_eq(supplied.as_bytes(), expected.as_bytes()) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "telegram_secret_invalid" })),
+        )
+            .into_response();
+    }
+
+    let update: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "body_not_json" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Walk every active TelegramWebhook workflow across every workspace.
+    // The portal pool already serves workspace-scoped reads on the
+    // `workflows` spine table; we project the rows portal-side and
+    // filter against the parsed update.
+    let workflows =
+        match crate::workflow_db::list_active_telegram_workflows(state.spine.pool()).await {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!("failed to list active telegram workflows: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+
+    let chat_id = update
+        .pointer("/message/chat/id")
+        .or_else(|| update.pointer("/edited_message/chat/id"))
+        .or_else(|| update.pointer("/channel_post/chat/id"))
+        .and_then(Value::as_i64);
+    let text = update
+        .pointer("/message/text")
+        .or_else(|| update.pointer("/edited_message/text"))
+        .or_else(|| update.pointer("/channel_post/text"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let bot_target = update
+        .pointer("/message/via_bot/username")
+        .or_else(|| update.pointer("/message/from/username"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    let mut emitted = 0usize;
+    for workflow in workflows {
+        let TriggerKind::TelegramWebhook {
+            bot_username,
+            chat_id_allowlist,
+            command_prefix,
+        } = &workflow.trigger
+        else {
+            continue;
+        };
+
+        if !bot_username.is_empty() && !bot_target.is_empty() && bot_target != bot_username {
+            continue;
+        }
+        if !chat_id_allowlist.is_empty() {
+            let allow: HashSet<i64> = chat_id_allowlist.iter().copied().collect();
+            match chat_id {
+                Some(c) if allow.contains(&c) => {}
+                _ => continue,
+            }
+        }
+        if let Some(prefix) = command_prefix {
+            if !text.starts_with(prefix) {
+                continue;
+            }
+        }
+
+        let payload = serde_json::json!({
+            "trigger_kind": "telegram_webhook",
+            "workflow_id": workflow.id,
+            "workspace_id": workflow.workspace_id,
+            "bot_username": bot_username,
+            "chat_id": chat_id,
+            "text": text,
+            "update": update,
+            "source": "telegram_webhook",
+        });
+        let metadata = EventMetadata {
+            correlation_id: None,
+            causation_id: None,
+            actor: "portal".to_string(),
+        };
+        let envelope = serde_json::json!({
+            "event": {
+                "type": "trigger.fired",
+                "workflow_id": workflow.id,
+                "trigger_kind": "telegram_webhook",
+                "payload": payload,
+            },
+            "actor": "portal",
+            "timestamp": chrono::Utc::now(),
+        });
+        if let Err(e) = state
+            .spine
+            .append_ext(
+                &workflow.workspace_id,
+                &format!("workflow:{}", workflow.id),
+                "workflow",
+                "trigger.fired",
+                envelope,
+                &metadata,
+                None,
+            )
+            .await
+        {
+            tracing::warn!("failed to emit telegram trigger.fired: {e}");
+            continue;
+        }
+        emitted += 1;
+    }
+
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({ "matched": emitted })),
+    )
+        .into_response()
+}
+
+/// Constant-time byte comparison. Avoids leaking the secret length /
+/// shared-prefix to a determined attacker. We accept the small
+/// non-secret-shaped allocation in exchange for a single code path.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}

--- a/crates/onsager-portal/src/handlers/triggers.rs
+++ b/crates/onsager-portal/src/handlers/triggers.rs
@@ -1,0 +1,481 @@
+//! Manual / replay trigger HTTP endpoints (#241 — Category 4 of the
+//! trigger taxonomy v2 umbrella #236).
+//!
+//! Two routes:
+//!
+//!   POST /api/workflows/{id}/triggers/manual/{name}
+//!   POST /api/workflows/{id}/triggers/replay/{source_event_id}
+//!
+//! Both are authenticated and workspace-scoped (membership required).
+//! Both emit two spine events:
+//!
+//!   1. `workflow.trigger_fired` — same shape forge's
+//!      `trigger_subscriber` already consumes, so a manual fire flows
+//!      through the workflow runtime exactly like a webhook fire would.
+//!   2. `workflow.manual_triggered` — audit-only, namespace `audit`,
+//!      capturing actor + workflow + trigger source for the audit log.
+//!
+//! Replay re-emits the payload of a past `TriggerFired` carrying a
+//! `replay_of` marker (and an accumulated `replay_chain`) so downstream
+//! consumers can distinguish original vs. replay fires. Replay-of-
+//! replay is allowed (#241 resolution).
+//!
+//! Authorization is "any authenticated workspace member" in v1, per
+//! the #241 resolution. Per-tenant role gating (admin-only,
+//! workflow-owner-only) is a follow-up.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventMetadata, TriggerKind};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::auth::AuthUser;
+use crate::credential_db;
+use crate::state::AppState;
+use crate::workflow_db;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ManualFireBody {
+    /// Optional JSON object merged into the emitted payload. Top-level
+    /// keys collide with the canonical fields (`workflow_id`,
+    /// `workspace_id`, `name`, `actor`, `source`, `fired_at`,
+    /// `trigger_kind`); colliding keys lose to the canonical values.
+    #[serde(default)]
+    pub payload: Option<Value>,
+}
+
+/// `POST /api/workflows/:id/triggers/manual/:name` — fire a manual
+/// trigger.
+pub async fn fire_manual(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((workflow_id, name)): Path<(String, String)>,
+    body: Option<Json<ManualFireBody>>,
+) -> Response {
+    let workflow = match load_workflow(&state, &workflow_id).await {
+        Ok(w) => w,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_membership(&state, &auth_user, &workflow.workspace_id).await {
+        return r;
+    }
+
+    // Trigger kind on the workflow row must be `Manual { name }` and the
+    // path-supplied `name` must match. v1 supports exactly one trigger
+    // per workflow (current schema), so a workflow that doesn't declare
+    // this manual trigger gets a 409 — the fire would emit a
+    // `trigger.fired` that no consumer would pick up.
+    match &workflow.trigger {
+        TriggerKind::Manual { name: declared } if declared == &name => {}
+        _ => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "manual_trigger_not_declared",
+                    "detail": format!(
+                        "workflow `{}` does not declare a manual trigger named `{}` \
+                         (its trigger kind is `{}`)",
+                        workflow.id,
+                        name,
+                        workflow.trigger.kind_tag(),
+                    ),
+                })),
+            )
+                .into_response();
+        }
+    }
+    if !workflow.active {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "workflow_inactive",
+                "detail": "activate the workflow before firing a manual trigger",
+            })),
+        )
+            .into_response();
+    }
+
+    let extra = body.map(|Json(b)| b.payload).unwrap_or(None);
+    let now = Utc::now();
+    let mut payload = serde_json::json!({
+        "trigger_kind": "manual",
+        "workflow_id": workflow.id,
+        "workspace_id": workflow.workspace_id,
+        "name": name,
+        "fired_at": now,
+        "actor": auth_user.user_id,
+        "source": "ui",
+    });
+    merge_extra(&mut payload, extra);
+
+    let trigger_event_id = match emit_trigger_fired(
+        &state,
+        &workflow,
+        "manual",
+        payload,
+        &auth_user.user_id,
+        now,
+    )
+    .await
+    {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = emit_audit(
+        &state,
+        &workflow,
+        "ui_fire",
+        serde_json::json!({
+            "manual_name": name,
+            "trigger_event_id": trigger_event_id,
+        }),
+        &auth_user.user_id,
+        now,
+    )
+    .await
+    {
+        return r;
+    }
+
+    Json(serde_json::json!({
+        "workflow_id": workflow.id,
+        "trigger_kind": "manual",
+        "name": name,
+        "trigger_event_id": trigger_event_id,
+        "actor": auth_user.user_id,
+    }))
+    .into_response()
+}
+
+/// `POST /api/workflows/:id/triggers/replay/:source_event_id` — re-emit
+/// a past `TriggerFired` event under a workflow.
+pub async fn replay(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((workflow_id, source_event_id)): Path<(String, i64)>,
+) -> Response {
+    let workflow = match load_workflow(&state, &workflow_id).await {
+        Ok(w) => w,
+        Err(r) => return r,
+    };
+    if let Err(r) = require_membership(&state, &auth_user, &workflow.workspace_id).await {
+        return r;
+    }
+
+    let source = match load_trigger_fired(&state, source_event_id).await {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+
+    let now = Utc::now();
+    let payload =
+        build_replay_payload(&source, &workflow, source_event_id, &auth_user.user_id, now);
+
+    let trigger_event_id = match emit_trigger_fired(
+        &state,
+        &workflow,
+        "replay",
+        payload,
+        &auth_user.user_id,
+        now,
+    )
+    .await
+    {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
+    if let Err(r) = emit_audit(
+        &state,
+        &workflow,
+        "ui_replay",
+        serde_json::json!({
+            "source_event_id": source_event_id,
+            "source_trigger_kind": source.trigger_kind,
+            "trigger_event_id": trigger_event_id,
+        }),
+        &auth_user.user_id,
+        now,
+    )
+    .await
+    {
+        return r;
+    }
+
+    Json(serde_json::json!({
+        "workflow_id": workflow.id,
+        "trigger_kind": "replay",
+        "source_event_id": source_event_id,
+        "trigger_event_id": trigger_event_id,
+        "actor": auth_user.user_id,
+    }))
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct WorkflowRow {
+    id: String,
+    workspace_id: String,
+    trigger: TriggerKind,
+    active: bool,
+}
+
+async fn load_workflow(state: &AppState, workflow_id: &str) -> Result<WorkflowRow, Response> {
+    let workflow = match workflow_db::get_workflow(state.spine.pool(), workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "workflow not found" })),
+            )
+                .into_response());
+        }
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
+        }
+    };
+    Ok(WorkflowRow {
+        id: workflow.id,
+        workspace_id: workflow.workspace_id,
+        trigger: workflow.trigger,
+        active: workflow.active,
+    })
+}
+
+async fn require_membership(
+    state: &AppState,
+    auth_user: &AuthUser,
+    workspace_id: &str,
+) -> Result<(), Response> {
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
+        if pinned != workspace_id {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": "pat_workspace_scope_mismatch",
+                    "detail": "PAT is pinned to a different workspace",
+                })),
+            )
+                .into_response());
+        }
+    }
+    match credential_db::is_workspace_member(&state.pool, workspace_id, &auth_user.user_id).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "workflow not found" })),
+        )
+            .into_response()),
+        Err(e) => {
+            tracing::error!("failed to check workspace membership: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+    }
+}
+
+struct PastTriggerFired {
+    trigger_kind: String,
+    payload: Value,
+}
+
+async fn load_trigger_fired(state: &AppState, event_id: i64) -> Result<PastTriggerFired, Response> {
+    let row = match state.spine.get_ext_event_by_id(event_id).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "source_event_not_found",
+                    "detail": format!("no event with id {event_id}"),
+                })),
+            )
+                .into_response());
+        }
+        Err(e) => {
+            tracing::error!("failed to fetch source event: {e}");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
+        }
+    };
+
+    // Accept either the FactoryEvent envelope or the bare FactoryEventKind
+    // shape — both have appeared in events_ext historically.
+    let kind = if let Ok(env) = serde_json::from_value::<FactoryEvent>(row.data.clone()) {
+        env.event
+    } else {
+        match serde_json::from_value::<FactoryEventKind>(row.data) {
+            Ok(k) => k,
+            Err(_) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "source_event_not_factory_event",
+                        "detail": "event payload is not a FactoryEvent",
+                    })),
+                )
+                    .into_response());
+            }
+        }
+    };
+    match kind {
+        FactoryEventKind::TriggerFired {
+            trigger_kind,
+            payload,
+            ..
+        } => Ok(PastTriggerFired {
+            trigger_kind,
+            payload,
+        }),
+        _ => Err((
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "source_event_not_trigger_fired",
+                "detail": "source event is not a TriggerFired event",
+            })),
+        )
+            .into_response()),
+    }
+}
+
+fn build_replay_payload(
+    source: &PastTriggerFired,
+    workflow: &WorkflowRow,
+    source_event_id: i64,
+    actor: &str,
+    now: chrono::DateTime<Utc>,
+) -> Value {
+    let mut payload = match source.payload.clone() {
+        Value::Object(map) => Value::Object(map),
+        other => serde_json::json!({ "original_payload": other }),
+    };
+    if let Value::Object(map) = &mut payload {
+        let mut chain: Vec<i64> = map
+            .get("replay_chain")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|x| x.as_i64()).collect())
+            .unwrap_or_default();
+        chain.push(source_event_id);
+        map.insert("replay_of".into(), Value::from(source_event_id));
+        map.insert(
+            "replay_chain".into(),
+            Value::Array(chain.into_iter().map(Value::from).collect()),
+        );
+        map.insert("replay_actor".into(), Value::String(actor.to_string()));
+        map.insert("replay_fired_at".into(), Value::String(now.to_rfc3339()));
+        map.insert("workflow_id".into(), Value::String(workflow.id.clone()));
+        map.insert(
+            "workspace_id".into(),
+            Value::String(workflow.workspace_id.clone()),
+        );
+        map.insert("trigger_kind".into(), Value::String("replay".into()));
+        map.insert("source".into(), Value::String("ui_replay".into()));
+    }
+    payload
+}
+
+fn merge_extra(into: &mut Value, extra: Option<Value>) {
+    let Some(extra) = extra else { return };
+    if let (Value::Object(target), Value::Object(extra)) = (into, extra) {
+        for (k, v) in extra {
+            // Canonical fields win — never overwrite the route-level
+            // identity of the fire.
+            target.entry(k).or_insert(v);
+        }
+    }
+}
+
+async fn emit_trigger_fired(
+    state: &AppState,
+    workflow: &WorkflowRow,
+    trigger_kind: &str,
+    payload: Value,
+    actor: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<i64, Response> {
+    let envelope = FactoryEvent {
+        event: FactoryEventKind::TriggerFired {
+            workflow_id: workflow.id.clone(),
+            trigger_kind: trigger_kind.to_string(),
+            payload,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+        timestamp: now,
+    };
+    let data = match serde_json::to_value(&envelope) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("failed to serialize trigger.fired: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+    };
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+    };
+    state
+        .spine
+        .append_ext(
+            &workflow.workspace_id,
+            &format!("workflow:{}", workflow.id),
+            "workflow",
+            "trigger.fired",
+            data,
+            &metadata,
+            None,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("failed to emit trigger.fired: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })
+}
+
+async fn emit_audit(
+    state: &AppState,
+    workflow: &WorkflowRow,
+    event_subtype: &str,
+    detail: Value,
+    actor: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<(), Response> {
+    let payload = serde_json::json!({
+        "workflow_id": workflow.id,
+        "workspace_id": workflow.workspace_id,
+        "actor": actor,
+        "event_subtype": event_subtype,
+        "fired_at": now,
+        "detail": detail,
+    });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: actor.to_string(),
+    };
+    state
+        .spine
+        .append_ext(
+            &workflow.workspace_id,
+            &format!("audit:workflow:{}", workflow.id),
+            "audit",
+            "workflow.manual_triggered",
+            payload,
+            &metadata,
+            None,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("failed to emit workflow.manual_triggered: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })?;
+    Ok(())
+}

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -22,8 +22,9 @@ use serde_json::Value;
 
 use onsager_github::webhook::{verify_signature, SignatureCheck};
 use onsager_spine::webhook_routing::{
-    route_check_event, route_issues_labeled, route_pull_request_closed, spine_namespace,
-    RoutedEvent,
+    route_check_event, route_issues_labeled, route_pull_request_closed,
+    route_pull_request_closed_workflows, route_workflow_run_completed_workflows, spine_namespace,
+    RoutedEvent, WorkflowTrigger,
 };
 
 use crate::handlers::{issues, pull_request};
@@ -236,7 +237,100 @@ async fn route_workflow_events(
         "check_suite" | "check_run" | "status" => {
             route_check_event(event, payload).into_iter().collect()
         }
-        "pull_request" => route_pull_request_closed(payload).into_iter().collect(),
+        "pull_request" => {
+            // Gate-side `manual_approval_signal` is unconditional on a
+            // `closed+merged` delivery (legacy issue-#118 behaviour).
+            // The new `github_pull_request_closed` workflow trigger
+            // (#240) fans out separately and respects per-workflow
+            // filters (e.g. only-merged).
+            let mut events: Vec<RoutedEvent> =
+                route_pull_request_closed(payload).into_iter().collect();
+            let repo_owner = payload
+                .pointer("/repository/owner/login")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let repo_name = payload
+                .pointer("/repository/name")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if !repo_owner.is_empty() && !repo_name.is_empty() {
+                let candidates =
+                    match crate::workflow_db::find_active_pull_request_closed_workflows(
+                        &state.pool,
+                        repo_owner,
+                        repo_name,
+                    )
+                    .await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!(
+                                repo_owner,
+                                repo_name,
+                                error = %e,
+                                "failed to query active pull-request-closed workflows"
+                            );
+                            Vec::new()
+                        }
+                    };
+                let triggers: Vec<WorkflowTrigger> = candidates
+                    .into_iter()
+                    .map(|w| WorkflowTrigger {
+                        id: w.id,
+                        workspace_id: w.workspace_id,
+                        trigger: w.trigger,
+                    })
+                    .collect();
+                events.extend(route_pull_request_closed_workflows(payload, &triggers));
+            }
+            events
+        }
+        "workflow_run" => {
+            let repo_owner = payload
+                .pointer("/repository/owner/login")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let repo_name = payload
+                .pointer("/repository/name")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let workflow_name = payload
+                .pointer("/workflow_run/name")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if repo_owner.is_empty() || repo_name.is_empty() || workflow_name.is_empty() {
+                return Vec::new();
+            }
+            let candidates = match crate::workflow_db::find_active_workflow_run_completed_workflows(
+                &state.pool,
+                repo_owner,
+                repo_name,
+                workflow_name,
+            )
+            .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(
+                        repo_owner,
+                        repo_name,
+                        workflow_name,
+                        error = %e,
+                        "failed to query active workflow-run-completed workflows"
+                    );
+                    return Vec::new();
+                }
+            };
+            let triggers: Vec<WorkflowTrigger> = candidates
+                .into_iter()
+                .map(|w| WorkflowTrigger {
+                    id: w.id,
+                    workspace_id: w.workspace_id,
+                    trigger: w.trigger,
+                })
+                .collect();
+            route_workflow_run_completed_workflows(payload, &triggers)
+        }
         _ => Vec::new(),
     }
 }

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -14,6 +14,7 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Run the webhook server.
     Serve {
@@ -67,6 +68,12 @@ enum Command {
         /// Use this flag for explicit opt-in outside Railway.
         #[arg(long, env = "DEV_LOGIN_ENABLED", default_value_t = false)]
         dev_login_enabled: bool,
+        /// Shared secret echoed back by Telegram in the
+        /// `X-Telegram-Bot-Api-Secret-Token` header on every webhook
+        /// delivery. When unset the `/webhooks/telegram` route returns
+        /// 503. (#240 Category 3)
+        #[arg(long, env = "TELEGRAM_WEBHOOK_SECRET")]
+        telegram_webhook_secret: Option<String>,
     },
     /// Backfill issues + PRs for an existing project.
     Backfill {
@@ -112,6 +119,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             sso_return_host_allowlist,
             sso_auth_domain,
             dev_login_enabled,
+            telegram_webhook_secret,
         } => {
             let allowlist = sso_return_host_allowlist
                 .as_deref()
@@ -146,6 +154,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     .filter(|s| !s.is_empty())
                     .map(|s| s.trim_end_matches('/').to_string()),
                 dev_login_enabled: dev_login_enabled || is_railway_preview,
+                telegram_webhook_secret: telegram_webhook_secret.filter(|s| !s.is_empty()),
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -13,9 +13,9 @@ use crate::handlers::{
     live_data as live_data_handlers, nodes as node_handlers, pats as pat_handlers,
     projects as project_handlers, registry_events as registry_event_handlers,
     registry_triggers as registry_trigger_handlers, sessions as session_handlers,
-    spine as spine_handlers, tasks as task_handlers, webhook,
-    workflow_kinds as workflow_kind_handlers, workflows as workflow_handlers,
-    workspaces as workspace_handlers,
+    spine as spine_handlers, tasks as task_handlers, telegram_webhook,
+    triggers as trigger_handlers, webhook, workflow_kinds as workflow_kind_handlers,
+    workflows as workflow_handlers, workspaces as workspace_handlers,
 };
 use crate::proxy_cache::ProxyCache;
 use crate::state::AppState;
@@ -292,7 +292,26 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             get(session_handlers::session_logs),
         )
         .route("/api/nodes", get(node_handlers::list_nodes))
-        .route("/api/tasks", post(task_handlers::create_task));
+        .route("/api/tasks", post(task_handlers::create_task))
+        // Manual / replay trigger endpoints (#241 — Category 4 of the
+        // trigger taxonomy umbrella #236). UI button click and
+        // workflow replays land here; the CLI surface is the
+        // standalone `onsager-trigger` binary which writes events
+        // directly to the spine without portal in the loop.
+        .route(
+            "/api/workflows/{id}/triggers/manual/{name}",
+            post(trigger_handlers::fire_manual),
+        )
+        .route(
+            "/api/workflows/{id}/triggers/replay/{source_event_id}",
+            post(trigger_handlers::replay),
+        )
+        // Telegram bot webhook ingress (#240 — Category 3 of the
+        // trigger taxonomy umbrella #236). Verifies the
+        // X-Telegram-Bot-Api-Secret-Token header against
+        // `TELEGRAM_WEBHOOK_SECRET`, then routes the update to active
+        // `TelegramWebhook` workflows.
+        .route("/webhooks/telegram", post(telegram_webhook::handle));
 
     // Dev-login: always in debug builds; in release only when
     // DEV_LOGIN_ENABLED=true (Railway preview environments).

--- a/crates/onsager-portal/src/workflow.rs
+++ b/crates/onsager-portal/src/workflow.rs
@@ -111,4 +111,16 @@ impl Workflow {
             _ => None,
         }
     }
+
+    /// `(repo_owner, repo_name)` extracted from the trigger config for any
+    /// GitHub-shaped webhook trigger (issues, PR-closed, workflow-run-completed).
+    /// Returns `None` for non-GitHub kinds.
+    pub fn github_repo_any(&self) -> Option<(&str, &str)> {
+        match &self.trigger {
+            TriggerKind::GithubIssueWebhook { repo, .. }
+            | TriggerKind::GithubPullRequestClosed { repo, .. }
+            | TriggerKind::GithubWorkflowRunCompleted { repo, .. } => repo.split_once('/'),
+            _ => None,
+        }
+    }
 }

--- a/crates/onsager-portal/src/workflow_db.rs
+++ b/crates/onsager-portal/src/workflow_db.rs
@@ -343,6 +343,72 @@ pub async fn find_active_github_workflows_for_workspace_repo(
     rows.into_iter().map(row_to_workflow).collect()
 }
 
+/// All active `github_pull_request_closed` workflows on `(repo_owner,
+/// repo_name)`. Used by the GitHub webhook handler to fan out a single
+/// `pull_request.closed` delivery to every subscriber.
+pub async fn find_active_pull_request_closed_workflows(
+    pool: &PgPool,
+    repo_owner: &str,
+    repo_name: &str,
+) -> anyhow::Result<Vec<Workflow>> {
+    let repo = format!("{repo_owner}/{repo_name}");
+    let rows = sqlx::query(
+        "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
+                workspace_id, install_id, created_by, created_at, updated_at \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'github_pull_request_closed' \
+            AND trigger_config ->> 'repo' = $1",
+    )
+    .bind(&repo)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(row_to_workflow).collect()
+}
+
+/// All active `github_workflow_run_completed` workflows on `(repo_owner,
+/// repo_name, workflow_name)`.
+pub async fn find_active_workflow_run_completed_workflows(
+    pool: &PgPool,
+    repo_owner: &str,
+    repo_name: &str,
+    workflow_name: &str,
+) -> anyhow::Result<Vec<Workflow>> {
+    let repo = format!("{repo_owner}/{repo_name}");
+    let rows = sqlx::query(
+        "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
+                workspace_id, install_id, created_by, created_at, updated_at \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'github_workflow_run_completed' \
+            AND trigger_config ->> 'repo' = $1 \
+            AND trigger_config ->> 'workflow_name' = $2",
+    )
+    .bind(&repo)
+    .bind(workflow_name)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(row_to_workflow).collect()
+}
+
+/// All active `telegram_webhook` workflows. The Telegram webhook
+/// receiver lacks a per-installation discriminator (Telegram identifies
+/// the bot via the secret-token header rather than a payload field) so
+/// the receiver loads every active row and filters in-memory by
+/// `bot_username` / `chat_id_allowlist` / `command_prefix`.
+pub async fn list_active_telegram_workflows(pool: &PgPool) -> anyhow::Result<Vec<Workflow>> {
+    let rows = sqlx::query(
+        "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
+                workspace_id, install_id, created_by, created_at, updated_at \
+           FROM workflows \
+          WHERE active = TRUE \
+            AND trigger_kind = 'telegram_webhook'",
+    )
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter().map(row_to_workflow).collect()
+}
+
 /// Whether any other active workflow on `(repo_owner, repo_name)` still
 /// needs webhook delivery. Used by the deactivation hook to decide if it
 /// can deregister the repo-level webhook.

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -588,12 +588,28 @@ pub const EVENTS: EventManifest = EventManifest {
             // - Forge event-trigger listeners (#239 — spine_event /
             //   pg_notify / outbox_row).
             // - Portal — live GitHub `issues.labeled` webhook receiver
-            //   (#222 Slice 1) plus the future `onsager trigger fire` CLI
-            //   / "Run now" UI button (#241).
+            //   (#222 Slice 1), GitHub `pull_request.closed` /
+            //   `workflow_run.completed` / Telegram receivers (#240),
+            //   the `onsager trigger fire` CLI and the dashboard
+            //   "Run now" / replay endpoints (#241).
             producers: &[Subsystem::Stiglab, Subsystem::Forge, Subsystem::Portal],
             consumers: &[Subsystem::Forge],
             audit_only: false,
             description: "A trigger fired (webhook / schedule / event / manual).",
+        },
+        EventDefinition {
+            kind: "workflow.manual_triggered",
+            schema_version: 1,
+            // Producers: portal (UI button + replay endpoint) and the
+            // `onsager-trigger` CLI which writes events directly to the
+            // spine — both surfaces emit alongside the underlying
+            // `trigger.fired` event so audit views can attribute manual /
+            // replay fires to a user (#241).
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            audit_only: true,
+            description:
+                "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
         },
         EventDefinition {
             kind: "stage.entered",

--- a/crates/onsager-registry/src/triggers.rs
+++ b/crates/onsager-registry/src/triggers.rs
@@ -66,6 +66,13 @@ pub enum TriggerCategory {
 pub enum TriggerUiKind {
     /// Webhook receivers (the existing GitHub-issue form).
     Webhook,
+    /// GitHub `pull_request.closed` form (repo + merged predicate).
+    GithubPullRequestClosed,
+    /// GitHub `workflow_run.completed` form (repo + workflow + filters).
+    GithubWorkflowRunCompleted,
+    /// Telegram bot webhook form (bot username + chat allowlist +
+    /// optional command prefix).
+    TelegramWebhook,
     /// Cron-expression input with a human-readable preview.
     Cron,
     /// Single-shot delay (seconds + anchor selector).
@@ -121,15 +128,40 @@ pub const TRIGGERS: TriggerManifest = TriggerManifest {
     triggers: &[
         TriggerDefinition {
             kind_tag: "github_issue_webhook",
-            producer: Subsystem::Stiglab,
-            // Category 3 per #236 — webhooks are external HTTP requests,
-            // not internal event-bus signals. Putting them in `Event`
-            // would force `check-triggers` to allow Stiglab as an Event
-            // producer, weakening enforcement for true event triggers
-            // like `spine_event`.
+            // Producer is portal — `/webhooks/github` lives there since
+            // #222 Slice 1 (PR #248); stiglab no longer hosts the
+            // receiver. Keeping the row in `Request` matches #236's
+            // category split (webhooks are external HTTP requests, not
+            // internal event-bus signals).
+            producer: Subsystem::Portal,
             category: TriggerCategory::Request,
             ui_kind: TriggerUiKind::Webhook,
             description: "Fires when a GitHub issue is labeled with the configured label.",
+        },
+        // -- External request (#240) ---------------------------------------
+        TriggerDefinition {
+            kind_tag: "github_pull_request_closed",
+            producer: Subsystem::Portal,
+            category: TriggerCategory::Request,
+            ui_kind: TriggerUiKind::GithubPullRequestClosed,
+            description:
+                "Fires when a GitHub pull request closes; optional `merged` predicate.",
+        },
+        TriggerDefinition {
+            kind_tag: "github_workflow_run_completed",
+            producer: Subsystem::Portal,
+            category: TriggerCategory::Request,
+            ui_kind: TriggerUiKind::GithubWorkflowRunCompleted,
+            description:
+                "Fires when a GitHub Actions workflow run completes; filter by name / event / branch / conclusion.",
+        },
+        TriggerDefinition {
+            kind_tag: "telegram_webhook",
+            producer: Subsystem::Portal,
+            category: TriggerCategory::Request,
+            ui_kind: TriggerUiKind::TelegramWebhook,
+            description:
+                "Fires on a Telegram bot webhook; optional chat-id allowlist + command prefix.",
         },
         // -- Schedule (#238) -----------------------------------------------
         TriggerDefinition {
@@ -202,6 +234,10 @@ mod tests {
         let kinds: Vec<&str> = TRIGGERS.triggers.iter().map(|t| t.kind_tag).collect();
         // Foundation kinds.
         assert!(kinds.contains(&"github_issue_webhook"));
+        // External request (#240).
+        assert!(kinds.contains(&"github_pull_request_closed"));
+        assert!(kinds.contains(&"github_workflow_run_completed"));
+        assert!(kinds.contains(&"telegram_webhook"));
         // Schedule (#238).
         assert!(kinds.contains(&"cron"));
         assert!(kinds.contains(&"delay"));
@@ -234,10 +270,18 @@ mod tests {
             assert_eq!(TRIGGERS.lookup(k).unwrap().category, TriggerCategory::Event);
         }
         // Request kinds — external HTTP webhooks.
-        assert_eq!(
-            TRIGGERS.lookup("github_issue_webhook").unwrap().category,
-            TriggerCategory::Request
-        );
+        for k in [
+            "github_issue_webhook",
+            "github_pull_request_closed",
+            "github_workflow_run_completed",
+            "telegram_webhook",
+        ] {
+            assert_eq!(
+                TRIGGERS.lookup(k).unwrap().category,
+                TriggerCategory::Request,
+                "expected {k} to be in Request category"
+            );
+        }
         // Manual kinds.
         for k in ["manual", "replay"] {
             assert_eq!(
@@ -250,7 +294,7 @@ mod tests {
     #[test]
     fn lookup_returns_known_entry() {
         let entry = TRIGGERS.lookup("github_issue_webhook").unwrap();
-        assert_eq!(entry.producer, Subsystem::Stiglab);
+        assert_eq!(entry.producer, Subsystem::Portal);
         assert_eq!(entry.category, TriggerCategory::Request);
         assert_eq!(entry.ui_kind, TriggerUiKind::Webhook);
     }
@@ -267,7 +311,7 @@ mod tests {
         assert_eq!(triggers.len(), TRIGGERS.triggers.len());
         let first = &triggers[0];
         assert_eq!(first["kind_tag"], "github_issue_webhook");
-        assert_eq!(first["producer"], "stiglab");
+        assert_eq!(first["producer"], "portal");
         assert_eq!(first["category"], "request");
         assert_eq!(first["ui_kind"], "webhook");
         assert!(first["description"].as_str().is_some());

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -580,6 +580,20 @@ pub enum FactoryEventKind {
         payload: serde_json::Value,
     },
 
+    /// Audit record for a manual / CLI / replay trigger fire (#241).
+    /// Emitted alongside the underlying `TriggerFired` so audit views
+    /// can attribute fires to a user. `event_subtype` distinguishes
+    /// surfaces (`"ui_fire"`, `"ui_replay"`, `"cli_fire"`,
+    /// `"cli_replay"`); `detail` carries source-specific fields
+    /// (manual name, source event id).
+    WorkflowManualTriggered {
+        workflow_id: String,
+        workspace_id: String,
+        actor: String,
+        event_subtype: String,
+        detail: serde_json::Value,
+    },
+
     /// A workflow-tagged artifact entered a new stage.
     StageEntered {
         artifact_id: ArtifactId,
@@ -771,6 +785,7 @@ impl FactoryEventKind {
             Self::RefractDecomposed { .. } => "refract.decomposed",
             Self::RefractFailed { .. } => "refract.failed",
             Self::TriggerFired { .. } => "trigger.fired",
+            Self::WorkflowManualTriggered { .. } => "workflow.manual_triggered",
             Self::StageEntered { .. } => "stage.entered",
             Self::StageGatePassed { .. } => "stage.gate_passed",
             Self::StageGateFailed { .. } => "stage.gate_failed",
@@ -855,6 +870,10 @@ impl FactoryEventKind {
             | Self::StageGatePassed { .. }
             | Self::StageGateFailed { .. }
             | Self::StageAdvanced { .. } => "workflow",
+            // Audit-only fan-out for manual fires (#241). Lives in the
+            // `audit` namespace so audit views can filter without
+            // mixing with first-class workflow runtime events.
+            Self::WorkflowManualTriggered { .. } => "audit",
             Self::TypeProposed { .. }
             | Self::TypeApproved { .. }
             | Self::TypeDeprecated { .. }
@@ -933,6 +952,9 @@ impl FactoryEventKind {
             | Self::RefractDecomposed { intent_id, .. }
             | Self::RefractFailed { intent_id, .. } => intent_id.clone(),
             Self::TriggerFired { workflow_id, .. } => format!("workflow:{workflow_id}"),
+            Self::WorkflowManualTriggered { workflow_id, .. } => {
+                format!("audit:workflow:{workflow_id}")
+            }
             Self::StageEntered { artifact_id, .. }
             | Self::StageGatePassed { artifact_id, .. }
             | Self::StageGateFailed { artifact_id, .. }

--- a/crates/onsager-spine/src/trigger.rs
+++ b/crates/onsager-spine/src/trigger.rs
@@ -32,6 +32,49 @@ pub enum TriggerKind {
     /// `repo` is the `"owner/name"` slug.
     GithubIssueWebhook { repo: String, label: String },
 
+    // -- External request (#240) -------------------------------------------
+    /// A GitHub `pull_request.closed` webhook whose `merged` flag matches
+    /// `predicate.merged` (when set). `repo` is the `"owner/name"` slug.
+    /// `predicate` is optional — an absent predicate matches every closed
+    /// PR; the common case sets `merged: true` to fire only on merges.
+    GithubPullRequestClosed {
+        repo: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        predicate: Option<PullRequestClosedPredicate>,
+    },
+
+    /// A GitHub `workflow_run.completed` webhook. `repo` is the
+    /// `"owner/name"` slug; `workflow_name` matches against the run's
+    /// `workflow_run.name` field. Optional filters narrow further by
+    /// the run's `event`, `head_branch`, and `conclusion`.
+    GithubWorkflowRunCompleted {
+        repo: String,
+        workflow_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        event: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        head_branch: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        conclusion: Option<String>,
+    },
+
+    /// A Telegram bot webhook. `bot_username` matches against the bot
+    /// the update was delivered to (Telegram identifies the bot via the
+    /// secret-token header we register at `setWebhook` time, but the
+    /// bot username carries through the payload for human review).
+    /// `chat_id_allowlist`, when non-empty, restricts firing to updates
+    /// whose `chat.id` matches one of the listed values; an empty list
+    /// matches every chat the bot can see. `command_prefix`, when set,
+    /// matches against the `text`/`message.text` field — typical use
+    /// is `/onsager`.
+    TelegramWebhook {
+        bot_username: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        chat_id_allowlist: Vec<i64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        command_prefix: Option<String>,
+    },
+
     // -- Schedule (#238) ----------------------------------------------------
     /// Fire on a cron schedule. `expression` is a 5- or 6-field cron string
     /// (minute, hour, day-of-month, month, day-of-week, optional seconds).
@@ -97,6 +140,17 @@ pub enum TriggerKind {
     Replay { source_event_id: String },
 }
 
+/// Predicate for [`TriggerKind::GithubPullRequestClosed`]. Today the only
+/// predicate is `merged` — a `Some(true)` match fires only on merges,
+/// `Some(false)` fires only on closed-without-merge, and `None` fires on
+/// every close. Future fields (e.g. `base_branch`, `labels`) extend with
+/// `serde(default)` so existing rows keep parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PullRequestClosedPredicate {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merged: Option<bool>,
+}
+
 /// Anchor for [`TriggerKind::Delay`]. v1 only supports
 /// `WorkflowActivatedAt` (delay measured from the workflow row's
 /// `created_at` / `last_fired_at` baseline). Future variants:
@@ -159,6 +213,9 @@ impl TriggerKind {
     pub const fn kind_tag(&self) -> &'static str {
         match self {
             TriggerKind::GithubIssueWebhook { .. } => "github_issue_webhook",
+            TriggerKind::GithubPullRequestClosed { .. } => "github_pull_request_closed",
+            TriggerKind::GithubWorkflowRunCompleted { .. } => "github_workflow_run_completed",
+            TriggerKind::TelegramWebhook { .. } => "telegram_webhook",
             TriggerKind::Cron { .. } => "cron",
             TriggerKind::Delay { .. } => "delay",
             TriggerKind::Interval { .. } => "interval",
@@ -242,6 +299,9 @@ impl TriggerKind {
 fn static_kind_tag(kind_tag: &str) -> Option<&'static str> {
     match kind_tag {
         "github_issue_webhook" => Some("github_issue_webhook"),
+        "github_pull_request_closed" => Some("github_pull_request_closed"),
+        "github_workflow_run_completed" => Some("github_workflow_run_completed"),
+        "telegram_webhook" => Some("telegram_webhook"),
         "cron" => Some("cron"),
         "delay" => Some("delay"),
         "interval" => Some("interval"),
@@ -328,6 +388,90 @@ mod tests {
         let (kind, cfg) = original.to_storage();
         let back = TriggerKind::from_storage(kind, &cfg).unwrap();
         assert_eq!(back, original);
+    }
+
+    // -- External-request variants (#240) ----------------------------------
+
+    #[test]
+    fn github_pull_request_closed_round_trips() {
+        let t = TriggerKind::GithubPullRequestClosed {
+            repo: "acme/widgets".into(),
+            predicate: Some(PullRequestClosedPredicate { merged: Some(true) }),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "github_pull_request_closed");
+        assert_eq!(cfg["repo"], "acme/widgets");
+        assert_eq!(cfg["predicate"]["merged"], true);
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn github_pull_request_closed_predicate_optional() {
+        let t = TriggerKind::GithubPullRequestClosed {
+            repo: "acme/widgets".into(),
+            predicate: None,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert!(cfg.get("predicate").is_none());
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn github_workflow_run_completed_round_trips() {
+        let t = TriggerKind::GithubWorkflowRunCompleted {
+            repo: "acme/widgets".into(),
+            workflow_name: "rust".into(),
+            event: Some("push".into()),
+            head_branch: Some("main".into()),
+            conclusion: Some("success".into()),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "github_workflow_run_completed");
+        assert_eq!(cfg["workflow_name"], "rust");
+        assert_eq!(cfg["head_branch"], "main");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn github_workflow_run_completed_filters_optional() {
+        let t = TriggerKind::GithubWorkflowRunCompleted {
+            repo: "acme/widgets".into(),
+            workflow_name: "rust".into(),
+            event: None,
+            head_branch: None,
+            conclusion: None,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert!(cfg.get("event").is_none());
+        assert!(cfg.get("head_branch").is_none());
+        assert!(cfg.get("conclusion").is_none());
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn telegram_webhook_round_trips() {
+        let t = TriggerKind::TelegramWebhook {
+            bot_username: "onsager_bot".into(),
+            chat_id_allowlist: vec![1234, 5678],
+            command_prefix: Some("/onsager".into()),
+        };
+        let (kind, cfg) = t.to_storage();
+        assert_eq!(kind, "telegram_webhook");
+        assert_eq!(cfg["bot_username"], "onsager_bot");
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
+    }
+
+    #[test]
+    fn telegram_webhook_chat_allowlist_optional() {
+        let t = TriggerKind::TelegramWebhook {
+            bot_username: "onsager_bot".into(),
+            chat_id_allowlist: vec![],
+            command_prefix: None,
+        };
+        let (kind, cfg) = t.to_storage();
+        assert!(cfg.get("chat_id_allowlist").is_none());
+        assert!(cfg.get("command_prefix").is_none());
+        assert_eq!(TriggerKind::from_storage(kind, &cfg).unwrap(), t);
     }
 
     // -- Schedule variants (#238) ------------------------------------------

--- a/crates/onsager-spine/src/webhook_routing.rs
+++ b/crates/onsager-spine/src/webhook_routing.rs
@@ -22,6 +22,7 @@
 use serde_json::Value;
 
 use crate::factory_event::FactoryEventKind;
+use crate::trigger::TriggerKind;
 
 /// A single spine event the webhook handler should emit.
 #[derive(Debug, Clone, PartialEq)]
@@ -217,6 +218,179 @@ pub fn route_check_event(event: &str, payload: &Value) -> Option<RoutedEvent> {
             conclusion,
         },
     })
+}
+
+/// Per-workflow `pull_request.closed` routing (#240). For each matching
+/// workflow whose trigger config matches the delivered payload, emit one
+/// `workflow.trigger_fired` event. `matched` is the slice of candidate
+/// workflows on `(repo_owner, repo_name)` — the routing function applies
+/// the per-workflow `predicate.merged` filter against the delivered
+/// `merged` flag and drops non-matches.
+pub fn route_pull_request_closed_workflows(
+    payload: &Value,
+    matched: &[WorkflowTrigger],
+) -> Vec<RoutedEvent> {
+    if payload.get("action").and_then(Value::as_str) != Some("closed") {
+        return Vec::new();
+    }
+    let Some(pr) = payload.get("pull_request") else {
+        return Vec::new();
+    };
+    let merged = pr.get("merged").and_then(Value::as_bool).unwrap_or(false);
+    let pr_number = pr.get("number").and_then(Value::as_u64).unwrap_or(0);
+    let title = pr.get("title").and_then(Value::as_str).unwrap_or("");
+    let head_branch = pr
+        .pointer("/head/ref")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let base_branch = pr
+        .pointer("/base/ref")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let Some(repo) = payload.get("repository") else {
+        return Vec::new();
+    };
+    let repo_owner = repo
+        .pointer("/owner/login")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let repo_name = repo.get("name").and_then(Value::as_str).unwrap_or("");
+
+    matched
+        .iter()
+        .filter(|w| match &w.trigger {
+            TriggerKind::GithubPullRequestClosed { predicate, .. } => match predicate {
+                Some(p) => match p.merged {
+                    Some(want) => want == merged,
+                    None => true,
+                },
+                None => true,
+            },
+            _ => false,
+        })
+        .map(|w| {
+            let payload = serde_json::json!({
+                "repo_owner": repo_owner,
+                "repo_name": repo_name,
+                "pr_number": pr_number,
+                "title": title,
+                "head_branch": head_branch,
+                "base_branch": base_branch,
+                "merged": merged,
+                "workspace_id": w.workspace_id,
+                "source": trigger_source::WEBHOOK,
+                "trigger_kind": "github_pull_request_closed",
+            });
+            RoutedEvent {
+                kind: FactoryEventKind::TriggerFired {
+                    workflow_id: w.id.clone(),
+                    trigger_kind: "github_pull_request_closed".to_string(),
+                    payload,
+                },
+            }
+        })
+        .collect()
+}
+
+/// Per-workflow `workflow_run.completed` routing (#240). The filter
+/// `name == workflow_name` is performed by the SQL caller; this function
+/// applies the optional in-trigger filters (`event`, `head_branch`,
+/// `conclusion`) and drops non-matches.
+pub fn route_workflow_run_completed_workflows(
+    payload: &Value,
+    matched: &[WorkflowTrigger],
+) -> Vec<RoutedEvent> {
+    if payload.get("action").and_then(Value::as_str) != Some("completed") {
+        return Vec::new();
+    }
+    let Some(run) = payload.get("workflow_run") else {
+        return Vec::new();
+    };
+    let run_event = run.get("event").and_then(Value::as_str).unwrap_or("");
+    let head_branch = run.get("head_branch").and_then(Value::as_str).unwrap_or("");
+    let conclusion = run.get("conclusion").and_then(Value::as_str).unwrap_or("");
+    let run_name = run.get("name").and_then(Value::as_str).unwrap_or("");
+    let run_id = run.get("id").and_then(Value::as_i64).unwrap_or(0);
+    let head_sha = run.get("head_sha").and_then(Value::as_str).unwrap_or("");
+    let html_url = run.get("html_url").and_then(Value::as_str).unwrap_or("");
+    let Some(repo) = payload.get("repository") else {
+        return Vec::new();
+    };
+    let repo_owner = repo
+        .pointer("/owner/login")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let repo_name = repo.get("name").and_then(Value::as_str).unwrap_or("");
+
+    matched
+        .iter()
+        .filter(|w| match &w.trigger {
+            TriggerKind::GithubWorkflowRunCompleted {
+                workflow_name,
+                event,
+                head_branch: hb,
+                conclusion: cc,
+                ..
+            } => {
+                if workflow_name != run_name {
+                    return false;
+                }
+                if let Some(filter) = event {
+                    if filter != run_event {
+                        return false;
+                    }
+                }
+                if let Some(filter) = hb {
+                    if filter != head_branch {
+                        return false;
+                    }
+                }
+                if let Some(filter) = cc {
+                    if filter != conclusion {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => false,
+        })
+        .map(|w| {
+            let payload = serde_json::json!({
+                "repo_owner": repo_owner,
+                "repo_name": repo_name,
+                "workflow_name": run_name,
+                "event": run_event,
+                "head_branch": head_branch,
+                "head_sha": head_sha,
+                "conclusion": conclusion,
+                "run_id": run_id,
+                "html_url": html_url,
+                "workspace_id": w.workspace_id,
+                "source": trigger_source::WEBHOOK,
+                "trigger_kind": "github_workflow_run_completed",
+            });
+            RoutedEvent {
+                kind: FactoryEventKind::TriggerFired {
+                    workflow_id: w.id.clone(),
+                    trigger_kind: "github_workflow_run_completed".to_string(),
+                    payload,
+                },
+            }
+        })
+        .collect()
+}
+
+/// Workflow row projection used by the multi-workflow webhook routers
+/// (`route_pull_request_closed_workflows`,
+/// `route_workflow_run_completed_workflows`). Carries the full
+/// per-workflow `TriggerKind` so the routers can apply per-workflow
+/// filters (e.g. `predicate.merged`, `head_branch`) without round-
+/// tripping through string lookups.
+#[derive(Debug, Clone)]
+pub struct WorkflowTrigger {
+    pub id: String,
+    pub workspace_id: String,
+    pub trigger: TriggerKind,
 }
 
 /// Inspect a `pull_request` payload; when it's `closed` with `merged=true`
@@ -473,5 +647,182 @@ mod tests {
             "repository": {"name": "widgets", "owner": {"login": "acme"}},
         });
         assert!(route_pull_request_closed(&payload).is_none());
+    }
+
+    // -- #240 multi-workflow routers ---------------------------------------
+
+    fn pr_workflow(merged: Option<bool>) -> WorkflowTrigger {
+        WorkflowTrigger {
+            id: "wf_pr".to_string(),
+            workspace_id: "w1".to_string(),
+            trigger: TriggerKind::GithubPullRequestClosed {
+                repo: "acme/widgets".into(),
+                predicate: merged
+                    .map(|m| crate::trigger::PullRequestClosedPredicate { merged: Some(m) }),
+            },
+        }
+    }
+
+    #[test]
+    fn pr_closed_workflows_emits_when_merged_predicate_matches() {
+        let payload = json!({
+            "action": "closed",
+            "pull_request": {
+                "number": 42,
+                "merged": true,
+                "title": "fix the bug",
+                "head": {"ref": "feature"},
+                "base": {"ref": "main"},
+            },
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![pr_workflow(Some(true))];
+        let out = route_pull_request_closed_workflows(&payload, &workflows);
+        assert_eq!(out.len(), 1);
+        match &out[0].kind {
+            FactoryEventKind::TriggerFired { payload, .. } => {
+                assert_eq!(payload["pr_number"], 42);
+                assert_eq!(payload["merged"], true);
+                assert_eq!(payload["head_branch"], "feature");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn pr_closed_workflows_skips_when_predicate_misses() {
+        let payload = json!({
+            "action": "closed",
+            "pull_request": {"number": 1, "merged": false, "title": "x"},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![pr_workflow(Some(true))];
+        assert!(route_pull_request_closed_workflows(&payload, &workflows).is_empty());
+    }
+
+    #[test]
+    fn pr_closed_workflows_no_predicate_fires_on_unmerged() {
+        let payload = json!({
+            "action": "closed",
+            "pull_request": {"number": 1, "merged": false, "title": "x"},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![pr_workflow(None)];
+        assert_eq!(
+            route_pull_request_closed_workflows(&payload, &workflows).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn pr_closed_workflows_ignores_non_closed_action() {
+        let payload = json!({
+            "action": "opened",
+            "pull_request": {"number": 1, "merged": false},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        assert!(
+            route_pull_request_closed_workflows(&payload, &[pr_workflow(Some(true))]).is_empty()
+        );
+    }
+
+    fn run_workflow(
+        name: &str,
+        event: Option<&str>,
+        head_branch: Option<&str>,
+        conclusion: Option<&str>,
+    ) -> WorkflowTrigger {
+        WorkflowTrigger {
+            id: "wf_run".to_string(),
+            workspace_id: "w1".to_string(),
+            trigger: TriggerKind::GithubWorkflowRunCompleted {
+                repo: "acme/widgets".into(),
+                workflow_name: name.into(),
+                event: event.map(String::from),
+                head_branch: head_branch.map(String::from),
+                conclusion: conclusion.map(String::from),
+            },
+        }
+    }
+
+    #[test]
+    fn workflow_run_completed_emits_when_filters_match() {
+        let payload = json!({
+            "action": "completed",
+            "workflow_run": {
+                "id": 9001,
+                "name": "rust",
+                "event": "push",
+                "head_branch": "main",
+                "head_sha": "abc",
+                "conclusion": "success",
+                "html_url": "https://github.com/acme/widgets/actions/runs/9001",
+            },
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![run_workflow(
+            "rust",
+            Some("push"),
+            Some("main"),
+            Some("success"),
+        )];
+        let out = route_workflow_run_completed_workflows(&payload, &workflows);
+        assert_eq!(out.len(), 1);
+        match &out[0].kind {
+            FactoryEventKind::TriggerFired { payload, .. } => {
+                assert_eq!(payload["run_id"], 9001);
+                assert_eq!(payload["workflow_name"], "rust");
+                assert_eq!(payload["conclusion"], "success");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn workflow_run_completed_skips_when_filter_misses() {
+        let payload = json!({
+            "action": "completed",
+            "workflow_run": {
+                "id": 1,
+                "name": "rust",
+                "event": "pull_request",
+                "head_branch": "main",
+                "conclusion": "success",
+            },
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![run_workflow("rust", Some("push"), None, None)];
+        assert!(route_workflow_run_completed_workflows(&payload, &workflows).is_empty());
+    }
+
+    #[test]
+    fn workflow_run_completed_ignores_wrong_workflow_name() {
+        let payload = json!({
+            "action": "completed",
+            "workflow_run": {
+                "id": 1,
+                "name": "frontend",
+                "event": "push",
+                "head_branch": "main",
+                "conclusion": "success",
+            },
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![run_workflow("rust", None, None, None)];
+        assert!(route_workflow_run_completed_workflows(&payload, &workflows).is_empty());
+    }
+
+    #[test]
+    fn workflow_run_completed_ignores_in_progress_action() {
+        let payload = json!({
+            "action": "in_progress",
+            "workflow_run": {"id": 1, "name": "rust", "event": "push"},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        assert!(route_workflow_run_completed_workflows(
+            &payload,
+            &[run_workflow("rust", None, None, None)]
+        )
+        .is_empty());
     }
 }

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -288,6 +288,7 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::RefractDecomposed { .. }
         | FactoryEventKind::RefractFailed { .. }
         | FactoryEventKind::TriggerFired { .. }
+        | FactoryEventKind::WorkflowManualTriggered { .. }
         | FactoryEventKind::TypeProposed { .. }
         | FactoryEventKind::TypeApproved { .. }
         | FactoryEventKind::TypeDeprecated { .. }

--- a/docs/events.md
+++ b/docs/events.md
@@ -64,6 +64,7 @@ that requires a coordinated rollout.
 | `ising` | ising | 6 |
 | `refract` | refract | 3 |
 | `workflow` | stiglab (trigger) / forge (stage) | 5 |
+| `audit` | (unknown — update `stream_producer` in xtask) | 1 |
 | `registry` | synodic (catalog crud) | 9 |
 | `gate` | onsager-portal (GitHub) / forge (manual) | 2 |
 
@@ -950,6 +951,25 @@ All gates on a stage resolved and the artifact advanced to the next stage (or re
 | `workflow_id` | `String` |  |
 | `from_stage_index` | `u32` |  |
 | `to_stage_index` | `Option<u32>` | `None` when the artifact has just completed the final stage. _(optional)_ |
+
+## `audit` events
+
+Producer subsystem: **(unknown — update `stream_producer` in xtask)**.
+
+### `workflow.manual_triggered`
+
+- Variant: `FactoryEventKind::WorkflowManualTriggered`
+- Stream: `audit`
+
+Audit record for a manual / CLI / replay trigger fire (#241). Emitted alongside the underlying `TriggerFired` so audit views can attribute fires to a user. `event_subtype` distinguishes surfaces (`"ui_fire"`, `"ui_replay"`, `"cli_fire"`, `"cli_replay"`); `detail` carries source-specific fields (manual name, source event id).
+
+| Field | Type | Description |
+|---|---|---|
+| `workflow_id` | `String` |  |
+| `workspace_id` | `String` |  |
+| `actor` | `String` |  |
+| `event_subtype` | `String` |  |
+| `detail` | `serde_json::Value` |  |
 
 ## `registry` events
 

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -453,6 +453,10 @@ pub const EXTERNAL_ONLY_ROUTES: &[(&str, &str)] = &[
         "GitHub webhook receiver — called by GitHub, not the dashboard",
     ),
     (
+        "/webhooks/telegram",
+        "Telegram bot webhook receiver — called by Telegram, not the dashboard (#240)",
+    ),
+    (
         "/api/governance/{*path}",
         "catchall proxy that forwards to synodic; covered route-by-route via the synodic check",
     ),


### PR DESCRIPTION
## Summary

Closes the remaining children of the trigger taxonomy v2 umbrella (#236) — Category 3 (#240) and Category 4 UI surface (#241). #237/#238/#239 already landed; #118 (routine conversions) is still `draft` and out of scope.

### Category 3 — external-request triggers (Closes #240)

- Three new `onsager_spine::TriggerKind` variants: `GithubPullRequestClosed { repo, predicate }`, `GithubWorkflowRunCompleted { repo, workflow_name, event?, head_branch?, conclusion? }`, `TelegramWebhook { bot_username, chat_id_allowlist, command_prefix? }`. Round-trip tests + registry manifest entries (with new `TriggerUiKind` variants) + `check-triggers` clean.
- Portal's GitHub webhook handler now fans out `pull_request.closed` and `workflow_run.completed` deliveries to every active workflow on `(repo, …)`, with per-workflow predicate / filter matching done in `onsager_spine::webhook_routing`. The legacy `pull_request.closed+merged → gate.manual_approval_signal` path still fires unconditionally — the new `github_pull_request_closed` trigger fans out independently.
- New Telegram receiver at `POST /webhooks/telegram`. Constant-time `X-Telegram-Bot-Api-Secret-Token` check against `TELEGRAM_WEBHOOK_SECRET`; loads every active `TelegramWebhook` workflow and filters by `bot_username` / `chat_id_allowlist` / `command_prefix` before emitting `trigger.fired`. Added to the api-contract lint's external-only allowlist.
- Switches the `github_issue_webhook` registry producer to `Portal` (the receiver moved there in #222 Slice 1).

### Category 4 — manual / replay portal + UI (Closes #241)

The CLI half (`onsager-trigger`) already shipped in #247. This PR adds:

- Portal endpoints `POST /api/workflows/:id/triggers/manual/:name` and `POST /api/workflows/:id/triggers/replay/:source_event_id`. Auth + workspace-membership scoped; both emit a canonical `trigger.fired` plus a `workflow.manual_triggered` audit event with actor + workflow + surface (`ui_fire`, `ui_replay`).
- New `FactoryEventKind::WorkflowManualTriggered` variant (namespace `audit`) + audit-only registry entry so `check-events` covers the audit fan-out and the existing CLI emit path is registry-backed.
- Dashboard `<WorkflowActions>` gains a "Run now" button (full button on desktop, overflow item on mobile) that's visible iff the workflow's backend `trigger.kind` is `manual` and the workflow is `active`. New `api.fireManualTrigger` / `api.replayTrigger` client methods.
- `WorkflowTrigger` carries the wire `kind_tag` + optional `manual_name` so the UI can branch on the backend kind without losing the legacy github-label render path.

### Verification

- `cargo build --workspace` ✓
- `cargo test --workspace --lib` ✓ (74 → 82 trigger / webhook routing tests; new round-trips for all three #240 variants and the per-workflow PR/workflow-run routers)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --all -- --check` ✓
- `cargo run -p xtask -- check-events / check-triggers / lint-seams / check-api-contract / check-file-budget` all clean
- `pnpm --filter dashboard build` ✓

## Test plan
- [x] Unit: serde round-trips for `GithubPullRequestClosed` / `GithubWorkflowRunCompleted` / `TelegramWebhook`.
- [x] Unit: `route_pull_request_closed_workflows` + `route_workflow_run_completed_workflows` honor per-workflow predicates / filters.
- [ ] Integration (manual): synthesize `pull_request.closed+merged` webhook delivery against a workflow with `GithubPullRequestClosed { merged: Some(true) }` and confirm `trigger.fired` lands.
- [ ] Integration (manual): synthesize `workflow_run.completed` for `name=rust event=push head_branch=main conclusion=success` and confirm `trigger.fired` lands for a matching workflow.
- [ ] Integration (manual): set `TELEGRAM_WEBHOOK_SECRET`, deliver a webhook, observe matched count + `trigger.fired`.
- [ ] Integration (manual): activate a `Manual { name }` workflow, click "Run now" in the dashboard, confirm an artifact registers and `workflow.manual_triggered` appears in the audit stream.

https://claude.ai/code/session_016WLVqqroPQZVuFAvtKsvJU

---
_Generated by [Claude Code](https://claude.ai/code/session_016WLVqqroPQZVuFAvtKsvJU)_