### PR TITLE
trim event manifest + canonical user-facing vocabulary

### DIFF
--- a/.claude/skills/dashboard-ui/SKILL.md
+++ b/.claude/skills/dashboard-ui/SKILL.md
@@ -80,6 +80,27 @@ Any hit in your diff should be replaced with the shadcn primitive.
 - Styling lives in one place (the `ui/` component) — ad-hoc native elements
   diverge quickly and are expensive to re-skin later.
 
+## Vocabulary: the canonical 4 nouns
+
+User-facing surfaces (page titles, headings, button copy, route
+segments, public API field names, user-visible docs) use exactly four
+top-level nouns: **Workflow**, **Run**, **Artifact**, **Stage**. Per
+spec #286 / root `CLAUDE.md` § "User-facing vocabulary":
+
+- **Internal-only** (stay in Rust / migrations / spine, never in
+  user copy): `shaping`, `bundle`, `sealed`, `spec`,
+  `ArtifactVersionId`.
+- **Surface-internal** (visible only inside a workflow / run
+  drill-down, never as a top-level navigation noun): `gate`,
+  `verdict`, `governance`, `session`, `node`, `issue`.
+
+When you write a page title, a button label, a heading, or a
+field name, default to one of the four canonical nouns. Use the
+demoted vocabulary only inside a workflow- or run-detail drill-down,
+and never as a top-level navigation item or noun. Enforcement is
+PR review — there is no mechanical lint — so spotting drift in your
+own diff before opening the PR is the bar.
+
 ## UX principle: avoid manual input, streamline everything
 
 When designing any flow that touches external systems (GitHub, Railway,

--- a/.claude/skills/issue-spec/references/spec-format.md
+++ b/.claude/skills/issue-spec/references/spec-format.md
@@ -216,6 +216,19 @@ The timeout duration is server-configurable via environment variable. Per-sessio
 - Keep it brief — notes are context, not a second design section.
 - Omit this section entirely if there's nothing to note.
 
+## User-facing vocabulary
+
+When a spec touches a user-facing surface (dashboard pages, button
+copy, public API field names, route segments, user-visible docs),
+use the canonical 4 nouns: **Workflow**, **Run**, **Artifact**,
+**Stage**. Spec #286 / root `CLAUDE.md` § "User-facing vocabulary"
+demote everything else (`shaping`, `bundle`, `sealed`, `gate`,
+`verdict`, `governance`, `session`, `node`, `issue`, `spec`) to
+internal-only or surface-internal — they stay rich in Rust /
+migration / spine vocabulary but never surface to users at the top
+level. Internal/seam vocabulary stays distinct per the audit's
+"keep distinct" findings; this rule only governs what users see.
+
 ## Context Economy Rules
 
 Smaller specs produce better results — for both AI implementation and human review:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,65 @@ subsystems. Internal-quality work that doesn't fit those projections —
 interior-to-a-subsystem hygiene — is equally in scope and should be specced
 and shipped on the same footing as feature work.
 
+## User-facing vocabulary (canonical 4 nouns)
+
+Per spec #286 the dashboard, public API field names, route segments,
+button copy, page titles, and user-visible docs use exactly four
+top-level nouns. Anything else is internal-only or surface-internal
+(visible only inside a workflow/run drill-down, never as a top-level
+navigation noun).
+
+The four canonical nouns:
+
+- **Workflow** — the automation unit (trigger + ordered stages +
+  prompts). Lives at `/api/workflows`. Persisted in spine `workflows`
+  / `workflow_stages` (Lever D).
+- **Run** — one execution of a workflow against an artifact. Lives at
+  `/api/workflows/:id/runs`. Has a status and a sequence of stage
+  outcomes.
+- **Artifact** — what a run produces (issue, PR, deployment, etc.).
+  Already the core noun; lives at `/api/spine/artifacts`. Persisted
+  in spine `artifacts`.
+- **Stage** — a step within a workflow definition (gate kind +
+  parameters). A workflow's structural unit; never a top-level
+  navigation noun.
+
+**Demoted to internal-only.** These terms stay rich in Rust /
+migration / spine vocabulary but never surface to users:
+
+- **shaping** — legacy term for agent-session dispatch. Stays in
+  internal Rust (`shaping_listener.rs`, `ShapingRequest`,
+  `ShapingResult`). The user-facing event-name leakage
+  (`stiglab.shaping_result_ready`) was renamed to
+  `stiglab.session_result_ready` per spec #285.
+- **bundle / sealed / ArtifactVersionId** — internal storage terms.
+  The user-facing concept is "artifact version".
+- **spec** — dev-process term for a GitHub issue with implementation
+  intent. Lives in CLAUDE.md and the `issue-spec` skill; never
+  surfaces in the dashboard.
+
+**Demoted to surface-internal.** Visible only inside a workflow / run
+drill-down, not as a top-level navigation item:
+
+- **gate / verdict** — control points within a stage. Visible in
+  workflow detail and run history; never a top-level surface.
+- **governance** — the audit/escalation surface. Subsumed into run
+  history's verdict view.
+- **session** — a stage execution context. Visible only as a stage
+  gate kind ("agent-session") and as a drill-down from a run's stage
+  history.
+- **node** — infrastructure; visible only in settings, not as a
+  top-level noun.
+- **issue** — the GitHub issue that triggered or was produced by a
+  run. An artifact kind, not a separate concept.
+
+**Enforcement is doc-only.** Dashboard tsx is too varied for a
+useful grep-based vocabulary lint, and the 2026-05-09 audit found
+no significant leakage. The doc commitment plus PR review is the
+enforcement mechanism; a mechanical lint can be added later if drift
+recurs. This vocabulary is for surfaces users see — the seam-level /
+internal vocabulary stays rich per "Internal aesthetic" above.
+
 ## Architectural drift patterns to watch
 
 Loose runtime coupling is correct and stays — but the seams it creates are

--- a/apps/dashboard/src/components/factory/LineageDAG.tsx
+++ b/apps/dashboard/src/components/factory/LineageDAG.tsx
@@ -25,7 +25,7 @@ export function LineageDAG({ artifact }: LineageDAGProps) {
   if (paired.length === 0) {
     return (
       <div className="rounded-md border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
-        No runs yet. Lanes appear once a workflow dispatches this artifact.
+        No runs yet. Lanes appear once the first run starts for this artifact.
       </div>
     )
   }

--- a/apps/dashboard/src/components/factory/LineageDAG.tsx
+++ b/apps/dashboard/src/components/factory/LineageDAG.tsx
@@ -25,7 +25,7 @@ export function LineageDAG({ artifact }: LineageDAGProps) {
   if (paired.length === 0) {
     return (
       <div className="rounded-md border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
-        No shaping runs yet. Lanes appear once Forge dispatches this artifact.
+        No runs yet. Lanes appear once a workflow dispatches this artifact.
       </div>
     )
   }

--- a/apps/dashboard/src/pages/ArtifactDetailPage.tsx
+++ b/apps/dashboard/src/pages/ArtifactDetailPage.tsx
@@ -252,7 +252,7 @@ export function ArtifactDetailPage() {
           title={
             isTerminal
               ? "Cannot retry an artifact in a terminal state"
-              : "Request another shaping run"
+              : "Request another run"
           }
         >
           <RefreshCw className="mr-1 h-3.5 w-3.5" />

--- a/apps/dashboard/tests/smoke/lineage-dag.test.tsx
+++ b/apps/dashboard/tests/smoke/lineage-dag.test.tsx
@@ -30,7 +30,7 @@ describe("LineageDAG", () => {
       </MemoryRouter>,
     );
     expect(
-      screen.getByText(/No shaping runs yet/i),
+      screen.getByText(/No runs yet/i),
     ).toBeInTheDocument();
   });
 

--- a/apps/dashboard/tests/smoke/lineage-dag.test.tsx
+++ b/apps/dashboard/tests/smoke/lineage-dag.test.tsx
@@ -30,7 +30,7 @@ describe("LineageDAG", () => {
       </MemoryRouter>,
     );
     expect(
-      screen.getByText(/No runs yet/i),
+      screen.getByText(/No runs yet\. Lanes appear once the first run starts/i),
     ).toBeInTheDocument();
   });
 

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -20,7 +20,7 @@ use crate::core::persistence;
 use crate::core::pipeline::{ForgePipeline, PipelineEvent};
 use crate::core::scheduler;
 use crate::core::session_listener::{self, SessionCompleted, SessionCompletedHandler};
-use crate::core::shaping_result_listener;
+use crate::core::session_result_listener;
 use crate::core::signal_cache::SignalCache;
 use crate::core::stage_runner::{self, StageEvent};
 use crate::core::trigger_subscriber::{
@@ -211,8 +211,6 @@ pub fn run(database_url: &str, tick_ms: u64) {
                         .iter()
                         .map(|e| match e {
                             StageEvent::StageEntered { artifact_id, .. }
-                            | StageEvent::GatePassed { artifact_id, .. }
-                            | StageEvent::GateFailed { artifact_id, .. }
                             | StageEvent::StageAdvanced { artifact_id, .. } => artifact_id.clone(),
                         })
                         .collect();
@@ -322,8 +320,6 @@ pub fn run(database_url: &str, tick_ms: u64) {
                     if let Some(ref spine) = spine {
                         let workflow_id = match event {
                             StageEvent::StageEntered { workflow_id, .. }
-                            | StageEvent::GatePassed { workflow_id, .. }
-                            | StageEvent::GateFailed { workflow_id, .. }
                             | StageEvent::StageAdvanced { workflow_id, .. } => workflow_id,
                         };
                         match workflows_snapshot.get(workflow_id) {
@@ -555,35 +551,36 @@ pub fn run(database_url: &str, tick_ms: u64) {
             }
         });
 
-        // Spawn the Lever C shaping-result listener. Tails
-        // `stiglab.shaping_result_ready`, parses the typed variant, and
+        // Spawn the Lever C session-result listener. Tails
+        // `stiglab.session_result_ready`, parses the typed variant, and
         // parks the embedded `ShapingResult` in `pending_shapings` keyed
-        // by its `request_id`. Same warm-start strategy.
-        let shaping_shared = shared.clone();
+        // by its `request_id`. Same warm-start strategy. (Renamed from
+        // shaping_result_listener per spec #285.)
+        let session_result_shared = shared.clone();
         let pending_shapings_for_listener = pending_shapings.clone();
         tokio::spawn(async move {
             let store = {
-                let state = shaping_shared.read().await;
+                let state = session_result_shared.read().await;
                 state.spine.clone()
             };
             let Some(store) = store else {
-                tracing::info!("forge: shaping_result listener disabled (no spine connection)");
+                tracing::info!("forge: session_result listener disabled (no spine connection)");
                 return;
             };
             let since = match store.max_event_id().await {
                 Ok(cursor) => cursor,
                 Err(e) => {
                     tracing::warn!(
-                        "forge: max_event_id lookup failed ({e}); starting shaping_result \
+                        "forge: max_event_id lookup failed ({e}); starting session_result \
                          listener from the beginning"
                     );
                     None
                 }
             };
             if let Err(e) =
-                shaping_result_listener::run(store, pending_shapings_for_listener, since).await
+                session_result_listener::run(store, pending_shapings_for_listener, since).await
             {
-                tracing::error!("forge: shaping_result listener exited: {e}");
+                tracing::error!("forge: session_result listener exited: {e}");
             }
         });
 
@@ -1107,40 +1104,6 @@ async fn emit_stage_event(spine: &EventStore, workflow: &Workflow, event: &Stage
                 "workspace_id": workspace_id,
                 "stage_index": stage_index,
                 "stage_name": stage_name,
-            }),
-        ),
-        StageEvent::GatePassed {
-            artifact_id,
-            workflow_id,
-            stage_index,
-            gate_kind,
-        } => (
-            format!("workflow:{artifact_id}"),
-            "stage.gate_passed",
-            serde_json::json!({
-                "artifact_id": artifact_id,
-                "workflow_id": workflow_id,
-                "workspace_id": workspace_id,
-                "stage_index": stage_index,
-                "gate_kind": gate_kind,
-            }),
-        ),
-        StageEvent::GateFailed {
-            artifact_id,
-            workflow_id,
-            stage_index,
-            gate_kind,
-            reason,
-        } => (
-            format!("workflow:{artifact_id}"),
-            "stage.gate_failed",
-            serde_json::json!({
-                "artifact_id": artifact_id,
-                "workflow_id": workflow_id,
-                "workspace_id": workspace_id,
-                "stage_index": stage_index,
-                "gate_kind": gate_kind,
-                "reason": reason,
             }),
         ),
         StageEvent::StageAdvanced {

--- a/crates/forge/src/core/gate_verdict_listener.rs
+++ b/crates/forge/src/core/gate_verdict_listener.rs
@@ -161,15 +161,4 @@ mod tests {
         assert!(classify_verdict(kind).is_none());
     }
 
-    #[test]
-    fn classify_returns_none_for_summary_variant() {
-        // SynodicGateEvaluated is the dashboard summary; it does not
-        // carry the full GateVerdict payload phase-4 will act on.
-        let kind = FactoryEventKind::SynodicGateEvaluated {
-            gate_id: "g_eval".into(),
-            artifact_id: ArtifactId::new("art_x"),
-            verdict: onsager_spine::factory_event::VerdictSummary::Allow,
-        };
-        assert!(classify_verdict(kind).is_none());
-    }
 }

--- a/crates/forge/src/core/gate_verdict_listener.rs
+++ b/crates/forge/src/core/gate_verdict_listener.rs
@@ -160,5 +160,4 @@ mod tests {
         };
         assert!(classify_verdict(kind).is_none());
     }
-
 }

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -11,7 +11,7 @@ pub mod persistence;
 pub mod pipeline;
 pub mod scheduler;
 pub mod session_listener;
-pub mod shaping_result_listener;
+pub mod session_result_listener;
 pub mod signal_cache;
 pub mod stage_runner;
 pub mod state;

--- a/crates/forge/src/core/pending.rs
+++ b/crates/forge/src/core/pending.rs
@@ -7,7 +7,7 @@
 //! pipeline decision keyed by the request's correlation id, and the
 //! corresponding listener thread records the response into one of these
 //! maps when the matching event lands on the spine
-//! (`synodic.gate_verdict`, `stiglab.shaping_result_ready`).
+//! (`synodic.gate_verdict`, `stiglab.session_result_ready`).
 //!
 //! Phase-4 wires these maps into `ForgePipeline::tick`'s state machine so
 //! the resume path consults them. Phase-3 only populates them — keeping

--- a/crates/forge/src/core/pipeline.rs
+++ b/crates/forge/src/core/pipeline.rs
@@ -5,7 +5,7 @@
 //! decision emits a request event (`forge.gate_requested`,
 //! `forge.shaping_dispatched`), parks itself keyed by the request's
 //! correlation id, and resumes on a later tick once the corresponding
-//! response (`synodic.gate_verdict`, `stiglab.shaping_result_ready`)
+//! response (`synodic.gate_verdict`, `stiglab.session_result_ready`)
 //! lands in the [`PendingVerdicts`] / [`PendingShapings`] maps the
 //! event listeners populate.
 //!
@@ -157,7 +157,7 @@ pub struct ForgePipeline {
     /// claim on resume. Cloned in from `ForgeSharedState` so the
     /// listener task and the pipeline see the same map.
     pending_verdicts: PendingVerdicts,
-    /// Shaping results the `shaping_result_listener` parks. Same
+    /// Session results the `session_result_listener` parks. Same
     /// sharing model as [`Self::pending_verdicts`].
     pending_shapings: PendingShapings,
 }

--- a/crates/forge/src/core/session_result_listener.rs
+++ b/crates/forge/src/core/session_result_listener.rs
@@ -1,4 +1,4 @@
-//! Listener that records `stiglab.shaping_result_ready` events into
+//! Listener that records `stiglab.session_result_ready` events into
 //! [`PendingShapings`] (spec #131 / ADR 0004 Lever C, phase 3).
 //!
 //! Symmetric with [`crate::core::gate_verdict_listener`]: filters on
@@ -67,16 +67,16 @@ impl Dispatcher {
 }
 
 /// Pure classifier: extract the `(request_id, ShapingResult)` pair from a
-/// [`FactoryEventKind`], or `None` if the kind is not a shaping result.
+/// [`FactoryEventKind`], or `None` if the kind is not a session result.
 ///
 /// Key is the `request_id` Forge stamped on the originating
 /// `forge.shaping_dispatched`. The duplicate top-level `artifact_id` on
 /// the event is kept for stream routing; we don't need it here.
-pub fn classify_shaping_result(
+pub fn classify_session_result(
     kind: FactoryEventKind,
 ) -> Option<(String, onsager_spine::protocol::ShapingResult)> {
     match kind {
-        FactoryEventKind::StiglabShapingResultReady { result, .. } => {
+        FactoryEventKind::StiglabSessionResultReady { result, .. } => {
             Some((result.request_id.clone(), result))
         }
         _ => None,
@@ -86,7 +86,7 @@ pub fn classify_shaping_result(
 #[async_trait]
 impl EventHandler for Dispatcher {
     async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
-        if notification.event_type != "stiglab.shaping_result_ready" {
+        if notification.event_type != "stiglab.session_result_ready" {
             return Ok(());
         }
 
@@ -94,10 +94,10 @@ impl EventHandler for Dispatcher {
             return Ok(());
         };
 
-        if let Some((request_id, result)) = classify_shaping_result(kind) {
+        if let Some((request_id, result)) = classify_session_result(kind) {
             tracing::info!(
                 request_id = %request_id,
-                "forge: parking stiglab.shaping_result_ready for pipeline resume"
+                "forge: parking stiglab.session_result_ready for pipeline resume"
             );
             self.pending.insert(&request_id, result);
         }
@@ -112,7 +112,7 @@ mod tests {
     use onsager_spine::factory_event::ShapingOutcome;
     use onsager_spine::protocol::ShapingResult;
 
-    fn shaping_completed(req: &str) -> ShapingResult {
+    fn session_completed(req: &str) -> ShapingResult {
         ShapingResult {
             request_id: req.into(),
             outcome: ShapingOutcome::Completed,
@@ -130,11 +130,11 @@ mod tests {
 
     #[test]
     fn classify_extracts_request_id_and_full_result() {
-        let kind = FactoryEventKind::StiglabShapingResultReady {
+        let kind = FactoryEventKind::StiglabSessionResultReady {
             artifact_id: ArtifactId::new("art_x"),
-            result: shaping_completed("req_42"),
+            result: session_completed("req_42"),
         };
-        let (request_id, result) = classify_shaping_result(kind).expect("matches variant");
+        let (request_id, result) = classify_session_result(kind).expect("matches variant");
         assert_eq!(request_id, "req_42");
         assert_eq!(result.outcome, ShapingOutcome::Completed);
         assert_eq!(result.content_ref.unwrap().uri, "git://repo@abc");
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn classify_returns_none_for_session_completed() {
         // Lifecycle event — different consumer (SessionLinker writes
-        // vertical_lineage). Must not be parked as a shaping result.
+        // vertical_lineage). Must not be parked as a session result.
         let kind = FactoryEventKind::StiglabSessionCompleted {
             session_id: "s".into(),
             request_id: "r".into(),
@@ -153,7 +153,7 @@ mod tests {
             branch: None,
             pr_number: None,
         };
-        assert!(classify_shaping_result(kind).is_none());
+        assert!(classify_session_result(kind).is_none());
     }
 
     #[test]
@@ -163,6 +163,6 @@ mod tests {
             target_version: 0,
             priority: 0,
         };
-        assert!(classify_shaping_result(kind).is_none());
+        assert!(classify_session_result(kind).is_none());
     }
 }

--- a/crates/forge/src/core/stage_runner.rs
+++ b/crates/forge/src/core/stage_runner.rs
@@ -25,6 +25,12 @@ use super::workflow::{GateOutcome, GateSpec, Workflow};
 
 /// Event emitted by a single stage-runner tick. These translate 1:1 to
 /// `stage.*` factory events on the spine.
+///
+/// Per spec #285 the per-gate `GatePassed` / `GateFailed` variants are
+/// gone; the run timeline reconstructs gate outcomes from
+/// `synodic.gate_verdict` and the stage advancement signal. Parking on
+/// failure is still tracked on the artifact row's
+/// `workflow_parked_reason`, just no longer mirrored as a spine event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StageEvent {
     /// The artifact transitioned into a new stage.
@@ -33,21 +39,6 @@ pub enum StageEvent {
         workflow_id: String,
         stage_index: u32,
         stage_name: String,
-    },
-    /// A gate on the current stage resolved successfully.
-    GatePassed {
-        artifact_id: String,
-        workflow_id: String,
-        stage_index: u32,
-        gate_kind: String,
-    },
-    /// A gate on the current stage failed. Artifact is parked.
-    GateFailed {
-        artifact_id: String,
-        workflow_id: String,
-        stage_index: u32,
-        gate_kind: String,
-        reason: String,
     },
     /// All gates on the stage resolved; artifact advances.
     StageAdvanced {
@@ -176,11 +167,10 @@ fn advance_single_artifact<E: GateEvaluator>(
 
     let mut any_pending = false;
     let mut gate_failures: Vec<(String, String)> = Vec::new();
-    let mut gate_passes: Vec<String> = Vec::new();
 
     for gate in &stage.gates {
         match evaluator.evaluate(&artifact_snapshot, workflow, stage_index, gate) {
-            GateOutcome::Pass => gate_passes.push(gate.kind_tag().to_string()),
+            GateOutcome::Pass => {}
             GateOutcome::Fail(reason) => {
                 gate_failures.push((gate.kind_tag().to_string(), reason));
             }
@@ -189,10 +179,12 @@ fn advance_single_artifact<E: GateEvaluator>(
     }
 
     if !gate_failures.is_empty() {
-        // Park in UnderReview with the combined failure reason. Only emit
-        // a GateFailed event per gate if the park reason is newly being
-        // set (or would change) — otherwise repeated ticks over the same
-        // failing condition would spam identical events.
+        // Park in UnderReview with the combined failure reason. Only
+        // touch the row when the park reason actually changes so
+        // repeated ticks over the same failing condition don't keep
+        // bumping `updated_at`. Per spec #285 the per-gate
+        // `stage.gate_failed` mirror event is gone; the parked reason
+        // on the artifact row is the durable record.
         let parked_reason = gate_failures
             .iter()
             .map(|(k, r)| format!("{k}: {r}"))
@@ -202,15 +194,6 @@ fn advance_single_artifact<E: GateEvaluator>(
             .get(artifact_id)
             .and_then(|a| a.workflow_parked_reason.clone());
         if existing_reason.as_deref() != Some(parked_reason.as_str()) {
-            for (gate_kind, reason) in gate_failures {
-                events.push(StageEvent::GateFailed {
-                    artifact_id: artifact_id.as_str().to_string(),
-                    workflow_id: workflow.workflow_id.clone(),
-                    stage_index,
-                    gate_kind,
-                    reason,
-                });
-            }
             park_artifact(store, artifact_id, parked_reason);
         }
         return;
@@ -227,18 +210,9 @@ fn advance_single_artifact<E: GateEvaluator>(
         return;
     }
 
-    // All gates passed — advance the artifact to the next stage. Only now
-    // do we emit `GatePassed` events — otherwise every tick where *some*
-    // gates pass but others are pending would spam the stream.
-    for gate_kind in gate_passes {
-        events.push(StageEvent::GatePassed {
-            artifact_id: artifact_id.as_str().to_string(),
-            workflow_id: workflow.workflow_id.clone(),
-            stage_index,
-            gate_kind,
-        });
-    }
-
+    // All gates passed — advance the artifact to the next stage. Per
+    // spec #285 we no longer emit a per-gate `stage.gate_passed`;
+    // `stage.advanced` (below) is the durable signal.
     let next_index = stage_index + 1;
     let next_stage = workflow.stage(next_index as usize).cloned();
 

--- a/crates/forge/src/core/stage_runner_tests.rs
+++ b/crates/forge/src/core/stage_runner_tests.rs
@@ -198,12 +198,22 @@ mod tests {
         let events = advance_workflow_artifacts(&workflows, &mut store, &eval);
         let art = store.get(&id).unwrap();
         assert_eq!(art.state, ArtifactState::UnderReview);
-        assert!(art.workflow_parked_reason.is_some());
-        assert!(events.iter().any(|e| matches!(
-            e,
-            StageEvent::GateFailed { gate_kind, .. } if gate_kind == "external_check"
-        )));
-        // Artifact stays on stage 0 — failure parks, doesn't advance.
+        let parked = art
+            .workflow_parked_reason
+            .as_deref()
+            .expect("artifact parked");
+        assert!(
+            parked.contains("external_check"),
+            "parked reason should name the failing gate: {parked}"
+        );
+        // No StageAdvanced event — failure parks, doesn't advance. Per
+        // spec #285 there is no per-gate event either.
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, StageEvent::StageAdvanced { .. }))
+        );
+        // Artifact stays on stage 0.
         assert_eq!(art.current_stage_index, Some(0));
     }
 
@@ -350,63 +360,11 @@ mod tests {
     }
 
     #[test]
-    fn gate_passed_events_emit_only_when_stage_advances() {
-        // A gate that passes while another is pending should NOT emit a
-        // GatePassed event every tick — otherwise the stream spams
-        // duplicate events (issue #80 copilot-review).
-        let wf = make_workflow(
-            "wf_noise",
-            vec![make_stage(
-                "s0",
-                Some(ArtifactState::InProgress),
-                vec![
-                    GateSpec::AgentSession {
-                        shaping_intent: serde_json::Value::Null,
-                    },
-                    GateSpec::ManualApproval {
-                        signal_kind: "approve".into(),
-                    },
-                ],
-            )],
-        );
-        let mut store = ArtifactStore::new();
-        let id = enroll(&mut store, &wf, "noisy");
-        let mut workflows = HashMap::new();
-        workflows.insert(wf.workflow_id.clone(), wf);
-
-        // agent_session passes, manual_approval pending.
-        let mut eval = MockEvaluator::new();
-        eval.set(id.as_str(), "agent_session", GateOutcome::Pass);
-
-        // Three ticks with the same outcome — must not emit GatePassed
-        // over and over.
-        let mut total_gate_passed = 0;
-        for _ in 0..3 {
-            let events = advance_workflow_artifacts(&workflows, &mut store, &eval);
-            total_gate_passed += events
-                .iter()
-                .filter(|e| matches!(e, StageEvent::GatePassed { .. }))
-                .count();
-        }
-        assert_eq!(
-            total_gate_passed, 0,
-            "no GatePassed events should fire while another gate is pending"
-        );
-
-        // Once both pass, the runner emits a single batch.
-        eval.set(id.as_str(), "manual_approval", GateOutcome::Pass);
-        let events = advance_workflow_artifacts(&workflows, &mut store, &eval);
-        let batch = events
-            .iter()
-            .filter(|e| matches!(e, StageEvent::GatePassed { .. }))
-            .count();
-        assert_eq!(batch, 2);
-    }
-
-    #[test]
-    fn gate_failed_events_emit_only_on_park_state_change() {
-        // Two ticks with the same failing gate: the second tick is a
-        // no-op because the parked reason already matches.
+    fn parking_is_idempotent_across_ticks() {
+        // Two ticks with the same failing gate: the second tick must
+        // not flap the parked reason. Per spec #285 there is no
+        // per-gate `stage.gate_failed` event; the artifact row is the
+        // durable record.
         let wf = make_workflow(
             "wf_quiet_fail",
             vec![make_stage(
@@ -429,22 +387,25 @@ mod tests {
             GateOutcome::Fail("red".into()),
         );
 
-        let tick1 = advance_workflow_artifacts(&workflows, &mut store, &eval);
+        advance_workflow_artifacts(&workflows, &mut store, &eval);
+        let parked_after_first = store
+            .get(&id)
+            .unwrap()
+            .workflow_parked_reason
+            .clone()
+            .expect("first tick parks");
+
+        advance_workflow_artifacts(&workflows, &mut store, &eval);
+        let parked_after_second = store
+            .get(&id)
+            .unwrap()
+            .workflow_parked_reason
+            .clone()
+            .expect("still parked");
+
         assert_eq!(
-            tick1
-                .iter()
-                .filter(|e| matches!(e, StageEvent::GateFailed { .. }))
-                .count(),
-            1
-        );
-        let tick2 = advance_workflow_artifacts(&workflows, &mut store, &eval);
-        assert_eq!(
-            tick2
-                .iter()
-                .filter(|e| matches!(e, StageEvent::GateFailed { .. }))
-                .count(),
-            0,
-            "re-emitting the same failure each tick would spam the stream"
+            parked_after_first, parked_after_second,
+            "second tick must not flap the parked reason"
         );
     }
 

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -243,13 +243,13 @@ pub const EVENTS: EventManifest = EventManifest {
             description: "A session finished successfully; carries optional artifact_id, token usage, branch, and PR number.",
         },
         EventDefinition {
-            kind: "stiglab.shaping_result_ready",
+            kind: "stiglab.session_result_ready",
             schema_version: 1,
             producers: &[Subsystem::Stiglab],
             consumers: &[Subsystem::Forge],
             diagnostic_only: false,
             reason: None,
-            description: "Full ShapingResult ready for Forge to act on (replaces POST /api/shaping response).",
+            description: "Full session ShapingResult ready for Forge to act on (replaces POST /api/shaping response). Renamed from stiglab.shaping_result_ready per spec #285.",
         },
         EventDefinition {
             kind: "stiglab.session_failed",
@@ -280,33 +280,10 @@ pub const EVENTS: EventManifest = EventManifest {
             description: "Dashboard task request from portal; stiglab dispatches the session to an agent node.",
         },
         // -- Synodic events -------------------------------------------------
-        EventDefinition {
-            kind: "synodic.gate_evaluated",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("dashboard filtering & audit trail; gate_verdict is the consumer event"),
-            description: "Gate request evaluated and a verdict issued (summary; full payload on synodic.gate_verdict).",
-        },
-        EventDefinition {
-            kind: "synodic.gate_denied",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("dashboard deny-verdict filtering"),
-            description: "Gate request denied (subset of gate_evaluated, for filtering).",
-        },
-        EventDefinition {
-            kind: "synodic.gate_modified",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("dashboard modify-verdict filtering"),
-            description: "Gate request resolved with verdict Modify (subset of gate_evaluated).",
-        },
+        // Per spec #285: the redundant `synodic.gate_evaluated` /
+        // `gate_denied` / `gate_modified` summary variants were dropped;
+        // the dashboard renders gate timelines from `synodic.gate_verdict`
+        // directly (verdict-shape filtering is a query-side concern).
         EventDefinition {
             kind: "synodic.gate_verdict",
             schema_version: 1,
@@ -514,24 +491,9 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some("rendered in workflow run timeline"),
             description: "A workflow-tagged artifact entered a new stage.",
         },
-        EventDefinition {
-            kind: "stage.gate_passed",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("rendered in workflow run timeline"),
-            description: "A gate on the current stage resolved successfully.",
-        },
-        EventDefinition {
-            kind: "stage.gate_failed",
-            schema_version: 1,
-            producers: &[Subsystem::Forge],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("rendered in workflow run timeline"),
-            description: "A gate on the current stage failed; the artifact is parked.",
-        },
+        // Per spec #285: per-gate `stage.gate_passed` / `stage.gate_failed`
+        // events were dropped; the run timeline reconstructs gate outcomes
+        // from `synodic.gate_verdict` plus the stage advancement signal.
         EventDefinition {
             kind: "stage.advanced",
             schema_version: 1,
@@ -541,88 +503,12 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some("rendered in workflow run timeline"),
             description: "All gates on a stage resolved and the artifact advanced.",
         },
-        // -- Registry events (issue #14) ------------------------------------
-        EventDefinition {
-            kind: "registry.type_proposed",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "A new artifact type was proposed (not yet active).",
-        },
-        EventDefinition {
-            kind: "registry.type_approved",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "A proposed type was approved and entered the active catalog.",
-        },
-        EventDefinition {
-            kind: "registry.type_deprecated",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "A type was deprecated (retained for audit).",
-        },
-        EventDefinition {
-            kind: "registry.adapter_registered",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "An adapter implementation was registered in the catalog.",
-        },
-        EventDefinition {
-            kind: "registry.adapter_deprecated",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "An adapter was deprecated.",
-        },
-        EventDefinition {
-            kind: "registry.gate_registered",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "A gate evaluator was registered.",
-        },
-        EventDefinition {
-            kind: "registry.gate_deprecated",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "A gate evaluator was deprecated.",
-        },
-        EventDefinition {
-            kind: "registry.profile_registered",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "An agent profile was registered.",
-        },
-        EventDefinition {
-            kind: "registry.profile_deprecated",
-            schema_version: 1,
-            producers: &[Subsystem::Synodic],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some("audit trail for registry catalog mutations"),
-            description: "An agent profile was deprecated.",
-        },
+        // -- Registry events removed by spec #285 ---------------------------
+        // The nine `registry.*` mutation events had no in-tree consumer
+        // or dashboard reader. The registry tables remain the source of
+        // truth; mutations no longer publish a spine event. Add a row
+        // back here when there is a real consumer.
+
         // -- Gate adapters (GitHub webhooks) --------------------------------
         EventDefinition {
             kind: "gate.check_updated",

--- a/crates/onsager-registry/src/registry_store.rs
+++ b/crates/onsager-registry/src/registry_store.rs
@@ -160,24 +160,22 @@ impl RegistryStore {
             .map_err(anyhow::Error::from)
     }
 
-    /// Deprecate a type. Per spec #285 no spine event is emitted; the
-    /// `reason` is captured only via the test-side audit trail.
-    pub async fn deprecate_type(
-        &self,
-        type_id: &str,
-        reason: &str,
-        actor: &str,
-    ) -> anyhow::Result<bool> {
+    /// Deprecate a type. Returns `true` if the row was actually
+    /// flipped to `deprecated`, `false` if it was already deprecated.
+    /// Per spec #285 no spine event is emitted and no `reason` column
+    /// exists on `artifact_types`; if a deprecation rationale needs to
+    /// be persisted, that's a schema change to the registry tables
+    /// rather than an event emission.
+    pub async fn deprecate_type(&self, type_id: &str, actor: &str) -> anyhow::Result<bool> {
         let workspace = self.workspace_id.clone();
         let actor = actor.to_owned();
         let type_id = type_id.to_owned();
-        let reason = reason.to_owned();
 
         self.store
             .transaction(move |tx| {
-                Box::pin(async move {
-                    deprecate_type_in_tx(tx, &workspace, &type_id, &reason, &actor).await
-                })
+                Box::pin(
+                    async move { deprecate_type_in_tx(tx, &workspace, &type_id, &actor).await },
+                )
             })
             .await
             .map_err(anyhow::Error::from)
@@ -239,7 +237,6 @@ async fn deprecate_type_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     workspace_id: &str,
     type_id: &str,
-    _reason: &str,
     _actor: &str,
 ) -> sqlx::Result<bool> {
     let updated: Option<(i32,)> = sqlx::query_as(

--- a/crates/onsager-registry/src/registry_store.rs
+++ b/crates/onsager-registry/src/registry_store.rs
@@ -1,15 +1,19 @@
 //! DB-facing registry operations — query, propose, approve, deprecate.
 //!
-//! This is the projection layer that makes the registry usable from code. The
-//! *authoritative* record is still the event stream: every mutation here
-//! writes both a row and a `registry.*` event in the same transaction.
+//! This is the projection layer that makes the registry usable from code.
+//! The registry tables (`artifact_types`, `artifact_adapters`,
+//! `gate_evaluators`, `agent_profiles`) are the source of truth.
+//!
+//! Per spec #285 these mutations no longer publish a `registry.*` spine
+//! event — the previous events had no in-tree consumer or dashboard
+//! reader and were instrumented pre-emptively for a registry timeline
+//! UI that never landed. Add an event back when there is a real
+//! consumer.
 //!
 //! See `registry.rs` for the trait-based plug points and value objects.
 
 use chrono::{DateTime, Utc};
-use onsager_spine::{
-    EventMetadata, EventStore, FactoryEvent, FactoryEventKind, append_factory_event_tx,
-};
+use onsager_spine::EventStore;
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Row, Transaction};
 
@@ -127,8 +131,8 @@ impl RegistryStore {
     }
 
     /// Propose a new artifact type. Inserts at revision 1 with status
-    /// `proposed` and emits `registry.type_proposed`. Idempotent: rerunning
-    /// with the same id is a no-op and emits no event.
+    /// `proposed`. Idempotent: rerunning with the same id is a no-op.
+    /// Per spec #285 no spine event is emitted.
     pub async fn propose_type(&self, def: &TypeDefinition, actor: &str) -> anyhow::Result<bool> {
         let workspace = self.workspace_id.clone();
         let actor = actor.to_owned();
@@ -156,7 +160,8 @@ impl RegistryStore {
             .map_err(anyhow::Error::from)
     }
 
-    /// Deprecate a type. Emits `registry.type_deprecated` with the reason.
+    /// Deprecate a type. Per spec #285 no spine event is emitted; the
+    /// `reason` is captured only via the test-side audit trail.
     pub async fn deprecate_type(
         &self,
         type_id: &str,
@@ -187,7 +192,7 @@ async fn propose_type_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     workspace_id: &str,
     def: &TypeDefinition,
-    actor: &str,
+    _actor: &str,
 ) -> sqlx::Result<bool> {
     let definition = serde_json::to_value(def)
         .map_err(|e| sqlx::Error::Protocol(format!("serialize TypeDefinition: {e}")))?;
@@ -206,27 +211,14 @@ async fn propose_type_in_tx(
     .fetch_optional(&mut **tx)
     .await?;
 
-    let Some((revision,)) = inserted else {
-        return Ok(false);
-    };
-
-    let evt = registry_event(
-        FactoryEventKind::TypeProposed {
-            type_id: def.type_id.as_str().to_owned(),
-            workspace_id: workspace_id.to_owned(),
-            revision,
-        },
-        actor,
-    );
-    append_factory_event_tx(tx, &evt, &actor_metadata(actor)).await?;
-    Ok(true)
+    Ok(inserted.is_some())
 }
 
 async fn approve_type_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     workspace_id: &str,
     type_id: &str,
-    actor: &str,
+    _actor: &str,
 ) -> sqlx::Result<bool> {
     let updated: Option<(i32,)> = sqlx::query_as(
         r#"
@@ -240,28 +232,15 @@ async fn approve_type_in_tx(
     .fetch_optional(&mut **tx)
     .await?;
 
-    let Some((revision,)) = updated else {
-        return Ok(false);
-    };
-
-    let evt = registry_event(
-        FactoryEventKind::TypeApproved {
-            type_id: type_id.to_owned(),
-            workspace_id: workspace_id.to_owned(),
-            revision,
-        },
-        actor,
-    );
-    append_factory_event_tx(tx, &evt, &actor_metadata(actor)).await?;
-    Ok(true)
+    Ok(updated.is_some())
 }
 
 async fn deprecate_type_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     workspace_id: &str,
     type_id: &str,
-    reason: &str,
-    actor: &str,
+    _reason: &str,
+    _actor: &str,
 ) -> sqlx::Result<bool> {
     let updated: Option<(i32,)> = sqlx::query_as(
         r#"
@@ -275,38 +254,7 @@ async fn deprecate_type_in_tx(
     .fetch_optional(&mut **tx)
     .await?;
 
-    if updated.is_none() {
-        return Ok(false);
-    }
-
-    let evt = registry_event(
-        FactoryEventKind::TypeDeprecated {
-            type_id: type_id.to_owned(),
-            workspace_id: workspace_id.to_owned(),
-            reason: reason.to_owned(),
-        },
-        actor,
-    );
-    append_factory_event_tx(tx, &evt, &actor_metadata(actor)).await?;
-    Ok(true)
-}
-
-fn registry_event(kind: FactoryEventKind, actor: &str) -> FactoryEvent {
-    FactoryEvent {
-        event: kind,
-        correlation_id: None,
-        causation_id: None,
-        actor: actor.to_owned(),
-        timestamp: Utc::now(),
-    }
-}
-
-fn actor_metadata(actor: &str) -> EventMetadata {
-    EventMetadata {
-        correlation_id: None,
-        causation_id: None,
-        actor: actor.to_owned(),
-    }
+    Ok(updated.is_some())
 }
 
 fn row_to_record(row: sqlx::postgres::PgRow) -> sqlx::Result<RegistryRecord> {

--- a/crates/onsager-registry/src/seed.rs
+++ b/crates/onsager-registry/src/seed.rs
@@ -1,25 +1,27 @@
 //! Idempotent seed loader for the factory registry.
 //!
-//! Loads a [`SeedCatalog`] (typically parsed from a YAML file) and materializes
-//! its entries into the registry tables, emitting the corresponding
-//! `registry.*` events onto the spine with `actor = "seed"`.
+//! Loads a [`SeedCatalog`] (typically parsed from a YAML file) and
+//! materializes its entries into the registry tables.
 //!
-//! Idempotency: the loader checks [`registry_seed_marker`] first. If a seed
-//! with the same name has already been applied to the workspace, it returns
-//! immediately with zero events. This is the bootstrap-termination rule from
-//! issue #14 — the seed runs exactly once; after that, every registry change
-//! goes through the normal propose/approve flow.
+//! Idempotency: the loader checks [`registry_seed_marker`] first. If a
+//! seed with the same name has already been applied to the workspace,
+//! it returns immediately. This is the bootstrap-termination rule from
+//! issue #14 — the seed runs exactly once; after that, every registry
+//! change goes through the normal propose/approve flow.
+//!
+//! Per spec #285 the loader no longer publishes `registry.*` spine
+//! events — the events had no in-tree consumer or dashboard reader.
+//! `SeedOutcome::events_emitted` is retained as a counter of registry
+//! rows actually inserted (renamed semantically, same field name kept
+//! for backwards compatibility on the public struct).
 
-use chrono::Utc;
-use onsager_spine::{
-    EventMetadata, EventStore, FactoryEvent, FactoryEventKind, append_factory_event_tx,
-};
+use onsager_spine::EventStore;
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 
-use crate::registry::{
-    AgentProfile, DEFAULT_WORKSPACE, RegistryStatus, SEED_ACTOR, TypeDefinition,
-};
+use crate::registry::{AgentProfile, DEFAULT_WORKSPACE, RegistryStatus, TypeDefinition};
+#[cfg(test)]
+use crate::registry::SEED_ACTOR;
 
 /// An adapter catalog entry as it appears in a seed file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,7 +67,12 @@ impl SeedCatalog {
     }
 }
 
-/// Outcome of a seed apply.
+/// Outcome of a seed apply. `rows_inserted` counts how many registry
+/// rows the apply actually wrote (some entries may already exist via
+/// `ON CONFLICT DO NOTHING`). The legacy `events_emitted` field is kept
+/// as an alias for backwards compatibility on the struct shape; per
+/// spec #285 the loader no longer publishes spine events, so the count
+/// matches `rows_inserted`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SeedOutcome {
     pub applied: bool,
@@ -74,9 +81,9 @@ pub struct SeedOutcome {
 
 /// Apply a seed catalog idempotently.
 ///
-/// The entire apply runs in a single transaction: either every row lands
-/// (registry tables + marker + events) or nothing does. Rerunning with the
-/// same `name`/`workspace_id` pair emits zero events.
+/// The entire apply runs in a single transaction: either every row
+/// lands (registry tables + marker) or nothing does. Rerunning with
+/// the same `name`/`workspace_id` pair is a no-op.
 pub async fn apply_seed(store: &EventStore, catalog: &SeedCatalog) -> anyhow::Result<SeedOutcome> {
     let workspace_id = catalog
         .workspace_id
@@ -115,13 +122,12 @@ async fn apply_in_tx(
         return Ok(SeedOutcome::default());
     }
 
-    let mut events_emitted = 0usize;
+    let mut rows_inserted = 0usize;
     let status = RegistryStatus::Approved.as_str();
 
-    // Only emit a registry.* event when the row was actually inserted. ON
-    // CONFLICT DO NOTHING returns 0 rows affected for duplicates (YAML
-    // duplicates or concurrent seeds), and an event in that case would
-    // falsely claim a registration happened.
+    // Count rows actually inserted. `ON CONFLICT DO NOTHING` returns 0
+    // rows_affected for duplicates (YAML duplicates or concurrent
+    // seeds); those don't bump the counter.
 
     for adapter in &catalog.adapters {
         let affected = sqlx::query(
@@ -140,13 +146,7 @@ async fn apply_in_tx(
         .rows_affected();
 
         if affected == 1 {
-            let evt = registry_event(FactoryEventKind::AdapterRegistered {
-                adapter_id: adapter.adapter_id.clone(),
-                workspace_id: workspace_id.to_owned(),
-                revision: 1,
-            });
-            append_factory_event_tx(tx, &evt, &seed_metadata()).await?;
-            events_emitted += 1;
+            rows_inserted += 1;
         }
     }
 
@@ -167,13 +167,7 @@ async fn apply_in_tx(
         .rows_affected();
 
         if affected == 1 {
-            let evt = registry_event(FactoryEventKind::GateRegistered {
-                evaluator_id: evaluator.evaluator_id.clone(),
-                workspace_id: workspace_id.to_owned(),
-                revision: 1,
-            });
-            append_factory_event_tx(tx, &evt, &seed_metadata()).await?;
-            events_emitted += 1;
+            rows_inserted += 1;
         }
     }
 
@@ -195,13 +189,7 @@ async fn apply_in_tx(
         .rows_affected();
 
         if affected == 1 {
-            let evt = registry_event(FactoryEventKind::ProfileRegistered {
-                profile_id: profile.profile_id.as_str().to_owned(),
-                workspace_id: workspace_id.to_owned(),
-                revision: 1,
-            });
-            append_factory_event_tx(tx, &evt, &seed_metadata()).await?;
-            events_emitted += 1;
+            rows_inserted += 1;
         }
     }
 
@@ -223,13 +211,7 @@ async fn apply_in_tx(
         .rows_affected();
 
         if affected == 1 {
-            let evt = registry_event(FactoryEventKind::TypeApproved {
-                type_id: type_def.type_id.as_str().to_owned(),
-                workspace_id: workspace_id.to_owned(),
-                revision: 1,
-            });
-            append_factory_event_tx(tx, &evt, &seed_metadata()).await?;
-            events_emitted += 1;
+            rows_inserted += 1;
         }
     }
 
@@ -243,26 +225,8 @@ async fn apply_in_tx(
 
     Ok(SeedOutcome {
         applied: true,
-        events_emitted,
+        events_emitted: rows_inserted,
     })
-}
-
-fn registry_event(kind: FactoryEventKind) -> FactoryEvent {
-    FactoryEvent {
-        event: kind,
-        correlation_id: None,
-        causation_id: None,
-        actor: SEED_ACTOR.to_owned(),
-        timestamp: Utc::now(),
-    }
-}
-
-fn seed_metadata() -> EventMetadata {
-    EventMetadata {
-        correlation_id: None,
-        causation_id: None,
-        actor: SEED_ACTOR.to_owned(),
-    }
 }
 
 /// Convert anyhow errors back into `sqlx::Error` so they can bubble out of
@@ -308,23 +272,8 @@ mod tests {
     }
 
     #[test]
-    fn seed_metadata_uses_seed_actor() {
-        let meta = seed_metadata();
-        assert_eq!(meta.actor, SEED_ACTOR);
+    fn seed_actor_is_seed() {
         assert_eq!(SEED_ACTOR, "seed");
-    }
-
-    #[test]
-    fn registry_event_preserves_kind() {
-        let evt = registry_event(FactoryEventKind::TypeApproved {
-            type_id: "Spec".into(),
-            workspace_id: DEFAULT_WORKSPACE.into(),
-            revision: 1,
-        });
-        assert_eq!(evt.actor, SEED_ACTOR);
-        assert_eq!(evt.event.event_type(), "registry.type_approved");
-        assert_eq!(evt.event.stream_type(), "registry");
-        assert_eq!(evt.event.stream_id(), "type:Spec");
     }
 
     #[test]

--- a/crates/onsager-registry/src/seed.rs
+++ b/crates/onsager-registry/src/seed.rs
@@ -67,15 +67,17 @@ impl SeedCatalog {
     }
 }
 
-/// Outcome of a seed apply. `rows_inserted` counts how many registry
-/// rows the apply actually wrote (some entries may already exist via
-/// `ON CONFLICT DO NOTHING`). The legacy `events_emitted` field is kept
-/// as an alias for backwards compatibility on the struct shape; per
-/// spec #285 the loader no longer publishes spine events, so the count
-/// matches `rows_inserted`.
+/// Outcome of a seed apply. Per spec #285 the loader no longer
+/// publishes `registry.*` spine events; the field name
+/// `events_emitted` is kept for struct-shape compatibility but now
+/// counts registry rows actually inserted (rows that hit `ON CONFLICT
+/// DO NOTHING` are not counted).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SeedOutcome {
     pub applied: bool,
+    /// Number of registry rows inserted by this apply. Pre-#285 this
+    /// counted spine events emitted; the two were 1:1, so the field
+    /// kept its name.
     pub events_emitted: usize,
 }
 

--- a/crates/onsager-registry/src/seed.rs
+++ b/crates/onsager-registry/src/seed.rs
@@ -19,9 +19,9 @@ use onsager_spine::EventStore;
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 
-use crate::registry::{AgentProfile, DEFAULT_WORKSPACE, RegistryStatus, TypeDefinition};
 #[cfg(test)]
 use crate::registry::SEED_ACTOR;
+use crate::registry::{AgentProfile, DEFAULT_WORKSPACE, RegistryStatus, TypeDefinition};
 
 /// An adapter catalog entry as it appears in a seed file.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/onsager-registry/tests/registry_flow.rs
+++ b/crates/onsager-registry/tests/registry_flow.rs
@@ -15,10 +15,10 @@ fn db_url() -> Option<String> {
 
 async fn wipe(store: &EventStore, workspace: &str) {
     // All deletes are scoped to the workspace under test so tests on shared
-    // or parallel DB backends don't clobber each other.
+    // or parallel DB backends don't clobber each other. Per spec #285
+    // registry mutations no longer publish spine events; the event-table
+    // wipe is dropped from this list.
     let scoped = [
-        "DELETE FROM events WHERE stream_type = 'registry' \
-         AND data->'event'->>'workspace_id' = $1",
         "DELETE FROM registry_seed_marker WHERE workspace_id = $1",
         "DELETE FROM artifact_types WHERE workspace_id = $1",
         "DELETE FROM artifact_adapters WHERE workspace_id = $1",
@@ -91,25 +91,9 @@ async fn propose_then_approve_type_lifecycle() {
             .unwrap()
     );
 
-    // Three registry events should have landed on the spine for this
-    // workspace. Filter on event_type (authoritative column) and
-    // workspace_id inside the envelope so we don't pick up other tests'
-    // rows on a shared DB.
-    let events: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM events \
-         WHERE stream_type = 'registry' \
-           AND event_type IN ('registry.type_proposed','registry.type_approved','registry.type_deprecated') \
-           AND data->'event'->>'workspace_id' = $1",
-    )
-    .bind(workspace)
-    .fetch_one(store.pool())
-    .await
-    .unwrap();
-    assert!(
-        events.0 >= 3,
-        "expected at least 3 events, got {}",
-        events.0
-    );
+    // Per spec #285 registry mutations no longer publish spine events.
+    // The registry tables themselves are the source of truth; the row
+    // assertions above already verified the lifecycle landed.
 
     wipe(&store, workspace).await;
 }

--- a/crates/onsager-registry/tests/registry_flow.rs
+++ b/crates/onsager-registry/tests/registry_flow.rs
@@ -77,19 +77,9 @@ async fn propose_then_approve_type_lifecycle() {
         .expect("row present");
     assert_eq!(row.status, RegistryStatus::Approved);
 
-    // deprecate emits the terminal event
-    assert!(
-        registry
-            .deprecate_type("DraftType", "superseded", "bob")
-            .await
-            .unwrap()
-    );
-    assert!(
-        !registry
-            .deprecate_type("DraftType", "noop", "bob")
-            .await
-            .unwrap()
-    );
+    // deprecate flips status to `deprecated`; second call is idempotent
+    assert!(registry.deprecate_type("DraftType", "bob").await.unwrap());
+    assert!(!registry.deprecate_type("DraftType", "bob").await.unwrap());
 
     // Per spec #285 registry mutations no longer publish spine events.
     // The registry tables themselves are the source of truth; the row

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -588,9 +588,9 @@ impl FactoryEventKind {
             Self::IntentSubmitted { .. }
             | Self::RefractDecomposed { .. }
             | Self::RefractFailed { .. } => "refract",
-            Self::TriggerFired { .. }
-            | Self::StageEntered { .. }
-            | Self::StageAdvanced { .. } => "workflow",
+            Self::TriggerFired { .. } | Self::StageEntered { .. } | Self::StageAdvanced { .. } => {
+                "workflow"
+            }
             // Audit-only fan-out for manual fires (#241). Lives in the
             // `audit` namespace so audit views can filter without
             // mixing with first-class workflow runtime events.
@@ -642,8 +642,9 @@ impl FactoryEventKind {
             Self::WorkflowManualTriggered { workflow_id, .. } => {
                 format!("audit:workflow:{workflow_id}")
             }
-            Self::StageEntered { artifact_id, .. }
-            | Self::StageAdvanced { artifact_id, .. } => format!("workflow:{artifact_id}"),
+            Self::StageEntered { artifact_id, .. } | Self::StageAdvanced { artifact_id, .. } => {
+                format!("workflow:{artifact_id}")
+            }
             Self::GateCheckUpdated {
                 repo_owner,
                 repo_name,

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -1,4 +1,4 @@
-// budget-allow: factory event enum (~50+ variants after spec #272 prune + #274 cut); macro/derive compression deferred to follow-up spec per #261
+// budget-allow: factory event enum (~40 variants after spec #285 prune); macro/derive compression deferred to follow-up spec per #261
 //! Factory events — the authoritative event types emitted to the factory event
 //! spine by each subsystem.
 //!
@@ -209,8 +209,8 @@ pub enum FactoryEventKind {
     /// state machine to advance / seal). Stiglab emits it only for
     /// sessions that were dispatched as shaping requests — direct task
     /// POSTs that produce no `ShapingResult` skip it.
-    StiglabShapingResultReady {
-        /// Artifact this shaping was for. Hoisted so `stream_id()` can
+    StiglabSessionResultReady {
+        /// Artifact this session was for. Hoisted so `stream_id()` can
         /// route the event without parsing the embedded result.
         artifact_id: ArtifactId,
         /// Full result payload — the same shape Forge previously
@@ -244,26 +244,6 @@ pub enum FactoryEventKind {
     PortalSessionRequested { session_id: String },
 
     // -- Synodic events (governance) ----------------------------------------
-    /// A gate request was evaluated and a verdict issued.
-    SynodicGateEvaluated {
-        gate_id: String,
-        artifact_id: ArtifactId,
-        verdict: VerdictSummary,
-    },
-
-    /// A gate request was denied (subset of gate_evaluated, for easy filtering).
-    SynodicGateDenied {
-        gate_id: String,
-        artifact_id: ArtifactId,
-        reason: String,
-    },
-
-    /// A gate request verdict was Modify (subset of gate_evaluated).
-    SynodicGateModified {
-        gate_id: String,
-        artifact_id: ArtifactId,
-    },
-
     /// Full gate verdict issued by Synodic in response to a
     /// `forge.gate_requested` event. Carries the complete `GateVerdict`
     /// payload — Allow, Deny{reason}, Modify{new_action}, or
@@ -271,10 +251,11 @@ pub enum FactoryEventKind {
     /// HTTP roundtrip.
     ///
     /// Replaces the legacy synchronous `forge → synodic POST /api/gate`
-    /// response per spec #131 / ADR 0004 Lever C. The summary variants
-    /// above (`SynodicGateEvaluated`, `SynodicGateDenied`,
-    /// `SynodicGateModified`) remain for dashboard filtering; this
-    /// variant is the one consumers act on.
+    /// response per spec #131 / ADR 0004 Lever C. The dashboard renders
+    /// gate timelines directly off this event (verdict-shape filtering
+    /// is a query-side concern); per spec #285 the redundant
+    /// `synodic.gate_evaluated` / `gate_denied` / `gate_modified`
+    /// summary variants are gone.
     SynodicGateVerdict {
         /// Correlation ID echoed from the originating
         /// `forge.gate_requested` event.
@@ -470,27 +451,13 @@ pub enum FactoryEventKind {
         stage_name: String,
     },
 
-    /// A gate on the current stage resolved successfully.
-    StageGatePassed {
-        artifact_id: ArtifactId,
-        workflow_id: String,
-        stage_index: u32,
-        gate_kind: String,
-    },
-
-    /// A gate on the current stage failed. The artifact is parked in
-    /// `under_review` until the gate-failure condition is cleared (e.g. a
-    /// new CI run succeeds, a reviewer approves).
-    StageGateFailed {
-        artifact_id: ArtifactId,
-        workflow_id: String,
-        stage_index: u32,
-        gate_kind: String,
-        reason: String,
-    },
-
     /// All gates on a stage resolved and the artifact advanced to the next
     /// stage (or reached terminal state when this was the last stage).
+    ///
+    /// Per spec #285 the redundant per-gate `stage.gate_passed` /
+    /// `stage.gate_failed` events are gone; the run timeline reconstructs
+    /// gate outcomes from `synodic.gate_verdict` plus this advancement
+    /// signal.
     StageAdvanced {
         artifact_id: ArtifactId,
         workflow_id: String,
@@ -499,69 +466,14 @@ pub enum FactoryEventKind {
         to_stage_index: Option<u32>,
     },
 
-    // -- Registry events (factory pipeline foundations, issue #14) ----------
-    /// A new artifact type was proposed (not yet active).
-    TypeProposed {
-        type_id: String,
-        workspace_id: String,
-        revision: i32,
-    },
-
-    /// A proposed type was approved and entered the active catalog.
-    TypeApproved {
-        type_id: String,
-        workspace_id: String,
-        revision: i32,
-    },
-
-    /// A type was deprecated (retained for audit, not used for new artifacts).
-    TypeDeprecated {
-        type_id: String,
-        workspace_id: String,
-        reason: String,
-    },
-
-    /// An adapter implementation was registered in the catalog.
-    AdapterRegistered {
-        adapter_id: String,
-        workspace_id: String,
-        revision: i32,
-    },
-
-    /// An adapter was deprecated.
-    AdapterDeprecated {
-        adapter_id: String,
-        workspace_id: String,
-        reason: String,
-    },
-
-    /// A gate evaluator was registered.
-    GateRegistered {
-        evaluator_id: String,
-        workspace_id: String,
-        revision: i32,
-    },
-
-    /// A gate evaluator was deprecated.
-    GateDeprecated {
-        evaluator_id: String,
-        workspace_id: String,
-        reason: String,
-    },
-
-    /// An agent profile was registered.
-    ProfileRegistered {
-        profile_id: String,
-        workspace_id: String,
-        revision: i32,
-    },
-
-    /// An agent profile was deprecated.
-    ProfileDeprecated {
-        profile_id: String,
-        workspace_id: String,
-        reason: String,
-    },
+    // -- Registry events removed by spec #285 -------------------------------
+    // The nine `registry.*` mutation events (`type_proposed`, `type_approved`,
+    // `type_deprecated`, `adapter_registered`, `adapter_deprecated`,
+    // `gate_registered`, `gate_deprecated`, `profile_registered`,
+    // `profile_deprecated`) had no in-tree consumer or dashboard reader;
+    // the registry tables are still the source of truth, but mutations no
+    // longer publish a spine event. Add a variant back here when there is
+    // a real consumer.
 
     // -- Workflow events (issue #81 — stiglab workflow CRUD + webhook) ------
     // `TriggerFired` is defined above in the issue #80 block; the stiglab
@@ -606,13 +518,10 @@ impl FactoryEventKind {
             Self::ForgeInsightObserved { .. } => "forge.insight_observed",
             Self::ForgeDecisionMade { .. } => "forge.decision_made",
             Self::StiglabSessionCompleted { .. } => "stiglab.session_completed",
-            Self::StiglabShapingResultReady { .. } => "stiglab.shaping_result_ready",
+            Self::StiglabSessionResultReady { .. } => "stiglab.session_result_ready",
             Self::StiglabSessionFailed { .. } => "stiglab.session_failed",
             Self::StiglabSessionAborted { .. } => "stiglab.session_aborted",
             Self::PortalSessionRequested { .. } => "portal.session_requested",
-            Self::SynodicGateEvaluated { .. } => "synodic.gate_evaluated",
-            Self::SynodicGateDenied { .. } => "synodic.gate_denied",
-            Self::SynodicGateModified { .. } => "synodic.gate_modified",
             Self::SynodicGateVerdict { .. } => "synodic.gate_verdict",
             Self::SynodicEscalationStarted { .. } => "synodic.escalation_started",
             Self::SynodicEscalationResolved { .. } => "synodic.escalation_resolved",
@@ -634,18 +543,7 @@ impl FactoryEventKind {
             Self::TriggerFired { .. } => "trigger.fired",
             Self::WorkflowManualTriggered { .. } => "workflow.manual_triggered",
             Self::StageEntered { .. } => "stage.entered",
-            Self::StageGatePassed { .. } => "stage.gate_passed",
-            Self::StageGateFailed { .. } => "stage.gate_failed",
             Self::StageAdvanced { .. } => "stage.advanced",
-            Self::TypeProposed { .. } => "registry.type_proposed",
-            Self::TypeApproved { .. } => "registry.type_approved",
-            Self::TypeDeprecated { .. } => "registry.type_deprecated",
-            Self::AdapterRegistered { .. } => "registry.adapter_registered",
-            Self::AdapterDeprecated { .. } => "registry.adapter_deprecated",
-            Self::GateRegistered { .. } => "registry.gate_registered",
-            Self::GateDeprecated { .. } => "registry.gate_deprecated",
-            Self::ProfileRegistered { .. } => "registry.profile_registered",
-            Self::ProfileDeprecated { .. } => "registry.profile_deprecated",
             Self::GateCheckUpdated { .. } => "gate.check_updated",
             Self::GateManualApprovalSignal { .. } => "gate.manual_approval_signal",
         }
@@ -668,14 +566,11 @@ impl FactoryEventKind {
             | Self::ForgeInsightObserved { .. }
             | Self::ForgeDecisionMade { .. } => "forge",
             Self::StiglabSessionCompleted { .. }
-            | Self::StiglabShapingResultReady { .. }
+            | Self::StiglabSessionResultReady { .. }
             | Self::StiglabSessionFailed { .. }
             | Self::StiglabSessionAborted { .. } => "stiglab",
             Self::PortalSessionRequested { .. } => "portal",
-            Self::SynodicGateEvaluated { .. }
-            | Self::SynodicGateDenied { .. }
-            | Self::SynodicGateModified { .. }
-            | Self::SynodicGateVerdict { .. }
+            Self::SynodicGateVerdict { .. }
             | Self::SynodicEscalationStarted { .. }
             | Self::SynodicEscalationResolved { .. }
             | Self::SynodicEscalationTimedOut { .. }
@@ -695,22 +590,11 @@ impl FactoryEventKind {
             | Self::RefractFailed { .. } => "refract",
             Self::TriggerFired { .. }
             | Self::StageEntered { .. }
-            | Self::StageGatePassed { .. }
-            | Self::StageGateFailed { .. }
             | Self::StageAdvanced { .. } => "workflow",
             // Audit-only fan-out for manual fires (#241). Lives in the
             // `audit` namespace so audit views can filter without
             // mixing with first-class workflow runtime events.
             Self::WorkflowManualTriggered { .. } => "audit",
-            Self::TypeProposed { .. }
-            | Self::TypeApproved { .. }
-            | Self::TypeDeprecated { .. }
-            | Self::AdapterRegistered { .. }
-            | Self::AdapterDeprecated { .. }
-            | Self::GateRegistered { .. }
-            | Self::GateDeprecated { .. }
-            | Self::ProfileRegistered { .. }
-            | Self::ProfileDeprecated { .. } => "registry",
             Self::GateCheckUpdated { .. } | Self::GateManualApprovalSignal { .. } => "gate",
         }
     }
@@ -734,11 +618,8 @@ impl FactoryEventKind {
             Self::StiglabSessionCompleted { session_id, .. }
             | Self::StiglabSessionFailed { session_id, .. }
             | Self::StiglabSessionAborted { session_id, .. } => session_id.clone(),
-            Self::StiglabShapingResultReady { artifact_id, .. } => artifact_id.to_string(),
+            Self::StiglabSessionResultReady { artifact_id, .. } => artifact_id.to_string(),
             Self::PortalSessionRequested { session_id, .. } => session_id.clone(),
-            Self::SynodicGateEvaluated { gate_id, .. } => gate_id.clone(),
-            Self::SynodicGateDenied { gate_id, .. } => gate_id.clone(),
-            Self::SynodicGateModified { gate_id, .. } => gate_id.clone(),
             Self::SynodicGateVerdict { gate_id, .. } => gate_id.clone(),
             Self::SynodicEscalationStarted { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicEscalationResolved { escalation_id, .. } => escalation_id.clone(),
@@ -762,18 +643,7 @@ impl FactoryEventKind {
                 format!("audit:workflow:{workflow_id}")
             }
             Self::StageEntered { artifact_id, .. }
-            | Self::StageGatePassed { artifact_id, .. }
-            | Self::StageGateFailed { artifact_id, .. }
             | Self::StageAdvanced { artifact_id, .. } => format!("workflow:{artifact_id}"),
-            Self::TypeProposed { type_id, .. }
-            | Self::TypeApproved { type_id, .. }
-            | Self::TypeDeprecated { type_id, .. } => format!("type:{type_id}"),
-            Self::AdapterRegistered { adapter_id, .. }
-            | Self::AdapterDeprecated { adapter_id, .. } => format!("adapter:{adapter_id}"),
-            Self::GateRegistered { evaluator_id, .. }
-            | Self::GateDeprecated { evaluator_id, .. } => format!("gate:{evaluator_id}"),
-            Self::ProfileRegistered { profile_id, .. }
-            | Self::ProfileDeprecated { profile_id, .. } => format!("profile:{profile_id}"),
             Self::GateCheckUpdated {
                 repo_owner,
                 repo_name,

--- a/crates/onsager-spine/src/factory_event_tests.rs
+++ b/crates/onsager-spine/src/factory_event_tests.rs
@@ -388,11 +388,11 @@ mod tests {
     }
 
     #[test]
-    fn stiglab_shaping_result_ready_roundtrip() {
+    fn stiglab_session_result_ready_roundtrip() {
         use crate::protocol::ShapingResult;
         use onsager_artifact::ContentRef;
 
-        let event = FactoryEventKind::StiglabShapingResultReady {
+        let event = FactoryEventKind::StiglabSessionResultReady {
             artifact_id: ArtifactId::new("art_shaped"),
             result: ShapingResult {
                 request_id: "req_shaping_42".into(),
@@ -410,12 +410,12 @@ mod tests {
         };
 
         // event_type / stream routing — phase-3 listeners filter on these.
-        assert_eq!(event.event_type(), "stiglab.shaping_result_ready");
+        assert_eq!(event.event_type(), "stiglab.session_result_ready");
         assert_eq!(event.stream_type(), "stiglab");
         assert_eq!(event.stream_id(), "art_shaped");
 
         let json = serde_json::to_value(&event).unwrap();
-        assert_eq!(json["type"], "stiglab_shaping_result_ready");
+        assert_eq!(json["type"], "stiglab_session_result_ready");
         assert_eq!(json["artifact_id"], "art_shaped");
         assert_eq!(json["result"]["request_id"], "req_shaping_42");
         assert_eq!(json["result"]["outcome"], "completed");

--- a/crates/stiglab/CLAUDE.md
+++ b/crates/stiglab/CLAUDE.md
@@ -78,7 +78,7 @@ What this means for stiglab specifically:
     (via `EventStore::append_ext`). Stiglab still keeps
     `SpineEmitter` for the agent-runtime emits
     (`emit_session_started/completed/failed`,
-    `emit_shaping_result_ready`) — those are session-lifecycle, not
+    `emit_session_result_ready`) — those are session-lifecycle, not
     dashboard-facing — and still uses the spine pool for in-process
     reads (`routes::projects::replay_issue_trigger`).
   - Workflow CRUD + GitHub side-effects
@@ -102,7 +102,7 @@ What this means for stiglab specifically:
   event you care about, write your response as a new event. Concrete
   pattern in production today: stiglab's `shaping_listener` consumes
   `forge.shaping_dispatched`, spawns the agent session, and emits
-  `stiglab.session_completed` + `stiglab.shaping_result_ready` when
+  `stiglab.session_completed` + `stiglab.session_result_ready` when
   the session reaches a terminal state (or `stiglab.session_failed`
   on the error path).
 - **Cargo deps.** `stiglab` may depend on `onsager-{artifact,

--- a/crates/stiglab/src/main.rs
+++ b/crates/stiglab/src/main.rs
@@ -145,7 +145,7 @@ async fn run_server(
     // request, calls the same dispatch core the HTTP route uses, and
     // reuses idempotency via `request_id` so spine redelivery never
     // produces a duplicate session. Result correlation flows back via
-    // `stiglab.shaping_result_ready` from the agent message handler.
+    // `stiglab.session_result_ready` from the agent message handler.
     //
     // Warm-start at `max_event_id` so a fresh boot doesn't replay every
     // historical request. Phase 6 will persist a per-process cursor.

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -108,20 +108,22 @@ pub async fn handle_agent_message(
                     tracing::warn!("failed to emit session_completed spine event: {e}");
                 }
 
-                // Emit `stiglab.shaping_result_ready` carrying the full
+                // Emit `stiglab.session_result_ready` carrying the full
                 // `ShapingResult` so Forge's pipeline can resume the
-                // parked decision (spec #131 / ADR 0004 Lever C, phase 3).
+                // parked decision (spec #131 / ADR 0004 Lever C, phase 3;
+                // renamed from `shaping_result_ready` per spec #285).
                 // The lifecycle event above stays for dashboard / node
                 // telemetry; this event is the actionable signal Forge
-                // consumes via `shaping_result_listener`. Sessions
+                // consumes via `session_result_listener`. Sessions
                 // without an artifact link are direct task POSTs that
                 // never produced a shaping request — skip them so we
                 // don't fabricate result events with empty fields.
                 if let Some(artifact_id) = artifact_id.as_deref()
                     && let Err(e) =
-                        emit_shaping_result_for_session(pool, spine, &session_id, artifact_id).await
+                        emit_session_result_for_session(pool, spine, &session_id, artifact_id)
+                            .await
                 {
-                    tracing::warn!("failed to emit shaping_result_ready spine event: {e}");
+                    tracing::warn!("failed to emit session_result_ready spine event: {e}");
                 }
             }
         }
@@ -224,7 +226,8 @@ async fn git_context_for_session(
 }
 
 /// Build a `ShapingResult` from a terminal session row and emit it as
-/// `stiglab.shaping_result_ready` (spec #131 / ADR 0004 Lever C, phase 3).
+/// `stiglab.session_result_ready` (spec #131 / ADR 0004 Lever C, phase 3;
+/// renamed from `shaping_result_ready` per spec #285).
 ///
 /// We synthesize a minimal `ShapingRequest` envelope from the session's
 /// stored `task_id` (= original request_id) and artifact link so the
@@ -234,7 +237,7 @@ async fn git_context_for_session(
 /// row (inputs, constraints, deadline) default to empty — Forge's
 /// pipeline never reads them off the result, only the request, so the
 /// adapter stays consistent with the HTTP path it replaces.
-async fn emit_shaping_result_for_session(
+async fn emit_session_result_for_session(
     pool: &AnyPool,
     spine: &SpineEmitter,
     session_id: &str,
@@ -273,7 +276,7 @@ async fn emit_shaping_result_for_session(
     let result = adapter::session_to_shaping_result(&synthesized_req, &session, duration_ms);
 
     spine
-        .emit_shaping_result_ready(onsager_artifact::ArtifactId::new(artifact_id), result)
+        .emit_session_result_ready(onsager_artifact::ArtifactId::new(artifact_id), result)
         .await
         .map_err(anyhow::Error::from)?;
     Ok(())

--- a/crates/stiglab/src/server/handler.rs
+++ b/crates/stiglab/src/server/handler.rs
@@ -120,8 +120,7 @@ pub async fn handle_agent_message(
                 // don't fabricate result events with empty fields.
                 if let Some(artifact_id) = artifact_id.as_deref()
                     && let Err(e) =
-                        emit_session_result_for_session(pool, spine, &session_id, artifact_id)
-                            .await
+                        emit_session_result_for_session(pool, spine, &session_id, artifact_id).await
                 {
                     tracing::warn!("failed to emit session_result_ready spine event: {e}");
                 }

--- a/crates/stiglab/src/server/shaping_listener.rs
+++ b/crates/stiglab/src/server/shaping_listener.rs
@@ -7,7 +7,7 @@
 //! to carry the full `ShapingRequest` payload as
 //! `FactoryEventKind::ForgeShapingDispatched.request`; the listener
 //! spawns a session and returns. Result correlation flows back via
-//! `stiglab.shaping_result_ready` from the agent message handler when
+//! `stiglab.session_result_ready` from the agent message handler when
 //! the session reaches a terminal state.
 //!
 //! The HTTP route stays alive during phase 3 so existing forge

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -155,21 +155,22 @@ impl SpineEmitter {
         .await
     }
 
-    /// Emit a `stiglab.shaping_result_ready` event carrying the full
-    /// `ShapingResult` payload so Forge's `shaping_result_listener` can
+    /// Emit a `stiglab.session_result_ready` event carrying the full
+    /// `ShapingResult` payload so Forge's `session_result_listener` can
     /// resume the parked pipeline decision (spec #131 / ADR 0004
-    /// Lever C, phase 3). Emitted alongside `stiglab.session_completed`:
-    /// the lifecycle event signals "this session finished" (used by the
+    /// Lever C, phase 3; renamed from `shaping_result_ready` per spec
+    /// #285). Emitted alongside `stiglab.session_completed`: the
+    /// lifecycle event signals "this session finished" (used by the
     /// dashboard); this event signals "the artifact outputs are ready
     /// for the next pipeline stage" (used by Forge's state machine).
     /// Sessions without an artifact link skip this — see
     /// `handler.rs::handle_agent_message` for the gate.
-    pub async fn emit_shaping_result_ready(
+    pub async fn emit_session_result_ready(
         &self,
         artifact_id: onsager_artifact::ArtifactId,
         result: onsager_spine::protocol::ShapingResult,
     ) -> Result<i64, sqlx::Error> {
-        self.emit(FactoryEventKind::StiglabShapingResultReady {
+        self.emit(FactoryEventKind::StiglabSessionResultReady {
             artifact_id,
             result,
         })
@@ -219,18 +220,13 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::ForgeGateRequested { artifact_id, .. }
         | FactoryEventKind::ForgeGateVerdict { artifact_id, .. }
         | FactoryEventKind::ForgeDecisionMade { artifact_id, .. }
-        | FactoryEventKind::StiglabShapingResultReady { artifact_id, .. }
-        | FactoryEventKind::SynodicGateEvaluated { artifact_id, .. }
-        | FactoryEventKind::SynodicGateDenied { artifact_id, .. }
-        | FactoryEventKind::SynodicGateModified { artifact_id, .. }
+        | FactoryEventKind::StiglabSessionResultReady { artifact_id, .. }
         | FactoryEventKind::SynodicGateVerdict { artifact_id, .. }
         | FactoryEventKind::SynodicEscalationStarted { artifact_id, .. }
         | FactoryEventKind::SynodicEscalationResolved { artifact_id, .. }
         | FactoryEventKind::SynodicEscalationTimedOut { artifact_id, .. }
         | FactoryEventKind::SynodicGateResolutionProposed { artifact_id, .. }
         | FactoryEventKind::StageEntered { artifact_id, .. }
-        | FactoryEventKind::StageGatePassed { artifact_id, .. }
-        | FactoryEventKind::StageGateFailed { artifact_id, .. }
         | FactoryEventKind::StageAdvanced { artifact_id, .. } => Some(artifact_id.as_str()),
         FactoryEventKind::StiglabSessionCompleted { artifact_id, .. }
         | FactoryEventKind::StiglabSessionFailed { artifact_id, .. } => artifact_id.as_deref(),
@@ -253,15 +249,6 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::RefractFailed { .. }
         | FactoryEventKind::TriggerFired { .. }
         | FactoryEventKind::WorkflowManualTriggered { .. }
-        | FactoryEventKind::TypeProposed { .. }
-        | FactoryEventKind::TypeApproved { .. }
-        | FactoryEventKind::TypeDeprecated { .. }
-        | FactoryEventKind::AdapterRegistered { .. }
-        | FactoryEventKind::AdapterDeprecated { .. }
-        | FactoryEventKind::GateRegistered { .. }
-        | FactoryEventKind::GateDeprecated { .. }
-        | FactoryEventKind::ProfileRegistered { .. }
-        | FactoryEventKind::ProfileDeprecated { .. }
         | FactoryEventKind::GateCheckUpdated { .. }
         | FactoryEventKind::GateManualApprovalSignal { .. }
         | FactoryEventKind::PortalSessionRequested { .. } => None,

--- a/docs/events.md
+++ b/docs/events.md
@@ -57,12 +57,11 @@ that requires a coordinated rollout.
 | `forge` | forge | 6 |
 | `stiglab` | stiglab | 4 |
 | `portal` | (unknown — update `stream_producer` in xtask) | 1 |
-| `synodic` | synodic | 12 |
+| `synodic` | synodic | 9 |
 | `ising` | ising | 6 |
 | `refract` | refract | 3 |
-| `workflow` | stiglab (trigger) / forge (stage) | 5 |
+| `workflow` | stiglab (trigger) / forge (stage) | 3 |
 | `audit` | (unknown — update `stream_producer` in xtask) | 1 |
-| `registry` | synodic (catalog crud) | 9 |
 | `gate` | onsager-portal (GitHub) / forge (manual) | 2 |
 
 Each section below covers one stream. Inside a section, every event lists its wire `event_type` string, the Rust variant name, the variant's doc comment, and a payload field table (where the field's own doc comment is the description).
@@ -264,9 +263,9 @@ A session finished successfully.
 | `branch` | `Option<String>` | Working-tree branch the agent pushed at session completion (issue #60). Used by `onsager-portal` to attach `vertical_lineage` when the matching PR webhook arrives. Optional — sessions that don't touch a git working dir leave it `None`. _(optional)_ |
 | `pr_number` | `Option<u64>` | PR number the agent opened, when known at completion time. Optional for the same reasons as `branch`. _(optional)_ |
 
-### `stiglab.shaping_result_ready`
+### `stiglab.session_result_ready`
 
-- Variant: `FactoryEventKind::StiglabShapingResultReady`
+- Variant: `FactoryEventKind::StiglabSessionResultReady`
 - Stream: `stiglab`
 
 Full `ShapingResult` produced by a Stiglab session, ready for Forge to act on. Replaces the legacy synchronous `forge → stiglab POST /api/shaping` HTTP response per spec #131 / ADR 0004 Lever C.
@@ -275,7 +274,7 @@ Emitted in addition to (not instead of) `stiglab.session_completed`: the lifecyc
 
 | Field | Type | Description |
 |---|---|---|
-| `artifact_id` | `ArtifactId` | Artifact this shaping was for. Hoisted so `stream_id()` can route the event without parsing the embedded result. |
+| `artifact_id` | `ArtifactId` | Artifact this session was for. Hoisted so `stream_id()` can route the event without parsing the embedded result. |
 | `result` | `crate::protocol::ShapingResult` | Full result payload — the same shape Forge previously consumed as the `POST /api/shaping` response body. `request_id` inside this struct correlates back to the originating `forge.shaping_dispatched`. |
 
 ### `stiglab.session_failed`
@@ -323,44 +322,6 @@ Dashboard task request from portal. Stiglab's `session_requested_listener` dispa
 
 Producer subsystem: **synodic**.
 
-### `synodic.gate_evaluated`
-
-- Variant: `FactoryEventKind::SynodicGateEvaluated`
-- Stream: `synodic`
-
-A gate request was evaluated and a verdict issued.
-
-| Field | Type | Description |
-|---|---|---|
-| `gate_id` | `String` |  |
-| `artifact_id` | `ArtifactId` |  |
-| `verdict` | `VerdictSummary` |  |
-
-### `synodic.gate_denied`
-
-- Variant: `FactoryEventKind::SynodicGateDenied`
-- Stream: `synodic`
-
-A gate request was denied (subset of gate_evaluated, for easy filtering).
-
-| Field | Type | Description |
-|---|---|---|
-| `gate_id` | `String` |  |
-| `artifact_id` | `ArtifactId` |  |
-| `reason` | `String` |  |
-
-### `synodic.gate_modified`
-
-- Variant: `FactoryEventKind::SynodicGateModified`
-- Stream: `synodic`
-
-A gate request verdict was Modify (subset of gate_evaluated).
-
-| Field | Type | Description |
-|---|---|---|
-| `gate_id` | `String` |  |
-| `artifact_id` | `ArtifactId` |  |
-
 ### `synodic.gate_verdict`
 
 - Variant: `FactoryEventKind::SynodicGateVerdict`
@@ -368,7 +329,7 @@ A gate request verdict was Modify (subset of gate_evaluated).
 
 Full gate verdict issued by Synodic in response to a `forge.gate_requested` event. Carries the complete `GateVerdict` payload — Allow, Deny{reason}, Modify{new_action}, or Escalate{context} — so Forge can act on it without a follow-up HTTP roundtrip.
 
-Replaces the legacy synchronous `forge → synodic POST /api/gate` response per spec #131 / ADR 0004 Lever C. The summary variants above (`SynodicGateEvaluated`, `SynodicGateDenied`, `SynodicGateModified`) remain for dashboard filtering; this variant is the one consumers act on.
+Replaces the legacy synchronous `forge → synodic POST /api/gate` response per spec #131 / ADR 0004 Lever C. The dashboard renders gate timelines directly off this event (verdict-shape filtering is a query-side concern); per spec #285 the redundant `synodic.gate_evaluated` / `gate_denied` / `gate_modified` summary variants are gone.
 
 | Field | Type | Description |
 |---|---|---|
@@ -635,41 +596,14 @@ A workflow-tagged artifact entered a new stage.
 | `stage_index` | `u32` |  |
 | `stage_name` | `String` |  |
 
-### `stage.gate_passed`
-
-- Variant: `FactoryEventKind::StageGatePassed`
-- Stream: `workflow`
-
-A gate on the current stage resolved successfully.
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `workflow_id` | `String` |  |
-| `stage_index` | `u32` |  |
-| `gate_kind` | `String` |  |
-
-### `stage.gate_failed`
-
-- Variant: `FactoryEventKind::StageGateFailed`
-- Stream: `workflow`
-
-A gate on the current stage failed. The artifact is parked in `under_review` until the gate-failure condition is cleared (e.g. a new CI run succeeds, a reviewer approves).
-
-| Field | Type | Description |
-|---|---|---|
-| `artifact_id` | `ArtifactId` |  |
-| `workflow_id` | `String` |  |
-| `stage_index` | `u32` |  |
-| `gate_kind` | `String` |  |
-| `reason` | `String` |  |
-
 ### `stage.advanced`
 
 - Variant: `FactoryEventKind::StageAdvanced`
 - Stream: `workflow`
 
 All gates on a stage resolved and the artifact advanced to the next stage (or reached terminal state when this was the last stage).
+
+Per spec #285 the redundant per-gate `stage.gate_passed` / `stage.gate_failed` events are gone; the run timeline reconstructs gate outcomes from `synodic.gate_verdict` plus this advancement signal.
 
 | Field | Type | Description |
 |---|---|---|
@@ -696,127 +630,6 @@ Audit record for a manual / CLI / replay trigger fire (#241). Emitted alongside 
 | `actor` | `String` |  |
 | `event_subtype` | `String` |  |
 | `detail` | `serde_json::Value` |  |
-
-## `registry` events
-
-Producer subsystem: **synodic (catalog crud)**.
-
-### `registry.type_proposed`
-
-- Variant: `FactoryEventKind::TypeProposed`
-- Stream: `registry`
-
-A new artifact type was proposed (not yet active).
-
-| Field | Type | Description |
-|---|---|---|
-| `type_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `revision` | `i32` |  |
-
-### `registry.type_approved`
-
-- Variant: `FactoryEventKind::TypeApproved`
-- Stream: `registry`
-
-A proposed type was approved and entered the active catalog.
-
-| Field | Type | Description |
-|---|---|---|
-| `type_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `revision` | `i32` |  |
-
-### `registry.type_deprecated`
-
-- Variant: `FactoryEventKind::TypeDeprecated`
-- Stream: `registry`
-
-A type was deprecated (retained for audit, not used for new artifacts).
-
-| Field | Type | Description |
-|---|---|---|
-| `type_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `reason` | `String` |  |
-
-### `registry.adapter_registered`
-
-- Variant: `FactoryEventKind::AdapterRegistered`
-- Stream: `registry`
-
-An adapter implementation was registered in the catalog.
-
-| Field | Type | Description |
-|---|---|---|
-| `adapter_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `revision` | `i32` |  |
-
-### `registry.adapter_deprecated`
-
-- Variant: `FactoryEventKind::AdapterDeprecated`
-- Stream: `registry`
-
-An adapter was deprecated.
-
-| Field | Type | Description |
-|---|---|---|
-| `adapter_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `reason` | `String` |  |
-
-### `registry.gate_registered`
-
-- Variant: `FactoryEventKind::GateRegistered`
-- Stream: `registry`
-
-A gate evaluator was registered.
-
-| Field | Type | Description |
-|---|---|---|
-| `evaluator_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `revision` | `i32` |  |
-
-### `registry.gate_deprecated`
-
-- Variant: `FactoryEventKind::GateDeprecated`
-- Stream: `registry`
-
-A gate evaluator was deprecated.
-
-| Field | Type | Description |
-|---|---|---|
-| `evaluator_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `reason` | `String` |  |
-
-### `registry.profile_registered`
-
-- Variant: `FactoryEventKind::ProfileRegistered`
-- Stream: `registry`
-
-An agent profile was registered.
-
-| Field | Type | Description |
-|---|---|---|
-| `profile_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `revision` | `i32` |  |
-
-### `registry.profile_deprecated`
-
-- Variant: `FactoryEventKind::ProfileDeprecated`
-- Stream: `registry`
-
-An agent profile was deprecated.
-
-| Field | Type | Description |
-|---|---|---|
-| `profile_id` | `String` |  |
-| `workspace_id` | `String` |  |
-| `reason` | `String` |  |
 
 ## `gate` events
 

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -190,17 +190,29 @@ fn extract_match_arms(stmts: &[Stmt]) -> Result<Vec<(String, String)>> {
 
     let mut out = Vec::new();
     for arm in &match_expr.arms {
-        let lit = match arm.body.as_ref() {
-            Expr::Lit(ExprLit {
-                lit: Lit::Str(s), ..
-            }) => s.value(),
-            _ => bail!("event_type() match arm body is not a string literal"),
-        };
+        let lit = arm_body_str(arm.body.as_ref())
+            .ok_or_else(|| anyhow!("event_type() match arm body is not a string literal"))?;
         for variant in collect_variants_from_pat(&arm.pat) {
             out.push((variant, lit.clone()));
         }
     }
     Ok(out)
+}
+
+/// Return the string-literal value of a match-arm body. Tolerates the
+/// `=> { "literal" }` block form rustfmt can produce when the arm
+/// pattern wraps onto multiple lines.
+fn arm_body_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => Some(s.value()),
+        Expr::Block(b) if b.block.stmts.len() == 1 => match &b.block.stmts[0] {
+            Stmt::Expr(inner, None) => arm_body_str(inner),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn collect_variants_from_pat(pat: &Pat) -> Vec<String> {

--- a/xtask/src/check_triggers.rs
+++ b/xtask/src/check_triggers.rs
@@ -146,17 +146,29 @@ fn extract_match_arms(stmts: &[Stmt]) -> Result<Vec<(String, String)>> {
 
     let mut out = Vec::new();
     for arm in &match_expr.arms {
-        let lit = match arm.body.as_ref() {
-            Expr::Lit(ExprLit {
-                lit: Lit::Str(s), ..
-            }) => s.value(),
-            _ => bail!("kind_tag() match arm body is not a string literal"),
-        };
+        let lit = arm_body_str(arm.body.as_ref())
+            .ok_or_else(|| anyhow!("kind_tag() match arm body is not a string literal"))?;
         for variant in collect_variants_from_pat(&arm.pat) {
             out.push((variant, lit.clone()));
         }
     }
     Ok(out)
+}
+
+/// Return the string-literal value of a match-arm body. Tolerates the
+/// `=> { "literal" }` block form rustfmt can produce when the arm
+/// pattern wraps onto multiple lines.
+fn arm_body_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => Some(s.value()),
+        Expr::Block(b) if b.block.stmts.len() == 1 => match &b.block.stmts[0] {
+            Stmt::Expr(inner, None) => arm_body_str(inner),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn collect_variants_from_pat(pat: &Pat) -> Vec<String> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -306,19 +306,31 @@ fn extract_match_arms(stmts: &[Stmt]) -> Result<Vec<(String, String)>> {
 
     let mut out = Vec::new();
     for arm in &match_expr.arms {
-        let lit = match arm.body.as_ref() {
-            Expr::Lit(ExprLit {
-                lit: Lit::Str(s), ..
-            }) => s.value(),
-            // event_type() returns &'static str literals. stream_type() likewise.
-            // Anything else (formatted strings, .to_string(), etc.) is unexpected.
-            _ => bail!("match arm body is not a string literal — generator can't handle it"),
-        };
+        let lit = arm_body_str(arm.body.as_ref()).ok_or_else(|| {
+            anyhow!("match arm body is not a string literal — generator can't handle it")
+        })?;
         for variant in collect_variants_from_pat(&arm.pat) {
             out.push((variant, lit.clone()));
         }
     }
     Ok(out)
+}
+
+/// Return the string-literal value of a match-arm body. Tolerates the
+/// `=> { "literal" }` block form rustfmt can produce when the arm
+/// pattern wraps onto multiple lines, so the gen-docs / lint parsers
+/// don't break on cosmetic reformat.
+fn arm_body_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => Some(s.value()),
+        Expr::Block(b) if b.block.stmts.len() == 1 => match &b.block.stmts[0] {
+            Stmt::Expr(inner, None) => arm_body_str(inner),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 /// From a pattern like `Self::A { .. } | Self::B { .. }` extract `["A", "B"]`.


### PR DESCRIPTION
## Summary

Implements two paired specs in one PR — the manifest cuts (#285) and the vocabulary doc commitment (#286) reinforce each other (the only remaining "shaping" leakage on a real consumer event lives at the spec #285 rename, and #286 makes that rename land under a documented vocabulary rule).

### Spec #285 — trim event manifest

- Drop `synodic.gate_evaluated` / `gate_denied` / `gate_modified` (redundant subsets of `synodic.gate_verdict`; dashboard renders gate timelines from the verdict directly — verified there's no dashboard caller for `gate_evaluated`).
- Drop `stage.gate_passed` / `stage.gate_failed` (per-gate mirrors with no consumer; the run timeline reconstructs gate outcomes from `synodic.gate_verdict` plus `stage.advanced`). The `StageEvent::GatePassed` / `GateFailed` internal variants and their tests are dropped along with the variants — parking on failure is still tracked durably on `artifact.workflow_parked_reason`.
- Drop the 9 `registry.*` mutation events (no in-tree consumer or dashboard reader; the registry tables remain the source of truth, the spine event emission was instrumented pre-emptively for a UI that never landed).
- Rename `stiglab.shaping_result_ready` → `stiglab.session_result_ready` atomically (producer + consumer + manifest + listener module rename + tests in one commit, no `serde(alias)`).

Manifest count: **42 events** (down from 56). `xtask check-events`, `lint-seams`, `check-api-contract`, `check-file-budget` all clean; `cargo test --workspace --all-targets` green.

### Spec #286 — canonical 4-noun user-facing vocabulary

- New "User-facing vocabulary" section in root `CLAUDE.md` naming the canonical 4 nouns (**Workflow** / **Run** / **Artifact** / **Stage**), the demoted-to-internal list (`shaping`, `bundle`, `sealed`, `spec`, `ArtifactVersionId`), the demoted-to-surface-internal list (`gate`, `verdict`, `governance`, `session`, `node`, `issue`), and the doc-only enforcement posture.
- Skill cross-links: `.claude/skills/issue-spec/references/spec-format.md` and `.claude/skills/dashboard-ui/SKILL.md` get a one-paragraph callout each so spec authors and dashboard PRs surface the rule at the point of work.
- Smoke audit (`grep -ri 'shaping\|bundle\|sealed' apps/dashboard/src --include='*.tsx'`) caught two user-visible "shaping run" strings — fixed in `LineageDAG` empty state and `ArtifactDetailPage` retry tooltip; the existing test fixture was updated to match. Re-run is clean.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace --all-targets` green (~14 test crates, all passing).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo run -p xtask -- check-events` clean (42 events, 4 subsystems scanned).
- [x] `cargo run -p xtask -- gen-event-docs --check` clean.
- [x] `cargo run -p xtask -- lint-seams` clean.
- [x] `cargo run -p xtask -- check-api-contract` clean.
- [x] `cargo run -p xtask -- check-file-budget` clean.
- [x] `cargo run -p xtask -- check-triggers` clean.
- [x] `pnpm --filter dashboard build` clean.
- [x] `pnpm --filter dashboard test` green (105 tests).
- [x] `pnpm --filter dashboard lint` clean.
- [x] `grep -ri 'shaping\|bundle\|sealed' apps/dashboard/src --include='*.tsx'` returns no user-facing leakage.

Closes #285
Closes #286

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMgxLfJLab9KaXNZpZ2yaA)_