### PR TITLE
docs(adr): propose 0006 (edge dispatcher) and 0007 (tools and skills as the public contract)

### DIFF
--- a/docs/adr/0006-edge-dispatcher-as-the-public-boundary.md
+++ b/docs/adr/0006-edge-dispatcher-as-the-public-boundary.md
@@ -1,0 +1,283 @@
+# ADR 0006 — Edge dispatcher as the public boundary
+
+- **Status**: Proposed
+- **Date**: 2026-05-09
+- **Identity impact**: no
+- **Tracking issues**: #283 (implementation spec); #222 (cleanup tail;
+  the 2026-05-06 status update flagged the open infra-level dispatch
+  question this ADR resolves).
+- **Supersedes**: none
+- **Superseded by**: none
+
+## Context
+
+ADR 0004's 2026-04-30 amendment named `portal` as the owner of
+clause 1 of the seam rule — the external HTTP boundary itself.
+Spec #222 carried that decision through six slices and a series of
+follow-ups (#257, #259, then commit `b601954` which finished
+sessions / tasks / nodes plus the dashboard `API_BASE` cutover).
+After all of that, every dashboard-facing `/api/*` route is
+*implemented* on portal: routes, handlers, schema, auth, spine
+reads and writes.
+
+But the production deployment topology never caught up. The
+production image is a single Docker container deployed to Railway,
+and Railway exposes exactly one process to the outside. That
+process is `stiglab`. Portal runs inside the same container, bound
+to `127.0.0.1:3002` (`PORTAL_BIND` in `crates/stiglab/deploy/
+entrypoint.sh`). Synodic and forge run alongside, also internal. To
+make portal's routes reachable from the dashboard, stiglab carries
+a wildcard catch-all — `route("/api/{*path}", any(routes::portal::
+proxy))` in `crates/stiglab/src/server/mod.rs` — that
+loopback-forwards every `/api/*` request to portal at
+`config.portal_url`. PR #264 re-introduced this proxy after the
+Slice 6 cutover precisely because the dashboard could not reach
+portal otherwise.
+
+The result is a structural tension that no further refactor inside
+the Onsager codebase can resolve:
+
+- **Code-level boundary**: portal owns `/api/*`. Every dashboard
+  route is portal-served. `lint-seams` and `check-api-contract`
+  enforce this.
+- **Process-level boundary**: stiglab is the externally-reachable
+  process. Every external `/api/*` request hits stiglab first and
+  is forwarded to portal over loopback. Stiglab is, in topology
+  terms, still the edge.
+
+ADR 0004's amendment closed the *code-level* gap (clause 1 has an
+owner). The process-level gap is the same shape one layer down: the
+route owner and the externally-exposed process disagree, and
+nothing in the Onsager source tree can reconcile them because the
+disagreement is between source code and deployment infrastructure.
+
+The dev environment already runs the right shape.
+`deploy/dev/Caddyfile` puts Caddy in front of every subsystem (one
+container per subsystem under `docker-compose`) and routes `/api/*`
+to `portal:3002`, `/agent*` to `stiglab:3000`, `/api/synodic/*` and
+`/api/forge/*` to their respective subsystems with prefix-strip.
+Same-origin for the dashboard, no proxy hop, no loopback. The dev
+topology is what the seam rule's amendment implies; the production
+topology is what we shipped to make Railway work.
+
+The proxy's docstring already documents this:
+
+> Post-#222 Slice 6 stiglab owns only `/agent/ws`. Everything else
+> under `/api/` is handled by portal. In dev, Caddy routes those
+> requests directly to portal; in the Railway single-container
+> deployment stiglab is the only process reachable from outside, so
+> this handler forwards the request over the loopback to portal at
+> `config.portal_url`.
+
+The proxy is no longer migration debt. It is the deployment
+topology's compensation for portal not being directly reachable.
+Either we remove the compensation (introduce an edge dispatcher in
+production) or we accept that the process-level boundary will
+permanently disagree with the code-level boundary.
+
+Two further forces push toward resolution:
+
+- **Future deployment targets.** Railway's single-container model is
+  one shape among several. A multi-container deploy, a different
+  cloud, or a self-hosted shape will each face the same question:
+  who is externally reachable, and how does portal's address get
+  surfaced? Pinning the answer once, in deployment infrastructure
+  rather than in stiglab's process, is a portability gain.
+- **Stiglab's identity.** Stiglab is the agent-session orchestrator.
+  The proxy makes it incidentally also the production HTTP edge.
+  That conflation is exactly what ADR 0004's amendment fought;
+  finishing the alignment finishes the amendment.
+
+## Decision
+
+Introduce a real edge dispatcher in the production deployment so
+the process-level boundary matches the route-level boundary that
+ADR 0004 established. Portal becomes the externally-reachable
+process for `/api/*`. Stiglab is externally reachable only for
+`/agent/ws` (the agent WebSocket — the one route stiglab still
+legitimately owns). The stiglab catch-all proxy and
+`crates/stiglab/src/server/routes/portal.rs` are deleted.
+
+Concretely: add Caddy to the production Docker image (`crates/
+stiglab/deploy/Dockerfile`). The entrypoint starts Caddy on
+`$PORT` (the port Railway exposes); Caddy reverse-proxies
+`/api/*` → `127.0.0.1:3002` (portal), `/agent*` →
+`127.0.0.1:3000` (stiglab), and `/*` → static files
+(`/app/static`, the dashboard build). The production Caddyfile
+under `crates/stiglab/deploy/Caddyfile` is a peer of
+`deploy/dev/Caddyfile` — same routing logic, different upstreams
+(loopback in production vs. inter-container in dev).
+
+The dev topology is unchanged. Same-origin behavior on the
+dashboard is unchanged. The dashboard's `apps/dashboard/src/lib/
+api/index.ts` keeps `/api` as the base — exactly because the
+dispatcher makes that true in both environments.
+
+Going forward, the rule that owns this ADR is:
+
+> The externally-reachable process is the edge dispatcher. The
+> Onsager subsystems (`portal`, `stiglab`, `synodic`, `forge`,
+> `ising`) are reachable only through the dispatcher's routing
+> config. Portal owns `/api/*`; stiglab owns `/agent/ws`; the rest
+> of the subsystems are not externally addressable.
+
+Cross-cutting: this is *not* an ADR 0001 violation. ADR 0001
+forbids synchronous HTTP between Onsager subsystems. The
+dispatcher is not a subsystem — it is deployment infrastructure,
+the same category as the database server or the OS process
+supervisor. Caddy doesn't import any Onsager crate and doesn't
+read or write the spine.
+
+## Rejected alternatives
+
+- **Keep the stiglab proxy as documented loopback infrastructure.**
+  Cheapest. Land a docstring update + CLAUDE.md note that re-frames
+  the proxy as deployment plumbing rather than migration debt. The
+  code-level boundary is correct already; the process-level
+  disagreement is an implementation detail of the Railway
+  topology. Rejected because the same disagreement re-appears at
+  every new deployment target, and because the proxy continues to
+  give stiglab a public surface area it should not have.
+- **Multi-service Railway deployment** (one Railway service per
+  subsystem). Closer to the dev topology. Rejected because the
+  reach is wide — separate Railway services need separate
+  Dockerfile entries, separate logs, separate scaling configs,
+  separate internal-DNS routing, separate health checks. The cost
+  is a fork of every operational concern. The single-container
+  image with an in-process dispatcher gets the same boundary
+  alignment without the operational fork.
+- **Switch off Railway entirely.** Real, but unrelated. The
+  deployment shape question stands regardless of the cloud.
+  Rejected as conflating two decisions.
+- **Use Railway's own ingress to route paths to multiple services.**
+  Equivalent to the multi-service alternative above; same
+  operational cost, same rejection.
+- **Move the proxy from stiglab to portal** (portal proxies its
+  own externally-exposed surface to internal subsystems).
+  Considered as a way to remove the stiglab proxy without
+  introducing Caddy. Rejected because portal is then doing both
+  edge dispatch and HTTP route serving in the same process — the
+  same conflation the ADR is trying to remove, just relocated.
+  Edge dispatch belongs in deployment infra, not in a subsystem.
+
+## Consequences
+
+### Positive
+
+- The process-level boundary matches the route-level boundary.
+  Stiglab is reachable from outside only for `/agent/ws`, which is
+  what its ownership of clause 1 of the seam rule actually
+  implies.
+- The stiglab `/api/*` proxy and `routes/portal.rs` are deletable.
+  `xtask check-api-contract` will report only `/agent/ws` as the
+  stiglab dashboard surface (the goal already noted in #222's
+  status update for slice 6).
+- The dev and production topologies converge. The dev Caddyfile
+  becomes a reviewable peer of the production Caddyfile; routing
+  drift between environments becomes visible in diff form.
+- New external integrations (GitLab, Slack, Linear) added to portal
+  are reachable in production without touching stiglab. The
+  process-level boundary is no longer a blocker for portal's
+  growth.
+- Future deployment targets inherit the same shape. The dispatcher
+  is the public boundary; everything else is internal. Self-hosted
+  or different-cloud deploys reuse the routing config with a
+  different upstream block.
+
+### Negative / trade-offs
+
+- One more component in the production image (Caddy binary).
+  Roughly ~40MB; a Caddyfile to maintain; one more thing whose
+  health Railway must observe. Mitigation: pin Caddy version in
+  the Dockerfile; smoke-test the routing in CI.
+- The image's `ENTRYPOINT` becomes responsible for one more
+  process. The existing entrypoint already manages four (synodic,
+  portal, forge, stiglab); adding Caddy is incremental, not a
+  structural change. Process supervision stays a `gosu` + `while
+  true` loop; if Railway later adopts a real supervisor
+  (s6-overlay, etc.) that is a separate decision.
+- The dispatcher config becomes part of the deployment contract.
+  A breaking route addition needs the Caddyfile updated in the
+  same PR. This is a desirable kind of explicit; it is also a
+  real per-route step that did not exist before.
+
+### Neutral
+
+- Dashboard API base URL is unchanged (`/api`). The dispatcher
+  makes same-origin true in production; nothing in the frontend
+  changes.
+- ADR 0001's runtime invariant is preserved. Caddy is not a
+  subsystem; no synchronous HTTP between Onsager subsystems is
+  added.
+- The dev Caddyfile is unchanged. Dev already had the right
+  shape; this ADR aligns production with dev, not the other way
+  around.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog of this decision: the dev
+Caddyfile and the production Caddyfile are reviewable peers. A
+new externally-reachable route (or a route ownership change)
+requires both Caddyfiles updated in the same PR. The pattern
+matches the "producer + consumer + manifest entry in one PR" rule
+from ADR 0004 Lever E — both halves of the contract land
+together so the half-wired drift pattern cannot recur on the
+topology layer.
+
+A small `xtask` check that diffs the route blocks of the two
+Caddyfiles and fails on divergence is the natural mechanical
+guardrail; it is filed as an item in the implementation spec
+opened alongside this ADR but is not a blocking dependency for
+landing the dispatcher itself.
+
+## Adoption checklist
+
+Execution lives in the implementation spec opened alongside this
+ADR (linked under Tracking issues above). Status as of
+2026-05-09:
+
+- [ ] Add Caddy to `crates/stiglab/deploy/Dockerfile` (runtime
+      stage).
+- [ ] Production Caddyfile under `crates/stiglab/deploy/Caddyfile`,
+      structurally mirroring `deploy/dev/Caddyfile` but with
+      loopback upstreams.
+- [ ] `crates/stiglab/deploy/entrypoint.sh` starts Caddy on `$PORT`;
+      stiglab binds to `127.0.0.1:3000` (no longer to `0.0.0.0`);
+      the `STIGLAB_HOST=0.0.0.0` env in the Dockerfile is removed.
+- [ ] Delete `crates/stiglab/src/server/routes/portal.rs` and the
+      `route("/api/{*path}", any(routes::portal::proxy))`
+      registration in `crates/stiglab/src/server/mod.rs`.
+- [ ] Stiglab no longer serves the static dashboard; the
+      `STIGLAB_STATIC_DIR` env and the `nest_service("/assets",
+      …)` / `fallback_service(…)` blocks in `mod.rs` move to the
+      Caddyfile (`/assets` cache headers, `index.html` no-cache,
+      SPA fallback).
+- [ ] Update root `CLAUDE.md` ("Architecture" + "The seam rule")
+      with the process-level edge clarification.
+- [ ] Update ADR 0004's adoption checklist to note this ADR as the
+      resolution of the process-level half of clause 1.
+- [ ] Smoke test: `just smoke-test` against a deploy with Caddy in
+      front of portal answers identically to today's stiglab-proxy
+      shape.
+
+## Out of scope
+
+- **TLS termination.** Railway terminates TLS at its edge; Caddy
+  inside the container speaks plain HTTP on `$PORT`. If a future
+  deployment target needs in-image TLS that is a separate
+  concern.
+- **Health-check shape.** Railway's existing health check needs to
+  point at `/api/health` (which now reaches portal via Caddy)
+  rather than at stiglab directly; the implementation spec covers
+  this but the protocol decision is unchanged.
+- **Multi-tenant routing.** Out of scope; the dispatcher routes by
+  path prefix, not by tenant. Workspace scoping continues to be a
+  request-level concern enforced by `require_workspace_access` in
+  portal.
+- **Migration to a different platform.** This ADR is portable by
+  design (the dispatcher pattern works on any single-process or
+  multi-process target) but does not commit Onsager to or away
+  from Railway.
+- **A separate ADR for the dev Caddyfile**, which already exists
+  and works — this ADR adopts the dev shape into production, not
+  the other way around.

--- a/docs/adr/0006-edge-dispatcher-as-the-public-boundary.md
+++ b/docs/adr/0006-edge-dispatcher-as-the-public-boundary.md
@@ -14,7 +14,7 @@
 ADR 0004's 2026-04-30 amendment named `portal` as the owner of
 clause 1 of the seam rule — the external HTTP boundary itself.
 Spec #222 carried that decision through six slices and a series of
-follow-ups (#257, #259, then commit `b601954` which finished
+follow-ups (#257, #259, and the final cleanup commit that landed
 sessions / tasks / nodes plus the dashboard `API_BASE` cutover).
 After all of that, every dashboard-facing `/api/*` route is
 *implemented* on portal: routes, handlers, schema, auth, spine
@@ -24,15 +24,20 @@ But the production deployment topology never caught up. The
 production image is a single Docker container deployed to Railway,
 and Railway exposes exactly one process to the outside. That
 process is `stiglab`. Portal runs inside the same container, bound
-to `127.0.0.1:3002` (`PORTAL_BIND` in `crates/stiglab/deploy/
-entrypoint.sh`). Synodic and forge run alongside, also internal. To
-make portal's routes reachable from the dashboard, stiglab carries
-a wildcard catch-all — `route("/api/{*path}", any(routes::portal::
-proxy))` in `crates/stiglab/src/server/mod.rs` — that
-loopback-forwards every `/api/*` request to portal at
-`config.portal_url`. PR #264 re-introduced this proxy after the
-Slice 6 cutover precisely because the dashboard could not reach
-portal otherwise.
+to `127.0.0.1:3002` via `PORTAL_BIND` in the stiglab deploy
+entrypoint (`crates/stiglab/deploy/entrypoint.sh`). Synodic and
+forge run alongside, also internal. To make portal's routes
+reachable from the dashboard, stiglab's router
+(`crates/stiglab/src/server/mod.rs`) carries a wildcard catch-all
+that loopback-forwards every `/api/*` request to portal at
+`config.portal_url`:
+
+```rust
+.route("/api/{*path}", any(routes::portal::proxy));
+```
+
+PR #264 re-introduced this proxy after the Slice 6 cutover
+precisely because the dashboard could not reach portal otherwise.
 
 The result is a structural tension that no further refactor inside
 the Onsager codebase can resolve:
@@ -92,16 +97,18 @@ Two further forces push toward resolution:
 
 Introduce a real edge dispatcher in the production deployment so
 the process-level boundary matches the route-level boundary that
-ADR 0004 established. Portal becomes the externally-reachable
-process for `/api/*`. Stiglab is externally reachable only for
-`/agent/ws` (the agent WebSocket — the one route stiglab still
-legitimately owns). The stiglab catch-all proxy and
-`crates/stiglab/src/server/routes/portal.rs` are deleted.
+ADR 0004 established. The dispatcher becomes the only
+externally-reachable process; it routes `/api/*` to portal (which
+keeps end-to-end ownership of those routes) and `/agent/ws` to
+stiglab (the one route stiglab still legitimately owns). No
+Onsager subsystem listens on a public port. The stiglab catch-all
+proxy and the `crates/stiglab/src/server/routes/portal.rs` module
+are deleted.
 
-Concretely: add Caddy to the production Docker image (`crates/
-stiglab/deploy/Dockerfile`). The entrypoint starts Caddy on
-`$PORT` (the port Railway exposes); Caddy reverse-proxies
-`/api/*` → `127.0.0.1:3002` (portal), `/agent*` →
+Concretely: add Caddy to the production Docker image
+(`crates/stiglab/deploy/Dockerfile`). The entrypoint starts Caddy
+on `$PORT` (the port Railway exposes); Caddy reverse-proxies
+`/api/*` → `127.0.0.1:3002` (portal), `/agent/ws` →
 `127.0.0.1:3000` (stiglab), and `/*` → static files
 (`/app/static`, the dashboard build). The production Caddyfile
 under `crates/stiglab/deploy/Caddyfile` is a peer of
@@ -109,8 +116,8 @@ under `crates/stiglab/deploy/Caddyfile` is a peer of
 (loopback in production vs. inter-container in dev).
 
 The dev topology is unchanged. Same-origin behavior on the
-dashboard is unchanged. The dashboard's `apps/dashboard/src/lib/
-api/index.ts` keeps `/api` as the base — exactly because the
+dashboard is unchanged. The dashboard keeps `/api` as the base
+URL (`apps/dashboard/src/lib/api/index.ts`) — exactly because the
 dispatcher makes that true in both environments.
 
 Going forward, the rule that owns this ADR is:

--- a/docs/adr/0007-tools-and-skills-as-the-public-contract.md
+++ b/docs/adr/0007-tools-and-skills-as-the-public-contract.md
@@ -1,0 +1,344 @@
+# ADR 0007 — Tools and skills as the public contract
+
+- **Status**: Proposed
+- **Date**: 2026-05-09
+- **Identity impact**: no
+- **Tracking issues**: #288 (implementation spec). Builds on ADR
+  0004 (clause-1 ownership) and ADR 0006 (the dispatcher as the
+  externally-reachable process); this ADR names the *protocol
+  shape* of clause 1 for AI runtimes.
+- **Supersedes**: none
+- **Superseded by**: none
+
+## Context
+
+ADR 0004 named `portal` as the owner of clause 1 — the external
+HTTP boundary itself. ADR 0006 named the dispatcher as the process
+that is externally reachable. Both decisions answered "where does
+the boundary live"; neither answered "what shape does the boundary
+take for AI runtimes that want to control the factory."
+
+The status-quo answer is REST. Portal exposes `/api/workflows`,
+`/api/spine/*`, `/api/governance/*`, etc. Any AI runtime that wants
+to drive the factory has to:
+
+- Learn the REST shape from `apps/dashboard/src/lib/api/`.
+- Write its own client code (HTTP, auth, error handling).
+- Maintain its own knowledge of which call to make in which order
+  (e.g. "to design a workflow, you POST `/api/workflows` then PATCH
+  it with stages, then activate it via `workflow.activate_requested`
+  on the spine").
+
+This is a real friction. Every new runtime — Claude Code, Cursor,
+Codex, Operator, custom agents — pays the integration tax. There
+is no shared standard for "here is what Onsager exposes" and no
+shared knowledge layer for "here is how to use it." The dashboard
+chat (currently `apps/dashboard/src/components/factory/workflows/
+ChatBuilder.tsx` — a placeholder with a stub LLM) sits in a
+privileged position by accident: it is the only client we are
+building, so it accumulates the operating procedures by default.
+
+Two patterns from the broader AI ecosystem are converging on the
+right shape:
+
+- **MCP (Model Context Protocol)** is the emerging standard for
+  exposing tools to AI runtimes. Anthropic, Cursor, OpenAI's tool
+  use, and the open-source agent stacks all support MCP servers.
+  A tool is a typed function (input schema, output schema, error
+  model) the AI can call.
+- **Skills** are the emerging standard for bundling *knowledge of
+  when to call what* with the tool grants themselves. A skill is a
+  markdown file with YAML frontmatter — `name`, `description`,
+  trigger phrases, allowed tools — that a runtime lazy-loads when
+  the trigger phrases match. Supabase ships a public skill pack
+  (`npx skills add supabase/agent-skills`) alongside its MCP server;
+  the same pattern works for Onsager.
+
+Onsager already has the skills *infrastructure* in-tree — 12
+internal-dev skills under `.claude/skills/` (`issue-spec`,
+`ci-triage`, `dashboard-ui`, `onsager-pre-push`, etc.). What is
+missing is the **outbound** layer: no MCP server, no public skills
+bundle. The 2026-05-09 audit confirms the greenfield: only an empty
+`crates/synodic/.mcp.json` (consumer-side, not host-side) and zero
+public skills.
+
+The user's stated direction (from the 2026-05-09 simplification
+conversation) is concrete:
+
+- Skills cover *both* knowledge and tool/API/MCP — knowledge alone
+  is useless without tools; tools alone are an under-specified API.
+- Tools should be exposed as a real API (MCP-based) so other AI
+  runtimes can design and operate workflows without locking in to
+  one runtime.
+- The dashboard chat is one client among many — equivalent to
+  Claude Code, Cursor, etc. — not a privileged control plane.
+- HITL UI (forms, diff previews, parameter pickers) renders inside
+  the chat as tool-call cards. The same tool a CLI agent calls
+  pops a card in the dashboard chat for human confirmation.
+
+This ADR commits Onsager to that shape.
+
+## Decision
+
+Onsager exposes itself to AI runtimes through a two-layer public
+contract: an **MCP server hosted by portal** and a **public skills
+bundle** distributable via `npx skills add`.
+
+**Layer 1 — MCP server in portal.** A new module under
+`crates/onsager-portal/src/mcp/` registers tools that cover both
+*action* paths and *diagnostic* paths:
+
+- *Action tools* — `propose_workflow`, `run_workflow`,
+  `edit_workflow`, `schedule_workflow`, `list_workflows`,
+  `list_runs`, `cancel_run`. Each tool delegates to the existing
+  portal HTTP handler that owns the corresponding REST route — no
+  logic duplication; the tool is a typed wrapper over an existing
+  capability.
+- *Diagnostic tools* — `inspect_run`, `get_stage_logs`,
+  `get_artifact`, `propose_remediation`. The diagnostic surface is
+  a first-class concern, not an afterthought: when a run fails the
+  AI client needs structured access to logs, current state, and
+  next-step suggestions, not a dead-end "something went wrong."
+
+The MCP server reuses portal's existing `AuthUser` extractor (PAT
+or session) and `require_workspace_access` helper. The dispatcher
+gets one new route block — `/mcp/*` → portal — added to both
+`deploy/dev/Caddyfile` and the production Caddyfile from ADR 0006.
+MCP transport is HTTP (POST `/mcp/messages`); other transports
+(stdio, websocket) can be added later if a use case demands.
+
+**Layer 2 — public skills bundle.** A new artifact —
+`onsager-ai/onsager-skills` — installable via `npx skills add
+onsager-ai/onsager-skills`. Each skill is a `SKILL.md` with YAML
+frontmatter (`name`, `description`, trigger phrases, `allowed_tools`)
+plus optional reference docs and templates. Initial public skills:
+
+- `onsager-design-workflow` — design a new workflow from intent;
+  uses `propose_workflow` + `edit_workflow`.
+- `onsager-run-workflow` — run a deployed workflow; uses
+  `run_workflow` + `list_workflows`.
+- `onsager-triage-run` — diagnose and resolve a failed run; uses
+  the diagnostic tools.
+- `onsager-explore-artifacts` — browse and inspect spine artifacts;
+  uses `get_artifact` + REST reads where appropriate.
+
+**Internal-dev skills stay private.** The 12 in-tree skills
+(`issue-spec`, `ci-triage`, `dashboard-ui`, `onsager-pre-push`,
+`onsager-pr-lifecycle`, `onsager-dev-process`, `web-testing`,
+`railway`, plus the four nested per-subsystem skills) are for
+working on the monorepo. They are not part of the public bundle —
+publishing them would expose internal review patterns and CI
+debugging procedures that have no value (and some risk) outside
+the development loop.
+
+**The dashboard chat becomes one MCP client among many.**
+`ChatBuilder.tsx` evolves from a stub-LLM placeholder into an in-app
+MCP client that connects to the local server. External clients
+(Claude Code, Cursor, custom agents) install the skills bundle and
+connect to the same MCP server. Tool surface and skill set are
+identical across all clients. No operation is available in one
+client and not the others.
+
+The rule that owns this ADR:
+
+> Every external workflow-control surface is exposed as an MCP tool
+> with a typed schema. Operate-the-factory knowledge is published
+> as skills. New tools and skills version together as the public
+> API contract. The dashboard chat is one client; no privileged
+> capability lives there that is not also reachable via MCP.
+
+Cross-cutting alignment with prior ADRs:
+
+- **ADR 0004** (clause 1 owned by portal): MCP server lives in
+  portal, governed by the same seam-rule discipline. Tools
+  internally invoke portal handlers, which emit spine events; no
+  bypass of the event bus.
+- **ADR 0006** (dispatcher is the external boundary): MCP traffic
+  enters through the dispatcher, same as REST. Loopback to portal
+  in production, inter-container in dev.
+- **ADR 0001** (spine for internal coordination): MCP tools are
+  *external* surface; their internal effects flow through the
+  spine like every other HTTP-handler effect.
+
+## Rejected alternatives
+
+- **REST-only (status quo).** Forces every AI runtime to write its
+  own integration layer plus maintain its own knowledge of operating
+  procedures. Rejected because every new runtime pays the integration
+  tax, and because the operating-procedures knowledge accumulates in
+  whichever client we happen to be building (today: the dashboard
+  chat). That privileged accumulation is exactly what this ADR is
+  removing.
+- **MCP without skills.** AI runtimes get tools but no knowledge of
+  when or how to use them. Rejected because the value of the skills
+  layer is recovering the human-aligned operating procedures
+  (sequencing, error handling, when-to-escalate). Tools alone are an
+  under-specified API surface; runtimes end up either re-deriving
+  the procedures from trial-and-error or falling back to free-form
+  prompting.
+- **Skills without MCP.** AI runtimes get docs but have to use REST
+  for actions. Rejected because skills declare tool grants, and
+  without a tool standard there is no shared schema for what those
+  grants mean. The combination is the value.
+- **A custom protocol (Onsager-specific RPC).** Re-invents MCP.
+  Rejected: MCP is the emerging standard across the AI ecosystem
+  (Anthropic, Cursor, OpenAI tool use, the open-source agent
+  stacks); aligning with it gets us interoperability for free.
+- **Embed an AI runtime in Onsager.** Make Onsager itself the
+  agent. Rejected — locks in one AI provider, conflates the factory
+  (Onsager) with the operator (the AI), and runs counter to the
+  user's stated direction of runtime-agnosticism. The factory
+  should be operable by any MCP-supporting runtime.
+- **Build the MCP server in stiglab.** Stiglab runs agent sessions;
+  it is the place where AI executes *inside* Onsager. The MCP
+  server is the place where AI executes *outside* Onsager. They
+  are different concerns. Building MCP into stiglab also violates
+  ADR 0004's clause-1 ownership — portal owns the external
+  boundary, period.
+- **Publish all skills (including internal-dev) as one bundle.**
+  Rejected. Internal-dev skills are for working *on* the monorepo;
+  they encode review patterns, CI debugging, the spec-driven
+  development loop. Exposing them publicly is reach-without-reason
+  and creates a maintenance burden (every internal skill change
+  becomes a public-API change). Two bundles, two audiences.
+
+## Consequences
+
+### Positive
+
+- **Runtime-agnostic by construction.** Any MCP-supporting AI client
+  can operate Onsager: today's clients (Claude Code, Cursor,
+  Codex, custom agents), and clients that don't exist yet inherit
+  the surface for free.
+- **Knowledge is downloadable.** New users (or new agents) install
+  the skills bundle and immediately know how to design and operate
+  workflows. The operating procedures stop being tribal knowledge.
+- **The dashboard chat becomes structurally honest.** ChatBuilder
+  evolves from a placeholder into a real MCP client; the chat
+  surface is no longer privileged or special. Anything it can do,
+  any client can do, and vice versa.
+- **The tool surface IS the public API.** Schemas, versioning,
+  deprecation — everything is explicit. No more "it depends on
+  which REST endpoints you happen to know."
+- **Future external integrations** (workflow control via Slack,
+  Linear, GitLab events, etc.) attach to the existing MCP surface
+  rather than each writing its own custom REST glue.
+- **The diagnostic surface is first-class.** Failed runs surface
+  structured `inspect_run` / `get_stage_logs` data instead of
+  dead-ending in "something went wrong"; AI clients (and humans)
+  recover the failure path the same way they navigate the success
+  path.
+
+### Negative / trade-offs
+
+- **The tool surface is now a public contract.** Adding, removing,
+  or changing a tool is a versioning event. Skills must stay
+  current with tool schemas. A backwards-compatibility policy is
+  needed once we have at least one tool that has evolved (deferred
+  to a follow-up; until then, tools are 1.0 and changes are
+  breaking).
+- **Two layers to maintain.** Tools (typed) and skills (markdown)
+  ship together when something changes. The dev-process counterpart
+  below makes that one PR by construction, but it is still real
+  per-change paperwork.
+- **MCP server is new code.** Test surface, security review, and
+  observability all need to be set up. Mitigation: the server
+  delegates to existing portal handlers, so the new code is mostly
+  protocol shell, not new business logic.
+- **Onsager-the-monorepo and Onsager-the-skills-bundle are two
+  release surfaces.** The bundle has to live somewhere distinct
+  enough to be `npx skills add`-installable. The implementation
+  spec picks the channel (subdirectory in the monorepo vs. separate
+  repo) — not pre-allocated here.
+
+### Neutral
+
+- **REST stays.** The dashboard's non-AI calls (listing workspaces,
+  fetching spine artifacts for the existing pages, etc.) keep
+  using REST. MCP is additive, not a replacement.
+- **ADR 0001's runtime invariant is preserved.** MCP tools are
+  exposed at the seam (clause 1) and translate to spine events for
+  internal coordination. No new sync HTTP between subsystems.
+- **The four identity bullets are unchanged.** Event bus, artifacts,
+  specs as ground truth, internal symmetry — all preserved. This
+  ADR is about the *outbound* shape of the existing factory, not a
+  change to its internals.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog: every new external
+workflow-control primitive lands as a tool (with a typed schema)
+plus a skill (with operating knowledge), in one PR. This mirrors
+the Lever E producer/consumer/manifest rule from ADR 0004 — both
+halves of the contract land together so the half-wired drift
+pattern (tool-without-skill or skill-without-tool) cannot recur.
+
+A small `xtask` check enforces it mechanically: every public tool
+the MCP server registers has at least one skill in the bundle that
+declares it under `allowed_tools`; every skill grant references a
+real registered tool. Filed as an item in the implementation spec
+opened alongside this ADR; not a blocker for the first tools to
+land but a blocker for the contract to stabilize.
+
+The product-side analog: the same shape ADR 0003 used for artifact
+kinds (registry-backed, manifest-validated) extends naturally to
+tool kinds. Future work may collapse the tool registry into the
+existing `onsager-registry` crate so tools live alongside artifacts
+and events in one place — that integration is a follow-up, not
+required for this ADR to land.
+
+## Adoption checklist
+
+Implementation lives in the spec opened alongside this ADR
+(linked under Tracking issues above). Status as of 2026-05-09:
+
+- [ ] Build MCP server in portal: new module `crates/onsager-portal/
+      src/mcp/` with server boilerplate, tool registration, request
+      routing.
+- [ ] Define and ship the initial action tools: `propose_workflow`,
+      `run_workflow`, `edit_workflow`, `schedule_workflow`,
+      `list_workflows`, `list_runs`, `cancel_run`. Each delegates
+      to the corresponding existing portal HTTP handler.
+- [ ] Define and ship the initial diagnostic tools: `inspect_run`,
+      `get_stage_logs`, `get_artifact`, `propose_remediation`.
+- [ ] Add `/mcp/*` route block to `deploy/dev/Caddyfile` and the
+      production Caddyfile from ADR 0006.
+- [ ] Create the public skills bundle (channel TBD by the
+      implementation spec). Initial skills: `onsager-design-workflow`,
+      `onsager-run-workflow`, `onsager-triage-run`,
+      `onsager-explore-artifacts`.
+- [ ] Migrate `apps/dashboard/src/components/factory/workflows/
+      ChatBuilder.tsx` to be an MCP client of the local server.
+      Render tool calls as inline HITL UI cards.
+- [ ] `xtask check-tools-and-skills` consistency lint: every public
+      tool has at least one skill granting it; every skill grant
+      references a real tool.
+- [ ] Update root `CLAUDE.md` with the MCP + skills surface; cross-
+      link from the seam-rule section.
+- [ ] Flip ADR 0007 to `Accepted` in the same PR that lands the
+      first end-to-end tool + skill pair (likely
+      `onsager-design-workflow` ↔ `propose_workflow`).
+
+## Out of scope
+
+- **Replacing REST with MCP.** REST stays for the dashboard's non-AI
+  calls. MCP is additive. A future ADR may revisit consolidation
+  once the tool surface has matured.
+- **Onsager hosting AI runtimes.** Stiglab continues to run agent
+  sessions inside the factory; that is unrelated to MCP, which is
+  about how the factory is *consumed* by external runtimes.
+- **MCP server authentication.** Reuses portal's existing
+  `AuthUser` extractor (PAT or session). No new auth mechanism.
+- **Tool-call rate limiting and quotas.** Future concern; reuses
+  portal's existing rate-limit infrastructure when added.
+- **Multi-tenant skill bundles** (per-workspace custom skills).
+  Future concern. This ADR commits to one public bundle.
+- **Backwards-compatibility policy for the tool surface.**
+  Deferred until at least one tool has evolved. Until then, tools
+  are 1.0 and changes are breaking; the implementation spec
+  documents this for the initial release.
+- **Migrating the existing in-tree internal-dev skills to a
+  shared skills standard.** They are already in skills format
+  (`.claude/skills/`); the question of unifying them with the
+  public bundle is deferred and may never make sense (they are
+  audience-distinct).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ see [`../architecture.md`](../architecture.md).
 | [0004](0004-tighten-the-seams.md) | Tighten the seams: HTTP at external boundaries, spine for everything internal | Accepted (2026-04-26, amended 2026-04-30) — all six levers landed (2026-04-30) |
 | [0005](0005-s5-governance-scales-with-scale.md) | S5 governance scales with scale | Accepted (2026-05-05) — `Identity impact: yes` |
 | [0006](0006-edge-dispatcher-as-the-public-boundary.md) | Edge dispatcher as the public boundary | Proposed (2026-05-09) — `Identity impact: no` |
+| [0007](0007-tools-and-skills-as-the-public-contract.md) | Tools and skills as the public contract | Proposed (2026-05-09) — `Identity impact: no` |
 
 ## How to add an ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ see [`../architecture.md`](../architecture.md).
 | [0003](0003-deliverable-and-registry-backed-kinds.md) | Deliverable as the workflow-run output; registry-backed artifact kinds | Accepted (2026-04-22) — v1 partially landed under #100 |
 | [0004](0004-tighten-the-seams.md) | Tighten the seams: HTTP at external boundaries, spine for everything internal | Accepted (2026-04-26, amended 2026-04-30) — all six levers landed (2026-04-30) |
 | [0005](0005-s5-governance-scales-with-scale.md) | S5 governance scales with scale | Accepted (2026-05-05) — `Identity impact: yes` |
+| [0006](0006-edge-dispatcher-as-the-public-boundary.md) | Edge dispatcher as the public boundary | Proposed (2026-05-09) — `Identity impact: no` |
 
 ## How to add an ADR
 


### PR DESCRIPTION
## Summary

Two ADRs that refine ADR 0004's clause-1 (external HTTP boundary) ownership at successive layers:

- **ADR 0006 — Edge dispatcher as the public boundary.** Aligns the production process-level boundary with the route-level boundary ADR 0004's 2026-04-30 amendment established. Portal owns `/api/*` end-to-end; the dispatcher (Caddy) becomes the only externally-reachable process; stiglab is externally reachable only for `/agent/ws`. Replaces the stiglab catch-all proxy reintroduced by PR #264. Implementation tracked in #283.
- **ADR 0007 — Tools and skills as the public contract.** Names the *protocol shape* of clause 1 for AI runtimes: portal hosts an MCP server (action + diagnostic tools that delegate to existing portal handlers) plus a public skills bundle distributable via `npx skills add`. Dashboard chat becomes one MCP client among many; external runtimes (Claude Code, Cursor, custom agents) get the same surface. Implementation tracked in #288.

Both **Proposed**. **Identity impact: no** for both — they refine ADR 0004's amendment without touching any of the four identity bullets in `CLAUDE.md`. Each ADR flips to **Accepted** when its corresponding implementation spec lands; this PR is doc-only.

## Companion cleanup specs (drafted in this session)

Three small spec issues filed alongside the ADRs, none required to land before either ADR:

- **#283** — implementation of ADR 0006 (Caddy in the production image; proxy + portal.rs deletion).
- **#285** — `spec(spine): trim event manifest`. Drops 13 redundant diagnostic-only events (synodic verdict subsets, stage gate-resolution duplicates, registry mutation cluster) plus one rename (`shaping_result_ready` → `session_result_ready`). Manifest goes 54 → 40 events; diagnostic count falls below real-event count for the first time.
- **#286** — `spec(dashboard): canonical 4-noun user-facing vocabulary`. Documents Workflow / Run / Artifact / Stage as the user-facing canon; demotes shaping/bundle/sealed/spec to internal-only and gate/verdict/governance/session/node/issue to surface-internal. Doc-only commitment in CLAUDE.md + skills.
- **#288** — implementation of ADR 0007 (MCP server in portal, four initial public skills, ChatBuilder migration).

## Why two ADRs, not one

ADR 0006 answers *which process is externally reachable*; ADR 0007 answers *what protocol that process speaks to AI runtimes*. They are independent decisions with independent rejected-alternatives surfaces, even though they both refine clause-1 ownership. Bundling them into one ADR would muddle the rationale for each.

## Test plan

- [ ] No code changes — no build/lint/test concerns.
- [ ] Verify both ADRs render cleanly on GitHub (headings, blockquotes, list formatting, fenced code blocks).
- [ ] Verify `docs/adr/README.md` index has both entries with correct status + `Identity impact` flag.
- [ ] Specs #283 / #288 capture the full Adoption checklists from each ADR as Plan items (verified at filing time).
- [ ] Specs #285 / #286 stand alone and don't depend on either ADR landing first.

Part of #283 / #288.

https://claude.ai/code/session_01QR4fdp424726ybTeJ6boi8