### PR TITLE
infra: bump workspace to Rust edition 2024

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ cargo fmt --all -- --check
 
 ## Conventions
 
-- Rust edition 2021, rustfmt formatting, clippy with warnings-as-errors
+- Rust edition 2024, rustfmt formatting, clippy with warnings-as-errors
 - thiserror for library errors, anyhow for application errors
 - Small focused commits, imperative mood, under 72 characters
 - Unit tests co-located in `#[cfg(test)]` modules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/onsager-ai/onsager"
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -25,7 +25,7 @@ use crate::core::shaping_result_listener;
 use crate::core::signal_cache::SignalCache;
 use crate::core::stage_runner::{self, StageEvent};
 use crate::core::trigger_subscriber::{
-    self, register_artifact_from_trigger, trigger_external_ref, TriggerFired, TriggerHandler,
+    self, TriggerFired, TriggerHandler, register_artifact_from_trigger, trigger_external_ref,
 };
 use crate::core::workflow::Workflow;
 use crate::core::workflow_gates::{LiveGateEvaluator, SpineGateEmitter};
@@ -858,8 +858,8 @@ async fn register_artifact(
         state.spine.clone()
     };
 
-    if let Some(spine) = spine.as_ref() {
-        if let Err(e) = persistence::insert_artifact_row(
+    if let Some(spine) = spine.as_ref()
+        && let Err(e) = persistence::insert_artifact_row(
             spine.pool(),
             id.as_str(),
             &req.kind,
@@ -868,21 +868,20 @@ async fn register_artifact(
             None,
         )
         .await
-        {
-            // Full sqlx::Error goes to the server log (which may carry
-            // constraint names, column types, etc.); the HTTP client
-            // only sees a stable, opaque error tag plus the artifact ID
-            // it submitted for correlation.
-            tracing::error!(artifact_id = %id, "forge: failed to register artifact in spine: {e}");
-            return (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(serde_json::json!({
-                    "error": "failed to persist artifact",
-                    "artifact_id": id.as_str(),
-                })),
-            )
-                .into_response();
-        }
+    {
+        // Full sqlx::Error goes to the server log (which may carry
+        // constraint names, column types, etc.); the HTTP client
+        // only sees a stable, opaque error tag plus the artifact ID
+        // it submitted for correlation.
+        tracing::error!(artifact_id = %id, "forge: failed to register artifact in spine: {e}");
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({
+                "error": "failed to persist artifact",
+                "artifact_id": id.as_str(),
+            })),
+        )
+            .into_response();
     }
 
     {

--- a/crates/forge/src/core/event_triggers.rs
+++ b/crates/forge/src/core/event_triggers.rs
@@ -31,8 +31,8 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Utc;
 use serde_json::Value;
-use sqlx::postgres::PgListener;
 use sqlx::PgPool;
+use sqlx::postgres::PgListener;
 use tokio::sync::Mutex;
 use tokio::time::interval;
 
@@ -268,11 +268,11 @@ async fn emit_event_trigger_fired(
         "fired_at": now,
         "source": source_kind,
     });
-    if let Value::Object(ref mut map) = payload {
-        if let Value::Object(extra_map) = extra {
-            for (k, v) in extra_map {
-                map.insert(k, v);
-            }
+    if let Value::Object(ref mut map) = payload
+        && let Value::Object(extra_map) = extra
+    {
+        for (k, v) in extra_map {
+            map.insert(k, v);
         }
     }
 
@@ -406,17 +406,23 @@ async fn refresh_pg_notify_channels(
         let to_unlisten: Vec<String> = current.difference(&wanted).cloned().collect();
 
         for ch in &to_listen {
-            if let Err(e) = listener.listen(ch).await {
-                tracing::warn!(channel = %ch, "forge pg_notify trigger: LISTEN failed: {e}");
-            } else {
-                current.insert(ch.clone());
+            match listener.listen(ch).await {
+                Err(e) => {
+                    tracing::warn!(channel = %ch, "forge pg_notify trigger: LISTEN failed: {e}");
+                }
+                _ => {
+                    current.insert(ch.clone());
+                }
             }
         }
         for ch in &to_unlisten {
-            if let Err(e) = listener.unlisten(ch).await {
-                tracing::warn!(channel = %ch, "forge pg_notify trigger: UNLISTEN failed: {e}");
-            } else {
-                current.remove(ch);
+            match listener.unlisten(ch).await {
+                Err(e) => {
+                    tracing::warn!(channel = %ch, "forge pg_notify trigger: UNLISTEN failed: {e}");
+                }
+                _ => {
+                    current.remove(ch);
+                }
             }
         }
     }

--- a/crates/forge/src/core/kernel.rs
+++ b/crates/forge/src/core/kernel.rs
@@ -181,15 +181,13 @@ impl SchedulingKernel for BaselineKernel {
             insight_kind,
             scope,
         } = &event.event
+            && *insight_kind == onsager_spine::factory_event::InsightKind::Failure
+            && let onsager_spine::factory_event::InsightScope::SpecificArtifact(id) = scope
         {
-            if *insight_kind == onsager_spine::factory_event::InsightKind::Failure {
-                if let onsager_spine::factory_event::InsightScope::SpecificArtifact(id) = scope {
-                    *self
-                        .failure_counts
-                        .entry(id.as_str().to_owned())
-                        .or_default() += 1;
-                }
-            }
+            *self
+                .failure_counts
+                .entry(id.as_str().to_owned())
+                .or_default() += 1;
         }
     }
 }

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -22,11 +22,11 @@ pub mod workflow_persistence;
 pub mod workflow_signal_listener;
 
 pub use artifact_store::ArtifactStore;
-pub use insight_cache::{InsightCache, DEFAULT_INSIGHT_CACHE_CAPACITY};
+pub use insight_cache::{DEFAULT_INSIGHT_CACHE_CAPACITY, InsightCache};
 pub use kernel::{BaselineKernel, SchedulingKernel, WorldState};
 pub use pipeline::ForgePipeline;
 pub use session_listener::{SessionCompleted, SessionCompletedHandler};
 pub use signal_cache::{Signal, SignalCache, SignalOutcome};
-pub use stage_runner::{advance_workflow_artifacts, enter_workflow, GateEvaluator, StageEvent};
+pub use stage_runner::{GateEvaluator, StageEvent, advance_workflow_artifacts, enter_workflow};
 pub use state::ForgeState;
 pub use workflow::{GateOutcome, GateSpec, StageSpec, TriggerKind, Workflow};

--- a/crates/forge/src/core/pipeline_tests.rs
+++ b/crates/forge/src/core/pipeline_tests.rs
@@ -300,10 +300,11 @@ mod tests {
         pending_shapings.insert(&req_id, shaping_failed(&req_id));
         let out = pipeline.tick(&BaselineKernel::new());
 
-        assert!(out
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::Error(_))));
+        assert!(
+            out.events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::Error(_)))
+        );
         assert!(!pipeline.is_parked());
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(
@@ -338,10 +339,11 @@ mod tests {
             },
         );
         let out = pipeline.tick(&BaselineKernel::new());
-        assert!(out
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::Error(_))));
+        assert!(
+            out.events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::Error(_)))
+        );
         assert!(!pipeline.is_parked());
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::Draft);
@@ -351,10 +353,12 @@ mod tests {
     fn tick_idles_when_no_work() {
         let mut pipeline = fresh_pipeline();
         let output = pipeline.tick(&BaselineKernel::new());
-        assert!(output
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::IdleTick))
+        );
     }
 
     #[test]
@@ -367,10 +371,12 @@ mod tests {
             .unwrap();
 
         let output = pipeline.tick(&BaselineKernel::new());
-        assert!(output
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::IdleTick)));
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::IdleTick))
+        );
         assert!(!pipeline.is_parked(), "paused tick must not park anything");
     }
 
@@ -579,10 +585,11 @@ mod tests {
             !has_advance,
             "sealing failure must abort the release transition"
         );
-        assert!(!out
-            .events
-            .iter()
-            .any(|e| matches!(e, PipelineEvent::BundleSealed { .. })));
+        assert!(
+            !out.events
+                .iter()
+                .any(|e| matches!(e, PipelineEvent::BundleSealed { .. }))
+        );
         let art = pipeline.store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::UnderReview);
         assert!(art.current_version_id.is_none());

--- a/crates/forge/src/core/stage_runner.rs
+++ b/crates/forge/src/core/stage_runner.rs
@@ -299,10 +299,11 @@ fn clear_parked_reason(store: &mut ArtifactStore, id: &ArtifactId) {
 }
 
 fn apply_state_change(store: &mut ArtifactStore, id: &ArtifactId, target: ArtifactState) {
-    if let Some(artifact) = store.get_mut(id) {
-        if artifact.state != target && artifact.state.can_transition_to(target) {
-            artifact.state = target;
-        }
+    if let Some(artifact) = store.get_mut(id)
+        && artifact.state != target
+        && artifact.state.can_transition_to(target)
+    {
+        artifact.state = target;
     }
 }
 
@@ -325,10 +326,11 @@ pub fn enter_workflow(
         artifact.workflow_id = Some(workflow.workflow_id.clone());
         artifact.current_stage_index = Some(0);
         artifact.workflow_parked_reason = None;
-        if let Some(target) = first_stage.target_state {
-            if artifact.state != target && artifact.state.can_transition_to(target) {
-                artifact.state = target;
-            }
+        if let Some(target) = first_stage.target_state
+            && artifact.state != target
+            && artifact.state.can_transition_to(target)
+        {
+            artifact.state = target;
         }
     }
 

--- a/crates/forge/src/core/stage_runner_tests.rs
+++ b/crates/forge/src/core/stage_runner_tests.rs
@@ -469,11 +469,12 @@ mod tests {
 
         let art = store.get(&id).unwrap();
         assert_eq!(art.current_stage_index, None);
-        assert!(art
-            .workflow_parked_reason
-            .as_deref()
-            .unwrap()
-            .contains("out of bounds"));
+        assert!(
+            art.workflow_parked_reason
+                .as_deref()
+                .unwrap()
+                .contains("out of bounds")
+        );
     }
 
     #[test]

--- a/crates/forge/src/core/trigger_subscriber.rs
+++ b/crates/forge/src/core/trigger_subscriber.rs
@@ -20,7 +20,7 @@ use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 
 use super::artifact_store::ArtifactStore;
-use super::stage_runner::{enter_workflow, StageEvent};
+use super::stage_runner::{StageEvent, enter_workflow};
 use super::workflow::Workflow;
 
 /// Parsed `trigger.fired` event payload.
@@ -307,32 +307,38 @@ mod tests {
         // stable key, so we don't fabricate one (which would re-introduce
         // duplicates).
         assert!(trigger_external_ref("wf", "k", &serde_json::json!({})).is_none());
-        assert!(trigger_external_ref(
-            "wf",
-            "k",
-            &serde_json::json!({ "repo_owner": "a", "repo_name": "b" })
-        )
-        .is_none());
-        assert!(trigger_external_ref(
-            "wf",
-            "k",
-            &serde_json::json!({
-                "repo_owner": "",
-                "repo_name": "b",
-                "issue_number": 1
-            })
-        )
-        .is_none());
-        assert!(trigger_external_ref(
-            "wf",
-            "k",
-            &serde_json::json!({
-                "repo_owner": "a",
-                "repo_name": "b",
-                "issue_number": 0
-            })
-        )
-        .is_none());
+        assert!(
+            trigger_external_ref(
+                "wf",
+                "k",
+                &serde_json::json!({ "repo_owner": "a", "repo_name": "b" })
+            )
+            .is_none()
+        );
+        assert!(
+            trigger_external_ref(
+                "wf",
+                "k",
+                &serde_json::json!({
+                    "repo_owner": "",
+                    "repo_name": "b",
+                    "issue_number": 1
+                })
+            )
+            .is_none()
+        );
+        assert!(
+            trigger_external_ref(
+                "wf",
+                "k",
+                &serde_json::json!({
+                    "repo_owner": "a",
+                    "repo_name": "b",
+                    "issue_number": 0
+                })
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/crates/forge/src/core/workflow_gates.rs
+++ b/crates/forge/src/core/workflow_gates.rs
@@ -22,8 +22,8 @@
 //! exclusively.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use onsager_artifact::Artifact;
 use onsager_spine::factory_event::{FactoryEventKind, GatePoint};
@@ -77,7 +77,7 @@ pub trait GateEmitter: Send + Sync {
     /// Emit `forge.gate_requested` keyed on `gate_id`. Same return
     /// semantics as [`Self::emit_shaping_dispatched`].
     fn emit_gate_requested(&self, workspace_id: &str, gate_id: &str, request: &GateRequest)
-        -> bool;
+    -> bool;
 }
 
 /// Production [`GateEmitter`] backed by an [`EventStore`]. Calls into
@@ -852,14 +852,18 @@ mod tests {
                 outcome: SignalOutcome::Success,
             },
         );
-        assert!(cache
-            .get(artifact.artifact_id.as_str(), AGENT_SESSION_SIGNAL)
-            .is_some());
+        assert!(
+            cache
+                .get(artifact.artifact_id.as_str(), AGENT_SESSION_SIGNAL)
+                .is_some()
+        );
 
         evaluator.on_stage_advanced(&artifact.artifact_id, 0);
-        assert!(cache
-            .get(artifact.artifact_id.as_str(), AGENT_SESSION_SIGNAL)
-            .is_none());
+        assert!(
+            cache
+                .get(artifact.artifact_id.as_str(), AGENT_SESSION_SIGNAL)
+                .is_none()
+        );
     }
 
     #[test]
@@ -878,18 +882,22 @@ mod tests {
 
         // Emit + park.
         evaluator.evaluate(&artifact, &wf, 0, &gate);
-        assert!(evaluator
-            .governance_in_flight
-            .lock()
-            .unwrap()
-            .contains_key(&(artifact.artifact_id.as_str().to_string(), 0)));
+        assert!(
+            evaluator
+                .governance_in_flight
+                .lock()
+                .unwrap()
+                .contains_key(&(artifact.artifact_id.as_str().to_string(), 0))
+        );
 
         evaluator.on_stage_advanced(&artifact.artifact_id, 0);
-        assert!(!evaluator
-            .governance_in_flight
-            .lock()
-            .unwrap()
-            .contains_key(&(artifact.artifact_id.as_str().to_string(), 0)));
+        assert!(
+            !evaluator
+                .governance_in_flight
+                .lock()
+                .unwrap()
+                .contains_key(&(artifact.artifact_id.as_str().to_string(), 0))
+        );
     }
 
     #[test]

--- a/crates/forge/src/core/workflow_persistence.rs
+++ b/crates/forge/src/core/workflow_persistence.rs
@@ -35,24 +35,27 @@ async fn load_workflows_filtered(
     pool: &PgPool,
     only_id: Option<&str>,
 ) -> Result<HashMap<String, Workflow>, sqlx::Error> {
-    let wf_rows =
-        match only_id {
-            Some(id) => sqlx::query(
+    let wf_rows = match only_id {
+        Some(id) => {
+            sqlx::query(
                 "SELECT workflow_id, name, trigger_kind, trigger_config, active, workspace_id, \
                         preset_id, install_id, created_by \
                    FROM workflows WHERE workflow_id = $1",
             )
             .bind(id)
             .fetch_all(pool)
-            .await?,
-            None => sqlx::query(
+            .await?
+        }
+        None => {
+            sqlx::query(
                 "SELECT workflow_id, name, trigger_kind, trigger_config, active, workspace_id, \
                         preset_id, install_id, created_by \
                    FROM workflows",
             )
             .fetch_all(pool)
-            .await?,
-        };
+            .await?
+        }
+    };
 
     let mut workflows = HashMap::new();
     for row in wf_rows {

--- a/crates/forge/src/core/workflow_signal_listener.rs
+++ b/crates/forge/src/core/workflow_signal_listener.rs
@@ -26,7 +26,7 @@ use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 
 use super::signal_cache::{Signal, SignalCache, SignalOutcome};
-use super::workflow_gates::{external_check_signal_kind, AGENT_SESSION_SIGNAL};
+use super::workflow_gates::{AGENT_SESSION_SIGNAL, external_check_signal_kind};
 
 /// Pure classifier: turn a [`FactoryEventKind`] into the signal it maps to
 /// (if any). Returned tuple is `(artifact_id, Signal)`.

--- a/crates/forge/tests/workflow_runtime.rs
+++ b/crates/forge/tests/workflow_runtime.rs
@@ -12,10 +12,10 @@ use forge::core::artifact_store::ArtifactStore;
 use forge::core::pending::PendingVerdicts;
 use forge::core::signal_cache::{Signal, SignalCache, SignalOutcome};
 use forge::core::stage_runner::advance_workflow_artifacts;
-use forge::core::trigger_subscriber::{register_artifact_from_trigger, TriggerFired};
+use forge::core::trigger_subscriber::{TriggerFired, register_artifact_from_trigger};
 use forge::core::workflow::{GateSpec, StageSpec, TriggerKind, Workflow};
 use forge::core::workflow_gates::{
-    external_check_signal_kind, GateEmitter, LiveGateEvaluator, AGENT_SESSION_SIGNAL,
+    AGENT_SESSION_SIGNAL, GateEmitter, LiveGateEvaluator, external_check_signal_kind,
 };
 use forge::core::workflow_signal_listener::classify_signal;
 use onsager_artifact::ArtifactState;

--- a/crates/ising/src/analyzers/gate_deny_rate.rs
+++ b/crates/ising/src/analyzers/gate_deny_rate.rs
@@ -173,10 +173,12 @@ mod tests {
         let insights = GateDenyRateAnalyzer::default().run(&model);
         assert_eq!(insights.len(), 1);
         assert_eq!(insights[0].evidence.len(), 5);
-        assert!(insights[0]
-            .evidence
-            .iter()
-            .all(|e| e.event_type == "forge.gate_verdict"));
+        assert!(
+            insights[0]
+                .evidence
+                .iter()
+                .all(|e| e.event_type == "forge.gate_verdict")
+        );
     }
 
     #[test]

--- a/crates/ising/src/analyzers/pr_churn.rs
+++ b/crates/ising/src/analyzers/pr_churn.rs
@@ -150,10 +150,12 @@ mod tests {
         let insights = PrChurnAnalyzer::default().run(&model);
         assert_eq!(insights.len(), 1);
         assert_eq!(insights[0].evidence.len(), 3);
-        assert!(insights[0]
-            .evidence
-            .iter()
-            .all(|e| e.event_type == "git.pr_opened"));
+        assert!(
+            insights[0]
+                .evidence
+                .iter()
+                .all(|e| e.event_type == "git.pr_opened")
+        );
     }
 
     #[test]

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -24,7 +24,7 @@ use onsager_spine::{EventMetadata, EventStore};
 use crate::analyzers::register_defaults;
 use crate::core::emitter::{EmitResult, EmitterConfig, InsightEmitter};
 use crate::core::{
-    insight_to_emitted_event, insight_to_rule_proposal, AnalyzerRegistry, FactoryModel,
+    AnalyzerRegistry, FactoryModel, insight_to_emitted_event, insight_to_rule_proposal,
 };
 
 /// How far back to look for forge events when rebuilding the factory model.
@@ -110,10 +110,13 @@ async fn run_tick(
                     // backing `insight_emitted` via `insight_id` so Synodic
                     // can audit the evidence without a second query.
                     if let Some(proposal) = insight_to_rule_proposal(&analyzer_name, &insight) {
-                        if let Err(e) = append_rule_proposed(spine, &proposal).await {
-                            tracing::warn!("ising: failed to append rule_proposed event: {e}");
-                        } else {
-                            proposals += 1;
+                        match append_rule_proposed(spine, &proposal).await {
+                            Err(e) => {
+                                tracing::warn!("ising: failed to append rule_proposed event: {e}");
+                            }
+                            _ => {
+                                proposals += 1;
+                            }
                         }
                     }
                 }

--- a/crates/onsager-github/src/api/app.rs
+++ b/crates/onsager-github/src/api/app.rs
@@ -16,7 +16,7 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
-use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 
 use crate::api::http::client;
@@ -57,12 +57,11 @@ pub fn normalize_pem(raw: &str) -> String {
         return trimmed.replace("\\n", "\n");
     }
     use base64::Engine;
-    if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(trimmed.as_bytes()) {
-        if let Ok(s) = String::from_utf8(bytes) {
-            if s.contains("-----BEGIN") {
-                return s;
-            }
-        }
+    if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(trimmed.as_bytes())
+        && let Ok(s) = String::from_utf8(bytes)
+        && s.contains("-----BEGIN")
+    {
+        return s;
     }
     trimmed.to_string()
 }

--- a/crates/onsager-github/src/api/issues.rs
+++ b/crates/onsager-github/src/api/issues.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::api::http::{client, GITHUB_API};
+use crate::api::http::{GITHUB_API, client};
 use crate::error::GithubError;
 
 /// An issue as returned by `GET /repos/{owner}/{repo}/issues`. GitHub's

--- a/crates/onsager-github/src/api/pulls.rs
+++ b/crates/onsager-github/src/api/pulls.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-use crate::api::http::{client, GITHUB_API};
+use crate::api::http::{GITHUB_API, client};
 use crate::error::GithubError;
 
 /// A pull request as returned by `GET /repos/{owner}/{repo}/pulls`.

--- a/crates/onsager-github/src/webhook/mod.rs
+++ b/crates/onsager-github/src/webhook/mod.rs
@@ -9,5 +9,5 @@
 pub mod event;
 pub mod signature;
 
-pub use event::{to_spine_events, WebhookEvent};
-pub use signature::{verify_signature, SignatureCheck};
+pub use event::{WebhookEvent, to_spine_events};
+pub use signature::{SignatureCheck, verify_signature};

--- a/crates/onsager-portal/src/auth.rs
+++ b/crates/onsager-portal/src/auth.rs
@@ -9,11 +9,11 @@
 //! finish moving the dependent routes to portal.
 
 use axum::extract::FromRequestParts;
-use axum::http::request::Parts;
 use axum::http::StatusCode;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::aead;
 use ring::digest;
 use ring::rand::{SecureRandom, SystemRandom};
@@ -92,7 +92,7 @@ pub fn generate_credential_key() -> String {
 // so route handlers don't have to import two namespaces.
 
 pub use onsager_github::api::oauth::{
-    exchange_code, github_authorize_url, GithubOAuthUser as GithubUser, GithubTokenResponse,
+    GithubOAuthUser as GithubUser, GithubTokenResponse, exchange_code, github_authorize_url,
 };
 
 /// Fetch the GitHub user behind an OAuth access token.
@@ -245,10 +245,10 @@ pub async fn verify_pat(
     if pat.revoked_at.is_some() {
         return Ok(PatVerifyOutcome::Revoked);
     }
-    if let Some(exp) = pat.expires_at {
-        if exp < chrono::Utc::now() {
-            return Ok(PatVerifyOutcome::Expired);
-        }
+    if let Some(exp) = pat.expires_at
+        && exp < chrono::Utc::now()
+    {
+        return Ok(PatVerifyOutcome::Expired);
     }
     Ok(PatVerifyOutcome::Ok(Box::new(pat)))
 }
@@ -359,77 +359,77 @@ impl FromRequestParts<AppState> for AuthUser {
         //    on the same request — cookie + Bearer normally doesn't happen
         //    in practice, but a CLI smoke test of the dashboard shouldn't
         //    silently fall through to the browser session.
-        if let Some(token) = parse_bearer_token(parts) {
-            if token.starts_with(PAT_TOKEN_NAMESPACE) {
-                match verify_pat(&state.pool, &token).await {
-                    Ok(PatVerifyOutcome::Ok(pat)) => {
-                        let user = match auth_db::get_user(&state.pool, &pat.user_id).await {
-                            Ok(Some(u)) => u,
-                            Ok(None) => {
-                                tracing::warn!(
-                                    pat_id = %pat.id,
-                                    "PAT references missing user — rejecting"
-                                );
-                                return Err(unauthorized_invalid_token());
-                            }
-                            Err(e) => {
-                                tracing::error!("PAT auth: failed to load user: {e}");
-                                return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
-                            }
-                        };
+        if let Some(token) = parse_bearer_token(parts)
+            && token.starts_with(PAT_TOKEN_NAMESPACE)
+        {
+            match verify_pat(&state.pool, &token).await {
+                Ok(PatVerifyOutcome::Ok(pat)) => {
+                    let user = match auth_db::get_user(&state.pool, &pat.user_id).await {
+                        Ok(Some(u)) => u,
+                        Ok(None) => {
+                            tracing::warn!(
+                                pat_id = %pat.id,
+                                "PAT references missing user — rejecting"
+                            );
+                            return Err(unauthorized_invalid_token());
+                        }
+                        Err(e) => {
+                            tracing::error!("PAT auth: failed to load user: {e}");
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                        }
+                    };
 
-                        // Best-effort touch — failure must not block the
-                        // request. Capture client metadata before the move.
-                        let pool = state.pool.clone();
-                        let pat_id = pat.id.clone();
-                        let ip = parts
-                            .headers
-                            .get("x-forwarded-for")
-                            .and_then(|v| v.to_str().ok())
-                            .and_then(|s| s.split(',').next())
-                            .map(|s| s.trim().to_string());
-                        let ua = parts
-                            .headers
-                            .get(axum::http::header::USER_AGENT)
-                            .and_then(|v| v.to_str().ok())
-                            .map(|s| s.to_string());
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                pat_db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref())
-                                    .await
-                            {
-                                tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
-                            }
-                        });
+                    // Best-effort touch — failure must not block the
+                    // request. Capture client metadata before the move.
+                    let pool = state.pool.clone();
+                    let pat_id = pat.id.clone();
+                    let ip = parts
+                        .headers
+                        .get("x-forwarded-for")
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.split(',').next())
+                        .map(|s| s.trim().to_string());
+                    let ua = parts
+                        .headers
+                        .get(axum::http::header::USER_AGENT)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    tokio::spawn(async move {
+                        if let Err(e) =
+                            pat_db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref())
+                                .await
+                        {
+                            tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
+                        }
+                    });
 
-                        let session_kind = session_kind_for_github_id(user.github_id);
-                        return Ok(AuthUser {
-                            user_id: user.id,
-                            github_login: user.github_login,
-                            github_name: user.github_name,
-                            github_avatar_url: user.github_avatar_url,
-                            principal: RequestPrincipal::Pat {
-                                pat_id: pat.id,
-                                workspace_id: pat.workspace_id,
-                            },
-                            session_kind,
-                        });
-                    }
-                    Ok(PatVerifyOutcome::Unknown)
-                    | Ok(PatVerifyOutcome::Revoked)
-                    | Ok(PatVerifyOutcome::Expired) => {
-                        return Err(unauthorized_invalid_token());
-                    }
-                    Err(e) => {
-                        tracing::error!("PAT verification failed: {e}");
-                        return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
-                    }
+                    let session_kind = session_kind_for_github_id(user.github_id);
+                    return Ok(AuthUser {
+                        user_id: user.id,
+                        github_login: user.github_login,
+                        github_name: user.github_name,
+                        github_avatar_url: user.github_avatar_url,
+                        principal: RequestPrincipal::Pat {
+                            pat_id: pat.id,
+                            workspace_id: pat.workspace_id,
+                        },
+                        session_kind,
+                    });
+                }
+                Ok(PatVerifyOutcome::Unknown)
+                | Ok(PatVerifyOutcome::Revoked)
+                | Ok(PatVerifyOutcome::Expired) => {
+                    return Err(unauthorized_invalid_token());
+                }
+                Err(e) => {
+                    tracing::error!("PAT verification failed: {e}");
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
                 }
             }
-            // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
-            // are owned by their dedicated routes — fall through so the
-            // cookie path still works for the dashboard.
         }
+        // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
+        // are owned by their dedicated routes — fall through so the
+        // cookie path still works for the dashboard.
 
         // 2) Fall back to the session cookie.
         let session_id = parts

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -25,8 +25,8 @@ use onsager_artifact::ArtifactId;
 use onsager_spine::factory_event::FactoryEventKind;
 use onsager_spine::{EventMetadata, EventStore};
 
-use onsager_github::api::issues::{list_recent_issues, Issue};
-use onsager_github::api::pulls::{list_recent_pulls, Pull};
+use onsager_github::api::issues::{Issue, list_recent_issues};
+use onsager_github::api::pulls::{Pull, list_recent_pulls};
 
 use crate::db::{self, IssueLifecycleState, PrLifecycleState};
 

--- a/crates/onsager-portal/src/dev_auth.rs
+++ b/crates/onsager-portal/src/dev_auth.rs
@@ -25,15 +25,15 @@
 //! spine. Portal writes to those tables via raw SQL — same DB, same
 //! shape, no shared crate needed.
 
-use axum::extract::State;
-use axum::http::{header, StatusCode};
-use axum::response::{IntoResponse, Response};
 use axum::Json;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
-use crate::auth::{generate_session_token, SessionKind};
+use crate::auth::{SessionKind, generate_session_token};
 use crate::auth_db::{self, User};
 use crate::state::AppState;
 
@@ -53,9 +53,12 @@ pub const DEV_WORKSPACE_SLUG: &str = "dev";
 /// back to `dev` so the build works in CI and rootless containers where
 /// `$USER` may be unset.
 pub fn dev_username() -> String {
-    std::env::var("USER")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
+    dev_username_from(std::env::var("USER").ok())
+}
+
+/// Pure variant of [`dev_username`] used for testing without env mutation.
+fn dev_username_from(user: Option<String>) -> String {
+    user.filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "dev".to_string())
 }
 
@@ -225,12 +228,13 @@ mod tests {
 
     #[test]
     fn dev_username_falls_back_to_dev() {
-        let prev = std::env::var("USER").ok();
-        std::env::remove_var("USER");
-        assert_eq!(dev_username(), "dev");
-        if let Some(v) = prev {
-            std::env::set_var("USER", v);
-        }
+        // Test the pure variant so we don't have to mutate the
+        // process-wide env (which races with parallel tests under
+        // edition 2024's unsafe env API).
+        assert_eq!(dev_username_from(None), "dev");
+        assert_eq!(dev_username_from(Some(String::new())), "dev");
+        assert_eq!(dev_username_from(Some("   ".into())), "dev");
+        assert_eq!(dev_username_from(Some("alice".into())), "alice");
     }
 
     #[test]

--- a/crates/onsager-portal/src/feedback/mod.rs
+++ b/crates/onsager-portal/src/feedback/mod.rs
@@ -34,9 +34,9 @@ mod dispatch;
 mod registry;
 
 pub use dispatch::{
-    command_response, dispatch, dispatch_with_id, CommandResponse, DispatchError, DispatchHandle,
+    CommandResponse, DispatchError, DispatchHandle, command_response, dispatch, dispatch_with_id,
 };
-pub use registry::{await_with_timeout, AwaitError, CorrelationRegistry, Waiter, MAX_SYNC_TIMEOUT};
+pub use registry::{AwaitError, CorrelationRegistry, MAX_SYNC_TIMEOUT, Waiter, await_with_timeout};
 
 /// Default timeout for fast-write helpers (`1s`). The hard cap is
 /// [`MAX_SYNC_TIMEOUT`] (`2s`) — anything that needs more should be a

--- a/crates/onsager-portal/src/handlers/auth.rs
+++ b/crates/onsager-portal/src/handlers/auth.rs
@@ -5,22 +5,22 @@
 //! URLs through `routes::portal::proxy` so existing dashboard fetches
 //! land here without an API_BASE cutover (Slice 6 of spec #222).
 
-use axum::extract::{Query, State};
-use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Redirect, Response};
 use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Redirect, Response};
 use chrono::Utc;
 use uuid::Uuid;
 
 use crate::auth::{
-    self, exchange_code, generate_session_token, generate_state, get_github_user,
-    github_authorize_url, AuthUser, RequestPrincipal,
+    self, AuthUser, RequestPrincipal, exchange_code, generate_session_token, generate_state,
+    get_github_user, github_authorize_url,
 };
 use crate::auth_db::{self, User};
 use crate::config::Config;
 use crate::sso::{
-    self, generate_exchange_code, return_to_allowed, secrets_equal, sign_state, verify_state,
-    SsoMode, StateClaims, EXCHANGE_CODE_LIFETIME_SECS, STATE_LIFETIME_SECS,
+    self, EXCHANGE_CODE_LIFETIME_SECS, STATE_LIFETIME_SECS, SsoMode, StateClaims,
+    generate_exchange_code, return_to_allowed, secrets_equal, sign_state, verify_state,
 };
 use crate::state::AppState;
 
@@ -174,11 +174,11 @@ pub async fn github_callback(
             if cookie_csrf != Some(c.c.as_str()) {
                 return (StatusCode::BAD_REQUEST, "invalid OAuth state").into_response();
             }
-            if let Some(ref rt) = c.r {
-                if !return_to_allowed(&config.sso_return_host_allowlist, rt) {
-                    tracing::warn!(return_to = %rt, "callback rejected delegated SSO: return_to no longer allowed");
-                    return (StatusCode::FORBIDDEN, "return_to not allowed").into_response();
-                }
+            if let Some(ref rt) = c.r
+                && !return_to_allowed(&config.sso_return_host_allowlist, rt)
+            {
+                tracing::warn!(return_to = %rt, "callback rejected delegated SSO: return_to no longer allowed");
+                return (StatusCode::FORBIDDEN, "return_to not allowed").into_response();
             }
             c.r.clone()
         }

--- a/crates/onsager-portal/src/handlers/credentials.rs
+++ b/crates/onsager-portal/src/handlers/credentials.rs
@@ -7,13 +7,13 @@
 //! in W2. Every route funnels through `require_workspace_access` for
 //! the 404-not-403 membership check + PAT scope guardrail.
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde::Deserialize;
 
-use crate::auth::{encrypt_credential, AuthUser, RequestPrincipal};
+use crate::auth::{AuthUser, RequestPrincipal, encrypt_credential};
 use crate::credential_db;
 use crate::state::AppState;
 
@@ -31,17 +31,17 @@ async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match credential_db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),

--- a/crates/onsager-portal/src/handlers/github_app.rs
+++ b/crates/onsager-portal/src/handlers/github_app.rs
@@ -13,16 +13,16 @@
 //!   App JWT to look up the install's account, persists the
 //!   installation row, and redirects the browser back to the dashboard.
 
-use axum::extract::{Query, State};
-use axum::http::{header, StatusCode};
-use axum::response::{IntoResponse, Redirect, Response};
 use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Redirect, Response};
 use chrono::Utc;
 use onsager_github::api::app as gh_app;
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::auth::{generate_state, parse_cookie, AuthUser};
+use crate::auth::{AuthUser, generate_state, parse_cookie};
 use crate::handlers::installations::require_workspace_access;
 use crate::installation::GitHubAppInstallation;
 use crate::installation_db;

--- a/crates/onsager-portal/src/handlers/installations.rs
+++ b/crates/onsager-portal/src/handlers/installations.rs
@@ -13,17 +13,17 @@
 //! - `GET /api/workspaces/:workspace_id/github-installations/:install_row_id/repos/:owner/:repo/labels`
 //!   — list labels (powers the workflow trigger label combobox).
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
 use onsager_github::api::app as gh_app;
 use serde::Deserialize;
 use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
-use crate::auth::{encrypt_credential, AuthUser};
+use crate::auth::{AuthUser, encrypt_credential};
 use crate::installation::{GitHubAccountType, GitHubAppInstallation};
 use crate::installation_db;
 use crate::state::AppState;
@@ -38,17 +38,17 @@ pub(crate) async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match installation_db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),

--- a/crates/onsager-portal/src/handlers/live_data.rs
+++ b/crates/onsager-portal/src/handlers/live_data.rs
@@ -26,15 +26,15 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use onsager_spine::webhook_routing::{
-    build_trigger_fired_events, spine_namespace, trigger_source, IssueTriggerContext, RoutedEvent,
-    WorkflowMatch,
+    IssueTriggerContext, RoutedEvent, WorkflowMatch, build_trigger_fired_events, spine_namespace,
+    trigger_source,
 };
 
 use crate::auth::AuthUser;
@@ -257,7 +257,7 @@ pub async fn list_project_issues(
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": "GitHub App not configured" })),
             )
-                .into_response()
+                .into_response();
         }
         Err(e) => {
             tracing::error!("installation_token_for failed: {e}");
@@ -363,7 +363,7 @@ pub async fn get_project_issue(
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": "GitHub App not configured" })),
             )
-                .into_response()
+                .into_response();
         }
         Err(e) => {
             tracing::error!("installation_token_for failed: {e}");
@@ -492,7 +492,7 @@ pub async fn list_project_pulls(
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": "GitHub App not configured" })),
             )
-                .into_response()
+                .into_response();
         }
         Err(e) => {
             tracing::error!("installation_token_for failed: {e}");
@@ -609,7 +609,7 @@ pub async fn backfill_project(
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "error": format!("invalid strategy: {e}") })),
             )
-                .into_response()
+                .into_response();
         }
     };
 
@@ -695,7 +695,7 @@ pub async fn replay_issue_trigger(
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({ "error": "GitHub App not configured" })),
             )
-                .into_response()
+                .into_response();
         }
         Err(e) => {
             tracing::error!("installation_token_for failed: {e}");

--- a/crates/onsager-portal/src/handlers/nodes.rs
+++ b/crates/onsager-portal/src/handlers/nodes.rs
@@ -2,14 +2,14 @@
 //!
 //! Moved from `crates/stiglab/src/server/routes/nodes.rs`.
 
+use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 
 use crate::auth::AuthUser;
-use crate::handlers::sessions::missing_workspace;
 use crate::handlers::sessions::WorkspaceQuery;
+use crate::handlers::sessions::missing_workspace;
 use crate::handlers::workspaces::require_workspace_access;
 use crate::session_db;
 use crate::state::AppState;
@@ -28,10 +28,10 @@ pub async fn list_nodes(
     if workspace_id.is_empty() {
         return missing_workspace();
     }
-    if auth_user.user_id != "anonymous" {
-        if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await {
-            return r;
-        }
+    if auth_user.user_id != "anonymous"
+        && let Err(r) = require_workspace_access(&state.pool, &auth_user, &workspace_id).await
+    {
+        return r;
     }
     match session_db::list_nodes(&state.pool).await {
         Ok(nodes) => Json(serde_json::json!({ "nodes": nodes })).into_response(),

--- a/crates/onsager-portal/src/handlers/pats.rs
+++ b/crates/onsager-portal/src/handlers/pats.rs
@@ -12,15 +12,15 @@
 //! `routes::portal::proxy` so the dashboard's API_BASE cutover (Slice 6)
 //! can land independently.
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::auth::{generate_pat_token, AuthUser};
+use crate::auth::{AuthUser, generate_pat_token};
 use crate::pat_db::{self, UserPat};
 use crate::state::AppState;
 

--- a/crates/onsager-portal/src/handlers/projects.rs
+++ b/crates/onsager-portal/src/handlers/projects.rs
@@ -7,10 +7,10 @@
 //! Project deletion blocks with a clear error when live sessions
 //! reference the project; there is no cascade and no soft-delete in v1.
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
 use onsager_github::api::app as gh_app;
 use serde::Deserialize;
@@ -212,10 +212,10 @@ pub async fn get_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
     };
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != project.workspace_id {
-            return not_found("project not found");
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != project.workspace_id
+    {
+        return not_found("project not found");
     }
     if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
         return r;
@@ -240,10 +240,10 @@ pub async fn delete_project(
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
     };
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != project.workspace_id {
-            return not_found("project not found");
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != project.workspace_id
+    {
+        return not_found("project not found");
     }
     if let Err(r) = require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await {
         return r;

--- a/crates/onsager-portal/src/handlers/pull_request.rs
+++ b/crates/onsager-portal/src/handlers/pull_request.rs
@@ -8,8 +8,8 @@
 //! - synodic gate evaluation per `(pr_artifact_id, head_sha)` (Phase 2)
 
 use onsager_artifact::ArtifactId;
-use onsager_spine::factory_event::FactoryEventKind;
 use onsager_spine::EventMetadata;
+use onsager_spine::factory_event::FactoryEventKind;
 use serde_json::Value;
 
 use onsager_github::api::pulls::CheckConclusion;
@@ -188,18 +188,18 @@ pub async fn handle(
 
     // Session↔PR correlation: on `opened`, attach a vertical_lineage row if a
     // recent session pushed `head.ref` against this project (Phase 1).
-    if matches!(act, PrAction::Opened) && !head_ref.is_empty() {
-        if let Some(session_id) =
+    if matches!(act, PrAction::Opened)
+        && !head_ref.is_empty()
+        && let Some(session_id) =
             db::find_session_for_branch(&state.pool, &project.id, &head_ref).await?
-        {
-            db::link_session_to_pr_artifact(
-                &state.pool,
-                &artifact.artifact_id,
-                &session_id,
-                artifact.current_version,
-            )
-            .await?;
-        }
+    {
+        db::link_session_to_pr_artifact(
+            &state.pool,
+            &artifact.artifact_id,
+            &session_id,
+            artifact.current_version,
+        )
+        .await?;
     }
 
     // Phase 2: gate the commit and post a check run.
@@ -336,50 +336,37 @@ pub async fn handle(
     // Phase 2 label-sync migration (`.github/workflows/pr-spec-sync.yml`).
     // Best-effort: only attempted when a github_token is configured. Failures
     // are logged so the workflow can stay live as a safety net during rollout.
-    if let Some(tok) = state.config.github_token.as_deref() {
-        if !body.is_empty() {
-            let linked = crate::handlers::spec_link::linked_issues(&body);
-            if !linked.is_empty() {
-                use onsager_github::api::issues::set_label;
-                for issue_number in linked {
-                    let result = match (act, merged) {
-                        (PrAction::Opened, _) => {
-                            set_label(Some(tok), owner, name, issue_number, "in-progress", true)
-                                .await
-                        }
-                        (PrAction::Closed, true) => {
-                            // PR merged — move spec from `in-progress` to `done`
-                            // to mirror the human-driven label progression.
-                            let _ = set_label(
-                                Some(tok),
-                                owner,
-                                name,
-                                issue_number,
-                                "in-progress",
-                                false,
-                            )
-                            .await;
-                            set_label(Some(tok), owner, name, issue_number, "done", true).await
-                        }
-                        (PrAction::Closed, false) => {
-                            // Closed without merge — revert to `planned` so the
-                            // spec re-enters the queue cleanly.
-                            let _ = set_label(
-                                Some(tok),
-                                owner,
-                                name,
-                                issue_number,
-                                "in-progress",
-                                false,
-                            )
-                            .await;
-                            set_label(Some(tok), owner, name, issue_number, "planned", true).await
-                        }
-                        (PrAction::Synchronize, _) => Ok(()),
-                    };
-                    if let Err(e) = result {
-                        tracing::warn!(error = %e, issue = issue_number, "spec label sync failed");
+    if let Some(tok) = state.config.github_token.as_deref()
+        && !body.is_empty()
+    {
+        let linked = crate::handlers::spec_link::linked_issues(&body);
+        if !linked.is_empty() {
+            use onsager_github::api::issues::set_label;
+            for issue_number in linked {
+                let result = match (act, merged) {
+                    (PrAction::Opened, _) => {
+                        set_label(Some(tok), owner, name, issue_number, "in-progress", true).await
                     }
+                    (PrAction::Closed, true) => {
+                        // PR merged — move spec from `in-progress` to `done`
+                        // to mirror the human-driven label progression.
+                        let _ =
+                            set_label(Some(tok), owner, name, issue_number, "in-progress", false)
+                                .await;
+                        set_label(Some(tok), owner, name, issue_number, "done", true).await
+                    }
+                    (PrAction::Closed, false) => {
+                        // Closed without merge — revert to `planned` so the
+                        // spec re-enters the queue cleanly.
+                        let _ =
+                            set_label(Some(tok), owner, name, issue_number, "in-progress", false)
+                                .await;
+                        set_label(Some(tok), owner, name, issue_number, "planned", true).await
+                    }
+                    (PrAction::Synchronize, _) => Ok(()),
+                };
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, issue = issue_number, "spec label sync failed");
                 }
             }
         }

--- a/crates/onsager-portal/src/handlers/registry_events.rs
+++ b/crates/onsager-portal/src/handlers/registry_events.rs
@@ -13,8 +13,8 @@
 //! portal so the dashboard's `API_BASE` cutover (#222 Slice 6) can
 //! eventually drop the `routes::portal::proxy` shim.
 
-use axum::response::{IntoResponse, Response};
 use axum::Json;
+use axum::response::{IntoResponse, Response};
 use onsager_registry::EVENTS;
 
 /// GET /api/registry/events — return the event-type registry manifest.

--- a/crates/onsager-portal/src/handlers/registry_triggers.rs
+++ b/crates/onsager-portal/src/handlers/registry_triggers.rs
@@ -13,8 +13,8 @@
 //! portal so the dashboard's `API_BASE` cutover (#222 Slice 6) can
 //! eventually drop the `routes::portal::proxy` shim.
 
-use axum::response::{IntoResponse, Response};
 use axum::Json;
+use axum::response::{IntoResponse, Response};
 use onsager_registry::TRIGGERS;
 
 /// GET /api/registry/triggers — return the trigger-kind registry manifest.

--- a/crates/onsager-portal/src/handlers/sessions.rs
+++ b/crates/onsager-portal/src/handlers/sessions.rs
@@ -3,11 +3,11 @@
 //! Moved from `crates/stiglab/src/server/routes/sessions.rs`. All DB
 //! access goes through `crate::session_db` (PgPool).
 
+use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use futures_util::stream;
 use serde::Deserialize;
 use std::convert::Infallible;

--- a/crates/onsager-portal/src/handlers/spine.rs
+++ b/crates/onsager-portal/src/handlers/spine.rs
@@ -11,10 +11,10 @@
 //! stays in stiglab for the agent-runtime emits; portal calls
 //! `state.spine.append_ext` directly.
 
+use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use onsager_spine::EventMetadata;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
@@ -440,7 +440,7 @@ pub async fn get_artifact(
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({ "error": "artifact not found" })),
             )
-                .into_response()
+                .into_response();
         }
         Err(e) => {
             tracing::error!("spine artifact query failed: {e}");

--- a/crates/onsager-portal/src/handlers/tasks.rs
+++ b/crates/onsager-portal/src/handlers/tasks.rs
@@ -10,10 +10,10 @@
 //! 4. Returns immediately. Stiglab's `session_requested_listener` picks up
 //!    the event, fetches credentials, and dispatches to the agent WebSocket.
 
+use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use chrono::Utc;
 use onsager_spine::EventMetadata;
 use serde::Serialize;
@@ -136,16 +136,16 @@ pub async fn create_task(
                 return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
             }
         };
-        if let Some(ref explicit) = request.workspace_id {
-            if explicit != &project.workspace_id {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": "workspace_id does not match the project's workspace",
-                    })),
-                )
-                    .into_response();
-            }
+        if let Some(ref explicit) = request.workspace_id
+            && explicit != &project.workspace_id
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "workspace_id does not match the project's workspace",
+                })),
+            )
+                .into_response();
         }
         if let Err(r) =
             require_workspace_access(&state.pool, &auth_user, &project.workspace_id).await

--- a/crates/onsager-portal/src/handlers/telegram_webhook.rs
+++ b/crates/onsager-portal/src/handlers/telegram_webhook.rs
@@ -16,11 +16,11 @@
 
 use std::collections::HashSet;
 
+use axum::Json;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use axum::Json;
 use onsager_spine::{EventMetadata, TriggerKind};
 use serde_json::Value;
 
@@ -120,10 +120,10 @@ pub async fn handle(
                 _ => continue,
             }
         }
-        if let Some(prefix) = command_prefix {
-            if !text.starts_with(prefix) {
-                continue;
-            }
+        if let Some(prefix) = command_prefix
+            && !text.starts_with(prefix)
+        {
+            continue;
         }
 
         let payload = serde_json::json!({

--- a/crates/onsager-portal/src/handlers/triggers.rs
+++ b/crates/onsager-portal/src/handlers/triggers.rs
@@ -24,10 +24,10 @@
 //! the #241 resolution. Per-tenant role gating (admin-only,
 //! workflow-owner-only) is a follow-up.
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventMetadata, TriggerKind};
@@ -255,17 +255,17 @@ async fn require_membership(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match credential_db::is_workspace_member(&state.pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -13,18 +13,18 @@
 //! Bad signatures and unknown installations both return `401`. Malformed
 //! payloads return `400`. Successful dispatches return `202` (accepted).
 
+use axum::Json;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use axum::Json;
 use serde_json::Value;
 
-use onsager_github::webhook::{verify_signature, SignatureCheck};
+use onsager_github::webhook::{SignatureCheck, verify_signature};
 use onsager_spine::webhook_routing::{
-    route_check_event, route_issues_labeled, route_pull_request_closed,
-    route_pull_request_closed_workflows, route_workflow_run_completed_workflows, spine_namespace,
-    RoutedEvent, WorkflowTrigger,
+    RoutedEvent, WorkflowTrigger, route_check_event, route_issues_labeled,
+    route_pull_request_closed, route_pull_request_closed_workflows,
+    route_workflow_run_completed_workflows, spine_namespace,
 };
 
 use crate::handlers::{issues, pull_request};

--- a/crates/onsager-portal/src/handlers/workflow_kinds.rs
+++ b/crates/onsager-portal/src/handlers/workflow_kinds.rs
@@ -10,9 +10,9 @@
 //! here (matches the `BUILTIN_WORKFLOW_KINDS` filter in
 //! `onsager-registry::catalog`).
 
-use axum::response::{IntoResponse, Response};
 use axum::Json;
-use onsager_registry::catalog::{workflow_builtin_types, BUILTIN_WORKFLOW_KINDS};
+use axum::response::{IntoResponse, Response};
+use onsager_registry::catalog::{BUILTIN_WORKFLOW_KINDS, workflow_builtin_types};
 use onsager_registry::registry::MergeRule;
 use serde::Serialize;
 

--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -9,24 +9,24 @@
 //! Repo scope and label creation live in `crate::workflow_activation`;
 //! this module just handles the HTTP shape + input validation.
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
-use onsager_github::api::app::{mint_app_jwt, mint_installation_token, AppConfig};
+use onsager_github::api::app::{AppConfig, mint_app_jwt, mint_installation_token};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::auth::{decrypt_credential, AuthUser};
+use crate::auth::{AuthUser, decrypt_credential};
 use crate::credential_db;
 use crate::installation_db;
-use crate::preset::{resolve_preset, PRESET_IDS};
+use crate::preset::{PRESET_IDS, resolve_preset};
 use crate::state::AppState;
 use crate::workflow::{GateKind, TriggerKind, Workflow, WorkflowStage};
 use crate::workflow_activation::{
-    deregister_webhook, ensure_label_exists, ensure_repo_in_scope, ensure_webhook_registered,
-    ActivationError,
+    ActivationError, deregister_webhook, ensure_label_exists, ensure_repo_in_scope,
+    ensure_webhook_registered,
 };
 use crate::workflow_db;
 
@@ -58,17 +58,17 @@ async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match credential_db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),
@@ -649,8 +649,10 @@ pub async fn patch_workflow(
         if let Err(r) = activate_workflow(&state, &workflow_id, &headers).await {
             return r;
         }
-    } else if let Err(r) = deactivate_workflow(&state, &workflow_id).await {
-        return r;
+    } else {
+        if let Err(r) = deactivate_workflow(&state, &workflow_id).await {
+            return r;
+        }
     }
 
     let updated = workflow_db::get_workflow(spine, &workflow_id)
@@ -691,10 +693,10 @@ pub async fn delete_workflow(
         return r;
     }
 
-    if workflow.active {
-        if let Err(r) = deactivate_workflow(&state, &workflow_id).await {
-            return r;
-        }
+    if workflow.active
+        && let Err(r) = deactivate_workflow(&state, &workflow_id).await
+    {
+        return r;
     }
 
     if let Err(e) = workflow_db::delete_workflow(spine, &workflow_id).await {

--- a/crates/onsager-portal/src/handlers/workspaces.rs
+++ b/crates/onsager-portal/src/handlers/workspaces.rs
@@ -5,10 +5,10 @@
 //! GitHub's private-resource pattern — non-members can't enumerate
 //! workspaces via 403 vs 404 differentiation).
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
 use serde::Deserialize;
 use sqlx::postgres::PgPool;
@@ -32,17 +32,17 @@ pub(crate) async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match workspace_db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use axum::routing::{any, delete, get, post, put};
 use axum::Router;
+use axum::routing::{any, delete, get, post, put};
 
 use crate::config::Config;
 use crate::gate::GateClient;
@@ -41,10 +41,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // doesn't see them on a cold start. Best-effort: if the tables
     // aren't there yet, log and continue — stiglab's first migration run
     // will create them, and the next portal start will seed.
-    if cfg!(debug_assertions) || config.dev_login_enabled {
-        if let Err(e) = crate::dev_auth::seed_dev_user_and_workspace(&pool).await {
-            tracing::warn!(error = %e, "portal dev-login seeder skipped (workspaces table missing?)");
-        }
+    if (cfg!(debug_assertions) || config.dev_login_enabled)
+        && let Err(e) = crate::dev_auth::seed_dev_user_and_workspace(&pool).await
+    {
+        tracing::warn!(error = %e, "portal dev-login seeder skipped (workspaces table missing?)");
     }
 
     let gate = Arc::new(GateClient::new(config.synodic_url.clone()));

--- a/crates/onsager-portal/src/sso.rs
+++ b/crates/onsager-portal/src/sso.rs
@@ -12,8 +12,8 @@
 //! `return_to` URL. The owner refuses any `return_to` whose host is not in
 //! `SSO_RETURN_HOST_ALLOWLIST`.
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::hmac;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};

--- a/crates/onsager-portal/src/workflow_activation.rs
+++ b/crates/onsager-portal/src/workflow_activation.rs
@@ -24,7 +24,7 @@
 
 use std::time::Duration;
 
-use onsager_github::api::app::{list_installation_repos, InstallationToken};
+use onsager_github::api::app::{InstallationToken, list_installation_repos};
 use serde::Serialize;
 use thiserror::Error;
 
@@ -166,10 +166,10 @@ fn resolve_webhook_base(headers: &axum::http::HeaderMap) -> Option<String> {
             return Some(format!("https://{trimmed}"));
         }
     }
-    if trust_forwarded_headers() {
-        if let Some(origin) = origin_from_headers(headers) {
-            return Some(origin);
-        }
+    if trust_forwarded_headers()
+        && let Some(origin) = origin_from_headers(headers)
+    {
+        return Some(origin);
     }
     None
 }
@@ -426,7 +426,7 @@ pub async fn ensure_webhook_registered(
         Ok(()) => {}
         Err(WebhookUrlReject::Invalid) => return Err(ActivationError::WebhookUrlInvalid { url }),
         Err(WebhookUrlReject::NotReachable) => {
-            return Err(ActivationError::WebhookUrlNotReachable { url })
+            return Err(ActivationError::WebhookUrlNotReachable { url });
         }
     }
     let list_url = format!("https://api.github.com/repos/{owner}/{repo}/hooks");
@@ -653,7 +653,11 @@ mod tests {
     impl ScopedEnvVar {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var(key).ok();
-            std::env::set_var(key, value);
+            // SAFETY: edition 2024 marks env mutation as `unsafe`. Each
+            // test in this module acquires `env_lock()` before
+            // constructing any `ScopedEnvVar`, so no other thread reads
+            // or writes env concurrently.
+            unsafe { std::env::set_var(key, value) };
             Self { key, previous }
         }
 
@@ -662,17 +666,19 @@ mod tests {
         /// earlier layers don't resolve from ambient env.
         fn unset(key: &'static str) -> Self {
             let previous = std::env::var(key).ok();
-            std::env::remove_var(key);
+            // SAFETY: see `set` above; same `env_lock()` discipline.
+            unsafe { std::env::remove_var(key) };
             Self { key, previous }
         }
     }
 
     impl Drop for ScopedEnvVar {
         fn drop(&mut self) {
+            // SAFETY: see `ScopedEnvVar::set`; same `env_lock()` discipline.
             if let Some(previous) = &self.previous {
-                std::env::set_var(self.key, previous);
+                unsafe { std::env::set_var(self.key, previous) };
             } else {
-                std::env::remove_var(self.key);
+                unsafe { std::env::remove_var(self.key) };
             }
         }
     }

--- a/crates/onsager-portal/src/workflow_db.rs
+++ b/crates/onsager-portal/src/workflow_db.rs
@@ -94,12 +94,12 @@ pub async fn insert_workflow_with_stages(
     // workflow self-amplifies — every fire produces another `trigger.fired`
     // event that the same workflow listens to. Reject at create time;
     // forge's event-trigger listener also has a runtime backstop.
-    if let TriggerKind::SpineEvent { event_kind, .. } = &workflow.trigger {
-        if event_kind == "trigger.fired" {
-            anyhow::bail!(
-                "spine_event workflow cannot listen for `trigger.fired` (would self-amplify)"
-            );
-        }
+    if let TriggerKind::SpineEvent { event_kind, .. } = &workflow.trigger
+        && event_kind == "trigger.fired"
+    {
+        anyhow::bail!(
+            "spine_event workflow cannot listen for `trigger.fired` (would self-amplify)"
+        );
     }
     let install_id_text = workflow.install_id.to_string();
 

--- a/crates/onsager-registry/src/evaluators.rs
+++ b/crates/onsager-registry/src/evaluators.rs
@@ -192,11 +192,12 @@ mod tests {
     #[tokio::test]
     async fn ci_green_paths() {
         let g = CiGreen::default();
-        assert!(g
-            .evaluate(&ctx(serde_json::json!({"ci_status": "success"})))
-            .await
-            .unwrap()
-            .is_allow());
+        assert!(
+            g.evaluate(&ctx(serde_json::json!({"ci_status": "success"})))
+                .await
+                .unwrap()
+                .is_allow()
+        );
         assert!(matches!(
             g.evaluate(&ctx(serde_json::json!({"ci_status": "failure"})))
                 .await

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -608,8 +608,7 @@ pub const EVENTS: EventManifest = EventManifest {
             producers: &[Subsystem::Portal],
             consumers: &[],
             audit_only: true,
-            description:
-                "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
+            description: "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
         },
         EventDefinition {
             kind: "stage.entered",

--- a/crates/onsager-registry/src/lib.rs
+++ b/crates/onsager-registry/src/lib.rs
@@ -17,8 +17,8 @@ pub mod triggers;
 
 pub use catalog::*;
 pub use evaluators::*;
-pub use events::{EventDefinition, EventManifest, Subsystem, EVENTS};
+pub use events::{EVENTS, EventDefinition, EventManifest, Subsystem};
 pub use registry::*;
 pub use registry_store::*;
 pub use seed::*;
-pub use triggers::{TriggerCategory, TriggerDefinition, TriggerManifest, TriggerUiKind, TRIGGERS};
+pub use triggers::{TRIGGERS, TriggerCategory, TriggerDefinition, TriggerManifest, TriggerUiKind};

--- a/crates/onsager-registry/src/registry_store.rs
+++ b/crates/onsager-registry/src/registry_store.rs
@@ -8,12 +8,12 @@
 
 use chrono::{DateTime, Utc};
 use onsager_spine::{
-    append_factory_event_tx, EventMetadata, EventStore, FactoryEvent, FactoryEventKind,
+    EventMetadata, EventStore, FactoryEvent, FactoryEventKind, append_factory_event_tx,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Row, Transaction};
 
-use crate::registry::{RegistryStatus, TypeDefinition, DEFAULT_WORKSPACE};
+use crate::registry::{DEFAULT_WORKSPACE, RegistryStatus, TypeDefinition};
 
 /// Row-like view of an entry in one of the four registry tables.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -318,7 +318,7 @@ fn row_to_record(row: sqlx::postgres::PgRow) -> sqlx::Result<RegistryRecord> {
         other => {
             return Err(sqlx::Error::Protocol(format!(
                 "unknown registry status: {other}"
-            )))
+            )));
         }
     };
     Ok(RegistryRecord {

--- a/crates/onsager-registry/src/seed.rs
+++ b/crates/onsager-registry/src/seed.rs
@@ -12,13 +12,13 @@
 
 use chrono::Utc;
 use onsager_spine::{
-    append_factory_event_tx, EventMetadata, EventStore, FactoryEvent, FactoryEventKind,
+    EventMetadata, EventStore, FactoryEvent, FactoryEventKind, append_factory_event_tx,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 
 use crate::registry::{
-    AgentProfile, RegistryStatus, TypeDefinition, DEFAULT_WORKSPACE, SEED_ACTOR,
+    AgentProfile, DEFAULT_WORKSPACE, RegistryStatus, SEED_ACTOR, TypeDefinition,
 };
 
 /// An adapter catalog entry as it appears in a seed file.
@@ -295,14 +295,16 @@ mod tests {
         assert!(type_ids.contains(&"GateEvaluator"));
         assert!(type_ids.contains(&"AgentProfile"));
 
-        assert!(seed
-            .evaluators
-            .iter()
-            .any(|e| e.evaluator_id == "HumanApproval"));
-        assert!(seed
-            .profiles
-            .iter()
-            .any(|p| p.profile_id.as_str() == "Human"));
+        assert!(
+            seed.evaluators
+                .iter()
+                .any(|e| e.evaluator_id == "HumanApproval")
+        );
+        assert!(
+            seed.profiles
+                .iter()
+                .any(|p| p.profile_id.as_str() == "Human")
+        );
     }
 
     #[test]

--- a/crates/onsager-registry/src/triggers.rs
+++ b/crates/onsager-registry/src/triggers.rs
@@ -144,24 +144,21 @@ pub const TRIGGERS: TriggerManifest = TriggerManifest {
             producer: Subsystem::Portal,
             category: TriggerCategory::Request,
             ui_kind: TriggerUiKind::GithubPullRequestClosed,
-            description:
-                "Fires when a GitHub pull request closes; optional `merged` predicate.",
+            description: "Fires when a GitHub pull request closes; optional `merged` predicate.",
         },
         TriggerDefinition {
             kind_tag: "github_workflow_run_completed",
             producer: Subsystem::Portal,
             category: TriggerCategory::Request,
             ui_kind: TriggerUiKind::GithubWorkflowRunCompleted,
-            description:
-                "Fires when a GitHub Actions workflow run completes; filter by name / event / branch / conclusion.",
+            description: "Fires when a GitHub Actions workflow run completes; filter by name / event / branch / conclusion.",
         },
         TriggerDefinition {
             kind_tag: "telegram_webhook",
             producer: Subsystem::Portal,
             category: TriggerCategory::Request,
             ui_kind: TriggerUiKind::TelegramWebhook,
-            description:
-                "Fires on a Telegram bot webhook; optional chat-id allowlist + command prefix.",
+            description: "Fires on a Telegram bot webhook; optional chat-id allowlist + command prefix.",
         },
         // -- Schedule (#238) -----------------------------------------------
         TriggerDefinition {

--- a/crates/onsager-registry/tests/registry_flow.rs
+++ b/crates/onsager-registry/tests/registry_flow.rs
@@ -4,8 +4,8 @@
 //! Skipped unless `DATABASE_URL` is set.
 
 use onsager_registry::{
-    apply_seed, register_engineering_catalog, RegistryKind, RegistryStatus, RegistryStore,
-    SeedCatalog, TypeDefinition,
+    RegistryKind, RegistryStatus, RegistryStore, SeedCatalog, TypeDefinition, apply_seed,
+    register_engineering_catalog,
 };
 use onsager_spine::EventStore;
 
@@ -78,14 +78,18 @@ async fn propose_then_approve_type_lifecycle() {
     assert_eq!(row.status, RegistryStatus::Approved);
 
     // deprecate emits the terminal event
-    assert!(registry
-        .deprecate_type("DraftType", "superseded", "bob")
-        .await
-        .unwrap());
-    assert!(!registry
-        .deprecate_type("DraftType", "noop", "bob")
-        .await
-        .unwrap());
+    assert!(
+        registry
+            .deprecate_type("DraftType", "superseded", "bob")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !registry
+            .deprecate_type("DraftType", "noop", "bob")
+            .await
+            .unwrap()
+    );
 
     // Three registry events should have landed on the spine for this
     // workspace. Filter on event_type (authoritative column) and

--- a/crates/onsager-registry/tests/seed_idempotency.rs
+++ b/crates/onsager-registry/tests/seed_idempotency.rs
@@ -3,7 +3,7 @@
 //! Skipped unless `DATABASE_URL` is set (matches the convention in
 //! `store::tests`). Run via `just test-spine`.
 
-use onsager_registry::{apply_seed, SeedCatalog, DEFAULT_WORKSPACE};
+use onsager_registry::{DEFAULT_WORKSPACE, SeedCatalog, apply_seed};
 use onsager_spine::EventStore;
 
 fn db_url() -> Option<String> {

--- a/crates/onsager-spine/examples/producer_consumer.rs
+++ b/crates/onsager-spine/examples/producer_consumer.rs
@@ -7,8 +7,8 @@
 //! cargo run --example producer_consumer
 //! ```
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use chrono::Utc;

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -63,10 +63,10 @@ pub use factory_event::{
 pub use listener::{EventHandler, Listener};
 pub use namespace::{Namespace, NamespaceError};
 pub use store::{
-    append_factory_event_tx, EventMetadata, EventNotification, EventRecord, EventStore,
+    EventMetadata, EventNotification, EventRecord, EventStore, append_factory_event_tx,
 };
 pub use trigger::{DelayAnchor, JsonFilter, TriggerKind, TriggerStorageError};
 pub use webhook_routing::{
-    build_trigger_fired_events, route_check_event, route_issues_labeled, route_pull_request_closed,
-    spine_namespace, trigger_source, IssueTriggerContext, RoutedEvent, WorkflowMatch,
+    IssueTriggerContext, RoutedEvent, WorkflowMatch, build_trigger_fired_events, route_check_event,
+    route_issues_labeled, route_pull_request_closed, spine_namespace, trigger_source,
 };

--- a/crates/onsager-spine/src/listener.rs
+++ b/crates/onsager-spine/src/listener.rs
@@ -273,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn listener_backfill_and_live() {
         use crate::factory_event::{FactoryEvent, FactoryEventKind};
-        use crate::store::{append_factory_event_tx, EventMetadata, EventStore};
+        use crate::store::{EventMetadata, EventStore, append_factory_event_tx};
         use chrono::Utc;
         use onsager_artifact::{ArtifactId, Kind};
         use std::sync::atomic::{AtomicI64, Ordering};

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -336,10 +336,9 @@ impl EventStore {
                     Ok(notification) => {
                         if let Ok(parsed) =
                             serde_json::from_str::<EventNotification>(notification.payload())
+                            && tx.send(parsed).is_err()
                         {
-                            if tx.send(parsed).is_err() {
-                                break;
-                            }
+                            break;
                         }
                     }
                     Err(e) => {
@@ -377,10 +376,9 @@ impl EventStore {
                     Ok(notification) => {
                         if let Ok(parsed) =
                             serde_json::from_str::<EventNotification>(notification.payload())
+                            && tx.send(parsed).await.is_err()
                         {
-                            if tx.send(parsed).await.is_err() {
-                                break;
-                            }
+                            break;
                         }
                     }
                     Err(e) => {

--- a/crates/onsager-spine/src/webhook_routing.rs
+++ b/crates/onsager-spine/src/webhook_routing.rs
@@ -82,10 +82,10 @@ pub fn build_trigger_fired_events(
                 "workspace_id": w.workspace_id,
                 "source": ctx.source,
             });
-            if let Some(uid) = ctx.replayed_by {
-                if let Some(obj) = payload.as_object_mut() {
-                    obj.insert("replayed_by".into(), Value::String(uid.to_string()));
-                }
+            if let Some(uid) = ctx.replayed_by
+                && let Some(obj) = payload.as_object_mut()
+            {
+                obj.insert("replayed_by".into(), Value::String(uid.to_string()));
             }
             RoutedEvent {
                 kind: FactoryEventKind::TriggerFired {
@@ -335,20 +335,20 @@ pub fn route_workflow_run_completed_workflows(
                 if workflow_name != run_name {
                     return false;
                 }
-                if let Some(filter) = event {
-                    if filter != run_event {
-                        return false;
-                    }
+                if let Some(filter) = event
+                    && filter != run_event
+                {
+                    return false;
                 }
-                if let Some(filter) = hb {
-                    if filter != head_branch {
-                        return false;
-                    }
+                if let Some(filter) = hb
+                    && filter != head_branch
+                {
+                    return false;
                 }
-                if let Some(filter) = cc {
-                    if filter != conclusion {
-                        return false;
-                    }
+                if let Some(filter) = cc
+                    && filter != conclusion
+                {
+                    return false;
                 }
                 true
             }
@@ -819,10 +819,12 @@ mod tests {
             "workflow_run": {"id": 1, "name": "rust", "event": "push"},
             "repository": {"name": "widgets", "owner": {"login": "acme"}},
         });
-        assert!(route_workflow_run_completed_workflows(
-            &payload,
-            &[run_workflow("rust", None, None, None)]
-        )
-        .is_empty());
+        assert!(
+            route_workflow_run_completed_workflows(
+                &payload,
+                &[run_workflow("rust", None, None, None)]
+            )
+            .is_empty()
+        );
     }
 }

--- a/crates/onsager-trigger/src/main.rs
+++ b/crates/onsager-trigger/src/main.rs
@@ -19,7 +19,7 @@
 //! The CLI inherits the user's shell environment as its "auth" — there's
 //! no separate token; the CLI is operator-grade by design.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use clap::{Args, Parser, Subcommand};
 use onsager_registry::TRIGGERS;
@@ -133,11 +133,11 @@ async fn fire(store: &EventStore, args: &FireArgs, actor: &str) -> Result<()> {
         "actor": actor,
         "source": "cli",
     });
-    if let Some(extra) = extra_payload {
-        if let (Value::Object(ref mut map), Value::Object(extra_map)) = (&mut payload, extra) {
-            for (k, v) in extra_map {
-                map.insert(k, v);
-            }
+    if let Some(extra) = extra_payload
+        && let (Value::Object(map), Value::Object(extra_map)) = (&mut payload, extra)
+    {
+        for (k, v) in extra_map {
+            map.insert(k, v);
         }
     }
 

--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -11,7 +11,7 @@
 //! never statically linked into a shared process.
 
 use std::env;
-use std::process::{exit, Command};
+use std::process::{Command, exit};
 
 const HELP: &str = "\
 onsager — AI factory dispatcher

--- a/crates/stiglab/src/agent/connection.rs
+++ b/crates/stiglab/src/agent/connection.rs
@@ -40,10 +40,10 @@ pub async fn connect_and_run(config: AgentConfig) -> Result<()> {
     // Spawn outbound message forwarder
     let send_task = tokio::spawn(async move {
         while let Some(msg) = outbound_rx.recv().await {
-            if let Ok(json) = serde_json::to_string(&msg) {
-                if ws_sender.send(Message::Text(json)).await.is_err() {
-                    break;
-                }
+            if let Ok(json) = serde_json::to_string(&msg)
+                && ws_sender.send(Message::Text(json)).await.is_err()
+            {
+                break;
             }
         }
     });

--- a/crates/stiglab/src/agent/session/manager.rs
+++ b/crates/stiglab/src/agent/session/manager.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 
 use crate::core::{AgentMessage, Task};
 
@@ -141,10 +141,10 @@ impl SessionManager {
 
     pub async fn send_input(&self, session_id: &str, input: &str) {
         let sessions = self.sessions.read().await;
-        if let Some(proc) = sessions.get(session_id) {
-            if let Err(e) = proc.send_input(input) {
-                tracing::error!("failed to send input to session {session_id}: {e}");
-            }
+        if let Some(proc) = sessions.get(session_id)
+            && let Err(e) = proc.send_input(input)
+        {
+            tracing::error!("failed to send input to session {session_id}: {e}");
         }
     }
 }

--- a/crates/stiglab/src/agent/session/process.rs
+++ b/crates/stiglab/src/agent/session/process.rs
@@ -199,30 +199,28 @@ impl SessionProcess {
                         ClaudeEvent::StreamEvent { event: inner } => {
                             match inner.event_type.as_str() {
                                 "content_block_delta" => {
-                                    if let Some(delta) = inner.delta {
-                                        if delta.delta_type == "text_delta" {
-                                            if let Some(ref text) = delta.text {
-                                                accumulated_output.push_str(text);
-                                                let _ = tx.send(AgentMessage::SessionOutput {
-                                                    session_id: sid.clone(),
-                                                    chunk: text.clone(),
-                                                    stream: "stdout".to_string(),
-                                                });
-                                            }
-                                        }
+                                    if let Some(delta) = inner.delta
+                                        && delta.delta_type == "text_delta"
+                                        && let Some(ref text) = delta.text
+                                    {
+                                        accumulated_output.push_str(text);
+                                        let _ = tx.send(AgentMessage::SessionOutput {
+                                            session_id: sid.clone(),
+                                            chunk: text.clone(),
+                                            stream: "stdout".to_string(),
+                                        });
                                     }
                                 }
                                 "content_block_start" => {
-                                    if let Some(block) = inner.content_block {
-                                        if block.block_type == "tool_use" {
-                                            let tool_name =
-                                                block.name.as_deref().unwrap_or("unknown");
-                                            let _ = tx.send(AgentMessage::SessionOutput {
-                                                session_id: sid.clone(),
-                                                chunk: format!("[tool_use: {tool_name}]\n"),
-                                                stream: "stdout".to_string(),
-                                            });
-                                        }
+                                    if let Some(block) = inner.content_block
+                                        && block.block_type == "tool_use"
+                                    {
+                                        let tool_name = block.name.as_deref().unwrap_or("unknown");
+                                        let _ = tx.send(AgentMessage::SessionOutput {
+                                            session_id: sid.clone(),
+                                            chunk: format!("[tool_use: {tool_name}]\n"),
+                                            stream: "stdout".to_string(),
+                                        });
                                     }
                                 }
                                 _ => {} // content_block_stop and others — no action needed
@@ -232,10 +230,10 @@ impl SessionProcess {
                             subtype,
                             session_id: claude_sid,
                         } => {
-                            if subtype == "session_id" {
-                                if let Some(ref csid) = claude_sid {
-                                    tracing::info!("claude session id for {}: {}", sid, csid);
-                                }
+                            if subtype == "session_id"
+                                && let Some(ref csid) = claude_sid
+                            {
+                                tracing::info!("claude session id for {}: {}", sid, csid);
                             }
                         }
                         ClaudeEvent::Result {
@@ -316,10 +314,9 @@ impl SessionProcess {
 
     /// Consume the NDJSON completion result. Call before `wait()`.
     pub async fn take_ndjson_result(&mut self) -> Option<NdjsonResult> {
-        if let Some(rx) = self.completion_rx.take() {
-            rx.await.ok()
-        } else {
-            None
+        match self.completion_rx.take() {
+            Some(rx) => rx.await.ok(),
+            _ => None,
         }
     }
 

--- a/crates/stiglab/src/runner.rs
+++ b/crates/stiglab/src/runner.rs
@@ -13,10 +13,10 @@ use uuid::Uuid;
 
 use stiglab::agent::session::manager::SessionManager;
 use stiglab::core::{AgentMessage, Node, NodeStatus, ServerMessage};
+use stiglab::server::AnyPool;
 use stiglab::server::db;
 use stiglab::server::handler;
 use stiglab::server::state::{AgentConnection, AppState};
-use stiglab::server::AnyPool;
 
 pub async fn start_built_in_runner(
     state: &AppState,

--- a/crates/stiglab/src/server/auth.rs
+++ b/crates/stiglab/src/server/auth.rs
@@ -1,9 +1,9 @@
 use axum::extract::FromRequestParts;
-use axum::http::request::Parts;
 use axum::http::StatusCode;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::aead;
 use ring::digest;
 use ring::rand::{SecureRandom, SystemRandom};
@@ -231,10 +231,10 @@ pub async fn verify_pat(
     if pat.revoked_at.is_some() {
         return Ok(PatVerifyOutcome::Revoked);
     }
-    if let Some(exp) = pat.expires_at {
-        if exp < chrono::Utc::now() {
-            return Ok(PatVerifyOutcome::Expired);
-        }
+    if let Some(exp) = pat.expires_at
+        && exp < chrono::Utc::now()
+    {
+        return Ok(PatVerifyOutcome::Expired);
     }
     Ok(PatVerifyOutcome::Ok(Box::new(pat)))
 }
@@ -345,77 +345,76 @@ impl FromRequestParts<AppState> for AuthUser {
         //    on the same request — cookie + Bearer normally doesn't happen
         //    in practice, but a CLI smoke test of the dashboard shouldn't
         //    silently fall through to the browser session.
-        if let Some(token) = parse_bearer_token(parts) {
-            if token.starts_with(PAT_TOKEN_NAMESPACE) {
-                match verify_pat(&state.db, &token).await {
-                    Ok(PatVerifyOutcome::Ok(pat)) => {
-                        let user = match db::get_user(&state.db, &pat.user_id).await {
-                            Ok(Some(u)) => u,
-                            Ok(None) => {
-                                tracing::warn!(
-                                    pat_id = %pat.id,
-                                    "PAT references missing user — rejecting"
-                                );
-                                return Err(unauthorized_invalid_token());
-                            }
-                            Err(e) => {
-                                tracing::error!("PAT auth: failed to load user: {e}");
-                                return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
-                            }
-                        };
+        if let Some(token) = parse_bearer_token(parts)
+            && token.starts_with(PAT_TOKEN_NAMESPACE)
+        {
+            match verify_pat(&state.db, &token).await {
+                Ok(PatVerifyOutcome::Ok(pat)) => {
+                    let user = match db::get_user(&state.db, &pat.user_id).await {
+                        Ok(Some(u)) => u,
+                        Ok(None) => {
+                            tracing::warn!(
+                                pat_id = %pat.id,
+                                "PAT references missing user — rejecting"
+                            );
+                            return Err(unauthorized_invalid_token());
+                        }
+                        Err(e) => {
+                            tracing::error!("PAT auth: failed to load user: {e}");
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                        }
+                    };
 
-                        // Best-effort touch — failure must not block the
-                        // request. Capture client metadata before the move.
-                        let pool = state.db.clone();
-                        let pat_id = pat.id.clone();
-                        let ip = parts
-                            .headers
-                            .get("x-forwarded-for")
-                            .and_then(|v| v.to_str().ok())
-                            .and_then(|s| s.split(',').next())
-                            .map(|s| s.trim().to_string());
-                        let ua = parts
-                            .headers
-                            .get(axum::http::header::USER_AGENT)
-                            .and_then(|v| v.to_str().ok())
-                            .map(|s| s.to_string());
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref())
-                                    .await
-                            {
-                                tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
-                            }
-                        });
+                    // Best-effort touch — failure must not block the
+                    // request. Capture client metadata before the move.
+                    let pool = state.db.clone();
+                    let pat_id = pat.id.clone();
+                    let ip = parts
+                        .headers
+                        .get("x-forwarded-for")
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.split(',').next())
+                        .map(|s| s.trim().to_string());
+                    let ua = parts
+                        .headers
+                        .get(axum::http::header::USER_AGENT)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    tokio::spawn(async move {
+                        if let Err(e) =
+                            db::touch_user_pat(&pool, &pat_id, ip.as_deref(), ua.as_deref()).await
+                        {
+                            tracing::warn!(pat_id = %pat_id, "failed to touch PAT: {e}");
+                        }
+                    });
 
-                        let session_kind = session_kind_for_github_id(user.github_id);
-                        return Ok(AuthUser {
-                            user_id: user.id,
-                            github_login: user.github_login,
-                            github_name: user.github_name,
-                            github_avatar_url: user.github_avatar_url,
-                            principal: RequestPrincipal::Pat {
-                                pat_id: pat.id,
-                                workspace_id: pat.workspace_id,
-                            },
-                            session_kind,
-                        });
-                    }
-                    Ok(PatVerifyOutcome::Unknown)
-                    | Ok(PatVerifyOutcome::Revoked)
-                    | Ok(PatVerifyOutcome::Expired) => {
-                        return Err(unauthorized_invalid_token());
-                    }
-                    Err(e) => {
-                        tracing::error!("PAT verification failed: {e}");
-                        return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
-                    }
+                    let session_kind = session_kind_for_github_id(user.github_id);
+                    return Ok(AuthUser {
+                        user_id: user.id,
+                        github_login: user.github_login,
+                        github_name: user.github_name,
+                        github_avatar_url: user.github_avatar_url,
+                        principal: RequestPrincipal::Pat {
+                            pat_id: pat.id,
+                            workspace_id: pat.workspace_id,
+                        },
+                        session_kind,
+                    });
+                }
+                Ok(PatVerifyOutcome::Unknown)
+                | Ok(PatVerifyOutcome::Revoked)
+                | Ok(PatVerifyOutcome::Expired) => {
+                    return Err(unauthorized_invalid_token());
+                }
+                Err(e) => {
+                    tracing::error!("PAT verification failed: {e}");
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
                 }
             }
-            // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
-            // are owned by their dedicated routes — fall through so the
-            // cookie path still works for the dashboard.
         }
+        // Other Bearer tokens (e.g. SSO exchange secret on /sso/redeem)
+        // are owned by their dedicated routes — fall through so the
+        // cookie path still works for the dashboard.
 
         // 2) Fall back to the session cookie.
         let session_id = parts
@@ -528,7 +527,7 @@ mod tests {
     fn test_generate_credential_key_length() {
         let key = generate_credential_key();
         assert_eq!(key.len(), 64); // 32 bytes hex-encoded
-                                   // Should be valid hex
+        // Should be valid hex
         assert!(hex::decode(&key).is_ok());
     }
 

--- a/crates/stiglab/src/server/db/mod.rs
+++ b/crates/stiglab/src/server/db/mod.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use sqlx::pool::PoolOptions;
 use sqlx::AnyPool;
+use sqlx::pool::PoolOptions;
 
 mod credentials;
 mod github_installations;
@@ -18,9 +18,9 @@ mod tests;
 // ── Re-exports ──
 
 pub use credentials::{
-    delete_user_credential, get_all_user_credential_values, get_user_credential_value,
-    get_user_credentials, set_user_credential, user_credential_exists, user_has_credential_in,
-    UserCredential,
+    UserCredential, delete_user_credential, get_all_user_credential_values,
+    get_user_credential_value, get_user_credentials, set_user_credential, user_credential_exists,
+    user_has_credential_in,
 };
 
 pub use github_installations::{
@@ -35,7 +35,7 @@ pub use nodes::{
 };
 
 pub use pats::{
-    find_pats_by_prefix, insert_user_pat, list_user_pats, revoke_user_pat, touch_user_pat, UserPat,
+    UserPat, find_pats_by_prefix, insert_user_pat, list_user_pats, revoke_user_pat, touch_user_pat,
 };
 
 pub use projects::{
@@ -44,23 +44,23 @@ pub use projects::{
 };
 
 pub use sessions::{
-    append_session_log, claim_pending_session, find_session_by_idempotency_key, get_session,
-    get_session_logs, get_session_logs_after, get_session_owner, get_session_workspace,
-    insert_session, insert_session_with_idempotency_key, insert_session_with_user,
-    insert_session_with_user_and_project, insert_session_with_user_project_workspace,
-    list_pending_sessions_for_node, list_sessions, list_sessions_for_user_in_workspace,
-    update_session_state, LogChunk, LogChunkWithSeq,
+    LogChunk, LogChunkWithSeq, append_session_log, claim_pending_session,
+    find_session_by_idempotency_key, get_session, get_session_logs, get_session_logs_after,
+    get_session_owner, get_session_workspace, insert_session, insert_session_with_idempotency_key,
+    insert_session_with_user, insert_session_with_user_and_project,
+    insert_session_with_user_project_workspace, list_pending_sessions_for_node, list_sessions,
+    list_sessions_for_user_in_workspace, update_session_state,
 };
 
 pub use users::{
-    create_auth_session, get_auth_session, get_user, get_user_by_github_id, upsert_user,
-    AuthSession,
+    AuthSession, create_auth_session, get_auth_session, get_user, get_user_by_github_id,
+    upsert_user,
 };
 
 pub use workspaces::{
-    get_workspace, get_workspace_by_slug, insert_workspace, insert_workspace_member,
-    insert_workspace_with_creator, is_workspace_member, list_workspace_members,
-    list_workspace_members_with_users, list_workspaces_for_user, WorkspaceMemberWithUser,
+    WorkspaceMemberWithUser, get_workspace, get_workspace_by_slug, insert_workspace,
+    insert_workspace_member, insert_workspace_with_creator, is_workspace_member,
+    list_workspace_members, list_workspace_members_with_users, list_workspaces_for_user,
 };
 
 // ── Pool initialisation ──
@@ -69,10 +69,10 @@ pub async fn init_pool(database_url: &str) -> anyhow::Result<AnyPool> {
     // For SQLite: ensure parent directory exists and enable create-if-missing
     let connect_url = if database_url.starts_with("sqlite://") {
         let path = database_url.trim_start_matches("sqlite://");
-        if let Some(parent) = std::path::Path::new(path).parent() {
-            if !parent.as_os_str().is_empty() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
+        if let Some(parent) = std::path::Path::new(path).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await?;
         }
         // Append mode=rwc so SQLx creates the file if it doesn't exist
         if database_url.contains('?') {

--- a/crates/stiglab/src/server/db/tests.rs
+++ b/crates/stiglab/src/server/db/tests.rs
@@ -7,8 +7,8 @@ mod tests {
         WorkspaceMember,
     };
     use chrono::Utc;
-    use sqlx::pool::PoolOptions;
     use sqlx::AnyPool;
+    use sqlx::pool::PoolOptions;
     use uuid::Uuid;
 
     async fn test_pool() -> AnyPool {
@@ -252,9 +252,11 @@ mod tests {
             user_id: "u1".to_string(),
             joined_at: Utc::now(),
         };
-        assert!(insert_workspace_with_creator(&pool, &w2, &m2)
-            .await
-            .is_err());
+        assert!(
+            insert_workspace_with_creator(&pool, &w2, &m2)
+                .await
+                .is_err()
+        );
         assert!(get_workspace(&pool, &w2.id).await.unwrap().is_none());
         assert!(!is_workspace_member(&pool, &w2.id, "u1").await.unwrap());
     }

--- a/crates/stiglab/src/server/github_app.rs
+++ b/crates/stiglab/src/server/github_app.rs
@@ -12,9 +12,9 @@
 //! refactor in #220 Sub-issue B moves these surfaces into portal.
 
 pub use onsager_github::api::app::{
-    get_repo_default_branch, list_installation_repos, list_repo_labels, mint_app_jwt,
-    mint_installation_token, normalize_pem, AccessibleRepo, AppConfig, InstallationToken,
-    RepoLabel,
+    AccessibleRepo, AppConfig, InstallationToken, RepoLabel, get_repo_default_branch,
+    list_installation_repos, list_repo_labels, mint_app_jwt, mint_installation_token,
+    normalize_pem,
 };
 
 use onsager_github::api::app as gh_app;

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -1,7 +1,7 @@
 //! Shared logic for processing AgentMessage events (used by both the WebSocket
 //! handler and the built-in runner).
 
-use crate::core::{adapter, AgentMessage, SessionState};
+use crate::core::{AgentMessage, SessionState, adapter};
 use sqlx::AnyPool;
 
 use crate::server::db;
@@ -35,12 +35,12 @@ pub async fn handle_agent_message(
                 tracing::error!("failed to update session state: {e}");
             }
             // Emit spine event when session transitions to Running
-            if *state == SessionState::Running {
-                if let Some(spine) = spine {
-                    // We don't have request_id here, use task_id from the session as correlation
-                    if let Err(e) = spine.emit_session_started(&session_id, "", node_id).await {
-                        tracing::warn!("failed to emit session_started spine event: {e}");
-                    }
+            if *state == SessionState::Running
+                && let Some(spine) = spine
+            {
+                // We don't have request_id here, use task_id from the session as correlation
+                if let Err(e) = spine.emit_session_started(&session_id, "", node_id).await {
+                    tracing::warn!("failed to emit session_started spine event: {e}");
                 }
             }
         }
@@ -70,12 +70,11 @@ pub async fn handle_agent_message(
                     .await
                     .map(|logs| !logs.is_empty())
                     .unwrap_or(false);
-                if !already_streamed {
-                    if let Err(e) =
+                if !already_streamed
+                    && let Err(e) =
                         db::append_session_log(pool, &session_id, &output, "stdout").await
-                    {
-                        tracing::error!("failed to append final session output: {e}");
-                    }
+                {
+                    tracing::error!("failed to append final session output: {e}");
                 }
             }
             // Emit spine event for session completion. Best-effort branch
@@ -127,12 +126,11 @@ pub async fn handle_agent_message(
                 // without an artifact link are direct task POSTs that
                 // never produced a shaping request — skip them so we
                 // don't fabricate result events with empty fields.
-                if let Some(artifact_id) = artifact_id.as_deref() {
-                    if let Err(e) =
+                if let Some(artifact_id) = artifact_id.as_deref()
+                    && let Err(e) =
                         emit_shaping_result_for_session(pool, spine, &session_id, artifact_id).await
-                    {
-                        tracing::warn!("failed to emit shaping_result_ready spine event: {e}");
-                    }
+                {
+                    tracing::warn!("failed to emit shaping_result_ready spine event: {e}");
                 }
             }
         }

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -13,9 +13,9 @@ pub mod ws;
 
 pub use sqlx::AnyPool;
 
-use axum::http::{header, HeaderValue};
-use axum::routing::{any, get};
 use axum::Router;
+use axum::http::{HeaderValue, header};
+use axum::routing::{any, get};
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;

--- a/crates/stiglab/src/server/routes/mod.rs
+++ b/crates/stiglab/src/server/routes/mod.rs
@@ -1,9 +1,9 @@
 pub mod portal;
 pub mod shaping;
 
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use sqlx::AnyPool;
 
 use crate::server::auth::AuthUser;
@@ -32,17 +32,17 @@ pub async fn require_workspace_access(
     auth_user: &AuthUser,
     workspace_id: &str,
 ) -> Result<(), Response> {
-    if let Some(pinned) = auth_user.principal.pinned_workspace_id() {
-        if pinned != workspace_id {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "pat_workspace_scope_mismatch",
-                    "detail": "PAT is pinned to a different workspace",
-                })),
-            )
-                .into_response());
-        }
+    if let Some(pinned) = auth_user.principal.pinned_workspace_id()
+        && pinned != workspace_id
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "pat_workspace_scope_mismatch",
+                "detail": "PAT is pinned to a different workspace",
+            })),
+        )
+            .into_response());
     }
     match db::is_workspace_member(pool, workspace_id, &auth_user.user_id).await {
         Ok(true) => Ok(()),

--- a/crates/stiglab/src/server/shaping_listener.rs
+++ b/crates/stiglab/src/server/shaping_listener.rs
@@ -38,7 +38,7 @@ use async_trait::async_trait;
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 
-use crate::server::routes::shaping::{dispatch_shaping_inner, DispatchOutcome};
+use crate::server::routes::shaping::{DispatchOutcome, dispatch_shaping_inner};
 use crate::server::state::AppState;
 
 /// Run the shaping listener forever. Returns only if the underlying

--- a/crates/stiglab/src/server/state.rs
+++ b/crates/stiglab/src/server/state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use axum::extract::ws::Message;
 use sqlx::AnyPool;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 
 use crate::server::config::ServerConfig;
 use crate::server::spine::SpineEmitter;

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -13,10 +13,10 @@
 //! remain stiglab-local: `verify_pat`, hash invariants, and token format.
 
 use chrono::Utc;
-use sqlx::pool::PoolOptions;
 use sqlx::AnyPool;
+use sqlx::pool::PoolOptions;
 use stiglab::core::{User, Workspace, WorkspaceMember};
-use stiglab::server::auth::{generate_pat_token, hash_pat_token, PAT_PREFIX_LEN};
+use stiglab::server::auth::{PAT_PREFIX_LEN, generate_pat_token, hash_pat_token};
 use stiglab::server::db;
 use uuid::Uuid;
 

--- a/crates/synodic/src/cmd/init.rs
+++ b/crates/synodic/src/cmd/init.rs
@@ -76,18 +76,21 @@ fn setup_git_hooks(root: &Path) -> Result<()> {
 
     // Try to derive hooks from pipeline.yml
     let config_path = root.join(".harness/pipeline.yml");
-    if let Ok(config) = pipeline::load_config(&config_path) {
-        for (stage, filename) in [(Stage::Commit, "pre-commit"), (Stage::Push, "pre-push")] {
-            if let Some(script) = pipeline::generate_hook_script(&config.checks, stage) {
-                let hook_path = githooks_dir.join(filename);
-                std::fs::write(&hook_path, &script)?;
-                #[cfg(unix)]
-                set_executable(&hook_path)?;
-                eprintln!("L1: generated .githooks/{filename} from pipeline.yml");
+    match pipeline::load_config(&config_path) {
+        Ok(config) => {
+            for (stage, filename) in [(Stage::Commit, "pre-commit"), (Stage::Push, "pre-push")] {
+                if let Some(script) = pipeline::generate_hook_script(&config.checks, stage) {
+                    let hook_path = githooks_dir.join(filename);
+                    std::fs::write(&hook_path, &script)?;
+                    #[cfg(unix)]
+                    set_executable(&hook_path)?;
+                    eprintln!("L1: generated .githooks/{filename} from pipeline.yml");
+                }
             }
         }
-    } else {
-        eprintln!("L1: no .harness/pipeline.yml, skipping hook generation");
+        _ => {
+            eprintln!("L1: no .harness/pipeline.yml, skipping hook generation");
+        }
     }
 
     // Set hooksPath

--- a/crates/synodic/src/cmd/probe.rs
+++ b/crates/synodic/src/cmd/probe.rs
@@ -72,10 +72,10 @@ pub async fn run_probes(
         let reports = probing::run_all_probes(rule);
 
         for report in &reports {
-            if let Some(filter) = strategy_filter {
-                if report.strategy != filter {
-                    continue;
-                }
+            if let Some(filter) = strategy_filter
+                && report.strategy != filter
+            {
+                continue;
             }
 
             println!("  Strategy: {}", report.strategy);

--- a/crates/synodic/src/cmd/serve.rs
+++ b/crates/synodic/src/cmd/serve.rs
@@ -250,13 +250,13 @@ async fn create_event(
     State(store): State<Arc<dyn Storage>>,
     Json(body): Json<CreateGovernanceEvent>,
 ) -> Result<(StatusCode, Json<GovernanceEvent>), AppError> {
-    if let Some(ref sev) = body.severity {
-        if !VALID_SEVERITIES.contains(&sev.as_str()) {
-            return Err(AppError::BadRequest(format!(
-                "invalid severity '{sev}', must be one of: {}",
-                VALID_SEVERITIES.join(", ")
-            )));
-        }
+    if let Some(ref sev) = body.severity
+        && !VALID_SEVERITIES.contains(&sev.as_str())
+    {
+        return Err(AppError::BadRequest(format!(
+            "invalid severity '{sev}', must be one of: {}",
+            VALID_SEVERITIES.join(", ")
+        )));
     }
     let event = store.create_governance_event(body).await?;
     Ok((StatusCode::CREATED, Json(event)))

--- a/crates/synodic/src/core/engine_cache.rs
+++ b/crates/synodic/src/core/engine_cache.rs
@@ -74,20 +74,20 @@ impl EngineCache {
         // Fast path: cached engine matches the current revision.
         {
             let guard = self.cell.read().await;
-            if let Some(ref entry) = *guard {
-                if entry.revision == current {
-                    return Ok(Arc::clone(&entry.engine));
-                }
+            if let Some(ref entry) = *guard
+                && entry.revision == current
+            {
+                return Ok(Arc::clone(&entry.engine));
             }
         }
 
         // Slow path: rebuild under the write lock. Re-check inside the lock
         // so two racing misses produce only one fetch.
         let mut guard = self.cell.write().await;
-        if let Some(ref entry) = *guard {
-            if entry.revision == current {
-                return Ok(Arc::clone(&entry.engine));
-            }
+        if let Some(ref entry) = *guard
+            && entry.revision == current
+        {
+            return Ok(Arc::clone(&entry.engine));
         }
 
         // Fetch rules and bracket them with a second revision read to catch

--- a/crates/synodic/src/core/gate_adapter.rs
+++ b/crates/synodic/src/core/gate_adapter.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn tool_level_end_to_end_with_engine() {
-        use crate::core::intercept::{default_rules, InterceptEngine};
+        use crate::core::intercept::{InterceptEngine, default_rules};
 
         let gate_req = tool_level_request();
         let intercept_req = gate_request_to_intercept(&gate_req);

--- a/crates/synodic/src/core/gate_listener.rs
+++ b/crates/synodic/src/core/gate_listener.rs
@@ -178,21 +178,24 @@ impl EventHandler for Dispatcher {
 
         let verdict = self.evaluate(&request).await?;
 
-        if let Err(e) = self
+        match self
             .emit_verdict(&gate_id, artifact_id.clone(), gate_point, verdict)
             .await
         {
-            tracing::error!(
-                gate_id = %gate_id,
-                artifact_id = %artifact_id,
-                "synodic: failed to emit gate_verdict: {e}"
-            );
-        } else {
-            tracing::info!(
-                gate_id = %gate_id,
-                artifact_id = %artifact_id,
-                "synodic: emitted gate_verdict for forge.gate_requested"
-            );
+            Err(e) => {
+                tracing::error!(
+                    gate_id = %gate_id,
+                    artifact_id = %artifact_id,
+                    "synodic: failed to emit gate_verdict: {e}"
+                );
+            }
+            _ => {
+                tracing::info!(
+                    gate_id = %gate_id,
+                    artifact_id = %artifact_id,
+                    "synodic: emitted gate_verdict for forge.gate_requested"
+                );
+            }
         }
 
         Ok(())

--- a/crates/synodic/src/core/pipeline.rs
+++ b/crates/synodic/src/core/pipeline.rs
@@ -321,60 +321,60 @@ async fn run_l1_check_ui(
     let result = run_l1_check_inner(&name, &cmd, cwd, ui).await?;
 
     // If failed and has fix command, try auto-fix
-    if !result.passed {
-        if let Some(fix_cmd) = &fix {
-            ui.check_line(&ui.check_spinner(""), &format!("auto-fixing {name}..."));
-            // Run fix command silently
-            let fix_status = Command::new("sh")
-                .arg("-c")
-                .arg(fix_cmd)
+    if !result.passed
+        && let Some(fix_cmd) = &fix
+    {
+        ui.check_line(&ui.check_spinner(""), &format!("auto-fixing {name}..."));
+        // Run fix command silently
+        let fix_status = Command::new("sh")
+            .arg("-c")
+            .arg(fix_cmd)
+            .current_dir(cwd)
+            .output()
+            .await;
+
+        if let Ok(output) = fix_status
+            && output.status.success()
+        {
+            // Stage the fix
+            let add_status = Command::new("git")
+                .args(["add", "-A"])
                 .current_dir(cwd)
-                .output()
-                .await;
+                .status()
+                .await
+                .context("failed to run `git add -A` after auto-fix")?;
+            if !add_status.success() {
+                return Err(anyhow::anyhow!(
+                    "`git add -A` failed after auto-fix for check {name}"
+                ));
+            }
 
-            if let Ok(output) = fix_status {
-                if output.status.success() {
-                    // Stage the fix
-                    let add_status = Command::new("git")
-                        .args(["add", "-A"])
-                        .current_dir(cwd)
-                        .status()
-                        .await
-                        .context("failed to run `git add -A` after auto-fix")?;
-                    if !add_status.success() {
-                        return Err(anyhow::anyhow!(
-                            "`git add -A` failed after auto-fix for check {name}"
-                        ));
-                    }
+            // Only commit if there are staged changes
+            let staged = Command::new("git")
+                .args(["diff", "--cached", "--quiet"])
+                .current_dir(cwd)
+                .status()
+                .await
+                .context("failed to check staged auto-fix changes")?;
 
-                    // Only commit if there are staged changes
-                    let staged = Command::new("git")
-                        .args(["diff", "--cached", "--quiet"])
-                        .current_dir(cwd)
-                        .status()
-                        .await
-                        .context("failed to check staged auto-fix changes")?;
-
-                    if staged.code() == Some(1) {
-                        // There are staged changes — commit them
-                        let commit_status = Command::new("git")
-                            .args(["commit", "-m", &format!("fix: auto-fix {name}")])
-                            .current_dir(cwd)
-                            .status()
-                            .await
-                            .context("failed to run `git commit` after auto-fix")?;
-                        if !commit_status.success() {
-                            return Err(anyhow::anyhow!(
-                                "`git commit` failed after auto-fix for check {name}"
-                            ));
-                        }
-                    }
-
-                    // Re-run the check
-                    let retry = run_l1_check_inner(&name, &cmd, cwd, ui).await?;
-                    return Ok(retry);
+            if staged.code() == Some(1) {
+                // There are staged changes — commit them
+                let commit_status = Command::new("git")
+                    .args(["commit", "-m", &format!("fix: auto-fix {name}")])
+                    .current_dir(cwd)
+                    .status()
+                    .await
+                    .context("failed to run `git commit` after auto-fix")?;
+                if !commit_status.success() {
+                    return Err(anyhow::anyhow!(
+                        "`git commit` failed after auto-fix for check {name}"
+                    ));
                 }
             }
+
+            // Re-run the check
+            let retry = run_l1_check_inner(&name, &cmd, cwd, ui).await?;
+            return Ok(retry);
         }
     }
 
@@ -506,7 +506,7 @@ async fn run_semantic_check_ui(
     base_commit: Option<&str>,
     model: Option<&str>,
 ) -> Result<CheckResult> {
-    use crate::core::llm::{default_model_for_provider, LlmClient, LlmRequest};
+    use crate::core::llm::{LlmClient, LlmRequest, default_model_for_provider};
 
     let start = Instant::now();
     let pb = ui.check_spinner(name);
@@ -683,10 +683,10 @@ fn extract_json_from_text(text: &str) -> &str {
         }
     }
     // Try to find raw JSON object
-    if let Some(start) = trimmed.find('{') {
-        if let Some(end) = trimmed.rfind('}') {
-            return &trimmed[start..=end];
-        }
+    if let Some(start) = trimmed.find('{')
+        && let Some(end) = trimmed.rfind('}')
+    {
+        return &trimmed[start..=end];
     }
     trimmed
 }
@@ -869,24 +869,24 @@ pub async fn run_pipeline(
     let outcome = run_pipeline_loop(config, run_cfg, &work_dir, branch.as_deref(), ui, store).await;
 
     // Record error outcomes in telemetry
-    if let Ok(RunOutcome::Error(_)) = &outcome {
-        if let Some(s) = store {
-            let run_record = crate::core::storage::PipelineRun {
-                id: uuid::Uuid::new_v4().to_string(),
-                prompt: run_cfg.prompt.clone(),
-                branch: branch.as_ref().map(|b| b.to_string()),
-                outcome: "error".to_string(),
-                attempts: 0,
-                model: run_cfg.model.clone(),
-                build_duration_ms: None,
-                build_cost_usd: None,
-                inspect_duration_ms: None,
-                total_duration_ms: pipeline_start.elapsed().as_millis() as i64,
-                project_id: None,
-                created_at: chrono::Utc::now(),
-            };
-            let _ = s.record_pipeline_run(run_record).await;
-        }
+    if let Ok(RunOutcome::Error(_)) = &outcome
+        && let Some(s) = store
+    {
+        let run_record = crate::core::storage::PipelineRun {
+            id: uuid::Uuid::new_v4().to_string(),
+            prompt: run_cfg.prompt.clone(),
+            branch: branch.as_ref().map(|b| b.to_string()),
+            outcome: "error".to_string(),
+            attempts: 0,
+            model: run_cfg.model.clone(),
+            build_duration_ms: None,
+            build_cost_usd: None,
+            inspect_duration_ms: None,
+            total_duration_ms: pipeline_start.elapsed().as_millis() as i64,
+            project_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let _ = s.record_pipeline_run(run_record).await;
     }
 
     // --- CLEANUP: remove worktree ---

--- a/crates/synodic/src/core/proposal_listener.rs
+++ b/crates/synodic/src/core/proposal_listener.rs
@@ -115,16 +115,14 @@ impl EventHandler for Dispatcher {
             "synodic: ingested rule proposal"
         );
 
-        if is_safe_auto {
-            if let Err(e) = apply_auto_action(&*self.storage, &proposed_action).await {
-                // Don't block the listener on a single failed auto-apply —
-                // the proposal stays in the queue as `approved` for the
-                // operator to re-apply manually.
-                tracing::error!(
-                    proposal_id = %created.id,
-                    "synodic: auto-apply failed, leaving as approved for manual retry: {e}"
-                );
-            }
+        if is_safe_auto && let Err(e) = apply_auto_action(&*self.storage, &proposed_action).await {
+            // Don't block the listener on a single failed auto-apply —
+            // the proposal stays in the queue as `approved` for the
+            // operator to re-apply manually.
+            tracing::error!(
+                proposal_id = %created.id,
+                "synodic: auto-apply failed, leaving as approved for manual retry: {e}"
+            );
         }
 
         Ok(())

--- a/crates/synodic/src/core/ui.rs
+++ b/crates/synodic/src/core/ui.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use chrono::Local;
-use console::{style, Term};
+use console::{Term, style};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::core::pipeline::CheckResult;

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -27,8 +27,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
-use onsager_registry::{EventDefinition, Subsystem, EVENTS};
+use anyhow::{Context, Result, anyhow, bail};
+use onsager_registry::{EVENTS, EventDefinition, Subsystem};
 use syn::{Expr, ExprLit, ImplItem, Item, Lit, Pat, Stmt, Type, Visibility};
 
 const SPINE_SRC: &str = "crates/onsager-spine/src/factory_event.rs";

--- a/xtask/src/check_file_budget.rs
+++ b/xtask/src/check_file_budget.rs
@@ -38,12 +38,12 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
-use base64::{engine::general_purpose, Engine as _};
+use anyhow::{Context, Result, anyhow, bail};
+use base64::{Engine as _, engine::general_purpose};
 use rustc_hash::FxHashMap;
 use syn::spanned::Spanned;
 use syn::{Attribute, File as SynFile, Item, Meta};
-use tiktoken_rs::{CoreBPE, Rank, ENDOFPROMPT, ENDOFTEXT, O200K_BASE_PAT_STR};
+use tiktoken_rs::{CoreBPE, ENDOFPROMPT, ENDOFTEXT, O200K_BASE_PAT_STR, Rank};
 
 /// BPE merges file for the o200k_base encoding. Pinned in-tree so CI is
 /// offline and deterministic regardless of which `tiktoken-rs` ships.
@@ -292,10 +292,10 @@ fn walk_inner(dir: &Path, out: &mut Vec<PathBuf>) {
                 continue;
             }
             walk_inner(&path, out);
-        } else if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-            if matches!(ext, "rs" | "ts" | "tsx") {
-                out.push(path);
-            }
+        } else if let Some(ext) = path.extension().and_then(|s| s.to_str())
+            && matches!(ext, "rs" | "ts" | "tsx")
+        {
+            out.push(path);
         }
     }
 }
@@ -407,10 +407,10 @@ fn collect_cfg_test_ranges(items: &[Item], out: &mut Vec<std::ops::Range<usize>>
             }
             continue;
         }
-        if let Item::Mod(m) = item {
-            if let Some((_, inner)) = &m.content {
-                collect_cfg_test_ranges(inner, out);
-            }
+        if let Item::Mod(m) = item
+            && let Some((_, inner)) = &m.content
+        {
+            collect_cfg_test_ranges(inner, out);
         }
     }
 }

--- a/xtask/src/check_triggers.rs
+++ b/xtask/src/check_triggers.rs
@@ -22,8 +22,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
-use onsager_registry::{Subsystem, TriggerCategory, TRIGGERS};
+use anyhow::{Context, Result, anyhow, bail};
+use onsager_registry::{Subsystem, TRIGGERS, TriggerCategory};
 use syn::{Expr, ExprLit, ImplItem, Item, Lit, Pat, Stmt, Type, Visibility};
 
 const TRIGGER_SRC: &str = "crates/onsager-spine/src/trigger.rs";

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -22,7 +22,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use syn::visit::Visit;
 use syn::{Expr, ExprLit, Lit};
 
@@ -63,16 +63,15 @@ impl<'ast> Visit<'ast> for RouteVisitor {
         // records A before B (matching source order — the outermost call
         // is the deepest receiver).
         syn::visit::visit_expr_method_call(self, node);
-        if node.method == "route" {
-            if let Some(Expr::Lit(ExprLit {
+        if node.method == "route"
+            && let Some(Expr::Lit(ExprLit {
                 lit: Lit::Str(lit), ..
             })) = node.args.first()
-            {
-                self.out.push(BackendRoute {
-                    path: lit.value(),
-                    subsystem: self.subsystem,
-                });
-            }
+        {
+            self.out.push(BackendRoute {
+                path: lit.value(),
+                subsystem: self.subsystem,
+            });
         }
     }
 }
@@ -820,9 +819,11 @@ mod tests {
         let root = workspace_root();
         let calls = parse_ts_calls(&root.join("apps/dashboard/src/lib/sse.ts")).unwrap();
         let paths: Vec<_> = calls.iter().map(|c| c.path.as_str()).collect();
-        assert!(paths
-            .iter()
-            .any(|p| p.contains("/sessions/") && p.ends_with("/logs")));
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.contains("/sessions/") && p.ends_with("/logs"))
+        );
     }
 
     #[test]

--- a/xtask/src/lint_seams.rs
+++ b/xtask/src/lint_seams.rs
@@ -30,7 +30,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 
 const SUBSYSTEMS: &[&str] = &["forge", "stiglab", "synodic", "ising"];
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,7 +41,7 @@ mod slot;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use syn::{Expr, ExprLit, Fields, ImplItem, Item, Lit, Meta, Pat, Stmt, Type, Variant, Visibility};
 
 const SPINE_SRC: &str = "crates/onsager-spine/src/factory_event.rs";

--- a/xtask/src/slot.rs
+++ b/xtask/src/slot.rs
@@ -26,7 +26,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
 pub const MANIFEST_FILE: &str = ".dev-slots.json";


### PR DESCRIPTION
## Summary

Bumps the Onsager workspace from Rust edition 2021 to edition 2024.
Triggered by [`onsager-ai/duhem#5`](https://github.com/onsager-ai/duhem/issues/5),
which adopts edition 2024 from day one for the new Duhem repo and
flagged Onsager-on-2021 as the only deliberate divergence — closing
that gap unifies the toolchain story across both repos.

The change itself is mostly mechanical:

- **`cargo fix --edition --workspace`** handled the language-level
  rewrites.
- **`cargo clippy --workspace --all-targets --fix`** collapsed 54
  nested `if let`s into edition-2024 `let`-chain form.
- **`cargo fmt --all`** applied the edition-2024 rustfmt style
  (import-ordering changes, where-clause indentation, etc.).

The only hand-written changes:

- **`crates/onsager-portal/src/dev_auth.rs` + `workflow_activation.rs`** —
  edition 2024 marks `std::env::set_var` / `remove_var` as `unsafe`
  (they aren't thread-safe). Six call sites in test code and the
  `ScopedEnvVar` helper get `unsafe { … }` blocks with a SAFETY note
  citing the surrounding `ENV_LOCK` discipline.
- **`crates/onsager-trigger/src/main.rs`** — match-ergonomics 2024
  disallows a redundant `ref mut` binding inside an
  implicitly-borrowed pattern. `cargo fix --edition` flagged it but
  couldn't auto-rewrite; the fix is dropping the modifier.
- **`CLAUDE.md`** — Conventions section bumped to "Rust edition 2024"
  so the document of record stays in sync.

Toolchain pin (`rust-toolchain.toml` 1.95.0) and workspace
dependencies are deliberately untouched — those carry independent
risk and would muddy the bisect surface if anything regresses.

## Test plan

Verified locally:

- [x] `cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace --lib` — 114 passed, 0 failed.
- [x] `cargo test --workspace --bins` — 78 passed, 0 failed.
- [x] `cargo run -p xtask -- check-file-budget` clean.
- [x] `cargo run -p xtask -- lint-seams` clean.
- [x] `cargo run -p xtask -- check-events` clean.
- [x] `cargo run -p xtask -- check-triggers` clean.
- [x] `cargo run -p xtask -- check-api-contract` clean.
- [x] `cargo run -p xtask -- gen-event-docs --check` clean.
- [ ] CI `rust` workflow goes green (DB-backed integration tests in
      `tests/` need Postgres — left to CI).

Closes #270

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTRotJUqw87KVnWyAekzeV)_