### PR TITLE
feat(dashboard): consolidate settings into tabbed pages (#305)

### DIFF
--- a/apps/dashboard/src/components/governance/GovernanceEventsList.tsx
+++ b/apps/dashboard/src/components/governance/GovernanceEventsList.tsx
@@ -47,7 +47,7 @@ export function GovernanceEventsList({ workspaceId }: GovernanceEventsListProps)
   const queryClient = useQueryClient()
   const [filter, setFilter] = useState("")
 
-  const { data: events, isLoading } = useQuery({
+  const { data: events, isLoading, isError, error } = useQuery({
     queryKey: ["governance-events", workspaceId, filter],
     queryFn: () => api.getGovernanceEvents(workspaceId, filter || undefined),
     refetchInterval: 5000,
@@ -85,6 +85,11 @@ export function GovernanceEventsList({ workspaceId }: GovernanceEventsListProps)
         <CardContent className="px-4 md:px-6">
           {isLoading ? (
             <p className="py-8 text-center text-muted-foreground">Loading...</p>
+          ) : isError ? (
+            <p className="py-8 text-center text-sm text-destructive">
+              Failed to load events
+              {error instanceof Error ? `: ${error.message}` : "."}
+            </p>
           ) : !events || events.length === 0 ? (
             <p className="py-8 text-center text-muted-foreground">
               No governance events. Submit events via the synodic CLI or API.

--- a/apps/dashboard/src/components/governance/GovernanceEventsList.tsx
+++ b/apps/dashboard/src/components/governance/GovernanceEventsList.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import type { GovernanceEvent } from "@/lib/api"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+const TYPE_LABELS: Record<string, string> = {
+  tool_call_error: "Tool Error",
+  hallucination: "Hallucination",
+  compliance_violation: "Compliance",
+  misalignment: "Misalignment",
+}
+
+const SEVERITY_VARIANT: Record<
+  string,
+  "destructive" | "default" | "secondary" | "outline"
+> = {
+  critical: "destructive",
+  high: "destructive",
+  medium: "default",
+  low: "secondary",
+}
+
+const EVENT_TYPES = [
+  "",
+  "tool_call_error",
+  "hallucination",
+  "compliance_violation",
+  "misalignment",
+]
+
+interface GovernanceEventsListProps {
+  workspaceId: string
+}
+
+export function GovernanceEventsList({ workspaceId }: GovernanceEventsListProps) {
+  const queryClient = useQueryClient()
+  const [filter, setFilter] = useState("")
+
+  const { data: events, isLoading } = useQuery({
+    queryKey: ["governance-events", workspaceId, filter],
+    queryFn: () => api.getGovernanceEvents(workspaceId, filter || undefined),
+    refetchInterval: 5000,
+  })
+
+  const handleResolve = async (id: string) => {
+    const notes = prompt("Resolution notes:")
+    if (notes === null) return
+    await api.resolveGovernanceEvent(id, notes)
+    queryClient.invalidateQueries({ queryKey: ["governance-events"] })
+    queryClient.invalidateQueries({ queryKey: ["governance-stats"] })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="-mx-4 overflow-x-auto px-4 md:mx-0 md:overflow-visible md:px-0">
+        <div className="flex gap-2 whitespace-nowrap">
+          {EVENT_TYPES.map((t) => (
+            <Button
+              key={t}
+              variant={filter === t ? "default" : "outline"}
+              size="sm"
+              onClick={() => setFilter(t)}
+            >
+              {t ? TYPE_LABELS[t] || t : "All"}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-lg">Events</CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          {isLoading ? (
+            <p className="py-8 text-center text-muted-foreground">Loading...</p>
+          ) : !events || events.length === 0 ? (
+            <p className="py-8 text-center text-muted-foreground">
+              No governance events. Submit events via the synodic CLI or API.
+            </p>
+          ) : (
+            <>
+              {/* Mobile: card list */}
+              <div className="flex flex-col gap-2 md:hidden">
+                {events.map((e) => (
+                  <EventCard key={e.id} event={e} onResolve={handleResolve} />
+                ))}
+              </div>
+
+              {/* Desktop: table */}
+              <div className="hidden md:block">
+                <EventsTable events={events} onResolve={handleResolve} />
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function EventCard({
+  event,
+  onResolve,
+}: {
+  event: GovernanceEvent
+  onResolve: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3">
+      <div className="flex items-center gap-2">
+        <Badge variant={SEVERITY_VARIANT[event.severity] || "secondary"}>
+          {event.severity}
+        </Badge>
+        <Badge variant="outline">
+          {TYPE_LABELS[event.event_type] || event.event_type}
+        </Badge>
+        <div className="ml-auto">
+          {event.resolved ? (
+            <Badge variant="secondary">Resolved</Badge>
+          ) : (
+            <Badge variant="destructive">Open</Badge>
+          )}
+        </div>
+      </div>
+      <p className="text-sm font-medium">{event.title}</p>
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="truncate">{event.source}</span>
+        <span className="shrink-0">
+          {new Date(event.created_at).toLocaleString()}
+        </span>
+      </div>
+      {!event.resolved && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onResolve(event.id)}
+          className="mt-1"
+        >
+          Resolve
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function EventsTable({
+  events,
+  onResolve,
+}: {
+  events: GovernanceEvent[]
+  onResolve: (id: string) => void
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Type</TableHead>
+          <TableHead>Severity</TableHead>
+          <TableHead>Title</TableHead>
+          <TableHead>Source</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {events.map((e) => (
+          <TableRow key={e.id}>
+            <TableCell>
+              <Badge variant="outline">
+                {TYPE_LABELS[e.event_type] || e.event_type}
+              </Badge>
+            </TableCell>
+            <TableCell>
+              <Badge variant={SEVERITY_VARIANT[e.severity] || "secondary"}>
+                {e.severity}
+              </Badge>
+            </TableCell>
+            <TableCell className="max-w-[300px] truncate">{e.title}</TableCell>
+            <TableCell className="text-muted-foreground">{e.source}</TableCell>
+            <TableCell>
+              {e.resolved ? (
+                <Badge variant="secondary">Resolved</Badge>
+              ) : (
+                <Badge variant="destructive">Open</Badge>
+              )}
+            </TableCell>
+            <TableCell className="text-xs text-muted-foreground">
+              {new Date(e.created_at).toLocaleString()}
+            </TableCell>
+            <TableCell>
+              {!e.resolved && (
+                <Button variant="ghost" size="sm" onClick={() => onResolve(e.id)}>
+                  Resolve
+                </Button>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/apps/dashboard/src/components/layout/UserMenu.tsx
+++ b/apps/dashboard/src/components/layout/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronsUpDown, LogOut, Monitor, Moon, Settings, Sun } from "lucide-react"
+import { Building2, ChevronsUpDown, LogOut, Monitor, Moon, Settings, Sun } from "lucide-react"
 import { Link } from "react-router-dom"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { useAuth } from "@/lib/auth"
+import { useOptionalActiveWorkspace } from "@/lib/workspace"
 
 // `icon`: legacy circular avatar button (kept for any non-sidebar use).
 // `row`:  full-width pill used in the sidebar footer — avatar + label +
@@ -24,6 +25,7 @@ export interface UserMenuProps {
 export function UserMenu({ variant = "icon" }: UserMenuProps) {
   const { user, logout } = useAuth()
   const { setTheme } = useTheme()
+  const activeWorkspace = useOptionalActiveWorkspace()
 
   // Auth is always-on as of #193 — `user` is non-null here for any
   // mounted UserMenu (it lives behind ProtectedRoute).
@@ -89,9 +91,17 @@ export function UserMenu({ variant = "icon" }: UserMenuProps) {
             <DropdownMenuSeparator />
           </>
         )}
+        {activeWorkspace && (
+          <DropdownMenuItem
+            render={<Link to={`/workspaces/${activeWorkspace.slug}/settings`} />}
+          >
+            <Building2 className="mr-2 h-4 w-4" />
+            Workspace settings
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem render={<Link to="/settings" />}>
           <Settings className="mr-2 h-4 w-4" />
-          Settings
+          Account settings
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuLabel>Theme</DropdownMenuLabel>

--- a/apps/dashboard/src/components/workspaces/WorkspaceCredentials.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCredentials.tsx
@@ -1,0 +1,289 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import type { Workspace } from "@/lib/api"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { KeyRound, Plus, Trash2 } from "lucide-react"
+
+const KNOWN_CREDENTIALS = [
+  {
+    name: "CLAUDE_CODE_OAUTH_TOKEN",
+    description: "OAuth token for Claude Code CLI authentication",
+  },
+  {
+    name: "ANTHROPIC_API_KEY",
+    description: "Anthropic API key for direct API access",
+  },
+]
+
+interface WorkspaceCredentialsProps {
+  workspace: Workspace
+}
+
+export function WorkspaceCredentials({ workspace }: WorkspaceCredentialsProps) {
+  const queryClient = useQueryClient()
+  const [newCredName, setNewCredName] = useState("")
+  const [newCredValue, setNewCredValue] = useState("")
+  const [editingCred, setEditingCred] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState("")
+  const [saveError, setSaveError] = useState<{ form: string; message: string } | null>(null)
+
+  const credKey = ["credentials", workspace.id]
+
+  const { data: credData } = useQuery({
+    queryKey: credKey,
+    queryFn: () => api.getCredentials(workspace.id),
+  })
+
+  const setCred = useMutation({
+    mutationFn: ({ name, value }: { name: string; value: string }) =>
+      api.setCredential(workspace.id, name, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: credKey })
+      setNewCredName("")
+      setNewCredValue("")
+      setEditingCred(null)
+      setEditValue("")
+      setSaveError(null)
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "Failed to save"
+      setSaveError({ form: editingCred ?? "custom", message })
+    },
+  })
+
+  const deleteCred = useMutation({
+    mutationFn: (name: string) => api.deleteCredential(workspace.id, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: credKey })
+    },
+  })
+
+  const credentials = credData?.credentials ?? []
+  const existingNames = new Set(credentials.map((c) => c.name))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+          <KeyRound className="h-4 w-4" />
+          Credentials
+        </CardTitle>
+        <CardDescription>
+          Encrypted at rest and passed to agent sessions launched from this
+          workspace as environment variables.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {credentials.map((cred) => (
+          <div key={cred.name} className="space-y-2 rounded-md border p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-mono text-sm font-medium">{cred.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  Updated {new Date(cred.updated_at).toLocaleDateString()}
+                </p>
+              </div>
+              {editingCred !== cred.name && (
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingCred(cred.name)
+                      setEditValue("")
+                      setSaveError(null)
+                    }}
+                  >
+                    Update
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => deleteCred.mutate(cred.name)}
+                    disabled={deleteCred.isPending}
+                    aria-label={`Delete ${cred.name}`}
+                    title={`Delete ${cred.name}`}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </div>
+              )}
+            </div>
+            {editingCred === cred.name && (
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (setCred.isPending) return
+                  if (editValue) setCred.mutate({ name: cred.name, value: editValue })
+                }}
+                className="space-y-2"
+              >
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="password"
+                    placeholder="New value"
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    className="flex-1"
+                  />
+                  <Button
+                    size="sm"
+                    type="submit"
+                    disabled={!editValue || setCred.isPending}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingCred(null)
+                      setEditValue("")
+                      setSaveError(null)
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                {saveError?.form === cred.name && (
+                  <p className="text-xs text-destructive">{saveError.message}</p>
+                )}
+              </form>
+            )}
+          </div>
+        ))}
+
+        {/* Quick-add known credentials */}
+        {KNOWN_CREDENTIALS.filter((k) => !existingNames.has(k.name)).length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">Add credential</p>
+            {KNOWN_CREDENTIALS.filter((k) => !existingNames.has(k.name)).map(
+              (known) => (
+                <div
+                  key={known.name}
+                  className="space-y-2 rounded-md border border-dashed p-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-sm">{known.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {known.description}
+                      </p>
+                    </div>
+                    {editingCred !== `new-${known.name}` && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0"
+                        onClick={() => {
+                          setEditingCred(`new-${known.name}`)
+                          setEditValue("")
+                          setSaveError(null)
+                        }}
+                      >
+                        <Plus className="mr-1 h-3 w-3" />
+                        Add
+                      </Button>
+                    )}
+                  </div>
+                  {editingCred === `new-${known.name}` && (
+                    <form
+                      onSubmit={(e) => {
+                        e.preventDefault()
+                        if (setCred.isPending) return
+                        if (editValue) setCred.mutate({ name: known.name, value: editValue })
+                      }}
+                      className="space-y-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Input
+                          type="password"
+                          placeholder="Value"
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          className="flex-1"
+                        />
+                        <Button
+                          size="sm"
+                          type="submit"
+                          disabled={!editValue || setCred.isPending}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="outline"
+                          onClick={() => {
+                            setEditingCred(null)
+                            setEditValue("")
+                            setSaveError(null)
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                      {saveError?.form === `new-${known.name}` && (
+                        <p className="text-xs text-destructive">{saveError.message}</p>
+                      )}
+                    </form>
+                  )}
+                </div>
+              ),
+            )}
+          </div>
+        )}
+
+        {/* Custom credential */}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (setCred.isPending) return
+            if (newCredName && newCredValue)
+              setCred.mutate({ name: newCredName, value: newCredValue })
+          }}
+          className="space-y-2 border-t pt-4"
+        >
+          <p className="text-sm font-medium text-muted-foreground">
+            Custom credential
+          </p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[auto_1fr_auto]">
+            <Input
+              placeholder="ENV_VAR_NAME"
+              value={newCredName}
+              onChange={(e) => setNewCredName(e.target.value.toUpperCase())}
+              className="sm:w-48"
+            />
+            <Input
+              type="password"
+              placeholder="Value"
+              value={newCredValue}
+              onChange={(e) => setNewCredValue(e.target.value)}
+            />
+            <Button
+              size="sm"
+              type="submit"
+              disabled={!newCredName || !newCredValue || setCred.isPending}
+            >
+              <Plus className="mr-1 h-3 w-3" />
+              Add
+            </Button>
+          </div>
+          {saveError?.form === "custom" && (
+            <p className="text-xs text-destructive">{saveError.message}</p>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/lib/useHashTab.ts
+++ b/apps/dashboard/src/lib/useHashTab.ts
@@ -9,38 +9,45 @@ function readHashValue(allowed: readonly string[]): string | null {
 /**
  * Hash-based tab state. `#tab-name` in the URL selects the active tab so
  * tabs survive reload and deep-link. Falls back to `defaultValue` when
- * the hash is missing or not one of `tabs`.
+ * the hash is missing or not one of `tabs` — both on first render and
+ * when the user clears or edits the hash to something unrecognized.
  *
- * The setter updates `window.location.hash` via `history.replaceState` so
- * tab switches don't pollute the back-button stack.
+ * The returned setter accepts an unknown string and validates it against
+ * `tabs`, so callers can wire it directly to e.g. `Tabs.onValueChange`
+ * without an unchecked cast. Invalid values are dropped silently.
+ *
+ * Updates use `history.replaceState` so tab switches don't pollute the
+ * back-button stack.
  */
 export function useHashTab<T extends string>(
   tabs: readonly T[],
   defaultValue: T,
-): [T, (next: T) => void] {
+): [T, (next: string) => void] {
   const [value, setValue] = useState<T>(() => {
     const fromHash = readHashValue(tabs as readonly string[])
-    return (fromHash as T) ?? defaultValue
+    return (fromHash as T | null) ?? defaultValue
   })
 
   useEffect(() => {
     const onHashChange = () => {
       const fromHash = readHashValue(tabs as readonly string[])
-      if (fromHash) setValue(fromHash as T)
+      setValue((fromHash as T | null) ?? defaultValue)
     }
     window.addEventListener("hashchange", onHashChange)
     return () => window.removeEventListener("hashchange", onHashChange)
-  }, [tabs])
+  }, [tabs, defaultValue])
 
   const update = useCallback(
-    (next: T) => {
-      setValue(next)
+    (next: string) => {
+      if (!(tabs as readonly string[]).includes(next)) return
+      const validated = next as T
+      setValue(validated)
       if (typeof window !== "undefined") {
-        const url = `${window.location.pathname}${window.location.search}#${next}`
+        const url = `${window.location.pathname}${window.location.search}#${validated}`
         window.history.replaceState(null, "", url)
       }
     },
-    [],
+    [tabs],
   )
 
   return [value, update]

--- a/apps/dashboard/src/lib/useHashTab.ts
+++ b/apps/dashboard/src/lib/useHashTab.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react"
+
+function readHashValue(allowed: readonly string[]): string | null {
+  if (typeof window === "undefined") return null
+  const raw = window.location.hash.replace(/^#/, "")
+  return allowed.includes(raw) ? raw : null
+}
+
+/**
+ * Hash-based tab state. `#tab-name` in the URL selects the active tab so
+ * tabs survive reload and deep-link. Falls back to `defaultValue` when
+ * the hash is missing or not one of `tabs`.
+ *
+ * The setter updates `window.location.hash` via `history.replaceState` so
+ * tab switches don't pollute the back-button stack.
+ */
+export function useHashTab<T extends string>(
+  tabs: readonly T[],
+  defaultValue: T,
+): [T, (next: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    const fromHash = readHashValue(tabs as readonly string[])
+    return (fromHash as T) ?? defaultValue
+  })
+
+  useEffect(() => {
+    const onHashChange = () => {
+      const fromHash = readHashValue(tabs as readonly string[])
+      if (fromHash) setValue(fromHash as T)
+    }
+    window.addEventListener("hashchange", onHashChange)
+    return () => window.removeEventListener("hashchange", onHashChange)
+  }, [tabs])
+
+  const update = useCallback(
+    (next: T) => {
+      setValue(next)
+      if (typeof window !== "undefined") {
+        const url = `${window.location.pathname}${window.location.search}#${next}`
+        window.history.replaceState(null, "", url)
+      }
+    },
+    [],
+  )
+
+  return [value, update]
+}

--- a/apps/dashboard/src/pages/GovernancePage.tsx
+++ b/apps/dashboard/src/pages/GovernancePage.tsx
@@ -1,53 +1,20 @@
-import { useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { useActiveWorkspace } from "@/lib/workspace"
 import type {
-  GovernanceEvent,
   IsingInsightEmittedEvent,
   RuleProposal,
 } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { usePageHeader } from "@/components/layout/PageHeader"
-
-const TYPE_LABELS: Record<string, string> = {
-  tool_call_error: "Tool Error",
-  hallucination: "Hallucination",
-  compliance_violation: "Compliance",
-  misalignment: "Misalignment",
-}
-
-const SEVERITY_VARIANT: Record<string, "destructive" | "default" | "secondary" | "outline"> = {
-  critical: "destructive",
-  high: "destructive",
-  medium: "default",
-  low: "secondary",
-}
-
-const EVENT_TYPES = ["", "tool_call_error", "hallucination", "compliance_violation", "misalignment"]
+import { GovernanceEventsList } from "@/components/governance/GovernanceEventsList"
 
 export function GovernancePage() {
   usePageHeader({ title: "Governance" })
   const workspace = useActiveWorkspace()
-  const [filter, setFilter] = useState("")
   const queryClient = useQueryClient()
-
-  const { data: events, isLoading } = useQuery({
-    queryKey: ["governance-events", workspace.id, filter],
-    queryFn: () =>
-      api.getGovernanceEvents(workspace.id, filter || undefined),
-    refetchInterval: 5000,
-  })
 
   const { data: stats } = useQuery({
     queryKey: ["governance-stats", workspace.id],
@@ -71,14 +38,6 @@ export function GovernancePage() {
     queryFn: () => api.getRuleProposals(workspace.id, "pending"),
     refetchInterval: 15000,
   })
-
-  const handleResolve = async (id: string) => {
-    const notes = prompt("Resolution notes:")
-    if (notes === null) return
-    await api.resolveGovernanceEvent(id, notes)
-    queryClient.invalidateQueries({ queryKey: ["governance-events"] })
-    queryClient.invalidateQueries({ queryKey: ["governance-stats"] })
-  }
 
   const handleProposalResolve = async (
     id: string,
@@ -110,21 +69,6 @@ export function GovernancePage() {
         )}
       </div>
 
-      <div className="-mx-4 overflow-x-auto px-4 md:mx-0 md:overflow-visible md:px-0">
-        <div className="flex gap-2 whitespace-nowrap">
-          {EVENT_TYPES.map((t) => (
-            <Button
-              key={t}
-              variant={filter === t ? "default" : "outline"}
-              size="sm"
-              onClick={() => setFilter(t)}
-            >
-              {t ? TYPE_LABELS[t] || t : "All"}
-            </Button>
-          ))}
-        </div>
-      </div>
-
       <RuleProposalsCard
         proposals={pendingProposals ?? []}
         onResolve={handleProposalResolve}
@@ -132,116 +76,8 @@ export function GovernancePage() {
 
       <IsingInsightsCard insights={insights ?? []} />
 
-      <Card>
-        <CardHeader className="px-4 md:px-6">
-          <CardTitle className="text-base md:text-lg">Events</CardTitle>
-        </CardHeader>
-        <CardContent className="px-4 md:px-6">
-          {isLoading ? (
-            <p className="py-8 text-center text-muted-foreground">Loading...</p>
-          ) : !events || events.length === 0 ? (
-            <p className="py-8 text-center text-muted-foreground">
-              No governance events. Submit events via the synodic CLI or API.
-            </p>
-          ) : (
-            <>
-              {/* Mobile: card list */}
-              <div className="flex flex-col gap-2 md:hidden">
-                {events.map((e) => (
-                  <EventCard key={e.id} event={e} onResolve={handleResolve} />
-                ))}
-              </div>
-
-              {/* Desktop: table */}
-              <div className="hidden md:block">
-                <EventsTable events={events} onResolve={handleResolve} />
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+      <GovernanceEventsList workspaceId={workspace.id} />
     </div>
-  )
-}
-
-function EventCard({ event, onResolve }: { event: GovernanceEvent; onResolve: (id: string) => void }) {
-  return (
-    <div className="flex flex-col gap-2 rounded-lg border p-3">
-      <div className="flex items-center gap-2">
-        <Badge variant={SEVERITY_VARIANT[event.severity] || "secondary"}>
-          {event.severity}
-        </Badge>
-        <Badge variant="outline">{TYPE_LABELS[event.event_type] || event.event_type}</Badge>
-        <div className="ml-auto">
-          {event.resolved ? (
-            <Badge variant="secondary">Resolved</Badge>
-          ) : (
-            <Badge variant="destructive">Open</Badge>
-          )}
-        </div>
-      </div>
-      <p className="text-sm font-medium">{event.title}</p>
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span className="truncate">{event.source}</span>
-        <span className="shrink-0">{new Date(event.created_at).toLocaleString()}</span>
-      </div>
-      {!event.resolved && (
-        <Button variant="outline" size="sm" onClick={() => onResolve(event.id)} className="mt-1">
-          Resolve
-        </Button>
-      )}
-    </div>
-  )
-}
-
-function EventsTable({ events, onResolve }: { events: GovernanceEvent[]; onResolve: (id: string) => void }) {
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Type</TableHead>
-          <TableHead>Severity</TableHead>
-          <TableHead>Title</TableHead>
-          <TableHead>Source</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>Created</TableHead>
-          <TableHead />
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {events.map((e) => (
-          <TableRow key={e.id}>
-            <TableCell>
-              <Badge variant="outline">{TYPE_LABELS[e.event_type] || e.event_type}</Badge>
-            </TableCell>
-            <TableCell>
-              <Badge variant={SEVERITY_VARIANT[e.severity] || "secondary"}>
-                {e.severity}
-              </Badge>
-            </TableCell>
-            <TableCell className="max-w-[300px] truncate">{e.title}</TableCell>
-            <TableCell className="text-muted-foreground">{e.source}</TableCell>
-            <TableCell>
-              {e.resolved ? (
-                <Badge variant="secondary">Resolved</Badge>
-              ) : (
-                <Badge variant="destructive">Open</Badge>
-              )}
-            </TableCell>
-            <TableCell className="text-xs text-muted-foreground">
-              {new Date(e.created_at).toLocaleString()}
-            </TableCell>
-            <TableCell>
-              {!e.resolved && (
-                <Button variant="ghost" size="sm" onClick={() => onResolve(e.id)}>
-                  Resolve
-                </Button>
-              )}
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
   )
 }
 

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -41,7 +41,7 @@ export function SettingsPage() {
         </p>
       </div>
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+      <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="tokens">Tokens</TabsTrigger>

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -1,92 +1,105 @@
 import { Link } from "react-router-dom"
 import { useAuth } from "@/lib/auth"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { useHashTab } from "@/lib/useHashTab"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ArrowRight, Building2, KeyRound, User } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ArrowRight, KeyRound, User } from "lucide-react"
 import { usePageHeader } from "@/components/layout/PageHeader"
 
+const TABS = ["profile", "tokens"] as const
+type TabValue = (typeof TABS)[number]
+
 /**
- * Account-wide settings (#166 settings split). Workspace-scoped settings
- * (credentials, projects, GitHub installs) live at
- * `/workspaces/:workspace/settings` since #166. This page covers only
- * the account itself: GitHub profile and personal access tokens.
+ * Account-scoped settings (#305). Two tabs:
+ * - Profile: the signed-in GitHub identity.
+ * - Tokens: link out to the personal access token manager.
+ *
+ * Workspace-scoped settings live at `/workspaces/:slug/settings` —
+ * reachable from the sidebar footer's avatar menu when a workspace is
+ * active. Notifications are deferred to a follow-up spec.
  */
 export function SettingsPage() {
   usePageHeader({ title: "Settings" })
   const { user } = useAuth()
+  const [tab, setTab] = useHashTab<TabValue>(TABS, "profile")
 
   return (
     <div className="space-y-4 md:space-y-6">
       <div>
-        <h1 className="hidden text-2xl font-bold tracking-tight md:block">Settings</h1>
+        <h1 className="hidden text-2xl font-bold tracking-tight md:block">
+          Settings
+        </h1>
         <p className="text-sm text-muted-foreground">
           Account profile and personal access tokens.
         </p>
       </div>
 
-      {user && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-              <User className="h-4 w-4" />
-              Profile
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-4">
-              {user.github_avatar_url && (
-                <img
-                  src={user.github_avatar_url}
-                  alt={user.github_login}
-                  className="h-12 w-12 rounded-full"
-                />
-              )}
-              <div>
-                <p className="font-medium">{user.github_name ?? user.github_login}</p>
-                <p className="text-sm text-muted-foreground">@{user.github_login}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+        <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="tokens">Tokens</TabsTrigger>
+        </TabsList>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-            <Building2 className="h-4 w-4" />
-            Workspaces
-          </CardTitle>
-          <CardDescription>
-            Manage GitHub installations, projects, members, and credentials
-            per workspace.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button render={<Link to="/workspaces" />} variant="outline">
-            Go to Workspaces
-            <ArrowRight className="ml-1 h-4 w-4" />
-          </Button>
-        </CardContent>
-      </Card>
+        <TabsContent value="profile" className="space-y-4 md:space-y-6">
+          {user && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+                  <User className="h-4 w-4" />
+                  Profile
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-4">
+                  {user.github_avatar_url && (
+                    <img
+                      src={user.github_avatar_url}
+                      alt={user.github_login}
+                      className="h-12 w-12 rounded-full"
+                    />
+                  )}
+                  <div>
+                    <p className="font-medium">
+                      {user.github_name ?? user.github_login}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      @{user.github_login}
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-            <KeyRound className="h-4 w-4" />
-            Personal access tokens
-          </CardTitle>
-          <CardDescription>
-            Bearer tokens for calling the Onsager API from CLIs, agents, and
-            scheduled jobs.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button render={<Link to="/settings/tokens" />} variant="outline">
-            Manage tokens
-            <ArrowRight className="ml-1 h-4 w-4" />
-          </Button>
-        </CardContent>
-      </Card>
+        <TabsContent value="tokens" className="space-y-4 md:space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+                <KeyRound className="h-4 w-4" />
+                Personal access tokens
+              </CardTitle>
+              <CardDescription>
+                Bearer tokens for calling the Onsager API from CLIs, agents,
+                and scheduled jobs.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button render={<Link to="/settings/tokens" />} variant="outline">
+                Manage tokens
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/apps/dashboard/src/pages/WorkspaceSettingsPage.tsx
+++ b/apps/dashboard/src/pages/WorkspaceSettingsPage.tsx
@@ -45,7 +45,7 @@ export function WorkspaceSettingsPage() {
         </p>
       </div>
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+      <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="workspace">Workspace</TabsTrigger>
           <TabsTrigger value="infrastructure">Infrastructure</TabsTrigger>
@@ -88,7 +88,7 @@ export function WorkspaceSettingsPage() {
 }
 
 function InfrastructureTab() {
-  const { data, isLoading } = useNodes()
+  const { data, isLoading, isError, error } = useNodes()
   const nodes = data?.nodes ?? []
 
   return (
@@ -102,6 +102,11 @@ function InfrastructureTab() {
       <CardContent className="px-4 md:px-6">
         {isLoading ? (
           <p className="py-8 text-center text-muted-foreground">Loading...</p>
+        ) : isError ? (
+          <p className="py-8 text-center text-sm text-destructive">
+            Failed to load nodes
+            {error instanceof Error ? `: ${error.message}` : "."}
+          </p>
         ) : (
           <NodeTable nodes={nodes} />
         )}

--- a/apps/dashboard/src/pages/WorkspaceSettingsPage.tsx
+++ b/apps/dashboard/src/pages/WorkspaceSettingsPage.tsx
@@ -1,77 +1,38 @@
-import { useState } from "react"
 import { Link } from "react-router-dom"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { api } from "@/lib/api"
 import { useActiveWorkspace } from "@/lib/workspace"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { useHashTab } from "@/lib/useHashTab"
+import { useNodes } from "@/hooks/useNodes"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { ArrowRight, Building2, Trash2, Plus, KeyRound } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ArrowRight, Building2 } from "lucide-react"
 import { usePageHeader } from "@/components/layout/PageHeader"
+import { WorkspaceCredentials } from "@/components/workspaces/WorkspaceCredentials"
+import { NodeTable } from "@/components/nodes/NodeTable"
+import { GovernanceEventsList } from "@/components/governance/GovernanceEventsList"
 
-const KNOWN_CREDENTIALS = [
-  {
-    name: "CLAUDE_CODE_OAUTH_TOKEN",
-    description: "OAuth token for Claude Code CLI authentication",
-  },
-  {
-    name: "ANTHROPIC_API_KEY",
-    description: "Anthropic API key for direct API access",
-  },
-]
+const TABS = ["workspace", "infrastructure", "governance"] as const
+type TabValue = (typeof TABS)[number]
 
 /**
- * Per-workspace settings page (#166). Owns credentials (#164 makes them
- * workspace-scoped on the wire) and links out to the workspace's GitHub
- * App installations and projects, which live on the existing
- * `/workspaces` picker page where the WorkspaceCard renders them.
+ * Workspace-scoped settings (#305). Three tabs:
+ * - Workspace: GitHub install link-out + credentials.
+ * - Infrastructure: registered agent nodes (folds the old /nodes page).
+ * - Governance audit: events list scoped to this workspace.
+ *
+ * Tab selection persists in the URL hash so deep links and reloads
+ * preserve which tab the user was on.
  */
 export function WorkspaceSettingsPage() {
   const workspace = useActiveWorkspace()
   usePageHeader({ title: `${workspace.name} · Settings` })
-  const queryClient = useQueryClient()
-  const [newCredName, setNewCredName] = useState("")
-  const [newCredValue, setNewCredValue] = useState("")
-  const [editingCred, setEditingCred] = useState<string | null>(null)
-  const [editValue, setEditValue] = useState("")
-  const [saveError, setSaveError] = useState<{ form: string; message: string } | null>(null)
-
-  // React Query keys carry the workspace id so cache lines don't collide
-  // across workspaces — switching the active workspace doesn't show
-  // stale credentials from the previous one.
-  const credKey = ["credentials", workspace.id]
-
-  const { data: credData } = useQuery({
-    queryKey: credKey,
-    queryFn: () => api.getCredentials(workspace.id),
-  })
-
-  const setCred = useMutation({
-    mutationFn: ({ name, value }: { name: string; value: string }) =>
-      api.setCredential(workspace.id, name, value),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: credKey })
-      setNewCredName("")
-      setNewCredValue("")
-      setEditingCred(null)
-      setEditValue("")
-      setSaveError(null)
-    },
-    onError: (error) => {
-      const message = error instanceof Error ? error.message : "Failed to save"
-      setSaveError({ form: editingCred ?? "custom", message })
-    },
-  })
-
-  const deleteCred = useMutation({
-    mutationFn: (name: string) => api.deleteCredential(workspace.id, name),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: credKey })
-    },
-  })
-
-  const credentials = credData?.credentials ?? []
-  const existingNames = new Set(credentials.map((c) => c.name))
+  const [tab, setTab] = useHashTab<TabValue>(TABS, "workspace")
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -80,253 +41,71 @@ export function WorkspaceSettingsPage() {
           Workspace settings
         </h1>
         <p className="text-sm text-muted-foreground">
-          Credentials and integrations scoped to <strong>{workspace.name}</strong>.
+          Settings scoped to <strong>{workspace.name}</strong>.
         </p>
       </div>
 
-      {/* Workspace card link-out: GitHub installations + projects + members
-          live on the WorkspacesPage card today. Until that surface is
-          factored apart, point the user there from the per-workspace
-          settings page so the model is consistent ("everything for this
-          workspace lives at /workspaces/:workspace/settings"). */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-            <Building2 className="h-4 w-4" />
-            Installations, projects, members
-          </CardTitle>
-          <CardDescription>
-            Manage the GitHub App installation, opt-in projects, and members
-            for this workspace.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button render={<Link to="/workspaces" />} variant="outline">
-            Open Workspaces
-            <ArrowRight className="ml-1 h-4 w-4" />
-          </Button>
-        </CardContent>
-      </Card>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+        <TabsList>
+          <TabsTrigger value="workspace">Workspace</TabsTrigger>
+          <TabsTrigger value="infrastructure">Infrastructure</TabsTrigger>
+          <TabsTrigger value="governance">Governance audit</TabsTrigger>
+        </TabsList>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-            <KeyRound className="h-4 w-4" />
-            Credentials
-          </CardTitle>
-          <CardDescription>
-            Encrypted at rest and passed to agent sessions launched from this
-            workspace as environment variables.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {credentials.map((cred) => (
-            <div
-              key={cred.name}
-              className="space-y-2 rounded-md border p-3"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-mono text-sm font-medium">{cred.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Updated {new Date(cred.updated_at).toLocaleDateString()}
-                  </p>
-                </div>
-                {editingCred !== cred.name && (
-                  <div className="flex shrink-0 items-center gap-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => {
-                        setEditingCred(cred.name)
-                        setEditValue("")
-                        setSaveError(null)
-                      }}
-                    >
-                      Update
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => deleteCred.mutate(cred.name)}
-                      disabled={deleteCred.isPending}
-                      aria-label={`Delete ${cred.name}`}
-                      title={`Delete ${cred.name}`}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                )}
-              </div>
-              {editingCred === cred.name && (
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault()
-                    if (setCred.isPending) return
-                    if (editValue) setCred.mutate({ name: cred.name, value: editValue })
-                  }}
-                  className="space-y-2"
-                >
-                  <div className="flex items-center gap-2">
-                    <Input
-                      type="password"
-                      placeholder="New value"
-                      value={editValue}
-                      onChange={(e) => setEditValue(e.target.value)}
-                      className="flex-1"
-                    />
-                    <Button
-                      size="sm"
-                      type="submit"
-                      disabled={!editValue || setCred.isPending}
-                    >
-                      Save
-                    </Button>
-                    <Button
-                      size="sm"
-                      type="button"
-                      variant="outline"
-                      onClick={() => {
-                        setEditingCred(null)
-                        setEditValue("")
-                        setSaveError(null)
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                  {saveError?.form === cred.name && (
-                    <p className="text-xs text-destructive">{saveError.message}</p>
-                  )}
-                </form>
-              )}
-            </div>
-          ))}
-
-          {/* Quick-add known credentials */}
-          {KNOWN_CREDENTIALS.filter((k) => !existingNames.has(k.name)).length >
-            0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Add credential
-              </p>
-              {KNOWN_CREDENTIALS.filter((k) => !existingNames.has(k.name)).map(
-                (known) => (
-                  <div
-                    key={known.name}
-                    className="space-y-2 rounded-md border border-dashed p-3"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate font-mono text-sm">{known.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {known.description}
-                        </p>
-                      </div>
-                      {editingCred !== `new-${known.name}` && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="shrink-0"
-                          onClick={() => {
-                            setEditingCred(`new-${known.name}`)
-                            setEditValue("")
-                            setSaveError(null)
-                          }}
-                        >
-                          <Plus className="mr-1 h-3 w-3" />
-                          Add
-                        </Button>
-                      )}
-                    </div>
-                    {editingCred === `new-${known.name}` && (
-                      <form
-                        onSubmit={(e) => {
-                          e.preventDefault()
-                          if (setCred.isPending) return
-                          if (editValue) setCred.mutate({ name: known.name, value: editValue })
-                        }}
-                        className="space-y-2"
-                      >
-                        <div className="flex items-center gap-2">
-                          <Input
-                            type="password"
-                            placeholder="Value"
-                            value={editValue}
-                            onChange={(e) => setEditValue(e.target.value)}
-                            className="flex-1"
-                          />
-                          <Button
-                            size="sm"
-                            type="submit"
-                            disabled={!editValue || setCred.isPending}
-                          >
-                            Save
-                          </Button>
-                          <Button
-                            size="sm"
-                            type="button"
-                            variant="outline"
-                            onClick={() => {
-                              setEditingCred(null)
-                              setEditValue("")
-                              setSaveError(null)
-                            }}
-                          >
-                            Cancel
-                          </Button>
-                        </div>
-                        {saveError?.form === `new-${known.name}` && (
-                          <p className="text-xs text-destructive">{saveError.message}</p>
-                        )}
-                      </form>
-                    )}
-                  </div>
-                )
-              )}
-            </div>
-          )}
-
-          {/* Custom credential */}
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              if (setCred.isPending) return
-              if (newCredName && newCredValue) setCred.mutate({ name: newCredName, value: newCredValue })
-            }}
-            className="space-y-2 border-t pt-4"
-          >
-            <p className="text-sm font-medium text-muted-foreground">
-              Custom credential
-            </p>
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[auto_1fr_auto]">
-              <Input
-                placeholder="ENV_VAR_NAME"
-                value={newCredName}
-                onChange={(e) => setNewCredName(e.target.value.toUpperCase())}
-                className="sm:w-48"
-              />
-              <Input
-                type="password"
-                placeholder="Value"
-                value={newCredValue}
-                onChange={(e) => setNewCredValue(e.target.value)}
-              />
-              <Button
-                size="sm"
-                type="submit"
-                disabled={!newCredName || !newCredValue || setCred.isPending}
-              >
-                <Plus className="mr-1 h-3 w-3" />
-                Add
+        <TabsContent value="workspace" className="space-y-4 md:space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base md:text-lg">
+                <Building2 className="h-4 w-4" />
+                Installations, projects, members
+              </CardTitle>
+              <CardDescription>
+                Manage the GitHub App installation, opt-in projects, and members
+                for this workspace.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button render={<Link to="/workspaces" />} variant="outline">
+                Open Workspaces
+                <ArrowRight className="ml-1 h-4 w-4" />
               </Button>
-            </div>
-            {saveError?.form === "custom" && (
-              <p className="text-xs text-destructive">{saveError.message}</p>
-            )}
-          </form>
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
+
+          <WorkspaceCredentials workspace={workspace} />
+        </TabsContent>
+
+        <TabsContent value="infrastructure" className="space-y-4 md:space-y-6">
+          <InfrastructureTab />
+        </TabsContent>
+
+        <TabsContent value="governance" className="space-y-4 md:space-y-6">
+          <GovernanceEventsList workspaceId={workspace.id} />
+        </TabsContent>
+      </Tabs>
     </div>
+  )
+}
+
+function InfrastructureTab() {
+  const { data, isLoading } = useNodes()
+  const nodes = data?.nodes ?? []
+
+  return (
+    <Card>
+      <CardHeader className="px-4 md:px-6">
+        <CardTitle className="text-base md:text-lg">Registered nodes</CardTitle>
+        <CardDescription>
+          Agent nodes available to run sessions for this workspace.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-4 md:px-6">
+        {isLoading ? (
+          <p className="py-8 text-center text-muted-foreground">Loading...</p>
+        ) : (
+          <NodeTable nodes={nodes} />
+        )}
+      </CardContent>
+    </Card>
   )
 }


### PR DESCRIPTION
Closes #305. Part of #289 (PR 5 slice).

## Summary

- **WorkspaceSettingsPage** now has three tabs: **Workspace** (GitHub install link-out + credentials), **Infrastructure** (registered nodes, folded in from `NodesPage`), and **Governance audit** (events list scoped to the workspace).
- **SettingsPage** now has two tabs: **Profile** and **Tokens**. Notifications deferred to a follow-up spec per #289.
- **UserMenu** (sidebar footer avatar) adds a "Workspace settings" entry when a workspace is active, alongside "Account settings". Resolves the active workspace via `useOptionalActiveWorkspace` so the chrome works outside the scoped layout.
- Extracts two shared building blocks: `WorkspaceCredentials` (used by the Workspace tab; was inline in the old page) and `GovernanceEventsList` (used by both `GovernancePage` and the new audit tab). `GovernancePage` switches to the shared component — single source of truth.
- New `useHashTab` hook backs both settings pages. Hash deep-links (`#infrastructure`, `#tokens`, …) route to the right tab and survive reload; tab switches use `history.replaceState` so they don't pollute the back stack.
- Standalone `/workspaces/:slug/nodes` route stays live for now; it gets deleted with a redirect in #289 PR 6.

## Test plan

- [x] `pnpm exec tsc -b` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` — 105/105 tests pass (existing `settings-credentials.test.tsx` covers the Workspace tab content since it's the default).
- [x] `cargo run -p xtask -- check-file-budget` clean (no file over the 8000-token ceiling).
- [x] `cargo run -p xtask -- check-api-contract` clean.
- [ ] Manual: visit `/workspaces/:slug/settings` → see three tabs; switch tabs and confirm hash updates (`#workspace`, `#infrastructure`, `#governance`); reload preserves the active tab.
- [ ] Manual: visit `/workspaces/:slug/settings#governance` directly → lands on Governance audit tab.
- [ ] Manual: visit `/settings` → see Profile / Tokens tabs; Tokens links to `/settings/tokens`.
- [ ] Manual: open the sidebar avatar menu inside a workspace → both "Workspace settings" and "Account settings" entries appear; outside a workspace, only "Account settings" appears.
- [ ] Manual mobile (360px): both settings pages render cleanly with tabs.

https://claude.ai/code/session_01DQCjeHQ4SZyAo8GW3FSP7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQCjeHQ4SZyAo8GW3FSP7i)_