### PR TITLE
feat(dashboard): workflow detail as tabbed hub

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/ActiveRunsBanner.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ActiveRunsBanner.tsx
@@ -42,17 +42,25 @@ export function ActiveRunsBanner({
     refetchInterval: 5000,
   })
 
+  // Landing-page fan-out: list workflows, then fetch runs per workflow.
+  // `allSettled` so one transient 5xx doesn't blank the whole banner —
+  // the workflows that *did* respond still render. Polls slower than the
+  // workflow-scoped query (15s vs 5s) because the N+1 pattern is more
+  // expensive than the single per-workflow call, and we pause when the
+  // tab isn't visible. PR 2b can replace this with a dedicated
+  // workspace-scoped "active runs" route.
   const workspaceQuery = useQuery({
     queryKey: ["active-runs", workspaceId],
     queryFn: async () => {
       const { workflows } = await api.listWorkflows(workspaceId)
-      const lists = await Promise.all(
+      const results = await Promise.allSettled(
         workflows.map((w) => api.getWorkflowRuns(w.id, 20).then((r) => r.runs)),
       )
-      return lists.flat()
+      return results.flatMap((r) => (r.status === "fulfilled" ? r.value : []))
     },
     enabled: !workflowId,
-    refetchInterval: 5000,
+    refetchInterval: 15000,
+    refetchIntervalInBackground: false,
   })
 
   const runs = useMemo(() => {

--- a/apps/dashboard/src/components/factory/workflows/ActiveRunsBanner.tsx
+++ b/apps/dashboard/src/components/factory/workflows/ActiveRunsBanner.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { CircleDot, Loader2, XCircle } from "lucide-react"
+import { api, ApiError, type WorkflowRun } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useActiveWorkspace } from "@/lib/workspace"
+
+// In-flight = the run hasn't reached a terminal stage status. `pending` and
+// `blocked` are both still moving (or waiting on a gate); `passed`/`failed`
+// are done. Cancel maps to abortArtifact on the run's artifact — there is
+// no per-run abort endpoint today, and the artifact is the durable unit.
+function isInFlight(run: WorkflowRun): boolean {
+  return run.status === "pending" || run.status === "blocked"
+}
+
+interface ActiveRunsBannerProps {
+  // When given, scopes the banner to one workflow. Omit on the Workflows
+  // landing to render every in-flight run in the workspace.
+  workflowId?: string
+  // Required so the landing variant can fan out across workflows. The
+  // detail variant passes it for consistency with the listing variant.
+  workspaceId: string
+  // Optional title override — the landing wants "Active runs", the detail
+  // page wants "In-flight" inline above the runs list.
+  title?: string
+}
+
+export function ActiveRunsBanner({
+  workflowId,
+  workspaceId,
+  title = "Active runs",
+}: ActiveRunsBannerProps) {
+  const workspace = useActiveWorkspace()
+
+  const scopedQuery = useQuery({
+    queryKey: ["workflow-runs", workflowId],
+    queryFn: () => api.getWorkflowRuns(workflowId!, 50),
+    enabled: !!workflowId,
+    refetchInterval: 5000,
+  })
+
+  const workspaceQuery = useQuery({
+    queryKey: ["active-runs", workspaceId],
+    queryFn: async () => {
+      const { workflows } = await api.listWorkflows(workspaceId)
+      const lists = await Promise.all(
+        workflows.map((w) => api.getWorkflowRuns(w.id, 20).then((r) => r.runs)),
+      )
+      return lists.flat()
+    },
+    enabled: !workflowId,
+    refetchInterval: 5000,
+  })
+
+  const runs = useMemo(() => {
+    const all = workflowId
+      ? (scopedQuery.data?.runs ?? [])
+      : (workspaceQuery.data ?? [])
+    return all.filter(isInFlight)
+  }, [workflowId, scopedQuery.data, workspaceQuery.data])
+
+  if (runs.length === 0) return null
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <CircleDot className="h-4 w-4 animate-pulse text-primary" />
+          {title}
+          <Badge variant="outline" className="ml-1">
+            {runs.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 md:px-6">
+        {runs.map((r) => (
+          <ActiveRunRow
+            key={r.id}
+            run={r}
+            workspaceSlug={workspace.slug}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ActiveRunRow({
+  run,
+  workspaceSlug,
+}: {
+  run: WorkflowRun
+  workspaceSlug: string
+}) {
+  const qc = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const cancel = useMutation({
+    mutationFn: () => {
+      if (!run.artifact_id) {
+        throw new ApiError("Run has no artifact to cancel.", 400)
+      }
+      return api.abortArtifact(run.artifact_id, {
+        reason: "cancelled from active-runs banner",
+        actor: "dashboard",
+      })
+    },
+    onSuccess: () => {
+      setError(null)
+      qc.invalidateQueries({ queryKey: ["workflow-runs", run.workflow_id] })
+      qc.invalidateQueries({ queryKey: ["active-runs"] })
+    },
+    onError: (err) => {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "unknown error"
+      setError(message)
+    },
+  })
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2">
+        <Badge variant="secondary" className="shrink-0">
+          {run.status}
+        </Badge>
+        {run.artifact_id ? (
+          <Link
+            to={`/workspaces/${workspaceSlug}/artifacts/${run.artifact_id}`}
+            className="min-w-0 flex-1 truncate font-mono text-xs hover:underline"
+          >
+            {run.artifact_id}
+          </Link>
+        ) : (
+          <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+            {run.id}
+          </span>
+        )}
+        <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+          {new Date(run.updated_at).toLocaleTimeString()}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={!run.artifact_id || cancel.isPending}
+          onClick={() => cancel.mutate()}
+          aria-label="Cancel run"
+        >
+          {cancel.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <XCircle className="h-3.5 w-3.5" />
+          )}
+          Cancel
+        </Button>
+      </div>
+      {error && (
+        <p className="px-3 text-xs text-destructive">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react"
+import { Link } from "react-router-dom"
+import { useQueries } from "@tanstack/react-query"
+import { Package } from "lucide-react"
+import { api, type WorkflowRun } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ArtifactBadge } from "./ArtifactBadge"
+import { useActiveWorkspace } from "@/lib/workspace"
+
+// Derived from the runs list: every run produces (at most) one artifact, so
+// the unique set of artifact ids on this workflow's runs is the artifact
+// inventory for the workflow. PR 2b replaces this with a dedicated backend
+// route; this PR keeps the surface shape stable so the swap is a data-source
+// change only.
+export function WorkflowArtifactsTab({ runs }: { runs: WorkflowRun[] }) {
+  const workspace = useActiveWorkspace()
+  const artifactIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          runs
+            .map((r) => r.artifact_id)
+            .filter((id): id is string => !!id),
+        ),
+      ),
+    [runs],
+  )
+
+  const queries = useQueries({
+    queries: artifactIds.map((id) => ({
+      queryKey: ["artifact", id],
+      queryFn: () => api.getArtifact(id),
+      refetchInterval: 5000,
+    })),
+  })
+
+  const loading = queries.some((q) => q.isLoading)
+  const items = useMemo(
+    () =>
+      queries
+        .map((q, i) => ({ id: artifactIds[i], artifact: q.data?.artifact }))
+        .filter((row) => !!row.artifact),
+    [queries, artifactIds],
+  )
+
+  if (artifactIds.length === 0) {
+    return <EmptyState />
+  }
+
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Artifacts</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 md:px-6">
+        {loading && items.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            Loading…
+          </p>
+        ) : (
+          items.map(({ id, artifact }) =>
+            artifact ? (
+              <Link
+                key={id}
+                to={`/workspaces/${workspace.slug}/artifacts/${id}`}
+                className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
+              >
+                <ArtifactBadge kind={artifact.kind} />
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {artifact.name ?? id}
+                </span>
+                <Badge
+                  variant={artifact.state === "released" ? "default" : "outline"}
+                  className="shrink-0"
+                >
+                  {artifact.state}
+                </Badge>
+                <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                  v{artifact.current_version}
+                </span>
+              </Link>
+            ) : null,
+          )
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyState() {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Package className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-base font-medium">No artifacts yet</p>
+          <p className="text-sm text-muted-foreground">
+            Artifacts appear here once this workflow produces them.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
@@ -27,11 +27,17 @@ export function WorkflowArtifactsTab({ runs }: { runs: WorkflowRun[] }) {
     [runs],
   )
 
+  // Artifacts move slowly compared to runs — kind/state/version churn on
+  // human timescales. Up to 50 runs means up to 50 parallel artifact
+  // fetches per interval, so we poll at 30s and pause when the tab isn't
+  // visible. PR 2b's workflow-scoped artifact route folds this into one
+  // request and lets us drop the per-item polling entirely.
   const queries = useQueries({
     queries: artifactIds.map((id) => ({
       queryKey: ["artifact", id],
       queryFn: () => api.getArtifact(id),
-      refetchInterval: 5000,
+      refetchInterval: 30000,
+      refetchIntervalInBackground: false,
     })),
   })
 

--- a/apps/dashboard/src/components/factory/workflows/WorkflowVerdictsTab.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowVerdictsTab.tsx
@@ -1,0 +1,152 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Gavel } from "lucide-react"
+import { api, type GovernanceEvent, type WorkflowRun } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+const SEVERITY_VARIANT: Record<
+  string,
+  "destructive" | "default" | "secondary" | "outline"
+> = {
+  critical: "destructive",
+  high: "destructive",
+  medium: "default",
+  low: "secondary",
+}
+
+// Does this governance event reference one of the workflow's artifact IDs?
+// PR 2b replaces this with a workflow-scoped backend route; until then we
+// pull the workspace-wide list and filter on whatever artifact-id reference
+// the event happens to carry. Synodic events vary in shape, so we probe
+// the common locations (`metadata.artifact_id`, `event.source`) and a
+// last-ditch scan of metadata string values.
+function referencesArtifact(
+  event: GovernanceEvent,
+  artifactIds: Set<string>,
+): boolean {
+  if (artifactIds.size === 0) return false
+  const meta = event.metadata ?? {}
+  const direct = meta["artifact_id"]
+  if (typeof direct === "string" && artifactIds.has(direct)) return true
+  if (event.source && artifactIds.has(event.source)) return true
+  for (const value of Object.values(meta)) {
+    if (typeof value === "string" && artifactIds.has(value)) return true
+  }
+  return false
+}
+
+export function WorkflowVerdictsTab({
+  workspaceId,
+  runs,
+  stages,
+}: {
+  workspaceId: string
+  runs: WorkflowRun[]
+  stages: { gate_kind: string }[]
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["governance-events", workspaceId],
+    queryFn: () => api.getGovernanceEvents(workspaceId),
+    refetchInterval: 5000,
+  })
+
+  const artifactIds = useMemo(
+    () =>
+      new Set(
+        runs
+          .map((r) => r.artifact_id)
+          .filter((id): id is string => !!id),
+      ),
+    [runs],
+  )
+
+  const filtered = useMemo(
+    () =>
+      (data ?? []).filter((e) => referencesArtifact(e, artifactIds)),
+    [data, artifactIds],
+  )
+
+  const hasGovernanceStage = stages.some(
+    (s) => s.gate_kind === "governance",
+  )
+
+  if (!hasGovernanceStage) {
+    return (
+      <EmptyState
+        title="No governance-gated stages"
+        body="This workflow has no governance gates, so no verdicts will appear here."
+      />
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="px-4 py-6 md:px-6">
+          <p className="text-center text-sm text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <EmptyState
+        title="No verdicts yet"
+        body="Verdicts appear once a governance gate evaluates an artifact from this workflow."
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Verdicts</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 md:px-6">
+        {filtered.map((e) => (
+          <div
+            key={e.id}
+            className="space-y-1 rounded-md border px-3 py-2"
+          >
+            <div className="flex items-center gap-2">
+              <Badge variant={SEVERITY_VARIANT[e.severity] ?? "outline"}>
+                {e.severity}
+              </Badge>
+              <Badge variant="outline" className="font-mono text-[10px]">
+                {e.event_type}
+              </Badge>
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                {new Date(e.created_at).toLocaleString()}
+              </span>
+            </div>
+            <p className="text-sm">{e.title}</p>
+            {e.resolved && (
+              <p className="text-xs text-muted-foreground">
+                resolved
+                {e.resolution_notes ? ` · ${e.resolution_notes}` : ""}
+              </p>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Gavel className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-base font-medium">{title}</p>
+          <p className="text-sm text-muted-foreground">{body}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Link, useParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import {
@@ -13,11 +13,20 @@ import { api, type StageRunStatus, type WorkflowRun } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+import { ActiveRunsBanner } from "@/components/factory/workflows/ActiveRunsBanner"
 import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
 import { ArtifactFlowOverview } from "@/components/factory/workflows/ArtifactFlowOverview"
 import { WorkflowActions } from "@/components/factory/workflows/WorkflowActions"
+import { WorkflowArtifactsTab } from "@/components/factory/workflows/WorkflowArtifactsTab"
 import { WorkflowEventsCard } from "@/components/factory/workflows/WorkflowEventsCard"
 import { WorkflowSessionsCard } from "@/components/factory/workflows/WorkflowSessionsCard"
+import { WorkflowVerdictsTab } from "@/components/factory/workflows/WorkflowVerdictsTab"
 import { outputArtifactKind } from "@/components/factory/workflows/workflow-meta"
 import { usePageHeader } from "@/components/layout/PageHeader"
 import { useActiveWorkspace } from "@/lib/workspace"
@@ -34,6 +43,18 @@ const STATUS_ICON: Record<StageRunStatus, typeof Circle> = {
   blocked: CircleDot,
   passed: CircleCheck,
   failed: CircleX,
+}
+
+const TAB_VALUES = ["definition", "runs", "artifacts", "verdicts"] as const
+type TabValue = (typeof TAB_VALUES)[number]
+const DEFAULT_TAB: TabValue = "runs"
+
+function readTabFromHash(): TabValue {
+  if (typeof window === "undefined") return DEFAULT_TAB
+  const raw = window.location.hash.replace(/^#/, "")
+  return (TAB_VALUES as readonly string[]).includes(raw)
+    ? (raw as TabValue)
+    : DEFAULT_TAB
 }
 
 export function WorkflowDetailPage() {
@@ -56,7 +77,28 @@ export function WorkflowDetailPage() {
     refetchInterval: 5000,
   })
   const workflow = data?.workflow
-  const runs = runsData?.runs ?? []
+  const runs = useMemo(() => runsData?.runs ?? [], [runsData])
+
+  const [tab, setTab] = useState<TabValue>(() => readTabFromHash())
+
+  // Keep state and the URL hash in sync. Initial state is seeded from the
+  // hash so a `#artifacts` deep link lands on the right tab; subsequent
+  // navigations (browser back/forward, manual edits) update via the
+  // `hashchange` listener; tab clicks push via `replaceState` so the
+  // back stack doesn't fill with every glance at the page.
+  useEffect(() => {
+    const onHashChange = () => setTab(readTabFromHash())
+    window.addEventListener("hashchange", onHashChange)
+    return () => window.removeEventListener("hashchange", onHashChange)
+  }, [])
+
+  const handleTabChange = (value: TabValue) => {
+    setTab(value)
+    const next = `#${value}`
+    if (window.location.hash !== next) {
+      window.history.replaceState(null, "", next)
+    }
+  }
 
   // Mobile chrome: back arrow + workflow name + ⋯ overflow with
   // Pause/Delete live in the global top bar. Desktop renders the
@@ -117,77 +159,127 @@ export function WorkflowDetailPage() {
         </Badge>
       </div>
 
-      <Card>
-        <CardHeader className="px-4 pb-2 pt-4 md:px-6">
-          <CardTitle className="text-base">Stages</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4 pb-4 md:px-6">
-          <div className="rounded-md border bg-muted/30 px-3 py-2">
-            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-              Flow
-            </div>
-            <ArtifactFlowOverview
-              triggerLabel={workflow.trigger.label ?? ""}
-              stages={workflow.stages}
-            />
+      <Tabs value={tab} onValueChange={(v) => handleTabChange(v as TabValue)}>
+        <TabsList className="w-full justify-start overflow-x-auto md:w-auto">
+          <TabsTrigger value="definition">Definition</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
+          <TabsTrigger value="verdicts">Verdicts</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="definition" className="space-y-4 pt-4 md:space-y-6">
+          <DefinitionTab workflow={workflow} />
+        </TabsContent>
+
+        <TabsContent value="runs" className="space-y-4 pt-4 md:space-y-6">
+          <ActiveRunsBanner
+            workflowId={workflow.id}
+            workspaceId={workspace.id}
+            title="In-flight"
+          />
+          <RunsList runs={runs} stageIds={workflow.stages.map((s) => s.id)} />
+          <WorkflowEventsCard workflowId={workflow.id} runs={runs} />
+          <WorkflowSessionsCard runs={runs} />
+        </TabsContent>
+
+        <TabsContent value="artifacts" className="space-y-4 pt-4 md:space-y-6">
+          <WorkflowArtifactsTab runs={runs} />
+        </TabsContent>
+
+        <TabsContent value="verdicts" className="space-y-4 pt-4 md:space-y-6">
+          <WorkflowVerdictsTab
+            workspaceId={workspace.id}
+            runs={runs}
+            stages={workflow.stages}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function DefinitionTab({
+  workflow,
+}: {
+  workflow: NonNullable<Awaited<ReturnType<typeof api.getWorkflow>>["workflow"]>
+}) {
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Stages</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4 pb-4 md:px-6">
+        <div className="rounded-md border bg-muted/30 px-3 py-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Flow
           </div>
-          {workflow.stages.map((s, i) => {
-            const output = outputArtifactKind(s.gate_kind, s.artifact_kind)
-            const transforms = output !== s.artifact_kind
-            return (
-              <div
-                key={s.id}
-                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
-              >
-                <div className="min-w-0 space-y-1">
-                  <div className="truncate text-sm font-medium">
-                    {i + 1}. {s.name}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                      {s.gate_kind}
-                    </span>
-                    <span className="text-muted-foreground/50">·</span>
-                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                      in
-                    </span>
-                    <ArtifactBadge kind={s.artifact_kind} />
-                    {transforms && (
-                      <>
-                        <ArrowRight className="h-3 w-3 text-muted-foreground" />
-                        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                          out
-                        </span>
-                        <ArtifactBadge kind={output} />
-                      </>
-                    )}
-                  </div>
+          <ArtifactFlowOverview
+            triggerLabel={workflow.trigger.label ?? ""}
+            stages={workflow.stages}
+          />
+        </div>
+        {workflow.stages.map((s, i) => {
+          const output = outputArtifactKind(s.gate_kind, s.artifact_kind)
+          const transforms = output !== s.artifact_kind
+          return (
+            <div
+              key={s.id}
+              className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+            >
+              <div className="min-w-0 space-y-1">
+                <div className="truncate text-sm font-medium">
+                  {i + 1}. {s.name}
+                </div>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {s.gate_kind}
+                  </span>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    in
+                  </span>
+                  <ArtifactBadge kind={s.artifact_kind} />
+                  {transforms && (
+                    <>
+                      <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                        out
+                      </span>
+                      <ArtifactBadge kind={output} />
+                    </>
+                  )}
                 </div>
               </div>
-            )
-          })}
-        </CardContent>
-      </Card>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}
 
-      <Card>
-        <CardHeader className="px-4 pb-2 pt-4 md:px-6">
-          <CardTitle className="text-base">Live artifacts</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4 pb-4 md:px-6">
-          {runs.length === 0 ? (
-            <p className="py-4 text-center text-sm text-muted-foreground">
-              No artifacts flowing yet. Tag an issue with the trigger label to
-              kick one off.
-            </p>
-          ) : (
-            runs.map((r) => <RunRow key={r.id} run={r} stageIds={workflow.stages.map((s) => s.id)} />)
-          )}
-        </CardContent>
-      </Card>
-
-      <WorkflowEventsCard workflowId={workflow.id} runs={runs} />
-      <WorkflowSessionsCard runs={runs} />
-    </div>
+function RunsList({
+  runs,
+  stageIds,
+}: {
+  runs: WorkflowRun[]
+  stageIds: string[]
+}) {
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <CardTitle className="text-base">Run history</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4 pb-4 md:px-6">
+        {runs.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No runs yet. Tag an issue with the trigger label to kick one off.
+          </p>
+        ) : (
+          runs.map((r) => <RunRow key={r.id} run={r} stageIds={stageIds} />)
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/apps/dashboard/src/pages/WorkflowsPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowsPage.tsx
@@ -7,6 +7,7 @@ import { useActiveWorkspace } from "@/lib/workspace"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ActiveRunsBanner } from "@/components/factory/workflows/ActiveRunsBanner"
 import { WorkflowBuilderSheet } from "@/components/factory/workflows/WorkflowBuilderSheet"
 import { usePageHeader } from "@/components/layout/PageHeader"
 
@@ -35,6 +36,8 @@ export function WorkflowsPage() {
           Create workflow
         </Button>
       </div>
+
+      <ActiveRunsBanner workspaceId={workspace.id} />
 
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>

--- a/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { WorkflowDetailPage } from "@/pages/WorkflowDetailPage"
+
+// Smoke coverage for the four-tab hub refactor (#301 / PR 2a of #289):
+// default tab is Runs, hash deep-links to a named tab, clicking a tab
+// updates the URL hash, and a hashchange event from outside flips the
+// active tab. The data-fetching tabs are mocked at the API surface; we
+// only assert the navigation contract here.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  getWorkflow: vi.fn(),
+  getWorkflowRuns: vi.fn(),
+  getArtifact: vi.fn(),
+  getGovernanceEvents: vi.fn(),
+  getSpineEvents: vi.fn(),
+  listWorkflows: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return { ...actual, api: apiMock }
+})
+
+import { WorkspaceScope } from "@/lib/workspace"
+
+const workspace = {
+  id: "ws_1",
+  slug: "acme",
+  name: "Acme",
+  created_by: "u1",
+  created_at: "2026-01-01",
+}
+
+const workflow = {
+  workflow: {
+    id: "wf_1",
+    workspace_id: "ws_1",
+    name: "Issue → PR",
+    preset: null,
+    status: "active",
+    trigger: {
+      kind: "github-label",
+      install_id: "42",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      label: "factory",
+      kind_tag: "github_issue_webhook",
+    },
+    stages: [
+      {
+        id: "s_1",
+        name: "Triage",
+        gate_kind: "agent-session",
+        artifact_kind: "Issue",
+        config: {},
+      },
+    ],
+    created_at: "2026-04-22T00:00:00Z",
+    updated_at: "2026-04-22T00:00:00Z",
+  },
+}
+
+function renderPage(initialPath: string) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route
+                    path="workflows/:id"
+                    element={<WorkflowDetailPage />}
+                  />
+                </Routes>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("WorkflowDetailPage tabbed hub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Hash persistence is a real browser thing; reset between tests so a
+    // stray `#artifacts` from one case doesn't leak into the next.
+    window.history.replaceState(null, "", "/workspaces/acme/workflows/wf_1")
+    apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+    apiMock.getWorkflow.mockResolvedValue(workflow)
+    apiMock.getWorkflowRuns.mockResolvedValue({ runs: [] })
+    apiMock.getArtifact.mockResolvedValue({
+      artifact: {
+        id: "a_1",
+        kind: "Issue",
+        name: "demo",
+        owner: null,
+        state: "active",
+        current_version: 1,
+        created_at: "",
+        updated_at: "",
+        created_by: "u",
+        versions: [],
+        vertical_lineage: [],
+      },
+    })
+    apiMock.getGovernanceEvents.mockResolvedValue([])
+    apiMock.getSpineEvents.mockResolvedValue({ events: [] })
+    apiMock.listWorkflows.mockResolvedValue({ workflows: [] })
+  })
+  afterEach(() => {
+    window.location.hash = ""
+  })
+
+  it("defaults to the Runs tab on first land", async () => {
+    renderPage("/workspaces/acme/workflows/wf_1")
+    const runsTab = await screen.findByRole("tab", { name: "Runs" })
+    await waitFor(() =>
+      expect(runsTab.getAttribute("data-active")).not.toBeNull(),
+    )
+    expect(
+      screen.getByRole("tab", { name: "Definition" }).getAttribute("data-active"),
+    ).toBeNull()
+  })
+
+  it("deep-links to the Artifacts tab via #artifacts in the URL", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/workspaces/acme/workflows/wf_1#artifacts",
+    )
+    renderPage("/workspaces/acme/workflows/wf_1#artifacts")
+    const artifactsTab = await screen.findByRole("tab", { name: "Artifacts" })
+    await waitFor(() =>
+      expect(artifactsTab.getAttribute("data-active")).not.toBeNull(),
+    )
+  })
+
+  it("updates window.location.hash when a tab is clicked", async () => {
+    renderPage("/workspaces/acme/workflows/wf_1")
+    const definitionTab = await screen.findByRole("tab", { name: "Definition" })
+    fireEvent.click(definitionTab)
+    await waitFor(() =>
+      expect(definitionTab.getAttribute("data-active")).not.toBeNull(),
+    )
+    expect(window.location.hash).toBe("#definition")
+  })
+
+  it("reacts to an external hashchange (browser back/forward)", async () => {
+    renderPage("/workspaces/acme/workflows/wf_1")
+    await screen.findByRole("tab", { name: "Verdicts" })
+    act(() => {
+      window.history.replaceState(
+        null,
+        "",
+        "/workspaces/acme/workflows/wf_1#verdicts",
+      )
+      window.dispatchEvent(new HashChangeEvent("hashchange"))
+    })
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("tab", { name: "Verdicts" })
+          .getAttribute("data-active"),
+      ).not.toBeNull(),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Refactor `WorkflowDetailPage` into a four-tab hub — **Definition / Runs / Artifacts / Verdicts** — per #289's locked design. PR 2a slice of #289.

- **Hash-based persistence** makes `#definition`, `#runs`, `#artifacts`, `#verdicts` shareable deep links. Default first-land tab is **Runs**. Tab clicks update via `replaceState` so the back stack stays clean; an external `hashchange` (browser back/forward) flips the active tab.
- **New shared `ActiveRunsBanner`** — single source of truth for in-flight rendering. Mounted at the top of the Runs tab and on the Workflows landing. Cancel button maps to `abortArtifact` on the run's artifact. PR 3 (#303) reuses it on run detail.
- **Artifacts tab** derives its list from `getWorkflowRuns` + per-item `getArtifact`. **Verdicts tab** pulls workspace-wide `getGovernanceEvents` and filters client-side to this workflow's artifact IDs. Both surfaces stay stable for PR 2b (#302), which swaps them to dedicated backend routes — data-source change only.
- Definition tab keeps the existing Stages card + flow overview. Runs tab keeps `WorkflowEventsCard` + `WorkflowSessionsCard`.

## Test plan

- [x] `pnpm test` — 24 files / 109 tests pass, including the new `workflow-detail-tabs` smoke (default tab, hash deep-link, click→hash, external hashchange).
- [x] `pnpm lint` clean.
- [x] `pnpm build` clean.
- [ ] Desktop + 360px mobile via `web-testing` skill — verify tabs render, default = Runs, deep links land correctly, empty states render.
- [ ] Manual: workflow with in-flight runs shows `ActiveRunsBanner` on both Workflows landing and the Runs tab.

Closes #301
Part of #289

https://claude.ai/code/session_015wzisq35iCJYXmq1XsnrwN

---
_Generated by [Claude Code](https://claude.ai/code/session_015wzisq35iCJYXmq1XsnrwN)_