### PR TITLE
feat(dashboard): collapse sidebar to two-surface IA (Chat + Workflows)

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -69,6 +69,9 @@ const PersonalAccessTokensPage = lazy(() =>
     default: m.PersonalAccessTokensPage,
   })),
 )
+const ChatPage = lazy(() =>
+  import("@/pages/ChatPage").then((m) => ({ default: m.ChatPage })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -287,6 +290,10 @@ function AppRoutes() {
                             <Route
                               index
                               element={<LazyRoute><FactoryOverviewPage /></LazyRoute>}
+                            />
+                            <Route
+                              path="chat"
+                              element={<LazyRoute><ChatPage /></LazyRoute>}
                             />
                             <Route
                               path="artifacts"

--- a/apps/dashboard/src/components/layout/AppSidebar.tsx
+++ b/apps/dashboard/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Factory, GitBranch, Inbox, Server, Terminal, Settings, Shield, Package, Activity } from "lucide-react"
+import { GitBranch, MessageSquare } from "lucide-react"
 import { OnsagerLogo } from "./OnsagerLogo"
 import { UserMenu } from "./UserMenu"
 import { Link, useLocation } from "react-router-dom"
@@ -8,7 +8,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -22,51 +21,20 @@ import { WorkspaceSwitcher } from "@/components/workspaces/WorkspaceSwitcher"
 
 interface NavItem {
   title: string
-  icon: typeof Factory
+  icon: typeof GitBranch
   /** Path relative to the active workspace root (`/workspaces/<slug>/...`). */
   path: string
 }
 
-interface NavSection {
-  label: string
-  items: NavItem[]
-}
-
-// Resource sections live under the active workspace. The path here is
-// the suffix appended to `/workspaces/<slug>/`. The Overview row uses
-// an empty suffix to mean "the workspace root".
-const SCOPED_SECTIONS: NavSection[] = [
-  {
-    label: "Factory",
-    items: [
-      { title: "Overview", icon: Factory, path: "" },
-      // Issues inbox (#168) — reference-only `Kind::GithubIssue` artifacts
-      // hydrated live via the portal proxy.
-      { title: "Issues", icon: Inbox, path: "issues" },
-      { title: "Workflows", icon: GitBranch, path: "workflows" },
-      { title: "Artifacts", icon: Package, path: "artifacts" },
-      { title: "Event Spine", icon: Activity, path: "spine" },
-    ],
-  },
-  {
-    label: "Governance",
-    items: [
-      { title: "Governance", icon: Shield, path: "governance" },
-    ],
-  },
-  {
-    label: "Infrastructure",
-    items: [
-      { title: "Sessions", icon: Terminal, path: "sessions" },
-      { title: "Nodes", icon: Server, path: "nodes" },
-    ],
-  },
-  {
-    label: "System",
-    items: [
-      { title: "Settings", icon: Settings, path: "settings" },
-    ],
-  },
+// Two-surface IA per spec #289: Chat (R&D — design workflows by talking
+// to the agent) and Workflows (production — library of deployed
+// automations). Everything else (Issues, Artifacts, Spine, Governance,
+// Sessions, Nodes, Factory Overview, Settings) stays reachable via the
+// ⌘K command palette and direct URL during the rollout — PR 1 only
+// changes what shows up in the sidebar nav.
+const SCOPED_ITEMS: NavItem[] = [
+  { title: "Chat", icon: MessageSquare, path: "chat" },
+  { title: "Workflows", icon: GitBranch, path: "workflows" },
 ]
 
 export function AppSidebar() {
@@ -90,25 +58,12 @@ export function AppSidebar() {
     if (isMobile) setOpenMobile(false)
   }
 
-  // Progressive disclosure: users with zero workspaces only see the
-  // System group + the switcher (which handles "create workspace").
-  // Once the first workspace lands the full nav unlocks. Gate on
-  // workspacesLoading only (not the aggregate `loading`) so the nav
-  // decision doesn't wait for the slower projects/installs queries.
+  // Progressive disclosure: users with zero workspaces see only the
+  // switcher (which handles "create workspace"). Once the first
+  // workspace lands the nav items unlock. Gate on workspacesLoading
+  // only (not the aggregate `loading`) so the nav decision doesn't
+  // wait for the slower projects/installs queries.
   const gateNav = !workspacesLoading && !hasWorkspace
-  const visibleSections = SCOPED_SECTIONS.filter((s) => {
-    if (gateNav && s.label !== "System") return false
-    return true
-  })
-
-  // Prefix every nav item's path with the active workspace's root.
-  // Outside a scoped route (e.g. while the picker is mounted) we point
-  // the suffix-less Overview row at the picker so the user lands
-  // somewhere they can pick a workspace.
-  const resolvePath = (suffix: string): string => {
-    if (suffix === "") return overviewPath
-    return linkBase ? `${linkBase}/${suffix}` : "/workspaces"
-  }
 
   return (
     <Sidebar>
@@ -120,22 +75,21 @@ export function AppSidebar() {
       </SidebarHeader>
       <SidebarContent>
         <WorkspaceSwitcher />
-        {visibleSections.map((section) => (
-          <SidebarGroup key={section.label}>
-            <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
+        {!gateNav && (
+          <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                {section.items.map((item) => {
-                  const path = resolvePath(item.path)
-                  // Outside a scoped route every non-Overview item shares
-                  // the `/workspaces` picker fallback — none of them is
+                {SCOPED_ITEMS.map((item) => {
+                  const path = linkBase
+                    ? `${linkBase}/${item.path}`
+                    : "/workspaces"
+                  // Outside a scoped route every item shares the
+                  // `/workspaces` picker fallback — none of them is
                   // really "this page", so don't highlight any.
                   const isActive =
-                    item.path === ""
-                      ? location.pathname === path
-                      : linkBase != null &&
-                        (location.pathname === path ||
-                          location.pathname.startsWith(`${path}/`))
+                    linkBase != null &&
+                    (location.pathname === path ||
+                      location.pathname.startsWith(`${path}/`))
                   return (
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton
@@ -151,7 +105,7 @@ export function AppSidebar() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-        ))}
+        )}
         <SetupChecklist progress={setupProgress} />
       </SidebarContent>
       <SidebarFooter className="gap-1 border-t p-2">

--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -12,6 +12,8 @@ import {
   Building2,
   Factory,
   GitBranch,
+  Inbox,
+  MessageSquare,
   Package,
   Search,
   Server,
@@ -165,6 +167,17 @@ function CommandPaletteDialog() {
             <CommandSeparator />
 
             <CommandGroup heading="Go to">
+              <CommandItem
+                keywords={["chat", "agent", "r&d"]}
+                onSelect={() => go(scoped("chat"))}
+              >
+                <MessageSquare className="mr-2 h-4 w-4" />
+                Chat
+              </CommandItem>
+              <CommandItem onSelect={() => go(scoped("workflows"))}>
+                <GitBranch className="mr-2 h-4 w-4" />
+                Workflows
+              </CommandItem>
               <CommandItem keywords={["overview"]} onSelect={() => go(overview)}>
                 <Factory className="mr-2 h-4 w-4" />
                 Factory overview
@@ -173,9 +186,9 @@ function CommandPaletteDialog() {
                 <Building2 className="mr-2 h-4 w-4" />
                 Workspaces
               </CommandItem>
-              <CommandItem onSelect={() => go(scoped("workflows"))}>
-                <GitBranch className="mr-2 h-4 w-4" />
-                Workflows
+              <CommandItem onSelect={() => go(scoped("issues"))}>
+                <Inbox className="mr-2 h-4 w-4" />
+                Issues
               </CommandItem>
               <CommandItem onSelect={() => go(scoped("artifacts"))}>
                 <Package className="mr-2 h-4 w-4" />

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -1,0 +1,38 @@
+import { MessageSquare } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { usePageHeader } from "@/components/layout/PageHeader"
+
+// Top-level Chat surface per spec #289. PR 1 (sidebar collapse) ships
+// the route as a stub so the new sidebar nav links somewhere live;
+// PR 4 (chat surface promotion) replaces this with the real MCP-backed
+// chat builder from #288.
+export function ChatPage() {
+  usePageHeader({ title: "Chat" })
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <div>
+        <h1 className="hidden text-2xl font-bold tracking-tight md:block">Chat</h1>
+        <p className="text-sm text-muted-foreground">
+          R&amp;D mode. Design workflows and run ad-hoc one-shots by talking
+          to the agent.
+        </p>
+      </div>
+      <Card>
+        <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <MessageSquare className="h-6 w-6" />
+          </div>
+          <div>
+            <p className="text-base font-medium">Chat surface coming soon</p>
+            <p className="max-w-md text-sm text-muted-foreground">
+              The agent-backed chat builder lands with the MCP backbone in a
+              follow-up PR. Until then, design workflows from the Workflows
+              page.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
+++ b/apps/dashboard/tests/smoke/app-sidebar-links.test.tsx
@@ -66,36 +66,37 @@ function renderAppSidebar(initialPath: string) {
 describe("AppSidebar nav link resolution", () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it("scopes nav links to the workspace in the URL", async () => {
-    renderAppSidebar("/workspaces/acme/sessions")
+  it("scopes the two-surface IA nav links to the workspace in the URL", async () => {
+    renderAppSidebar("/workspaces/acme/workflows")
 
+    // Two-surface IA per spec #289: only Chat + Workflows in the nav.
+    // Settings is reached via the footer avatar menu; everything else
+    // (Sessions, Nodes, Issues, Artifacts, Spine, Governance, Overview)
+    // is reachable via direct URL and the ⌘K command palette.
     await waitFor(() => {
-      const sessions = screen.getByRole("link", { name: /Sessions/i })
-      expect(sessions).toHaveAttribute("href", "/workspaces/acme/sessions")
+      const workflows = screen.getByRole("link", { name: /^Workflows$/ })
+      expect(workflows).toHaveAttribute("href", "/workspaces/acme/workflows")
     })
 
-    expect(
-      screen.getByRole("link", { name: /^Workflows$/ }),
-    ).toHaveAttribute("href", "/workspaces/acme/workflows")
-    expect(screen.getByRole("link", { name: /Settings/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /^Chat$/ })).toHaveAttribute(
       "href",
-      "/workspaces/acme/settings",
-    )
-    // Overview row uses an empty suffix; it should land on the workspace
-    // root rather than the global picker.
-    expect(screen.getByRole("link", { name: /Overview/i })).toHaveAttribute(
-      "href",
-      "/workspaces/acme",
+      "/workspaces/acme/chat",
     )
   })
 
   it("falls back to /workspaces when there is no workspace in the URL", async () => {
     renderAppSidebar("/settings")
 
-    // Wait for the workspaces query to resolve so the system row renders.
+    // Outside a scoped route every nav item shares the `/workspaces`
+    // picker fallback so the user lands somewhere that can resolve
+    // the missing workspace context.
     await waitFor(() => {
-      const settings = screen.getByRole("link", { name: /Settings/i })
-      expect(settings).toHaveAttribute("href", "/workspaces")
+      const workflows = screen.getByRole("link", { name: /^Workflows$/ })
+      expect(workflows).toHaveAttribute("href", "/workspaces")
     })
+    expect(screen.getByRole("link", { name: /^Chat$/ })).toHaveAttribute(
+      "href",
+      "/workspaces",
+    )
   })
 })


### PR DESCRIPTION
Part of #289 — PR 1 of 6 (Sidebar collapse).

## Summary

- Sidebar shrinks to **Chat | Workflows**; Settings stays reached via the footer avatar menu (`UserMenu` already there).
- Every other surface (Issues, Artifacts, Spine, Governance, Sessions, Nodes, Factory Overview, Settings) stays reachable via direct URL and the ⌘K command palette — old routes are untouched, so bookmarks keep working until PR 6 cleans up the now-orphaned pages.
- Chat ships as a stub page at `/workspaces/:workspace/chat` so the new nav links somewhere live; PR 4 replaces it with the MCP-backed chat builder from #288.
- `CommandPalette` gains a Chat entry (and the previously-missing Issues entry); every demoted surface is one ⌘K hop away.

## Delivers

- [x] **PR 1 — Sidebar collapse.** New sidebar component with Chat / Workflows / Settings (footer-anchored avatar menu) per `dashboard-ui`. Old route URLs stay live (their pages still render); only the sidebar nav changes.

## Test plan

- [x] `pnpm test` — 105/105 pass (existing `app-sidebar-links` smoke test rewritten for the new IA).
- [x] `pnpm build` — clean.
- [x] `pnpm lint` — clean.
- [x] `cargo run -p xtask -- lint-seams` — clean.
- [x] `cargo run -p xtask -- check-api-contract` — clean (no route or caller deltas).
- [ ] Manual smoke: every existing route URL (`/workspaces/:slug/{issues,artifacts,spine,governance,sessions,nodes,settings}`) still loads — verify post-merge or via `web-testing`.
- [ ] Manual smoke: ⌘K reaches every demoted destination (Chat, Issues, Artifacts, Spine, Governance, Sessions, Nodes, Factory overview, Workspaces, Settings).
- [ ] Manual smoke: mobile chrome — sidebar's two-surface IA + footer avatar menu fit cleanly per `dashboard-ui` mobile-chrome rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EANaqV2AfqHBCi8DGrvhfy)_