### PR TITLE
feat(infra): publish railway-preview check_run on every preview deploy

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -126,18 +126,30 @@ jobs:
             // Green only when Railway reports success AND the smoke-test
             // actually got a 200 from /api/health. Anything else
             // (Railway failure/error, or success with a broken
-            // healthcheck) is a red signal.
+            // healthcheck) is a red signal. The title is phrased so it
+            // matches the conclusion at a glance — a success-state with
+            // a failed smoke is "unhealthy", not "success".
             const healthy = state === 'success' && smoke === 'ok';
             const conclusion = healthy ? 'success' : 'failure';
-            const title = healthy
-              ? 'Preview deploy succeeded'
-              : `Preview deploy ${state}${smoke ? ` (smoke: ${smoke})` : ''}`;
+            let title;
+            if (healthy) {
+              title = 'Preview deploy succeeded';
+            } else if (state === 'success') {
+              title = `Preview deploy unhealthy (smoke: ${smoke || 'unknown'})`;
+            } else {
+              title = `Preview deploy ${state}`;
+            }
 
+            // `target_url` is Railway's deployment page (build log +
+            // runtime logs); `environment_url` is the deployed preview
+            // host. Label them distinctly so a reviewer doesn't have to
+            // guess which link goes where, and fall back to whichever
+            // is present so the summary never says "(no link)".
             const summary = [
               `Railway deployment state: \`${state}\`.`,
               smoke ? `Smoke-test \`/api/health\`: \`${smoke}\`.` : null,
               envUrl ? `Preview URL: ${envUrl}` : null,
-              `Railway: ${targetUrl || '(no link)'}`,
+              targetUrl ? `Railway deployment page: ${targetUrl}` : null,
             ].filter(Boolean).join('\n\n');
 
             await github.rest.checks.create({
@@ -147,8 +159,9 @@ jobs:
               head_sha: sha,
               status: 'completed',
               conclusion,
-              // Link to Railway's build log so a red check is one click
-              // from the failure details.
+              // Prefer the Railway deployment page (build + runtime
+              // logs in one place) so a red check is one click from
+              // the failure details; fall back to the preview host.
               details_url: targetUrl || envUrl || undefined,
               output: { title, summary },
             });

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -24,15 +24,22 @@ permissions:
   pull-requests: write
   contents: read
   deployments: read
+  # Lets the `railway-preview` step below post a check_run on the
+  # deployed commit so the harness sees deploy outcomes via
+  # `check_run.completed` webhooks instead of polling Railway (#295).
+  checks: write
 
 jobs:
   announce:
-    # Only react to successful Railway preview deploys. Railway names its PR
-    # environments `pr-<N>` — anything else is prod or a non-PR env and we
-    # ignore it here.
+    # React to every Railway preview deploy outcome — success, failure, and
+    # error — so the `railway-preview` check_run is published on red as
+    # well as green (#295). The smoke-test + sticky-comment steps below
+    # stay gated on `state == 'success'` so a failed deploy isn't reported
+    # as healthy. Railway names its PR environments `pr-<N>`; anything
+    # else is prod or a non-PR env and we ignore it here.
     if: >-
       github.event_name == 'deployment_status' &&
-      github.event.deployment_status.state == 'success' &&
+      contains(fromJSON('["success", "failure", "error"]'), github.event.deployment_status.state) &&
       startsWith(github.event.deployment.environment, 'pr-')
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +75,12 @@ jobs:
           echo "value=$url" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test /api/health
-        if: steps.url.outputs.value != ''
+        # Only smoke-test on successful deploys — a failed build has nothing
+        # to probe. The `railway-preview` check_run step below still fires
+        # in both branches.
+        if: >-
+          github.event.deployment_status.state == 'success' &&
+          steps.url.outputs.value != ''
         id: smoke
         env:
           URL: ${{ steps.url.outputs.value }}
@@ -86,8 +98,69 @@ jobs:
           done
           echo "status=failed" >> "$GITHUB_OUTPUT"
 
+      - name: Publish `railway-preview` check_run
+        # Always runs when the job fires, including on Railway build/
+        # healthcheck failures (#295). Attaches to the deployment's commit
+        # SHA so the check shows up on whichever PR's head matches —
+        # no PR-number lookup needed.
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_STATE: ${{ github.event.deployment_status.state }}
+          DEPLOY_SHA: ${{ github.event.deployment.sha }}
+          TARGET_URL: ${{ github.event.deployment_status.target_url }}
+          ENV_URL: ${{ steps.url.outputs.value }}
+          SMOKE_STATUS: ${{ steps.smoke.outputs.status }}
+        with:
+          script: |
+            const state = process.env.DEPLOY_STATE || 'unknown';
+            const sha = process.env.DEPLOY_SHA;
+            const smoke = process.env.SMOKE_STATUS || '';
+            const envUrl = process.env.ENV_URL || '';
+            const targetUrl = process.env.TARGET_URL || '';
+
+            if (!sha) {
+              core.warning('deployment_status event had no commit SHA — skipping check_run.');
+              return;
+            }
+
+            // Green only when Railway reports success AND the smoke-test
+            // actually got a 200 from /api/health. Anything else
+            // (Railway failure/error, or success with a broken
+            // healthcheck) is a red signal.
+            const healthy = state === 'success' && smoke === 'ok';
+            const conclusion = healthy ? 'success' : 'failure';
+            const title = healthy
+              ? 'Preview deploy succeeded'
+              : `Preview deploy ${state}${smoke ? ` (smoke: ${smoke})` : ''}`;
+
+            const summary = [
+              `Railway deployment state: \`${state}\`.`,
+              smoke ? `Smoke-test \`/api/health\`: \`${smoke}\`.` : null,
+              envUrl ? `Preview URL: ${envUrl}` : null,
+              `Railway: ${targetUrl || '(no link)'}`,
+            ].filter(Boolean).join('\n\n');
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'railway-preview',
+              head_sha: sha,
+              status: 'completed',
+              conclusion,
+              // Link to Railway's build log so a red check is one click
+              // from the failure details.
+              details_url: targetUrl || envUrl || undefined,
+              output: { title, summary },
+            });
+
       - name: Upsert preview comment
-        if: steps.pr.outputs.number != '' && steps.url.outputs.value != ''
+        # The sticky comment is "preview is live" — only post it when the
+        # deploy actually succeeded. Failed deploys are already visible
+        # via the `railway-preview` check above.
+        if: >-
+          github.event.deployment_status.state == 'success' &&
+          steps.pr.outputs.number != '' &&
+          steps.url.outputs.value != ''
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary

Implements [#295](https://github.com/onsager-ai/onsager/issues/295). The `preview-environment` workflow now publishes a `railway-preview` check_run for every Railway preview-deploy outcome (success, failure, and error), so the Claude Code harness sees deploy results as `check_run.completed` webhook events instead of having to poll Railway. Branch protection is unchanged — this is a signal, not a gate. The required-check follow-up lives in #296.

### What changed

- `.github/workflows/preview-environment.yml`:
  - `permissions:` adds `checks: write`.
  - `announce` job's `if:` now matches `success`, `failure`, and `error` deployment states (was: `success` only).
  - Smoke-test and sticky-comment steps gate on `state == 'success'` so red deploys aren't reported as healthy.
  - New "Publish `railway-preview` check_run" step calls `github.rest.checks.create` on `github.event.deployment.sha`. Conclusion is `success` only when Railway reports success AND `/api/health` returns 200 — anything else is `failure`, with `details_url` pointing at Railway's build log.

### Why a check_run vs a commit status

- Shows up in the PR's Checks tab next to `check`, `deploy-ready`, etc.
- Fires `check_run.completed` webhook events that the harness already subscribes to via `subscribe_pr_activity`.
- `mcp__github__pull_request_read get_check_runs` includes it.
- `enable_pr_auto_merge` can wait for it once #296 lands.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses.
- [ ] Live verification: this PR's own preview deploy publishes a green `railway-preview` check on success.
- [ ] Live verification (separate flaky-deploy PR): the check publishes red on Railway failure with a `details_url` that opens Railway's failed-build log.
- [ ] Harness verification: `<github-webhook-activity>` event arrives on `check_run.completed` for both outcomes.

Closes #295

https://claude.ai/code/session_01LnsHXj6r7Z24rAmPEDKrwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnsHXj6r7Z24rAmPEDKrwZ)_