### PR TITLE
prune dangling event-manifest wires (#272)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,13 +126,17 @@ Lever status (canonical: ADR 0004's adoption checklist). As of
   backfills + drops), the `BundleId` → `ArtifactVersionId` alias is
   gone (#219), and `workspace_install_ref` was renamed `install_id`
   (#219). One schema, one writer.
-- **E** (#150, PR #227): static event manifest at
-  `crates/onsager-registry/src/events.rs` (75 rows, one per
-  `FactoryEventKind` variant) declares producers/consumers per
+- **E** (#150, PR #227; tightened by #272): static event manifest at
+  `crates/onsager-registry/src/events.rs`, one row per
+  `FactoryEventKind` variant, declares producers/consumers per
   subsystem. `xtask check-events` enforces coverage, both-ends-
   declared, emit-call-sites match producers, and listener-call-
-  sites match consumers; events with no in-tree consumer are
-  tagged `audit_only`. Manifest exposed at `GET /api/registry/events`.
+  sites match consumers. Per #272, every row is either **real**
+  (non-empty `consumers`) or **diagnostic-only** (`diagnostic_only:
+  true` plus a non-empty `reason` string identifying what reads it
+  today, e.g. dashboard timeline / audit trail). Rows that are
+  neither are rejected at lint time. Manifest exposed at
+  `GET /api/registry/events`.
 - **F** (PR #207): `xtask/src/lint_api_contract.rs` asserts every
   backend route has a dashboard caller (or an allowlisted external-
   only reason) and every dashboard call lands on a backend route.

--- a/apps/dashboard/src/lib/api/types.ts
+++ b/apps/dashboard/src/lib/api/types.ts
@@ -444,7 +444,18 @@ export interface EventManifestEntry {
   schema_version: number;
   producers: EventSubsystem[];
   consumers: EventSubsystem[];
-  audit_only: boolean;
+  /**
+   * True when no subsystem consumer is expected — the event is read by a
+   * non-subsystem concern (dashboard timeline, audit trail). Paired with a
+   * non-empty `reason`. Per spec #272, replaces the prior `audit_only`
+   * field.
+   */
+  diagnostic_only: boolean;
+  /**
+   * Why this row is diagnostic-only (e.g. "rendered in dashboard event
+   * timeline"). Required when `diagnostic_only` is true; null otherwise.
+   */
+  reason: string | null;
   description: string;
 }
 

--- a/apps/dashboard/tests/smoke/lineage-dag.test.tsx
+++ b/apps/dashboard/tests/smoke/lineage-dag.test.tsx
@@ -106,7 +106,7 @@ describe("LineageDAG.buildLanes", () => {
         id: 1,
         stream_id: "s",
         stream_type: "forge",
-        event_type: "forge.idle_tick",
+        event_type: "forge.decision_made",
         data: {},
         actor: "forge",
         created_at: "2026-04-01T00:00:00Z",

--- a/crates/forge/src/core/gate_verdict_listener.rs
+++ b/crates/forge/src/core/gate_verdict_listener.rs
@@ -153,7 +153,11 @@ mod tests {
         // The listener filters by event_type before reaching the
         // classifier, but defense in depth: even if a different variant
         // arrives, we must not park it as a verdict.
-        let kind = FactoryEventKind::ForgeIdleTick;
+        let kind = FactoryEventKind::ForgeDecisionMade {
+            artifact_id: ArtifactId::new("art_unrelated"),
+            target_version: 0,
+            priority: 0,
+        };
         assert!(classify_verdict(kind).is_none());
     }
 

--- a/crates/forge/src/core/shaping_result_listener.rs
+++ b/crates/forge/src/core/shaping_result_listener.rs
@@ -158,7 +158,11 @@ mod tests {
 
     #[test]
     fn classify_returns_none_for_unrelated_event() {
-        let kind = FactoryEventKind::ForgeIdleTick;
+        let kind = FactoryEventKind::ForgeDecisionMade {
+            artifact_id: ArtifactId::new("art_unrelated"),
+            target_version: 0,
+            priority: 0,
+        };
         assert!(classify_shaping_result(kind).is_none());
     }
 }

--- a/crates/forge/src/core/workflow_signal_listener.rs
+++ b/crates/forge/src/core/workflow_signal_listener.rs
@@ -291,7 +291,11 @@ mod tests {
 
     #[test]
     fn unrelated_events_do_not_classify() {
-        let kind = FactoryEventKind::ForgeIdleTick;
+        let kind = FactoryEventKind::ForgeDecisionMade {
+            artifact_id: ArtifactId::new("art_unrelated"),
+            target_version: 0,
+            priority: 0,
+        };
         assert!(classify_signal(&kind).is_none());
     }
 

--- a/crates/ising/src/core/analyzer.rs
+++ b/crates/ising/src/core/analyzer.rs
@@ -83,7 +83,7 @@ mod tests {
                 observation: "everything is great".into(),
                 evidence: vec![FactoryEventRef {
                     event_id: 1,
-                    event_type: "forge.idle_tick".into(),
+                    event_type: "forge.decision_made".into(),
                 }],
                 suggested_action: None,
                 confidence: 0.5,

--- a/crates/onsager-portal/src/handlers/pull_request.rs
+++ b/crates/onsager-portal/src/handlers/pull_request.rs
@@ -83,15 +83,6 @@ pub async fn handle(
         .get("number")
         .and_then(|n| n.as_u64())
         .ok_or_else(|| anyhow::anyhow!("missing pr.number"))?;
-    // PR title is fetched live by the proxy; the message field on
-    // `GitCommitPushed` keeps a synchronize-time snapshot purely for the
-    // spine event payload (events are immutable historical facts, not a
-    // denormalization of current state — the artifact row stays clean).
-    let sync_message = pr
-        .get("title")
-        .and_then(|t| t.as_str())
-        .unwrap_or("")
-        .to_string();
     let url = pr
         .get("html_url")
         .and_then(|u| u.as_str())
@@ -143,48 +134,52 @@ pub async fn handle(
     // there is bounded by its TTL window. Portal does not need to push
     // invalidations cross-process.
 
-    // Emit the matching spine event under namespace `git`.
+    // Emit the matching spine event under namespace `git`. Synchronize
+    // (commit push) emits no spine event after spec #272 — `git.commit_pushed`
+    // had no consumer; the artifact version bump above is the only durable
+    // signal that a synchronize occurred.
     let stream_id = pr_stream_id(&project.id, pr_number);
-    let event = match act {
-        PrAction::Opened => FactoryEventKind::GitPrOpened {
+    let event: Option<FactoryEventKind> = match act {
+        PrAction::Opened => Some(FactoryEventKind::GitPrOpened {
             artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
             repo: format!("{owner}/{name}"),
             pr_number,
             url: url.clone(),
-        },
-        PrAction::Synchronize => FactoryEventKind::GitCommitPushed {
-            artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
-            sha: head_sha.clone(),
-            message: sync_message.clone(),
-            session_id: String::new(),
-        },
-        PrAction::Closed if merged => FactoryEventKind::GitPrMerged {
+        }),
+        PrAction::Synchronize => None,
+        PrAction::Closed if merged => Some(FactoryEventKind::GitPrMerged {
             artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
             pr_number,
             merge_sha: merge_sha.clone(),
-        },
-        PrAction::Closed => FactoryEventKind::GitPrClosed {
+        }),
+        PrAction::Closed => Some(FactoryEventKind::GitPrClosed {
             artifact_id: ArtifactId::new(artifact.artifact_id.clone()),
             pr_number,
-        },
+        }),
     };
 
     let metadata = EventMetadata {
         actor: "onsager-portal".into(),
         ..Default::default()
     };
-    let event_id = state
-        .spine
-        .append_ext(
-            &artifact.workspace_id,
-            &stream_id,
-            GIT_NAMESPACE,
-            event.event_type(),
-            serde_json::to_value(&event)?,
-            &metadata,
-            None,
+    let event_id: Option<i64> = if let Some(event) = event.as_ref() {
+        Some(
+            state
+                .spine
+                .append_ext(
+                    &artifact.workspace_id,
+                    &stream_id,
+                    GIT_NAMESPACE,
+                    event.event_type(),
+                    serde_json::to_value(event)?,
+                    &metadata,
+                    None,
+                )
+                .await?,
         )
-        .await?;
+    } else {
+        None
+    };
 
     // Session↔PR correlation: on `opened`, attach a vertical_lineage row if a
     // recent session pushed `head.ref` against this project (Phase 1).
@@ -251,7 +246,7 @@ pub async fn handle(
                     "forge.gate_verdict",
                     gate_event,
                     &metadata,
-                    Some(event_id),
+                    event_id,
                 )
                 .await?;
 
@@ -324,7 +319,7 @@ pub async fn handle(
                         "synodic.escalation_started",
                         escalation_payload,
                         &metadata,
-                        Some(event_id),
+                        event_id,
                     )
                     .await?;
             }

--- a/crates/onsager-portal/src/handlers/registry_events.rs
+++ b/crates/onsager-portal/src/handlers/registry_events.rs
@@ -40,7 +40,9 @@ mod tests {
         assert!(first["kind"].as_str().is_some());
         assert!(first["producers"].as_array().is_some());
         assert!(first["consumers"].as_array().is_some());
-        assert!(first["audit_only"].as_bool().is_some());
+        assert!(first["diagnostic_only"].as_bool().is_some());
+        // `reason` is `Option<&'static str>` — present in JSON, may be null.
+        assert!(first.get("reason").is_some());
     }
 
     #[tokio::test]

--- a/crates/onsager-registry/CLAUDE.md
+++ b/crates/onsager-registry/CLAUDE.md
@@ -15,7 +15,7 @@ projections of the registry's mutation events.
 - `registry_store.rs` — DB projection / CRUD.
 - `seed.rs` — idempotent seed loader.
 
-## Event manifest update process (#150)
+## Event manifest update process (#150, schema simplified by #272)
 
 `events.rs` carries `pub const EVENTS: EventManifest`, a static, human-
 reviewed table of every `FactoryEventKind` variant. Each row declares:
@@ -30,17 +30,27 @@ reviewed table of every `FactoryEventKind` variant. Each row declares:
 - `consumers` — subsystems that act on this event (dispatch off the
   `event_type` string and parse the payload). Dashboard-only reads do
   not count.
-- `audit_only` — `true` when no subsystem consumer is expected (the
-  event exists for audit / dashboard rendering only).
+- `diagnostic_only` — `true` when no subsystem consumer is expected
+  (the event is read by a non-subsystem concern: dashboard timeline,
+  audit trail). Must be paired with a non-empty `reason`. Per spec
+  #272 this replaces the prior `audit_only` flag.
+- `reason` — `Option<&'static str>` explaining what reads this event
+  today (e.g. `"rendered in dashboard event timeline"`). Required
+  when `diagnostic_only` is `true`; `None` for real rows. Free-form
+  by design.
+
+Every row is in one of two states: **real** (non-empty `consumers`)
+or **diagnostic-only** (`diagnostic_only: true` plus a non-empty
+`reason`). Rows that are neither are rejected at lint time.
 
 ### When to update
 
 | Change | Action |
 | --- | --- |
-| Add a `FactoryEventKind` variant | Add a row to `EVENTS` in the same PR. Producer + consumer must be wired or the event tagged `audit_only`. |
+| Add a `FactoryEventKind` variant | Add a row to `EVENTS` in the same PR. Producer + consumer must be wired, or the event marked `diagnostic_only: true` with a non-empty `reason`. |
 | Add a new producer for an existing event | Append the subsystem to `producers`. |
-| Add a new listener for an existing event | Append the subsystem to `consumers`; flip `audit_only` to `false` if it was set. |
-| Backwards-incompatible payload change | Bump `schema_version`. Producer + consumer support for the new version must ship together — coordinated via PRs / tests / review (`check-events` only enforces that a manifest row has ≥1 producer and either ≥1 consumer or `audit_only = true`; it does not reason about `schema_version`). |
+| Add a new listener for an existing event | Append the subsystem to `consumers`; flip `diagnostic_only` to `false` and set `reason: None` if it was set. |
+| Backwards-incompatible payload change | Bump `schema_version`. Producer + consumer support for the new version must ship together — coordinated via PRs / tests / review (`check-events` only enforces that a manifest row has ≥1 producer and is either real or diagnostic-only with a reason; it does not reason about `schema_version`). |
 | Backwards-compatible payload change (new optional field) | No version bump; manifest review still required — flag the change in the PR description. |
 | Remove a `FactoryEventKind` variant | Remove the manifest row in the same PR. |
 
@@ -60,7 +70,8 @@ field — even additive ones — must bump nothing on the manifest yet
 **must** include a manifest review (the PR diff touches `events.rs` or
 the producer/consumer fields are stale). Reviewers should ask: does the
 new field land with both a producer that sets it and a consumer that
-reads it? If not, hold the PR or tag the event `audit_only`.
+reads it? If not, hold the PR or mark the event `diagnostic_only: true`
+with a `reason`.
 
 ### CI enforcement
 
@@ -68,8 +79,9 @@ reads it? If not, hold the PR or tag the event `audit_only`.
 `.github/workflows/rust.yml`) and asserts:
 
 1. Every `FactoryEventKind` variant has a manifest row.
-2. Every manifest row declares ≥1 producer and either ≥1 consumer or
-   `audit_only = true`.
+2. Every manifest row declares ≥1 producer and is either real (≥1
+   consumer) or diagnostic-only (`diagnostic_only = true` plus a
+   non-empty `reason`).
 3. Every `append_ext(_, _, "<event_type>", ...)` literal under
    `crates/{forge,stiglab,synodic,ising}/src/` references an event whose
    `producers` list includes that subsystem.
@@ -86,9 +98,10 @@ truth and reviewers verify the producer subsystem matches.
 
 ### Read API
 
-The manifest is exposed at `GET /api/registry/events` (stiglab) so the
-dashboard can render the catalog without a hardcoded copy. Public by
-design — same pattern as `/api/workflow/kinds`.
+The manifest is exposed at `GET /api/registry/events` (portal owns
+this route as of #257) so the dashboard can render the catalog
+without a hardcoded copy. Public by design — same pattern as
+`/api/workflow/kinds`.
 
 ## Related
 
@@ -97,3 +110,5 @@ design — same pattern as `/api/workflow/kinds`.
 - ADR 0004 — six-lever seam-tightening plan.
 - Spec #131 — strategic plan; this manifest is **Lever E**.
 - Spec #150 — this lever's implementation.
+- Spec #272 — manifest schema simplification (drop `audit_only`,
+  introduce `diagnostic_only` + `reason`, prune dangling wires).

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -6,7 +6,17 @@
 //! the manifest is reviewed when changes land and CI (`cargo xtask
 //! check-events`) enforces the contract.
 //!
-//! See spec issue #150 and the registry CLAUDE.md for the update process.
+//! Schema (per spec #272): every row is in one of two states.
+//!
+//! 1. **Real** — `consumers` is non-empty. The event has at least one
+//!    in-tree subsystem listener.
+//! 2. **Diagnostic-only** — `diagnostic_only: true` plus a non-empty
+//!    `reason` string. The event is emitted today and read by something
+//!    concrete (dashboard timeline, audit trail) but no subsystem listens
+//!    for it.
+//!
+//! See spec issue #150 for the original Lever E plan and #272 for the
+//! schema simplification.
 
 use serde::Serialize;
 
@@ -45,6 +55,12 @@ impl Subsystem {
 }
 
 /// One row of the event-type registry manifest.
+///
+/// Every row is either **real** (`consumers` non-empty) or
+/// **diagnostic-only** (`diagnostic_only: true` plus a non-empty
+/// [`reason`]). `xtask check-events` rejects rows that are neither.
+///
+/// [`reason`]: EventDefinition::reason
 #[derive(Debug, Clone, Serialize)]
 pub struct EventDefinition {
     /// Wire `event_type` string, matching `FactoryEventKind::event_type()`
@@ -58,15 +74,22 @@ pub struct EventDefinition {
     pub producers: &'static [Subsystem],
     /// Subsystems that listen for this event and act on it (i.e. dispatch
     /// off the `event_type` string and parse the payload). Dashboard-only
-    /// reads do not count — set [`audit_only`] for those.
+    /// reads do not count — set [`diagnostic_only`] + [`reason`] for those.
     ///
-    /// [`audit_only`]: EventDefinition::audit_only
+    /// [`diagnostic_only`]: EventDefinition::diagnostic_only
+    /// [`reason`]: EventDefinition::reason
     pub consumers: &'static [Subsystem],
-    /// `true` when no subsystem consumer is expected — the event exists for
-    /// the dashboard / audit log only. Lets the "every event has a consumer"
-    /// check stay strict for events that should have one, while honestly
-    /// labelling events that shouldn't.
-    pub audit_only: bool,
+    /// `true` when no subsystem consumer is expected — the event is read
+    /// by a non-subsystem concern (dashboard timeline, audit trail). Must
+    /// be paired with a non-empty [`reason`].
+    ///
+    /// [`reason`]: EventDefinition::reason
+    pub diagnostic_only: bool,
+    /// Why this row is diagnostic-only — what reads it today (e.g.
+    /// `"rendered in dashboard event timeline"`). Required when
+    /// `diagnostic_only` is `true`; `None` for real rows. Free-form by
+    /// design.
+    pub reason: Option<&'static str>,
     /// One-line description for the manifest read API and dashboard.
     pub description: &'static str,
 }
@@ -87,15 +110,14 @@ impl EventManifest {
 /// have a row here; CI's `cargo xtask check-events` enforces it.
 pub const EVENTS: EventManifest = EventManifest {
     events: &[
-        // -- Artifact lifecycle (forge writes "artifact.state_changed"
-        //    via `emit_pipeline_event`; the others are written by the
-        //    portal / ingestion side). -------------------------------
+        // -- Artifact lifecycle ---------------------------------------------
         EventDefinition {
             kind: "artifact.registered",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "New artifact accepted and ID assigned.",
         },
         EventDefinition {
@@ -103,7 +125,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Artifact transitioned between lifecycle states.",
         },
         EventDefinition {
@@ -111,121 +134,48 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "New version committed for an artifact.",
-        },
-        EventDefinition {
-            kind: "artifact.lineage_extended",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "New vertical or horizontal lineage entry recorded.",
-        },
-        EventDefinition {
-            kind: "artifact.quality_recorded",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "New quality signal appended.",
-        },
-        EventDefinition {
-            kind: "artifact.routed",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "Released artifact dispatched to a consumer sink.",
         },
         EventDefinition {
             kind: "artifact.archived",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some(
+                "forge consumer in flight per spec #273; remains diagnostic-only until that PR lands",
+            ),
             description: "Artifact reached terminal state (archived).",
         },
-        // -- Warehouse / delivery / deliverable -------------------------
+        // -- Warehouse ------------------------------------------------------
         EventDefinition {
             kind: "warehouse.bundle_sealed",
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in dashboard event timeline for release observability"),
             description: "A new bundle was sealed for an artifact.",
         },
-        EventDefinition {
-            kind: "delivery.succeeded",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "A delivery attempt succeeded.",
-        },
-        EventDefinition {
-            kind: "delivery.failed",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "A delivery attempt failed; carries retry/abandoned flag.",
-        },
-        EventDefinition {
-            kind: "deliverable.created",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "A workflow run produced its first artifact reference.",
-        },
-        EventDefinition {
-            kind: "deliverable.updated",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "A workflow run added an artifact reference to its deliverable.",
-        },
-        // -- Git lifecycle (onsager-portal webhooks) --------------------
-        EventDefinition {
-            kind: "git.branch_created",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "A working branch was pushed for an artifact.",
-        },
-        EventDefinition {
-            kind: "git.commit_pushed",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "A commit was pushed to an artifact's branch.",
-        },
+        // -- Git lifecycle (onsager-portal webhooks) ------------------------
         EventDefinition {
             kind: "git.pr_opened",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A pull request was opened for an artifact.",
-        },
-        EventDefinition {
-            kind: "git.pr_review_received",
-            schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            audit_only: true,
-            description: "A reviewer left a verdict on a PR.",
         },
         EventDefinition {
             kind: "git.ci_completed",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A CI check finished for a PR.",
         },
         EventDefinition {
@@ -233,7 +183,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Forge, Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A PR was merged.",
         },
         EventDefinition {
@@ -241,16 +192,18 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A PR was closed without merging.",
         },
-        // -- Forge process events ---------------------------------------
+        // -- Forge process events -------------------------------------------
         EventDefinition {
             kind: "forge.shaping_dispatched",
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Stiglab],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "ShapingRequest sent to Stiglab via the spine (replaces POST /api/shaping).",
         },
         EventDefinition {
@@ -258,7 +211,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "ShapingResult received from Stiglab and recorded by Forge.",
         },
         EventDefinition {
@@ -266,7 +220,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Synodic],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "GateRequest sent to Synodic via the spine (replaces POST /api/gate).",
         },
         EventDefinition {
@@ -274,7 +229,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Ising],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "GateVerdict observed by Forge after Synodic responded.",
         },
         EventDefinition {
@@ -282,7 +238,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Insight forwarded to the scheduling kernel.",
         },
         EventDefinition {
@@ -290,56 +247,18 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("diagnostic trace of forge scheduling kernel; no downstream action"),
             description: "Scheduling kernel produced a ShapingDecision.",
         },
-        EventDefinition {
-            kind: "forge.idle_tick",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "Scheduling kernel returned None (idle, reduced frequency).",
-        },
-        EventDefinition {
-            kind: "forge.state_changed",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            audit_only: true,
-            description: "Forge process state machine transitioned.",
-        },
-        // -- Stiglab events --------------------------------------------
-        EventDefinition {
-            kind: "stiglab.session_created",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A new session was allocated for a shaping request.",
-        },
-        EventDefinition {
-            kind: "stiglab.session_dispatched",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A session was dispatched to a Stiglab node.",
-        },
-        EventDefinition {
-            kind: "stiglab.session_running",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A session began active execution.",
-        },
+        // -- Stiglab events -------------------------------------------------
         EventDefinition {
             kind: "stiglab.session_completed",
             schema_version: 1,
             producers: &[Subsystem::Stiglab],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A session finished successfully; carries optional artifact_id, token usage, branch, and PR number.",
         },
         EventDefinition {
@@ -347,7 +266,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Stiglab],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Full ShapingResult ready for Forge to act on (replaces POST /api/shaping response).",
         },
         EventDefinition {
@@ -355,7 +275,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Stiglab],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A session terminated with an error.",
         },
         EventDefinition {
@@ -363,57 +284,28 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Stiglab],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("dashboard event-timeline troubleshooting for node/deadline failures"),
             description: "A session was aborted (node lost, deadline exceeded).",
         },
-        EventDefinition {
-            kind: "stiglab.event_upgraded",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A session-internal event was promoted to a factory event.",
-        },
-        EventDefinition {
-            kind: "stiglab.node_registered",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A new Stiglab node joined the pool.",
-        },
-        EventDefinition {
-            kind: "stiglab.node_deregistered",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A Stiglab node left the pool.",
-        },
-        EventDefinition {
-            kind: "stiglab.node_heartbeat_missed",
-            schema_version: 1,
-            producers: &[Subsystem::Stiglab],
-            consumers: &[],
-            audit_only: true,
-            description: "A node missed its expected heartbeat.",
-        },
-        // -- Portal intents (dashboard → agent dispatch) ---------------
+        // -- Portal intents (dashboard → agent dispatch) --------------------
         EventDefinition {
             kind: "portal.session_requested",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Stiglab],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Dashboard task request from portal; stiglab dispatches the session to an agent node.",
         },
-        // -- Synodic events --------------------------------------------
+        // -- Synodic events -------------------------------------------------
         EventDefinition {
             kind: "synodic.gate_evaluated",
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("dashboard filtering & audit trail; gate_verdict is the consumer event"),
             description: "Gate request evaluated and a verdict issued (summary; full payload on synodic.gate_verdict).",
         },
         EventDefinition {
@@ -421,7 +313,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("dashboard deny-verdict filtering"),
             description: "Gate request denied (subset of gate_evaluated, for filtering).",
         },
         EventDefinition {
@@ -429,7 +322,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("dashboard modify-verdict filtering"),
             description: "Gate request resolved with verdict Modify (subset of gate_evaluated).",
         },
         EventDefinition {
@@ -437,7 +331,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Full GateVerdict in response to forge.gate_requested (replaces POST /api/gate response).",
         },
         EventDefinition {
@@ -445,7 +340,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for escalation context"),
             description: "An escalation was initiated.",
         },
         EventDefinition {
@@ -453,7 +349,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "An escalation was resolved (human, delegate, or timeout).",
         },
         EventDefinition {
@@ -461,7 +358,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "An escalation timed out and the default verdict was applied.",
         },
         EventDefinition {
@@ -469,7 +367,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "A delegate proposed a resolution for an active escalation.",
         },
         EventDefinition {
@@ -477,7 +376,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "A crystallization candidate rule was created.",
         },
         EventDefinition {
@@ -485,7 +385,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "A proposed rule was approved and entered the active set.",
         },
         EventDefinition {
@@ -493,7 +394,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "A rule was disabled.",
         },
         EventDefinition {
@@ -501,16 +403,18 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in synodic governance UI; audit trail"),
             description: "A rule was modified, producing a new version.",
         },
-        // -- Ising events ----------------------------------------------
+        // -- Ising events ---------------------------------------------------
         EventDefinition {
             kind: "ising.insight_detected",
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in dashboard ising views"),
             description: "An insight passed validation and was recorded on the spine.",
         },
         EventDefinition {
@@ -518,7 +422,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "Machine-readable signal emitted on the spine for other subsystems to consume.",
         },
         EventDefinition {
@@ -526,7 +431,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in dashboard ising views"),
             description: "An insight was deduplicated or fell below confidence threshold.",
         },
         EventDefinition {
@@ -534,7 +440,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[Subsystem::Synodic],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "An insight was packaged as a rule proposal for Synodic.",
         },
         EventDefinition {
@@ -542,7 +449,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("operator troubleshooting in dashboard"),
             description: "An analyzer encountered an error during its run.",
         },
         EventDefinition {
@@ -550,16 +458,18 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Ising],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("ising health monitoring in dashboard"),
             description: "Ising finished catching up from a lag position.",
         },
-        // -- Refract (intent decomposition) ----------------------------
+        // -- Refract (intent decomposition) ---------------------------------
         EventDefinition {
             kind: "refract.intent_submitted",
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in refract intent timeline"),
             description: "A new intent was submitted for decomposition.",
         },
         EventDefinition {
@@ -567,7 +477,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in refract intent timeline"),
             description: "A decomposer produced an artifact tree for an intent.",
         },
         EventDefinition {
@@ -575,10 +486,11 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Portal],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in refract intent timeline"),
             description: "Decomposition failed — no decomposer matched, or the matched decomposer errored out.",
         },
-        // -- Workflow runtime (issue #80 / #81) ------------------------
+        // -- Workflow runtime (issue #80 / #81) -----------------------------
         EventDefinition {
             kind: "trigger.fired",
             schema_version: 1,
@@ -594,7 +506,8 @@ pub const EVENTS: EventManifest = EventManifest {
             //   "Run now" / replay endpoints (#241).
             producers: &[Subsystem::Stiglab, Subsystem::Forge, Subsystem::Portal],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A trigger fired (webhook / schedule / event / manual).",
         },
         EventDefinition {
@@ -607,7 +520,8 @@ pub const EVENTS: EventManifest = EventManifest {
             // replay fires to a user (#241).
             producers: &[Subsystem::Portal],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for manual / CLI / replay fires"),
             description: "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
         },
         EventDefinition {
@@ -615,7 +529,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in workflow run timeline"),
             description: "A workflow-tagged artifact entered a new stage.",
         },
         EventDefinition {
@@ -623,7 +538,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in workflow run timeline"),
             description: "A gate on the current stage resolved successfully.",
         },
         EventDefinition {
@@ -631,7 +547,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in workflow run timeline"),
             description: "A gate on the current stage failed; the artifact is parked.",
         },
         EventDefinition {
@@ -639,16 +556,18 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Forge],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("rendered in workflow run timeline"),
             description: "All gates on a stage resolved and the artifact advanced.",
         },
-        // -- Registry events (issue #14) -------------------------------
+        // -- Registry events (issue #14) ------------------------------------
         EventDefinition {
             kind: "registry.type_proposed",
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "A new artifact type was proposed (not yet active).",
         },
         EventDefinition {
@@ -656,7 +575,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "A proposed type was approved and entered the active catalog.",
         },
         EventDefinition {
@@ -664,7 +584,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "A type was deprecated (retained for audit).",
         },
         EventDefinition {
@@ -672,7 +593,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "An adapter implementation was registered in the catalog.",
         },
         EventDefinition {
@@ -680,7 +602,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "An adapter was deprecated.",
         },
         EventDefinition {
@@ -688,7 +611,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "A gate evaluator was registered.",
         },
         EventDefinition {
@@ -696,7 +620,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "A gate evaluator was deprecated.",
         },
         EventDefinition {
@@ -704,7 +629,8 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "An agent profile was registered.",
         },
         EventDefinition {
@@ -712,17 +638,19 @@ pub const EVENTS: EventManifest = EventManifest {
             schema_version: 1,
             producers: &[Subsystem::Synodic],
             consumers: &[],
-            audit_only: true,
+            diagnostic_only: true,
+            reason: Some("audit trail for registry catalog mutations"),
             description: "An agent profile was deprecated.",
         },
-        // -- Gate adapters (GitHub webhooks) ---------------------------
+        // -- Gate adapters (GitHub webhooks) --------------------------------
         EventDefinition {
             kind: "gate.check_updated",
             schema_version: 1,
             // Portal owns the GitHub webhook ingress as of #222 Slice 1.
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A GitHub check_suite/check_run/status arrived for a tracked PR.",
         },
         EventDefinition {
@@ -731,7 +659,8 @@ pub const EVENTS: EventManifest = EventManifest {
             // Portal owns the GitHub webhook ingress as of #222 Slice 1.
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Forge],
-            audit_only: false,
+            diagnostic_only: false,
+            reason: None,
             description: "A manual-approval gate received a signal (e.g. PR merged).",
         },
     ],
@@ -742,9 +671,7 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    /// Manifest invariant: every `kind` is unique. A duplicate would let two
-    /// rows disagree on producers/consumers and silently win the "first
-    /// match" race in `lookup`.
+    /// Manifest invariant: every `kind` is unique.
     #[test]
     fn manifest_kinds_are_unique() {
         let mut seen: HashSet<&str> = HashSet::new();
@@ -753,20 +680,33 @@ mod tests {
         }
     }
 
-    /// Strict version of the Lever E "every event has a producer and a
-    /// consumer" check: an event must declare a producer, and must either
-    /// declare a consumer or be `audit_only`.
+    /// Strict version of the schema invariant: every row has a producer,
+    /// and is either real (non-empty consumers) or diagnostic-only with a
+    /// non-empty `reason` string.
     #[test]
-    fn manifest_every_event_has_producer_and_consumer_or_audit_only() {
+    fn manifest_every_event_has_producer_and_is_real_or_diagnostic() {
         for e in EVENTS.events {
             assert!(
                 !e.producers.is_empty(),
                 "event `{}` has no producer",
                 e.kind
             );
+            let real = !e.consumers.is_empty();
+            let diagnostic = e.diagnostic_only && e.reason.is_some_and(|r| !r.is_empty());
             assert!(
-                !e.consumers.is_empty() || e.audit_only,
-                "event `{}` has no consumer and is not audit_only",
+                real || diagnostic,
+                "event `{}` is neither real (non-empty consumers) nor \
+                 diagnostic-only (diagnostic_only=true with non-empty reason)",
+                e.kind
+            );
+            assert!(
+                !e.diagnostic_only || e.consumers.is_empty(),
+                "event `{}` is both real and diagnostic-only",
+                e.kind
+            );
+            assert!(
+                e.reason.is_none() || e.diagnostic_only,
+                "event `{}` has a reason but is not diagnostic-only",
                 e.kind
             );
         }
@@ -786,6 +726,8 @@ mod tests {
         assert!(first.get("kind").is_some());
         assert!(first.get("producers").is_some());
         assert!(first.get("consumers").is_some());
+        assert!(first.get("diagnostic_only").is_some());
+        assert!(first.get("reason").is_some());
     }
 
     #[test]
@@ -796,5 +738,16 @@ mod tests {
         assert!(def.producers.contains(&Subsystem::Forge));
         assert!(def.consumers.contains(&Subsystem::Stiglab));
         assert!(EVENTS.lookup("does.not_exist").is_none());
+    }
+
+    /// Diagnostic-only rows must carry a non-empty reason string.
+    #[test]
+    fn diagnostic_only_rows_have_reason() {
+        for e in EVENTS.events {
+            if e.diagnostic_only {
+                let r = e.reason.expect("diagnostic-only row missing reason");
+                assert!(!r.is_empty(), "event `{}` has empty reason", e.kind);
+            }
+        }
     }
 }

--- a/crates/onsager-spine/examples/producer_consumer.rs
+++ b/crates/onsager-spine/examples/producer_consumer.rs
@@ -70,10 +70,14 @@ async fn main() -> anyhow::Result<()> {
     let mut first_id: Option<i64> = None;
     for i in 1..=expected {
         let event = FactoryEvent {
-            event: FactoryEventKind::StiglabSessionCreated {
+            event: FactoryEventKind::StiglabSessionCompleted {
                 session_id: format!("stiglab:session:demo-{i}"),
                 request_id: format!("stiglab:request:{i}"),
-                node_id: "example-node".into(),
+                duration_ms: 100,
+                artifact_id: None,
+                token_usage: None,
+                branch: None,
+                pr_number: None,
             },
             correlation_id: None,
             causation_id: None,

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -1,4 +1,4 @@
-// budget-allow: 75-variant event enum; macro/derive compression deferred to follow-up spec per #261
+// budget-allow: factory event enum (~50+ variants after spec #272 prune); macro/derive compression deferred to follow-up spec per #261
 //! Factory events — the authoritative event types emitted to the factory event
 //! spine by each subsystem.
 //!
@@ -7,10 +7,7 @@
 //! library provides a single typed vocabulary.
 
 use chrono::{DateTime, Utc};
-use onsager_artifact::{
-    ArtifactId, ArtifactState, ArtifactVersionId, DeliverableId, Kind, KindId, QualitySignal,
-    WorkflowRunId,
-};
+use onsager_artifact::{ArtifactId, ArtifactState, ArtifactVersionId, Kind};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -80,33 +77,13 @@ pub enum FactoryEventKind {
         session_id: String,
     },
 
-    /// New vertical or horizontal lineage entry recorded.
-    ArtifactLineageExtended {
-        artifact_id: ArtifactId,
-        lineage_type: LineageType,
-        detail: serde_json::Value,
-    },
-
-    /// New quality signal appended.
-    ArtifactQualityRecorded {
-        artifact_id: ArtifactId,
-        signal: QualitySignal,
-    },
-
-    /// Released artifact dispatched to a consumer sink.
-    ArtifactRouted {
-        artifact_id: ArtifactId,
-        consumer_id: String,
-        sink: String,
-    },
-
     /// Artifact reached terminal state (archived).
     ArtifactArchived {
         artifact_id: ArtifactId,
         reason: String,
     },
 
-    // -- Warehouse & Delivery (warehouse-and-delivery-v0.1) -----------------
+    // -- Warehouse (warehouse-and-delivery-v0.1) ----------------------------
     /// A new bundle was sealed for an artifact (§5.1).
     BundleSealed {
         artifact_id: ArtifactId,
@@ -114,62 +91,12 @@ pub enum FactoryEventKind {
         version: u32,
     },
 
-    /// A delivery attempt succeeded; the receipt is stored on the delivery row (§5.3).
-    DeliverySucceeded {
-        bundle_id: ArtifactVersionId,
-        consumer_id: String,
-    },
-
-    /// A delivery attempt failed; includes whether the worker will retry or
-    /// has marked the delivery `Abandoned` (§5.3).
-    DeliveryFailed {
-        bundle_id: ArtifactVersionId,
-        consumer_id: String,
-        reason: String,
-        /// Whether the delivery has been abandoned (terminal) or will retry.
-        abandoned: bool,
-    },
-
-    // -- Deliverable (workflow-run output, issue #100/#101) -----------------
-    /// A workflow run produced its first artifact reference. Emitted once per
-    /// run; subsequent additions flow through `DeliverableUpdated`.
-    DeliverableCreated {
-        deliverable_id: DeliverableId,
-        workflow_run_id: WorkflowRunId,
-    },
-
-    /// A workflow run added an artifact reference to its deliverable under a
-    /// given kind. Replay is idempotent on exact `(kind, artifact_id)`.
-    DeliverableUpdated {
-        deliverable_id: DeliverableId,
-        workflow_run_id: WorkflowRunId,
-        kind: KindId,
-        artifact_id: ArtifactId,
-    },
-
     // -- Git lifecycle events -------------------------------------------------
-    GitBranchCreated {
-        artifact_id: ArtifactId,
-        repo: String,
-        branch: String,
-    },
-    GitCommitPushed {
-        artifact_id: ArtifactId,
-        sha: String,
-        message: String,
-        session_id: String,
-    },
     GitPrOpened {
         artifact_id: ArtifactId,
         repo: String,
         pr_number: u64,
         url: String,
-    },
-    GitPrReviewReceived {
-        artifact_id: ArtifactId,
-        pr_number: u64,
-        reviewer: String,
-        state: String,
     },
     GitCiCompleted {
         artifact_id: ArtifactId,
@@ -259,29 +186,7 @@ pub enum FactoryEventKind {
         priority: i32,
     },
 
-    /// Scheduling kernel returned None (idle, emitted at reduced frequency).
-    ForgeIdleTick,
-
-    /// Forge process state machine transitioned.
-    ForgeStateChanged {
-        from_state: ForgeProcessState,
-        to_state: ForgeProcessState,
-    },
-
-    // -- Stiglab events (session and node lifecycle) -------------------------
-    /// A new session was allocated for a shaping request.
-    StiglabSessionCreated {
-        session_id: String,
-        request_id: String,
-        node_id: String,
-    },
-
-    /// A session was dispatched to a Stiglab node.
-    StiglabSessionDispatched { session_id: String, node_id: String },
-
-    /// A session began active execution.
-    StiglabSessionRunning { session_id: String },
-
+    // -- Stiglab events (session lifecycle) ---------------------------------
     /// A session finished successfully.
     StiglabSessionCompleted {
         session_id: String,
@@ -348,26 +253,6 @@ pub enum FactoryEventKind {
 
     /// A session was aborted (e.g. node lost, deadline exceeded).
     StiglabSessionAborted { session_id: String, reason: String },
-
-    /// A session-internal event was promoted to a factory event.
-    StiglabEventUpgraded {
-        session_id: String,
-        original_event_type: String,
-        reason: String,
-    },
-
-    /// A new Stiglab node joined the pool.
-    StiglabNodeRegistered {
-        node_id: String,
-        name: String,
-        hostname: String,
-    },
-
-    /// A Stiglab node left the pool.
-    StiglabNodeDeregistered { node_id: String, reason: String },
-
-    /// A node missed its expected heartbeat.
-    StiglabNodeHeartbeatMissed { node_id: String },
 
     // -- Portal intents (dashboard → agent dispatch) -------------------------
     /// Dashboard task request from portal. Stiglab's
@@ -727,19 +612,9 @@ impl FactoryEventKind {
             Self::ArtifactRegistered { .. } => "artifact.registered",
             Self::ArtifactStateChanged { .. } => "artifact.state_changed",
             Self::ArtifactVersionCreated { .. } => "artifact.version_created",
-            Self::ArtifactLineageExtended { .. } => "artifact.lineage_extended",
-            Self::ArtifactQualityRecorded { .. } => "artifact.quality_recorded",
-            Self::ArtifactRouted { .. } => "artifact.routed",
             Self::ArtifactArchived { .. } => "artifact.archived",
             Self::BundleSealed { .. } => "warehouse.bundle_sealed",
-            Self::DeliverySucceeded { .. } => "delivery.succeeded",
-            Self::DeliveryFailed { .. } => "delivery.failed",
-            Self::DeliverableCreated { .. } => "deliverable.created",
-            Self::DeliverableUpdated { .. } => "deliverable.updated",
-            Self::GitBranchCreated { .. } => "git.branch_created",
-            Self::GitCommitPushed { .. } => "git.commit_pushed",
             Self::GitPrOpened { .. } => "git.pr_opened",
-            Self::GitPrReviewReceived { .. } => "git.pr_review_received",
             Self::GitCiCompleted { .. } => "git.ci_completed",
             Self::GitPrMerged { .. } => "git.pr_merged",
             Self::GitPrClosed { .. } => "git.pr_closed",
@@ -749,19 +624,10 @@ impl FactoryEventKind {
             Self::ForgeGateVerdict { .. } => "forge.gate_verdict",
             Self::ForgeInsightObserved { .. } => "forge.insight_observed",
             Self::ForgeDecisionMade { .. } => "forge.decision_made",
-            Self::ForgeIdleTick => "forge.idle_tick",
-            Self::ForgeStateChanged { .. } => "forge.state_changed",
-            Self::StiglabSessionCreated { .. } => "stiglab.session_created",
-            Self::StiglabSessionDispatched { .. } => "stiglab.session_dispatched",
-            Self::StiglabSessionRunning { .. } => "stiglab.session_running",
             Self::StiglabSessionCompleted { .. } => "stiglab.session_completed",
             Self::StiglabShapingResultReady { .. } => "stiglab.shaping_result_ready",
             Self::StiglabSessionFailed { .. } => "stiglab.session_failed",
             Self::StiglabSessionAborted { .. } => "stiglab.session_aborted",
-            Self::StiglabEventUpgraded { .. } => "stiglab.event_upgraded",
-            Self::StiglabNodeRegistered { .. } => "stiglab.node_registered",
-            Self::StiglabNodeDeregistered { .. } => "stiglab.node_deregistered",
-            Self::StiglabNodeHeartbeatMissed { .. } => "stiglab.node_heartbeat_missed",
             Self::PortalSessionRequested { .. } => "portal.session_requested",
             Self::SynodicGateEvaluated { .. } => "synodic.gate_evaluated",
             Self::SynodicGateDenied { .. } => "synodic.gate_denied",
@@ -810,17 +676,9 @@ impl FactoryEventKind {
             Self::ArtifactRegistered { .. }
             | Self::ArtifactStateChanged { .. }
             | Self::ArtifactVersionCreated { .. }
-            | Self::ArtifactLineageExtended { .. }
-            | Self::ArtifactQualityRecorded { .. }
-            | Self::ArtifactRouted { .. }
             | Self::ArtifactArchived { .. } => "artifact",
             Self::BundleSealed { .. } => "warehouse",
-            Self::DeliverySucceeded { .. } | Self::DeliveryFailed { .. } => "delivery",
-            Self::DeliverableCreated { .. } | Self::DeliverableUpdated { .. } => "deliverable",
-            Self::GitBranchCreated { .. }
-            | Self::GitCommitPushed { .. }
-            | Self::GitPrOpened { .. }
-            | Self::GitPrReviewReceived { .. }
+            Self::GitPrOpened { .. }
             | Self::GitCiCompleted { .. }
             | Self::GitPrMerged { .. }
             | Self::GitPrClosed { .. } => "git",
@@ -829,20 +687,11 @@ impl FactoryEventKind {
             | Self::ForgeGateRequested { .. }
             | Self::ForgeGateVerdict { .. }
             | Self::ForgeInsightObserved { .. }
-            | Self::ForgeDecisionMade { .. }
-            | Self::ForgeIdleTick
-            | Self::ForgeStateChanged { .. } => "forge",
-            Self::StiglabSessionCreated { .. }
-            | Self::StiglabSessionDispatched { .. }
-            | Self::StiglabSessionRunning { .. }
-            | Self::StiglabSessionCompleted { .. }
+            | Self::ForgeDecisionMade { .. } => "forge",
+            Self::StiglabSessionCompleted { .. }
             | Self::StiglabShapingResultReady { .. }
             | Self::StiglabSessionFailed { .. }
-            | Self::StiglabSessionAborted { .. }
-            | Self::StiglabEventUpgraded { .. }
-            | Self::StiglabNodeRegistered { .. }
-            | Self::StiglabNodeDeregistered { .. }
-            | Self::StiglabNodeHeartbeatMissed { .. } => "stiglab",
+            | Self::StiglabSessionAborted { .. } => "stiglab",
             Self::PortalSessionRequested { .. } => "portal",
             Self::SynodicGateEvaluated { .. }
             | Self::SynodicGateDenied { .. }
@@ -893,20 +742,9 @@ impl FactoryEventKind {
             Self::ArtifactRegistered { artifact_id, .. }
             | Self::ArtifactStateChanged { artifact_id, .. }
             | Self::ArtifactVersionCreated { artifact_id, .. }
-            | Self::ArtifactLineageExtended { artifact_id, .. }
-            | Self::ArtifactQualityRecorded { artifact_id, .. }
-            | Self::ArtifactRouted { artifact_id, .. }
             | Self::ArtifactArchived { artifact_id, .. } => artifact_id.to_string(),
             Self::BundleSealed { bundle_id, .. } => bundle_id.to_string(),
-            Self::DeliverySucceeded { bundle_id, .. } | Self::DeliveryFailed { bundle_id, .. } => {
-                bundle_id.to_string()
-            }
-            Self::DeliverableCreated { deliverable_id, .. }
-            | Self::DeliverableUpdated { deliverable_id, .. } => deliverable_id.to_string(),
-            Self::GitBranchCreated { artifact_id, .. }
-            | Self::GitCommitPushed { artifact_id, .. }
-            | Self::GitPrOpened { artifact_id, .. }
-            | Self::GitPrReviewReceived { artifact_id, .. }
+            Self::GitPrOpened { artifact_id, .. }
             | Self::GitCiCompleted { artifact_id, .. }
             | Self::GitPrMerged { artifact_id, .. }
             | Self::GitPrClosed { artifact_id, .. } => artifact_id.to_string(),
@@ -916,19 +754,10 @@ impl FactoryEventKind {
             Self::ForgeGateVerdict { artifact_id, .. } => artifact_id.to_string(),
             Self::ForgeInsightObserved { insight_id, .. } => insight_id.clone(),
             Self::ForgeDecisionMade { artifact_id, .. } => artifact_id.to_string(),
-            Self::ForgeIdleTick => "forge".to_string(),
-            Self::ForgeStateChanged { .. } => "forge".to_string(),
-            Self::StiglabSessionCreated { session_id, .. }
-            | Self::StiglabSessionDispatched { session_id, .. }
-            | Self::StiglabSessionRunning { session_id, .. }
-            | Self::StiglabSessionCompleted { session_id, .. }
+            Self::StiglabSessionCompleted { session_id, .. }
             | Self::StiglabSessionFailed { session_id, .. }
-            | Self::StiglabSessionAborted { session_id, .. }
-            | Self::StiglabEventUpgraded { session_id, .. } => session_id.clone(),
+            | Self::StiglabSessionAborted { session_id, .. } => session_id.clone(),
             Self::StiglabShapingResultReady { artifact_id, .. } => artifact_id.to_string(),
-            Self::StiglabNodeRegistered { node_id, .. }
-            | Self::StiglabNodeDeregistered { node_id, .. }
-            | Self::StiglabNodeHeartbeatMissed { node_id, .. } => node_id.clone(),
             Self::PortalSessionRequested { session_id, .. } => session_id.clone(),
             Self::SynodicGateEvaluated { gate_id, .. } => gate_id.clone(),
             Self::SynodicGateDenied { gate_id, .. } => gate_id.clone(),
@@ -988,15 +817,6 @@ impl FactoryEventKind {
 // Supporting enums
 // ---------------------------------------------------------------------------
 
-/// Whether a lineage entry is vertical (session→version) or horizontal
-/// (artifact→artifact).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LineageType {
-    Vertical,
-    Horizontal,
-}
-
 /// Outcome of a shaping request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1027,7 +847,9 @@ pub enum VerdictSummary {
     Escalate,
 }
 
-/// Forge process states.
+/// Forge process states. Used by forge's internal state machine; no longer
+/// carried on a `FactoryEventKind` variant after spec #272 retired
+/// `ForgeStateChanged`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ForgeProcessState {

--- a/crates/onsager-spine/src/factory_event_tests.rs
+++ b/crates/onsager-spine/src/factory_event_tests.rs
@@ -17,15 +17,6 @@ mod tests {
     }
 
     #[test]
-    fn forge_event_types() {
-        assert_eq!(
-            FactoryEventKind::ForgeIdleTick.event_type(),
-            "forge.idle_tick"
-        );
-        assert_eq!(FactoryEventKind::ForgeIdleTick.stream_type(), "forge");
-    }
-
-    #[test]
     fn git_event_types_and_streams() {
         let event = FactoryEventKind::GitPrOpened {
             artifact_id: ArtifactId::new("art_git123"),

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -58,7 +58,7 @@ pub use onsager_artifact::{
 pub use extension_event::ExtensionEventRecord;
 pub use factory_event::{
     EscalationResolution, EventRef, FactoryEvent, FactoryEventKind, ForgeProcessState, GatePoint,
-    InsightKind, InsightScope, LineageType, ShapingOutcome, VerdictSummary,
+    InsightKind, InsightScope, ShapingOutcome, VerdictSummary,
 };
 pub use listener::{EventHandler, Listener};
 pub use namespace::{Namespace, NamespaceError};

--- a/crates/onsager-spine/src/trigger.rs
+++ b/crates/onsager-spine/src/trigger.rs
@@ -13,8 +13,11 @@
 //! manifest at `crates/onsager-registry/src/triggers.rs` enforces:
 //! 1. Add a variant here with its config fields.
 //! 2. Add a row to the registry manifest with the snake-case `kind_tag`.
-//! 3. Wire a producer + consumer (or mark the manifest row
-//!    `diagnostic_only: true` with a non-empty `reason`).
+//! 3. Wire a producer for the new kind — the subsystem named in the
+//!    manifest row's `producer` field must fire `trigger.fired` for
+//!    this `TriggerKind` (and the runtime must be able to dispatch
+//!    it). `xtask check-triggers` enforces coverage + that each row
+//!    declares a producer in the category-appropriate subsystem.
 
 use std::collections::BTreeMap;
 

--- a/crates/onsager-spine/src/trigger.rs
+++ b/crates/onsager-spine/src/trigger.rs
@@ -13,7 +13,8 @@
 //! manifest at `crates/onsager-registry/src/triggers.rs` enforces:
 //! 1. Add a variant here with its config fields.
 //! 2. Add a row to the registry manifest with the snake-case `kind_tag`.
-//! 3. Wire a producer + consumer (or tag the manifest row `audit_only`).
+//! 3. Wire a producer + consumer (or mark the manifest row
+//!    `diagnostic_only: true` with a non-empty `reason`).
 
 use std::collections::BTreeMap;
 

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -34,15 +34,6 @@ pub async fn handle_agent_message(
             if let Err(e) = db::update_session_state(pool, &session_id, *state).await {
                 tracing::error!("failed to update session state: {e}");
             }
-            // Emit spine event when session transitions to Running
-            if *state == SessionState::Running
-                && let Some(spine) = spine
-            {
-                // We don't have request_id here, use task_id from the session as correlation
-                if let Err(e) = spine.emit_session_started(&session_id, "", node_id).await {
-                    tracing::warn!("failed to emit session_started spine event: {e}");
-                }
-            }
         }
         AgentMessage::SessionOutput {
             session_id,

--- a/crates/stiglab/src/server/routes/shaping.rs
+++ b/crates/stiglab/src/server/routes/shaping.rs
@@ -172,13 +172,6 @@ pub async fn dispatch_shaping_inner(
         }
     }
 
-    // Emit session-started spine event.
-    if let Some(ref spine) = state.spine {
-        let _ = spine
-            .emit_session_started(&session.id, &req.request_id, &target_node.id)
-            .await;
-    }
-
     Ok(DispatchOutcome::Created(session))
 }
 

--- a/crates/stiglab/src/server/session_requested_listener.rs
+++ b/crates/stiglab/src/server/session_requested_listener.rs
@@ -161,15 +161,6 @@ impl Dispatcher {
                         "stiglab: portal.session_requested — failed to update state: {e}"
                     );
                 }
-                if let Some(ref spine) = state.spine {
-                    let _ = spine
-                        .emit_session_started(
-                            &payload.session_id,
-                            &payload.task_id,
-                            &payload.node_id,
-                        )
-                        .await;
-                }
                 tracing::info!(
                     session_id = %payload.session_id,
                     node_id = %payload.node_id,

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -124,21 +124,6 @@ impl SpineEmitter {
             .await
     }
 
-    /// Emit a session-started event.
-    pub async fn emit_session_started(
-        &self,
-        session_id: &str,
-        request_id: &str,
-        node_id: &str,
-    ) -> Result<i64, sqlx::Error> {
-        self.emit(FactoryEventKind::StiglabSessionCreated {
-            session_id: session_id.to_string(),
-            request_id: request_id.to_string(),
-            node_id: node_id.to_string(),
-        })
-        .await
-    }
-
     /// Emit a session-completed event.
     ///
     /// `artifact_id` links the session to the factory pipeline artifact it
@@ -225,15 +210,9 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         FactoryEventKind::ArtifactRegistered { artifact_id, .. }
         | FactoryEventKind::ArtifactStateChanged { artifact_id, .. }
         | FactoryEventKind::ArtifactVersionCreated { artifact_id, .. }
-        | FactoryEventKind::ArtifactLineageExtended { artifact_id, .. }
-        | FactoryEventKind::ArtifactQualityRecorded { artifact_id, .. }
-        | FactoryEventKind::ArtifactRouted { artifact_id, .. }
         | FactoryEventKind::ArtifactArchived { artifact_id, .. }
         | FactoryEventKind::BundleSealed { artifact_id, .. }
-        | FactoryEventKind::GitBranchCreated { artifact_id, .. }
-        | FactoryEventKind::GitCommitPushed { artifact_id, .. }
         | FactoryEventKind::GitPrOpened { artifact_id, .. }
-        | FactoryEventKind::GitPrReviewReceived { artifact_id, .. }
         | FactoryEventKind::GitCiCompleted { artifact_id, .. }
         | FactoryEventKind::GitPrMerged { artifact_id, .. }
         | FactoryEventKind::GitPrClosed { artifact_id, .. }
@@ -251,7 +230,6 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::SynodicEscalationResolved { artifact_id, .. }
         | FactoryEventKind::SynodicEscalationTimedOut { artifact_id, .. }
         | FactoryEventKind::SynodicGateResolutionProposed { artifact_id, .. }
-        | FactoryEventKind::DeliverableUpdated { artifact_id, .. }
         | FactoryEventKind::StageEntered { artifact_id, .. }
         | FactoryEventKind::StageGatePassed { artifact_id, .. }
         | FactoryEventKind::StageGateFailed { artifact_id, .. }
@@ -260,20 +238,8 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::StiglabSessionFailed { artifact_id, .. } => artifact_id.as_deref(),
         // Variants below name no artifact — system / cross-workspace
         // telemetry. Fall back to "default".
-        FactoryEventKind::DeliverySucceeded { .. }
-        | FactoryEventKind::DeliveryFailed { .. }
-        | FactoryEventKind::DeliverableCreated { .. }
-        | FactoryEventKind::ForgeInsightObserved { .. }
-        | FactoryEventKind::ForgeIdleTick
-        | FactoryEventKind::ForgeStateChanged { .. }
-        | FactoryEventKind::StiglabSessionCreated { .. }
-        | FactoryEventKind::StiglabSessionDispatched { .. }
-        | FactoryEventKind::StiglabSessionRunning { .. }
+        FactoryEventKind::ForgeInsightObserved { .. }
         | FactoryEventKind::StiglabSessionAborted { .. }
-        | FactoryEventKind::StiglabEventUpgraded { .. }
-        | FactoryEventKind::StiglabNodeRegistered { .. }
-        | FactoryEventKind::StiglabNodeDeregistered { .. }
-        | FactoryEventKind::StiglabNodeHeartbeatMissed { .. }
         | FactoryEventKind::SynodicRuleProposed { .. }
         | FactoryEventKind::SynodicRuleApproved { .. }
         | FactoryEventKind::SynodicRuleDisabled { .. }

--- a/docs/events.md
+++ b/docs/events.md
@@ -52,13 +52,11 @@ that requires a coordinated rollout.
 
 | Stream | Producer subsystem | Event count |
 |---|---|---|
-| `artifact` | forge | 7 |
+| `artifact` | forge | 4 |
 | `warehouse` | warehouse worker (forge) | 1 |
-| `delivery` | delivery worker (forge) | 2 |
-| `deliverable` | forge | 2 |
-| `git` | onsager-portal (GitHub webhooks) | 7 |
-| `forge` | forge | 8 |
-| `stiglab` | stiglab | 11 |
+| `git` | onsager-portal (GitHub webhooks) | 4 |
+| `forge` | forge | 6 |
+| `stiglab` | stiglab | 4 |
 | `portal` | (unknown — update `stream_producer` in xtask) | 1 |
 | `synodic` | synodic | 12 |
 | `ising` | ising | 6 |
@@ -116,44 +114,6 @@ New version committed for an artifact.
 | `change_summary` | `String` |  |
 | `session_id` | `String` |  |
 
-### `artifact.lineage_extended`
-
-- Variant: `FactoryEventKind::ArtifactLineageExtended`
-- Stream: `artifact`
-
-New vertical or horizontal lineage entry recorded.
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `lineage_type` | `LineageType` |  |
-| `detail` | `serde_json::Value` |  |
-
-### `artifact.quality_recorded`
-
-- Variant: `FactoryEventKind::ArtifactQualityRecorded`
-- Stream: `artifact`
-
-New quality signal appended.
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `signal` | `QualitySignal` |  |
-
-### `artifact.routed`
-
-- Variant: `FactoryEventKind::ArtifactRouted`
-- Stream: `artifact`
-
-Released artifact dispatched to a consumer sink.
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `consumer_id` | `String` |  |
-| `sink` | `String` |  |
-
 ### `artifact.archived`
 
 - Variant: `FactoryEventKind::ArtifactArchived`
@@ -183,92 +143,9 @@ A new bundle was sealed for an artifact (§5.1).
 | `bundle_id` | `ArtifactVersionId` |  |
 | `version` | `u32` |  |
 
-## `delivery` events
-
-Producer subsystem: **delivery worker (forge)**.
-
-### `delivery.succeeded`
-
-- Variant: `FactoryEventKind::DeliverySucceeded`
-- Stream: `delivery`
-
-A delivery attempt succeeded; the receipt is stored on the delivery row (§5.3).
-
-| Field | Type | Description |
-|---|---|---|
-| `bundle_id` | `ArtifactVersionId` |  |
-| `consumer_id` | `String` |  |
-
-### `delivery.failed`
-
-- Variant: `FactoryEventKind::DeliveryFailed`
-- Stream: `delivery`
-
-A delivery attempt failed; includes whether the worker will retry or has marked the delivery `Abandoned` (§5.3).
-
-| Field | Type | Description |
-|---|---|---|
-| `bundle_id` | `ArtifactVersionId` |  |
-| `consumer_id` | `String` |  |
-| `reason` | `String` |  |
-| `abandoned` | `bool` | Whether the delivery has been abandoned (terminal) or will retry. |
-
-## `deliverable` events
-
-Producer subsystem: **forge**.
-
-### `deliverable.created`
-
-- Variant: `FactoryEventKind::DeliverableCreated`
-- Stream: `deliverable`
-
-A workflow run produced its first artifact reference. Emitted once per run; subsequent additions flow through `DeliverableUpdated`.
-
-| Field | Type | Description |
-|---|---|---|
-| `deliverable_id` | `DeliverableId` |  |
-| `workflow_run_id` | `WorkflowRunId` |  |
-
-### `deliverable.updated`
-
-- Variant: `FactoryEventKind::DeliverableUpdated`
-- Stream: `deliverable`
-
-A workflow run added an artifact reference to its deliverable under a given kind. Replay is idempotent on exact `(kind, artifact_id)`.
-
-| Field | Type | Description |
-|---|---|---|
-| `deliverable_id` | `DeliverableId` |  |
-| `workflow_run_id` | `WorkflowRunId` |  |
-| `kind` | `KindId` |  |
-| `artifact_id` | `ArtifactId` |  |
-
 ## `git` events
 
 Producer subsystem: **onsager-portal (GitHub webhooks)**.
-
-### `git.branch_created`
-
-- Variant: `FactoryEventKind::GitBranchCreated`
-- Stream: `git`
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `repo` | `String` |  |
-| `branch` | `String` |  |
-
-### `git.commit_pushed`
-
-- Variant: `FactoryEventKind::GitCommitPushed`
-- Stream: `git`
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `sha` | `String` |  |
-| `message` | `String` |  |
-| `session_id` | `String` |  |
 
 ### `git.pr_opened`
 
@@ -281,18 +158,6 @@ Producer subsystem: **onsager-portal (GitHub webhooks)**.
 | `repo` | `String` |  |
 | `pr_number` | `u64` |  |
 | `url` | `String` |  |
-
-### `git.pr_review_received`
-
-- Variant: `FactoryEventKind::GitPrReviewReceived`
-- Stream: `git`
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `pr_number` | `u64` |  |
-| `reviewer` | `String` |  |
-| `state` | `String` |  |
 
 ### `git.ci_completed`
 
@@ -411,66 +276,9 @@ Scheduling kernel produced a ShapingDecision.
 | `target_version` | `u32` |  |
 | `priority` | `i32` |  |
 
-### `forge.idle_tick`
-
-- Variant: `FactoryEventKind::ForgeIdleTick`
-- Stream: `forge`
-
-Scheduling kernel returned None (idle, emitted at reduced frequency).
-
-_No payload fields._
-
-### `forge.state_changed`
-
-- Variant: `FactoryEventKind::ForgeStateChanged`
-- Stream: `forge`
-
-Forge process state machine transitioned.
-
-| Field | Type | Description |
-|---|---|---|
-| `from_state` | `ForgeProcessState` |  |
-| `to_state` | `ForgeProcessState` |  |
-
 ## `stiglab` events
 
 Producer subsystem: **stiglab**.
-
-### `stiglab.session_created`
-
-- Variant: `FactoryEventKind::StiglabSessionCreated`
-- Stream: `stiglab`
-
-A new session was allocated for a shaping request.
-
-| Field | Type | Description |
-|---|---|---|
-| `session_id` | `String` |  |
-| `request_id` | `String` |  |
-| `node_id` | `String` |  |
-
-### `stiglab.session_dispatched`
-
-- Variant: `FactoryEventKind::StiglabSessionDispatched`
-- Stream: `stiglab`
-
-A session was dispatched to a Stiglab node.
-
-| Field | Type | Description |
-|---|---|---|
-| `session_id` | `String` |  |
-| `node_id` | `String` |  |
-
-### `stiglab.session_running`
-
-- Variant: `FactoryEventKind::StiglabSessionRunning`
-- Stream: `stiglab`
-
-A session began active execution.
-
-| Field | Type | Description |
-|---|---|---|
-| `session_id` | `String` |  |
 
 ### `stiglab.session_completed`
 
@@ -528,55 +336,6 @@ A session was aborted (e.g. node lost, deadline exceeded).
 |---|---|---|
 | `session_id` | `String` |  |
 | `reason` | `String` |  |
-
-### `stiglab.event_upgraded`
-
-- Variant: `FactoryEventKind::StiglabEventUpgraded`
-- Stream: `stiglab`
-
-A session-internal event was promoted to a factory event.
-
-| Field | Type | Description |
-|---|---|---|
-| `session_id` | `String` |  |
-| `original_event_type` | `String` |  |
-| `reason` | `String` |  |
-
-### `stiglab.node_registered`
-
-- Variant: `FactoryEventKind::StiglabNodeRegistered`
-- Stream: `stiglab`
-
-A new Stiglab node joined the pool.
-
-| Field | Type | Description |
-|---|---|---|
-| `node_id` | `String` |  |
-| `name` | `String` |  |
-| `hostname` | `String` |  |
-
-### `stiglab.node_deregistered`
-
-- Variant: `FactoryEventKind::StiglabNodeDeregistered`
-- Stream: `stiglab`
-
-A Stiglab node left the pool.
-
-| Field | Type | Description |
-|---|---|---|
-| `node_id` | `String` |  |
-| `reason` | `String` |  |
-
-### `stiglab.node_heartbeat_missed`
-
-- Variant: `FactoryEventKind::StiglabNodeHeartbeatMissed`
-- Stream: `stiglab`
-
-A node missed its expected heartbeat.
-
-| Field | Type | Description |
-|---|---|---|
-| `node_id` | `String` |  |
 
 ## `portal` events
 

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -6,7 +6,9 @@
 //! 1. **Coverage**: every `FactoryEventKind` variant has a manifest entry
 //!    keyed by its wire `event_type` string.
 //! 2. **Both ends declared**: every manifest entry has at least one
-//!    producer, and either at least one consumer or `audit_only = true`.
+//!    producer, and is either real (non-empty `consumers`) or
+//!    diagnostic-only (`diagnostic_only = true` plus a non-empty
+//!    `reason`).
 //! 3. **Emit call sites match producers**: every `append_ext(_, _,
 //!    "<event_type>", ...)` literal under
 //!    `crates/{forge,stiglab,synodic,ising}/src/` references an event
@@ -253,7 +255,8 @@ fn check_coverage(variants_to_kinds: &BTreeMap<String, String>, errors: &mut Vec
 }
 
 // ---------------------------------------------------------------------------
-// Check 2: every manifest entry has at least one producer + (consumer | audit_only)
+// Check 2: every manifest entry has at least one producer + is real
+// (non-empty consumers) or diagnostic-only (with non-empty reason).
 // ---------------------------------------------------------------------------
 
 fn check_both_ends_declared(errors: &mut Vec<String>) {
@@ -261,9 +264,24 @@ fn check_both_ends_declared(errors: &mut Vec<String>) {
         if e.producers.is_empty() {
             errors.push(format!("[manifest] `{}` declares no producer", e.kind));
         }
-        if e.consumers.is_empty() && !e.audit_only {
+        let real = !e.consumers.is_empty();
+        let diagnostic = e.diagnostic_only && e.reason.is_some_and(|r| !r.is_empty());
+        if !real && !diagnostic {
             errors.push(format!(
-                "[manifest] `{}` declares no consumer and is not audit_only",
+                "[manifest] `{}` is neither real (non-empty consumers) nor \
+                 diagnostic-only (diagnostic_only=true with non-empty reason)",
+                e.kind
+            ));
+        }
+        if e.diagnostic_only && !e.consumers.is_empty() {
+            errors.push(format!(
+                "[manifest] `{}` is both real and diagnostic-only — pick one",
+                e.kind
+            ));
+        }
+        if e.reason.is_some() && !e.diagnostic_only {
+            errors.push(format!(
+                "[manifest] `{}` has a reason but is not diagnostic-only",
                 e.kind
             ));
         }
@@ -450,34 +468,52 @@ mod tests {
     use super::*;
 
     /// Synthetic: pretend we have a manifest with a producer but no
-    /// consumer + audit_only=false. Mirrors `check_both_ends_declared`'s
+    /// consumer + diagnostic_only=false. Mirrors `check_both_ends_declared`'s
     /// branch directly since we can't mutate the static `EVENTS`.
     #[test]
-    fn predicate_flags_no_consumer_non_audit_event() {
+    fn predicate_flags_no_consumer_non_diagnostic_event() {
         fn declared_ok(
             producers: &[Subsystem],
             consumers: &[Subsystem],
-            audit_only: bool,
+            diagnostic_only: bool,
+            reason: Option<&'static str>,
         ) -> Vec<&'static str> {
             let mut errs = Vec::new();
             if producers.is_empty() {
                 errs.push("no producer");
             }
-            if consumers.is_empty() && !audit_only {
-                errs.push("no consumer");
+            let real = !consumers.is_empty();
+            let diagnostic = diagnostic_only && reason.is_some_and(|r| !r.is_empty());
+            if !real && !diagnostic {
+                errs.push("neither real nor diagnostic-only");
             }
             errs
         }
         assert_eq!(
-            declared_ok(&[Subsystem::Forge], &[], false),
-            vec!["no consumer"]
+            declared_ok(&[Subsystem::Forge], &[], false, None),
+            vec!["neither real nor diagnostic-only"]
         );
         assert_eq!(
-            declared_ok(&[Subsystem::Forge], &[], true),
+            declared_ok(&[Subsystem::Forge], &[], true, None),
+            vec!["neither real nor diagnostic-only"],
+            "diagnostic_only without reason must fail"
+        );
+        assert_eq!(
+            declared_ok(&[Subsystem::Forge], &[], true, Some("")),
+            vec!["neither real nor diagnostic-only"],
+            "empty reason must fail"
+        );
+        assert_eq!(
+            declared_ok(
+                &[Subsystem::Forge],
+                &[],
+                true,
+                Some("rendered in dashboard")
+            ),
             Vec::<&str>::new()
         );
         assert_eq!(
-            declared_ok(&[], &[Subsystem::Forge], false),
+            declared_ok(&[], &[Subsystem::Forge], false, None),
             vec!["no producer"]
         );
     }


### PR DESCRIPTION
## Summary

Schema simplification of the event manifest at `crates/onsager-registry/src/events.rs`: drop `audit_only` entirely, introduce `diagnostic_only: bool` + `reason: Option<&'static str>`. Every row is now either **real** (non-empty `consumers`) or **diagnostic-only** (`diagnostic_only: true` plus a non-empty `reason`). `xtask check-events` rejects rows that are neither.

Executes the per-event triage from #272:

- **DELETE 19** — 17 zero-producer enum stubs + 2 with live emit sites whose emit-site code is removed alongside the variant:
  - `artifact.lineage_extended`, `artifact.quality_recorded`, `artifact.routed`
  - `delivery.succeeded`, `delivery.failed`, `deliverable.created`, `deliverable.updated`
  - `git.branch_created`, `git.commit_pushed`, `git.pr_review_received`
  - `forge.idle_tick`, `forge.state_changed`
  - `stiglab.session_created`, `stiglab.session_dispatched`, `stiglab.session_running`, `stiglab.event_upgraded`, `stiglab.node_registered`, `stiglab.node_deregistered`, `stiglab.node_heartbeat_missed`
- **DIAGNOSTIC-ONLY 7 (triaged) + 23 (untriaged audit-shaped survivors)** — converted to `diagnostic_only: true` with per-row `reason` strings. The 23 untriaged survivors are pre-existing audit-shaped rows (governance, stage, registry, ising, refract, workflow.manual_triggered) that already had no subsystem consumer; they get sensible-default reasons aligned with what reads them today (dashboard governance UI / event timeline / audit trail).
- **DEFERRED PROMOTE 1** — `artifact.archived` stays diagnostic-only with `reason` pointing at spec #273; that PR will promote it to `consumers=[forge]`.

Side effects of the variant deletions:

- **Synchronize PR webhook** in `onsager-portal/handlers/pull_request.rs` no longer emits a spine event (the artifact version bump on synchronize remains the only durable signal). The Opened / Closed / Merged paths still emit their respective `git.pr_*` events.
- **`emit_session_started`** removed from stiglab's `SpineEmitter`. The three callers (`handler.rs`, `session_requested_listener.rs`, `routes/shaping.rs`) drop their now-no-op emit blocks.
- **`artifact_id_for_workspace_lookup`** match arms in `stiglab/server/spine.rs` pruned of all 14 deleted variants they referenced.
- Helper enum **`LineageType`** removed (only consumer was the deleted `ArtifactLineageExtended`); the `lib.rs` re-export goes with it. `ForgeProcessState` is kept — forge's internal state machine still uses it.
- Several test fixtures that used `forge.idle_tick` as a neutral "any unrelated event" placeholder migrated to `forge.decision_made` (still in the manifest as diagnostic-only): three forge listener unit tests, one ising analyzer unit test, the dashboard `lineage-dag` smoke test, and the spine `producer_consumer` example.
- Dashboard `EventManifestEntry` type drops `audit_only`, gains `diagnostic_only` and `reason: string | null`.

Updated docs:

- Root `CLAUDE.md` Lever E paragraph rewritten to describe the new two-state schema.
- `crates/onsager-registry/CLAUDE.md` field reference, update-process table, and CI-enforcement section all rewritten.
- `crates/onsager-spine/src/trigger.rs` doc-comment.

No DB migration is included. Deleted-variant rows in `events`/`events_ext` (only meaningful for `git.commit_pushed` and `stiglab.session_created`, which had real emit sites) are left as historical records — no consumer reads them, the dashboard event timeline can render them as opaque rows, and a follow-up cleanup migration is straightforward if it ever proves necessary.

Closes #272

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` — all suites passing (no failures across the 30+ test result lines)
- [x] `cargo run -p xtask -- check-events` — `clean (58 events, 4 subsystems scanned)`
- [x] `cargo run -p xtask -- lint-seams` clean
- [x] `cargo run -p xtask -- check-api-contract` clean (65 backend routes, 63 dashboard calls)
- [x] `cargo run -p xtask -- check-file-budget` clean (the existing `factory_event.rs` exemption still applies after the prune; comment updated to reflect the new variant count)
- [x] Dashboard `pnpm run build` clean (TS typecheck happens in `tsc -b` before vite build)

https://claude.ai/code/session_01BDjRiiKx8ndjHP7MzDs9Kn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDjRiiKx8ndjHP7MzDs9Kn)_