### PR TITLE
tighten post-push CI monitoring + Dockerfile preflight

### DIFF
--- a/.claude/skills/onsager-pr-lifecycle/SKILL.md
+++ b/.claude/skills/onsager-pr-lifecycle/SKILL.md
@@ -276,8 +276,56 @@ tags. The harness forwards them as user messages.
   PR is created (or the user asks you to watch it).
 - Unsubscribe with `mcp__github__unsubscribe_pr_activity` when done — not
   strictly necessary but cleaner.
-- Events are already filtered to CI failures + reviews. Treat each as
-  actionable; skip only if it's a duplicate of one you just addressed.
+- Treat each event as actionable; skip only if it's a duplicate of one you
+  just addressed.
+
+### What the subscription does NOT cover
+
+The subscription is **not** an "all CI events" feed. It's filtered to issue
+comments and review activity, plus a small set of well-known check_run
+state changes. In practice this leaks the following silent-failure
+surfaces, observed on real PRs:
+
+- **Commit statuses.** GitHub's `status` API is a separate channel from
+  `check_run`. Per-PR Railway deploys, GitGuardian, and any GitHub App
+  that posts via the legacy statuses API fire here, not as check_runs.
+  No `<github-webhook-activity>` event arrives — the failure is only
+  visible if you call `pull_request_read get_status` directly.
+- **`check_run` completion transitions.** The subscription fires on some
+  state changes but is not reliable for "the rust.yml `build` job just
+  finished failure". An in-progress check that completes after you've
+  ended your turn does not necessarily wake the session.
+
+PR #279 hit the first failure mode — Railway's deploy failure landed as a
+commit status, no webhook fired, and the agent ended its turn assuming
+the subscription would surface CI completion. It didn't, and the user
+had to flag it manually. The post-push sweep below closes the gap.
+
+### Post-push CI sweep (mandatory)
+
+Once the PR is open and you've subscribed, run this sweep **before
+declaring "all green" or ending the turn**:
+
+1. Read both surfaces explicitly:
+   - `pull_request_read` with `method: get_status` — pulls every commit
+     status for the head SHA. Treat any `state=failure` as actionable
+     even if no webhook fired.
+   - `pull_request_read` with `method: get_check_runs` — pulls every
+     check_run. Treat any `conclusion=failure` as actionable.
+2. Any check still `in_progress` or `queued` is **not** ground for
+   "completed" — record a TodoWrite item like *"Re-poll PR #N CI
+   ~5 min post-push"* and check it off only after a follow-up sweep
+   shows the check finished. Don't sleep-poll inside the same turn;
+   end the turn and let the user (or a subsequent webhook event) bring
+   you back.
+3. If the sweep returns nothing actionable but checks are still
+   running, say so explicitly in the end-of-turn summary
+   ("`build` and `Agent` still running; will follow up") so the user
+   doesn't infer the PR is fully green.
+
+The sweep is cheap (two MCP calls) and is the only mechanical defense
+against the silent-failure surfaces above. Skipping it is how PR #279
+shipped a broken Railway deploy that the agent never noticed.
 
 ## Reporting back to the user
 

--- a/.claude/skills/onsager-pre-push/SKILL.md
+++ b/.claude/skills/onsager-pre-push/SKILL.md
@@ -314,7 +314,11 @@ Retry up to 4 times with exponential backoff on transient network errors.
 **Never** use `--force` on main or long-lived branches without explicit ask.
 
 After push, the `pr-spec-sync.yml` workflow flips the linked spec to
-`in-progress` automatically on PR open.
+`in-progress` automatically on PR open. The `subscribe_pr_activity`
+subscription does **not** fire on every CI surface (commit statuses,
+some check_run completions) — once the PR is open run the post-push CI
+sweep in [`onsager-pr-lifecycle`](../onsager-pr-lifecycle/SKILL.md#post-push-ci-sweep-mandatory)
+(two `pull_request_read` calls) before declaring the push successful.
 
 ## Fast path
 

--- a/.claude/skills/railway/SKILL.md
+++ b/.claude/skills/railway/SKILL.md
@@ -29,7 +29,9 @@ authentication, error formatting, and pass/fail reporting.
 
 Run before any deploy or when triaging a build failure. Checks:
 - Lockfiles (`Cargo.lock`, `pnpm-lock.yaml`) tracked in git
-- Dockerfile COPY sources not gitignored
+- Dockerfile COPY sources both exist on disk and are tracked in git
+  (catches the PR #276 → #279 failure mode where a deleted crate left
+  ghost `COPY` references that aborted Docker's image build)
 - Railway vars don't contain `localhost` (dev/prod leak)
 - `DATABASE_URL` references Railway Postgres plugin
 

--- a/.claude/skills/railway/scripts/preflight.sh
+++ b/.claude/skills/railway/scripts/preflight.sh
@@ -42,27 +42,34 @@ check "Cargo.lock tracked in git" \
 check "pnpm-lock.yaml tracked in git" \
     git ls-files --error-unmatch pnpm-lock.yaml
 
-# Verify Dockerfiles don't COPY files that are gitignored
-docker_copy_ok=true
+# Verify Dockerfile COPY sources both exist on disk and are tracked in git.
+# Two distinct failure modes are caught here:
+#   1. COPY <src> where <src> doesn't exist (e.g. a crate was deleted but the
+#      Dockerfile wasn't updated — Docker's image build aborts at COPY time).
+#   2. COPY <src> where <src> exists but is gitignored (build context excludes
+#      it — Docker can't see the file even though local checks pass).
+docker_fail_log=$(mktemp)
 for dockerfile in crates/stiglab/deploy/Dockerfile deploy/synodic.Dockerfile; do
     [ -f "$dockerfile" ] || continue
     grep -oP '^\s*COPY\s+\K\S+' "$dockerfile" \
         | grep -v -- '--from=' \
         | while read -r src; do
             case "$src" in *\**|*\$*) continue;; esac
-            if [ -f "$src" ] && ! git ls-files --error-unmatch "$src" > /dev/null 2>&1; then
-                echo "  FAIL  $dockerfile: COPY source '$src' not in git"
-                echo "FAIL" >> /tmp/preflight-docker-fail.$$
+            if [ ! -e "$src" ]; then
+                echo "  FAIL  $dockerfile: COPY source '$src' does not exist on disk" >> "$docker_fail_log"
+            elif ! git ls-files --error-unmatch "$src" > /dev/null 2>&1; then
+                echo "  FAIL  $dockerfile: COPY source '$src' exists but is not tracked in git" >> "$docker_fail_log"
             fi
           done
 done
-if [ -f /tmp/preflight-docker-fail.$$ ]; then
-    rm -f /tmp/preflight-docker-fail.$$
+if [ -s "$docker_fail_log" ]; then
+    cat "$docker_fail_log"
     fail=$((fail + 1))
 else
-    echo "  PASS  Dockerfile COPY sources all tracked"
+    echo "  PASS  Dockerfile COPY sources all exist and are tracked"
     pass=$((pass + 1))
 fi
+rm -f "$docker_fail_log"
 
 # Railway variable checks (need token)
 if [ -z "$ONSAGER_RAILWAY_TOKEN" ]; then

--- a/.claude/skills/railway/scripts/preflight.sh
+++ b/.claude/skills/railway/scripts/preflight.sh
@@ -44,20 +44,39 @@ check "pnpm-lock.yaml tracked in git" \
 
 # Verify Dockerfile COPY sources both exist on disk and are tracked in git.
 # Two distinct failure modes are caught here:
-#   1. COPY <src> where <src> doesn't exist (e.g. a crate was deleted but the
-#      Dockerfile wasn't updated — Docker's image build aborts at COPY time).
-#   2. COPY <src> where <src> exists but is gitignored (build context excludes
-#      it — Docker can't see the file even though local checks pass).
+#   1. COPY <src...> where any <src> doesn't exist (e.g. a crate was deleted
+#      but the Dockerfile wasn't updated — Docker's image build aborts at
+#      COPY time).
+#   2. COPY <src...> where a <src> exists but is gitignored (build context
+#      excludes it — Docker can't see the file even though local checks pass).
+#
+# Multi-source COPY (`COPY a.toml b.lock ./`) and directory sources (`COPY
+# crates/ crates/`) are handled. `--from=<stage>` and `--chown=` lines are
+# skipped — those are inter-stage / metadata refs, not build-context paths.
 docker_fail_log=$(mktemp)
 for dockerfile in crates/stiglab/deploy/Dockerfile deploy/synodic.Dockerfile; do
     [ -f "$dockerfile" ] || continue
-    grep -oP '^\s*COPY\s+\K\S+' "$dockerfile" \
-        | grep -v -- '--from=' \
+    # Awk extracts every source token: drop the leading "COPY", the trailing
+    # destination ($NF), any `--*` flags. Skip whole lines containing
+    # `--from=` since those reference image stages, not the build context.
+    awk '
+        /^[[:space:]]*COPY[[:space:]]/ {
+            if ($0 ~ /--from=/) next
+            for (i = 2; i < NF; i++) {
+                if ($i ~ /^--/) continue
+                print $i
+            }
+        }
+    ' "$dockerfile" \
         | while read -r src; do
             case "$src" in *\**|*\$*) continue;; esac
             if [ ! -e "$src" ]; then
                 echo "  FAIL  $dockerfile: COPY source '$src' does not exist on disk" >> "$docker_fail_log"
-            elif ! git ls-files --error-unmatch "$src" > /dev/null 2>&1; then
+            elif [ -z "$(git ls-files -- "$src" 2>/dev/null)" ]; then
+                # `git ls-files -- <src>` lists every tracked path under <src>
+                # (works for both files and directories — directories are
+                # tracked transitively via their contents). Empty output =
+                # nothing tracked under this path = effectively gitignored.
                 echo "  FAIL  $dockerfile: COPY source '$src' exists but is not tracked in git" >> "$docker_fail_log"
             fi
           done


### PR DESCRIPTION
Closes #280.
Closes #281.

## Summary

Two follow-ups from PR #279's Railway-deploy-failure retrospective. Both are skill/script-only — no code, no tests, no CI surface changed.

## Delivers (#280 — silent-CI-failure procedural fix)

- [x] `.claude/skills/onsager-pr-lifecycle/SKILL.md` gains a "Post-push CI sweep (mandatory)" subsection that requires explicit `pull_request_read get_status` + `get_check_runs` calls before declaring a PR green.
- [x] Documents the silent-failure surfaces the `subscribe_pr_activity` subscription does **not** cover: commit statuses (Railway, GitGuardian, anything via the legacy statuses API) and check_run completion transitions that fire after the agent has ended its turn.
- [x] `.claude/skills/onsager-pre-push/SKILL.md` step 7 cross-links to the new sweep so the gap is closed regardless of which skill the agent re-enters from.

## Delivers (#281 — preflight Dockerfile path-existence check)

- [x] `.claude/skills/railway/scripts/preflight.sh` extends the Dockerfile COPY check to assert both **(a) the source exists on disk** and **(b) the source is tracked in git** — formerly only (b) was checked, conditional on (a) being true, so a deleted-but-still-referenced path silently passed.
- [x] Two failure modes now surface with distinct messages identifying the offending path.
- [x] Switched from `-f` to `-e` so the check covers directories too (some Dockerfiles `COPY <dir>/ <dir>/`).
- [x] `.claude/skills/railway/SKILL.md` updated to describe the new check and the PR #276 → #279 incident it catches.

## Why this matters

Both gaps were exposed by the same incident: PR #276 deleted `crates/onsager-warehouse/` and `crates/onsager-delivery/` without updating `crates/stiglab/deploy/Dockerfile`'s `COPY` references, breaking Railway deploys on every PR. Preflight reported pass (only checked gitignore). When the failure surfaced as a commit status on PR #279, no `<github-webhook-activity>` event fired, so the agent didn't notice until the user manually flagged it. #281 keeps the misconfig from being introduced; #280 keeps it from going silent if it slips through.

## Test plan

- [x] `sh .claude/skills/railway/scripts/preflight.sh` against the current branch tree: FAILs with `crates/onsager-warehouse/Cargo.toml does not exist on disk` and `crates/onsager-delivery/Cargo.toml does not exist on disk` — exactly the bug this check was added to catch. Once PR #279's Dockerfile fix lands on main, preflight returns clean here.
- [x] Same script against a contrived Dockerfile referencing `crates/totally-fake-crate/Cargo.toml`: FAILs with the exact missing path, exit code 1.
- [x] Same script against an unmodified tree: gitignore-only failures still surface separately with the original message (preserved behaviour).
- [x] Skill diff is prose-only; rendered in GitHub preview.

## Notes

- This PR does **not** include the Dockerfile fix itself — that lives on [#279](https://github.com/onsager-ai/onsager/pull/279). Once #279 lands, preflight on main will be clean. If #279 lands first, no merge conflict here (this PR doesn't touch the Dockerfile). If this PR lands first, #279 still applies cleanly.
- Identity impact: no.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ActKNYWkf6zFVHM2GC17R4)_