### PR TITLE
feat(dashboard): run detail tabbed hub at /runs/:runId (#303)

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -56,6 +56,9 @@ const WorkflowStartPage = lazy(() =>
 const WorkflowDetailPage = lazy(() =>
   import("@/pages/WorkflowDetailPage").then((m) => ({ default: m.WorkflowDetailPage })),
 )
+const RunDetailPage = lazy(() =>
+  import("@/pages/RunDetailPage").then((m) => ({ default: m.RunDetailPage })),
+)
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 )
@@ -342,6 +345,13 @@ function AppRoutes() {
                             <Route
                               path="workflows/:id"
                               element={<LazyRoute variant="detail"><WorkflowDetailPage /></LazyRoute>}
+                            />
+                            {/* Run detail hub (#303). Flat route — runs
+                                have unique IDs (artifact_id), so they
+                                don't need to be nested under workflow. */}
+                            <Route
+                              path="runs/:runId"
+                              element={<LazyRoute variant="detail"><RunDetailPage /></LazyRoute>}
                             />
                             <Route
                               path="settings"

--- a/apps/dashboard/src/lib/api/index.ts
+++ b/apps/dashboard/src/lib/api/index.ts
@@ -59,6 +59,8 @@ export type {
   StageRunStatus,
   WorkflowRunStage,
   WorkflowRun,
+  RunDetail,
+  RunLinkedSession,
   GitHubLabel,
   ArtifactActionRequest,
   OverrideGateRequestBody,

--- a/apps/dashboard/src/lib/api/sessions.ts
+++ b/apps/dashboard/src/lib/api/sessions.ts
@@ -7,6 +7,15 @@ export const sessions = {
   getSessions: (workspaceId: string) =>
     request<{ sessions: Session[] }>(`/sessions${scoped(workspaceId)}`),
   getSession: (id: string) => request<{ session: Session }>(`/sessions/${id}`),
+  /**
+   * Request cancellation of an in-flight session (#303). Best-effort —
+   * portal emits `portal.session_cancel_requested` and returns 202; the
+   * UI should not block on the agent actually stopping.
+   */
+  cancelSession: (id: string) =>
+    request<{ ok: boolean }>(`/sessions/${encodeURIComponent(id)}/cancel`, {
+      method: 'POST',
+    }),
   createTask: (task: TaskRequest) =>
     request<{ task: unknown; session: Session }>('/tasks', {
       method: 'POST',

--- a/apps/dashboard/src/lib/api/spine.ts
+++ b/apps/dashboard/src/lib/api/spine.ts
@@ -9,6 +9,11 @@ export const spine = {
       stream_type?: string;
       event_type?: string;
       stream_id?: string;
+      // Filter by run id (spec #303). A run is one artifact flowing
+      // through a workflow; backend joins this against `stream_id`,
+      // `data->>'artifact_id'`, and the `sessions.artifact_id` lookup
+      // so session-keyed events still surface.
+      run_id?: string;
       limit?: number;
     },
   ) =>

--- a/apps/dashboard/src/lib/api/types.ts
+++ b/apps/dashboard/src/lib/api/types.ts
@@ -552,6 +552,23 @@ export interface WorkflowRun {
   updated_at: string;
 }
 
+/** A session linked back to a run via `sessions.artifact_id` (spec #303). */
+export interface RunLinkedSession {
+  id: string;
+  state: Session['state'];
+  node_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Combined response shape for `GET /api/runs/:id` (spec #303). */
+export interface RunDetail {
+  run: WorkflowRun;
+  workflow: Workflow;
+  stages: WorkflowStage[];
+  sessions: RunLinkedSession[];
+}
+
 export interface GitHubLabel {
   name: string;
   color: string | null;

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -7,6 +7,8 @@ import type {
   CreateWorkflowRequest,
   CreateWorkflowStage,
   WorkflowRun,
+  RunDetail,
+  RunLinkedSession,
 } from './types';
 
 // Backend read shapes. Stiglab returns workflows with the unified
@@ -197,6 +199,25 @@ export const workflows = {
     request<{ runs: WorkflowRun[] }>(
       `/workflows/${encodeURIComponent(id)}/runs?limit=${limit}`,
     ),
+  // Run detail hub (#303). Backend returns the projected run alongside
+  // the parent workflow's backend shape; reuse `workflowFromBackend` so
+  // the rest of the dashboard sees the same nested `Workflow` shape it
+  // already consumes from `getWorkflow`.
+  getRun: async (runId: string): Promise<RunDetail> => {
+    const raw = await request<{
+      run: WorkflowRun;
+      workflow: BackendWorkflow;
+      stages: BackendWorkflowStage[];
+      sessions: RunLinkedSession[];
+    }>(`/runs/${encodeURIComponent(runId)}`);
+    const workflow = workflowFromBackend(raw.workflow, raw.stages);
+    return {
+      run: raw.run,
+      workflow,
+      stages: workflow.stages,
+      sessions: raw.sessions,
+    };
+  },
   // Manual / replay trigger fires (#241 — Category 4 of the trigger
   // taxonomy umbrella #236). Both endpoints emit a `trigger.fired`
   // spine event the workflow runtime consumes, plus a

--- a/apps/dashboard/src/pages/RunDetailPage.tsx
+++ b/apps/dashboard/src/pages/RunDetailPage.tsx
@@ -1,0 +1,482 @@
+import { Fragment, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  Circle,
+  CircleCheck,
+  CircleDot,
+  CircleX,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react"
+import { api, type SpineEvent, type StageRunStatus } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { useActiveWorkspace } from "@/lib/workspace"
+import { formatDistanceToNow } from "@/lib/utils"
+
+const STATUS_VARIANT: Record<
+  StageRunStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  pending: "outline",
+  blocked: "secondary",
+  passed: "default",
+  failed: "destructive",
+}
+
+const STATUS_ICON: Record<StageRunStatus, typeof Circle> = {
+  pending: Circle,
+  blocked: CircleDot,
+  passed: CircleCheck,
+  failed: CircleX,
+}
+
+function iconClass(status: StageRunStatus): string {
+  switch (status) {
+    case "passed":
+      return "text-green-500"
+    case "failed":
+      return "text-destructive"
+    case "blocked":
+      return "text-yellow-500"
+    default:
+      return "text-muted-foreground"
+  }
+}
+
+// Hash persistence keeps deep links to a specific tab working — the
+// router doesn't render different routes per tab (single page), so
+// `window.location.hash` is the source of truth for which tab is open.
+const TAB_VALUES = ["overview", "stages", "artifacts", "verdicts", "events"] as const
+type TabValue = (typeof TAB_VALUES)[number]
+
+function readHashTab(): TabValue {
+  if (typeof window === "undefined") return "overview"
+  const h = window.location.hash.replace(/^#/, "")
+  return (TAB_VALUES as readonly string[]).includes(h) ? (h as TabValue) : "overview"
+}
+
+export function RunDetailPage() {
+  const { runId = "" } = useParams<{ runId: string }>()
+  const workspace = useActiveWorkspace()
+  const [tab, setTab] = useState<TabValue>(readHashTab)
+
+  const handleTabChange = (next: TabValue) => {
+    setTab(next)
+    if (typeof window !== "undefined") {
+      window.history.replaceState(null, "", `#${next}`)
+    }
+  }
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["run", runId],
+    queryFn: () => api.getRun(runId),
+    enabled: !!runId,
+    refetchInterval: 5000,
+  })
+
+  usePageHeader({
+    title: data ? (
+      <span className="font-mono">{data.run.id.slice(0, 12)}</span>
+    ) : (
+      "Run"
+    ),
+    backTo: data
+      ? `/workspaces/${workspace.slug}/workflows/${data.workflow.id}`
+      : `/workspaces/${workspace.slug}/workflows`,
+  })
+
+  if (isLoading) {
+    return <p className="py-8 text-center text-muted-foreground">Loading…</p>
+  }
+  if (isError || !data) {
+    return (
+      <p className="py-8 text-center text-sm text-destructive">
+        Couldn&apos;t load run.
+      </p>
+    )
+  }
+
+  const { run, workflow, stages, sessions } = data
+  const stageById = new Map(stages.map((s) => [s.id, s]))
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {/* Desktop-only page header. Mobile uses the global top bar. */}
+      <div className="hidden space-y-2 md:block">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <h1 className="truncate text-2xl font-bold tracking-tight font-mono">
+              {run.id.slice(0, 12)}
+            </h1>
+            <p className="truncate text-sm text-muted-foreground">
+              <Link
+                className="hover:underline"
+                to={`/workspaces/${workspace.slug}/workflows/${workflow.id}`}
+              >
+                {workflow.name}
+              </Link>
+            </p>
+          </div>
+          <Badge variant={STATUS_VARIANT[run.status]}>{run.status}</Badge>
+        </div>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => handleTabChange(v as TabValue)}
+      >
+        <TabsList variant="line" className="w-full justify-start overflow-x-auto">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="stages">Stages</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
+          <TabsTrigger value="verdicts">Verdicts</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4 pt-2">
+          <Card>
+            <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+              <CardTitle className="text-base">Overview</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 px-4 pb-4 md:px-6 text-sm">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Row label="Status">
+                  <Badge variant={STATUS_VARIANT[run.status]}>{run.status}</Badge>
+                </Row>
+                <Row label="Workflow">
+                  <Link
+                    className="hover:underline"
+                    to={`/workspaces/${workspace.slug}/workflows/${workflow.id}`}
+                  >
+                    {workflow.name}
+                  </Link>
+                </Row>
+                <Row label="Artifact">
+                  {run.artifact_id ? (
+                    <Link
+                      className="font-mono hover:underline"
+                      to={`/workspaces/${workspace.slug}/artifacts/${run.artifact_id}`}
+                    >
+                      {run.artifact_id}
+                    </Link>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </Row>
+                <Row label="Started">
+                  {formatDistanceToNow(run.started_at)}
+                </Row>
+                <Row label="Updated">
+                  {formatDistanceToNow(run.updated_at)}
+                </Row>
+                <Row label="Sessions">{sessions.length}</Row>
+              </div>
+
+              <div className="rounded-md border bg-muted/30 px-3 py-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Stage progress
+                </div>
+                <div className="flex items-center gap-1.5">
+                  {run.stages.map((s) => {
+                    const Icon = STATUS_ICON[s.status]
+                    return (
+                      <Icon
+                        key={s.stage_id}
+                        aria-label={s.status}
+                        className={`h-4 w-4 ${iconClass(s.status)}`}
+                      />
+                    )
+                  })}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="stages" className="space-y-2 pt-2">
+          {run.stages.map((rs, i) => {
+            const stage = stageById.get(rs.stage_id)
+            const stageSessions = sessions.filter(
+              // No direct stage_id link on sessions; the agent-session
+              // gate typically maps 1:1 with a stage, so list all run
+              // sessions on every agent-session panel. Anything more
+              // precise needs a `sessions.stage_id` column.
+              () => stage?.gate_kind === "agent-session",
+            )
+            return (
+              <StagePanel
+                key={rs.stage_id}
+                index={i + 1}
+                name={stage?.name ?? `Stage ${i + 1}`}
+                gateKind={stage?.gate_kind ?? ""}
+                status={rs.status}
+                sessions={stageSessions}
+                workspaceSlug={workspace.slug}
+              />
+            )
+          })}
+        </TabsContent>
+
+        <TabsContent value="artifacts" className="space-y-2 pt-2">
+          <Card>
+            <CardContent className="space-y-2 px-4 py-4 md:px-6 text-sm">
+              {run.artifact_id ? (
+                <Link
+                  className="flex items-center justify-between rounded-md border px-3 py-2 hover:bg-muted/50"
+                  to={`/workspaces/${workspace.slug}/artifacts/${run.artifact_id}`}
+                >
+                  <span className="font-mono text-xs">{run.artifact_id}</span>
+                  <ArtifactBadge kind={workflow.stages[0]?.artifact_kind ?? "Issue"} />
+                </Link>
+              ) : (
+                <p className="py-4 text-center text-muted-foreground">
+                  No artifacts produced yet.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="verdicts" className="space-y-2 pt-2">
+          <VerdictsCard runId={run.id} workspaceId={workspace.id} />
+        </TabsContent>
+
+        <TabsContent value="events" className="space-y-2 pt-2">
+          <RunEventsCard runId={run.id} workspaceId={workspace.id} />
+        </TabsContent>
+      </Tabs>
+
+      {/* Render a hidden grid of all stage statuses so the page still
+          shows progress at a glance even when on a non-overview tab. */}
+      <div className="sr-only">
+        {run.stages.map((s) => (
+          <span key={s.stage_id}>{s.status}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-0.5">
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+function StagePanel({
+  index,
+  name,
+  gateKind,
+  status,
+  sessions,
+  workspaceSlug,
+}: {
+  index: number
+  name: string
+  gateKind: string
+  status: StageRunStatus
+  sessions: Array<{ id: string; state: string; node_id: string }>
+  workspaceSlug: string
+}) {
+  const [open, setOpen] = useState(false)
+  const Icon = STATUS_ICON[status]
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <Icon
+          aria-label={status}
+          className={`h-4 w-4 shrink-0 ${iconClass(status)}`}
+        />
+        <span className="truncate text-sm font-medium">
+          {index}. {name}
+        </span>
+        {gateKind && (
+          <Badge variant="outline" className="ml-auto shrink-0 text-[10px]">
+            {gateKind}
+          </Badge>
+        )}
+      </button>
+      {open && (
+        <div className="space-y-3 border-t bg-muted/20 px-3 py-3 text-sm">
+          {sessions.length === 0 ? (
+            <p className="text-muted-foreground">No sessions for this stage yet.</p>
+          ) : (
+            sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                workspaceSlug={workspaceSlug}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SessionRow({
+  session,
+  workspaceSlug,
+}: {
+  session: { id: string; state: string; node_id: string }
+  workspaceSlug: string
+}) {
+  const queryClient = useQueryClient()
+  const cancelMutation = useMutation({
+    mutationFn: () => api.cancelSession(session.id),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ["run"] }),
+  })
+
+  const terminal = session.state === "done" || session.state === "failed"
+
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2">
+      <div className="min-w-0 space-y-0.5">
+        <Link
+          to={`/workspaces/${workspaceSlug}/sessions/${session.id}`}
+          className="font-mono text-xs hover:underline"
+        >
+          {session.id.slice(0, 12)}
+        </Link>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <Badge variant="outline" className="text-[10px]">
+            {session.state}
+          </Badge>
+          <span className="font-mono">{session.node_id.slice(0, 8)}</span>
+        </div>
+      </div>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={terminal || cancelMutation.isPending}
+        onClick={() => cancelMutation.mutate()}
+      >
+        {cancelMutation.isPending ? "Cancelling…" : "Cancel"}
+      </Button>
+    </div>
+  )
+}
+
+function VerdictsCard({
+  runId,
+  workspaceId,
+}: {
+  runId: string
+  workspaceId: string
+}) {
+  // Gate verdicts are `synodic.gate_verdict` events keyed by `gate_id`,
+  // but their payloads carry the artifact_id back to the run. The
+  // run_id filter joins both shapes server-side.
+  const { data, isLoading } = useQuery({
+    queryKey: ["run-verdicts", runId],
+    queryFn: () =>
+      api.getSpineEvents(workspaceId, {
+        run_id: runId,
+        event_type: "synodic.gate_verdict",
+        limit: 100,
+      }),
+    refetchInterval: 5000,
+  })
+  const events = data?.events ?? []
+  return (
+    <Card>
+      <CardContent className="space-y-2 px-4 py-4 md:px-6">
+        {isLoading ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+        ) : events.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No gate verdicts for this run yet.
+          </p>
+        ) : (
+          events.map((e) => <EventRow key={`${e.id}-${e.stream_id}`} event={e} />)
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function RunEventsCard({
+  runId,
+  workspaceId,
+}: {
+  runId: string
+  workspaceId: string
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["run-events", runId],
+    queryFn: () =>
+      api.getSpineEvents(workspaceId, { run_id: runId, limit: 100 }),
+    refetchInterval: 5000,
+  })
+  const events = data?.events ?? []
+  return (
+    <Card>
+      <CardContent className="space-y-2 px-4 py-4 md:px-6">
+        {isLoading ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+        ) : events.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No events for this run yet.
+          </p>
+        ) : (
+          events.map((e) => <EventRow key={`${e.id}-${e.stream_id}`} event={e} />)
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EventRow({ event }: { event: SpineEvent }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <Badge variant="outline" className="shrink-0 font-mono text-[10px]">
+          {event.event_type}
+        </Badge>
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          {event.stream_id}
+        </span>
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+          {new Date(event.created_at).toLocaleString()}
+        </span>
+      </button>
+      {open && (
+        <Fragment>
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words border-t bg-muted/30 p-3 text-xs text-muted-foreground">
+            {JSON.stringify(event.data ?? {}, null, 2)}
+          </pre>
+        </Fragment>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -177,7 +177,11 @@ export function WorkflowDetailPage() {
             workspaceId={workspace.id}
             title="In-flight"
           />
-          <RunsList runs={runs} stageIds={workflow.stages.map((s) => s.id)} />
+          <RunsList
+            runs={runs}
+            stageIds={workflow.stages.map((s) => s.id)}
+            workspaceSlug={workspace.slug}
+          />
           <WorkflowEventsCard workflowId={workflow.id} runs={runs} />
           <WorkflowSessionsCard runs={runs} />
         </TabsContent>
@@ -261,9 +265,11 @@ function DefinitionTab({
 function RunsList({
   runs,
   stageIds,
+  workspaceSlug,
 }: {
   runs: WorkflowRun[]
   stageIds: string[]
+  workspaceSlug: string
 }) {
   return (
     <Card>
@@ -276,17 +282,35 @@ function RunsList({
             No runs yet. Tag an issue with the trigger label to kick one off.
           </p>
         ) : (
-          runs.map((r) => <RunRow key={r.id} run={r} stageIds={stageIds} />)
+          runs.map((r) => (
+            <RunRow
+              key={r.id}
+              run={r}
+              stageIds={stageIds}
+              workspaceSlug={workspaceSlug}
+            />
+          ))
         )}
       </CardContent>
     </Card>
   )
 }
 
-function RunRow({ run, stageIds }: { run: WorkflowRun; stageIds: string[] }) {
+function RunRow({
+  run,
+  stageIds,
+  workspaceSlug,
+}: {
+  run: WorkflowRun
+  stageIds: string[]
+  workspaceSlug: string
+}) {
   const byStage = new Map(run.stages.map((s) => [s.stage_id, s.status]))
   return (
-    <div className="space-y-2 rounded-md border p-3">
+    <Link
+      to={`/workspaces/${workspaceSlug}/runs/${run.id}`}
+      className="block space-y-2 rounded-md border p-3 hover:bg-muted/50"
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0 text-sm font-mono truncate">
           {run.artifact_id ?? run.id}
@@ -306,7 +330,7 @@ function RunRow({ run, stageIds }: { run: WorkflowRun; stageIds: string[] }) {
           )
         })}
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod projects;
 pub mod pull_request;
 pub mod registry_events;
 pub mod registry_triggers;
+pub mod runs;
 pub mod sessions;
 pub mod spec_link;
 pub mod spine;

--- a/crates/onsager-portal/src/handlers/runs.rs
+++ b/crates/onsager-portal/src/handlers/runs.rs
@@ -1,0 +1,197 @@
+//! Run-detail route (spec #303).
+//!
+//! `GET /api/runs/:id` is the hub endpoint for the dashboard's
+//! `RunDetailPage`. A "run" is one artifact flowing through a workflow:
+//! `runs.id == artifacts.artifact_id`. The shape combines:
+//!
+//! - the projected run (status + per-stage status), reusing the same
+//!   projection helper that `GET /api/workflows/:id/runs` returns, and
+//! - the parent `Workflow` (with its ordered stages), so the frontend
+//!   doesn't need a second roundtrip to render stage names / gate kinds, and
+//! - linked agent `Session` ids (the `sessions` table joins back via
+//!   `artifact_id`), so the Stages tab can deep-link into session logs.
+//!
+//! Auth: workspace-scoped through the artifact's `workspace_id`, mirroring
+//! `handlers/workflows.rs` (non-members get a flat 404).
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::auth::AuthUser;
+use crate::handlers::workspaces::require_workspace_access;
+use crate::state::AppState;
+use crate::workflow_db;
+
+#[derive(Debug, sqlx::FromRow)]
+struct RunRow {
+    artifact_id: String,
+    workspace_id: String,
+    workflow_id: Option<String>,
+    state: String,
+    current_stage_index: Option<i32>,
+    workflow_parked_reason: Option<String>,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct LinkedSession {
+    id: String,
+    state: String,
+    node_id: String,
+    created_at: String,
+    updated_at: String,
+}
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+/// GET /api/runs/:id — combined run + workflow + linked sessions view.
+pub async fn get_run(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(run_id): Path<String>,
+) -> Response {
+    let spine = state.spine.pool();
+
+    let row = match sqlx::query_as::<_, RunRow>(
+        "SELECT artifact_id, workspace_id, workflow_id, state, current_stage_index, \
+                workflow_parked_reason, created_at, updated_at \
+         FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(&run_id)
+    .fetch_optional(spine)
+    .await
+    {
+        Ok(Some(r)) => r,
+        Ok(None) => return not_found("run not found"),
+        Err(e) => {
+            tracing::error!("failed to load run row: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load run" })),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &row.workspace_id).await {
+        return r;
+    }
+
+    let workflow_id = match row.workflow_id.clone() {
+        Some(id) => id,
+        // Artifacts without a workflow_id are not "runs" — the runs index
+        // only surfaces artifacts that are flowing through a workflow.
+        None => return not_found("run is not associated with a workflow"),
+    };
+
+    let workflow = match workflow_db::get_workflow(spine, &workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return not_found("workflow not found"),
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    let stages = match workflow_db::list_stages_for_workflow(spine, &workflow_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to load stages: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+
+    let linked_sessions: Vec<LinkedSession> = match sqlx::query_as::<_, LinkedSession>(
+        "SELECT id, state, node_id, created_at, updated_at FROM sessions \
+         WHERE artifact_id = $1 ORDER BY created_at ASC",
+    )
+    .bind(&run_id)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to load linked sessions: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load linked sessions" })),
+            )
+                .into_response();
+        }
+    };
+
+    let run = project_run(&row, &stages);
+    Json(serde_json::json!({
+        "run": run,
+        "workflow": workflow,
+        "stages": stages,
+        "sessions": linked_sessions,
+    }))
+    .into_response()
+}
+
+/// Same projection rules as `handlers::workflows::project_run`. Kept
+/// inline because the source struct shape (`RunRow` vs `ArtifactRunRow`)
+/// differs by one nullable field; collapsing them into a shared helper
+/// would force the workflow handler to handle `Option<String>` for the
+/// `workflow_id` it always has.
+fn project_run(row: &RunRow, stages: &[crate::workflow::WorkflowStage]) -> serde_json::Value {
+    let current_idx = row
+        .current_stage_index
+        .and_then(|i| usize::try_from(i).ok());
+
+    let archived = row.state == "archived";
+    let released = row.state == "released";
+    let parked = row.workflow_parked_reason.is_some();
+
+    let stage_entries: Vec<serde_json::Value> = stages
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let status = match (released, archived, parked, current_idx) {
+                (true, _, _, _) => "passed",
+                (_, true, _, Some(idx)) if i < idx => "passed",
+                (_, true, _, Some(idx)) if i == idx => "failed",
+                (_, true, _, _) => "pending",
+                (_, _, true, Some(idx)) if i < idx => "passed",
+                (_, _, true, Some(idx)) if i == idx => "blocked",
+                (_, _, _, Some(idx)) if i < idx => "passed",
+                _ => "pending",
+            };
+            serde_json::json!({
+                "stage_id": s.id,
+                "status": status,
+                "updated_at": row.updated_at,
+            })
+        })
+        .collect();
+
+    let run_status = if released {
+        "passed"
+    } else if archived {
+        "failed"
+    } else if parked {
+        "blocked"
+    } else {
+        "pending"
+    };
+
+    serde_json::json!({
+        "id": row.artifact_id,
+        "workflow_id": row.workflow_id,
+        "artifact_id": row.artifact_id,
+        "status": run_status,
+        "stages": stage_entries,
+        "started_at": row.created_at,
+        "updated_at": row.updated_at,
+    })
+}

--- a/crates/onsager-portal/src/handlers/sessions.rs
+++ b/crates/onsager-portal/src/handlers/sessions.rs
@@ -9,6 +9,7 @@ use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use futures_util::stream;
+use onsager_spine::EventMetadata;
 use serde::Deserialize;
 use std::convert::Infallible;
 use std::time::Duration;
@@ -152,6 +153,66 @@ pub async fn get_session(
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }
+}
+
+/// POST /api/sessions/:id/cancel — emit `portal.session_cancel_requested`
+/// onto the spine. Stiglab's listener forwards a `CancelSession` to the
+/// session's agent (spec #303). Best-effort: terminal sessions / offline
+/// nodes log + drop the cancel.
+pub async fn cancel_session(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(session_id): Path<String>,
+) -> Response {
+    let workspace_id = match authorize_session_read(&state, &auth_user, &session_id).await {
+        Ok(ws) => ws,
+        Err(r) => return r,
+    };
+
+    // Resolve workspace for the spine emit; legacy personal sessions
+    // (no workspace) fall back to `"default"` to match the tasks
+    // handler's convention.
+    let ws_for_emit = workspace_id.as_deref().unwrap_or("default").to_string();
+
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: auth_user.user_id.clone(),
+    };
+    let data = serde_json::json!({
+        "session_id": session_id,
+        "actor": auth_user.user_id,
+    });
+
+    if let Err(e) = state
+        .spine
+        .append_ext(
+            &ws_for_emit,
+            &session_id,
+            "portal",
+            "portal.session_cancel_requested",
+            data,
+            &metadata,
+            None,
+        )
+        .await
+    {
+        tracing::error!(
+            session_id = %session_id,
+            "failed to emit portal.session_cancel_requested: {e}"
+        );
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "failed to enqueue cancel" })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({ "ok": true })),
+    )
+        .into_response()
 }
 
 /// GET /api/sessions/:id/logs — SSE stream of log chunks.

--- a/crates/onsager-portal/src/handlers/spine.rs
+++ b/crates/onsager-portal/src/handlers/spine.rs
@@ -35,6 +35,12 @@ pub struct EventsQuery {
     /// per-workflow views in the dashboard to pull just the events for
     /// one entity without scanning the whole table client-side.
     pub stream_id: Option<String>,
+    /// Filter to events tied to a specific run (spec #303). A "run" id
+    /// is an artifact_id; events join via either `stream_id = run_id`
+    /// (artifact-keyed) or via `data->>'artifact_id' = run_id` /
+    /// `data->>'session_id'` for session-keyed events linked back to
+    /// the artifact through the `sessions` table.
+    pub run_id: Option<String>,
     pub limit: Option<i64>,
 }
 
@@ -203,6 +209,19 @@ pub async fn list_events(
     }
     if let Some(sid) = params.stream_id.as_deref() {
         qb.push(" AND stream_id = ").push_bind(sid.to_string());
+    }
+    // run_id (spec #303): a run is an artifact, but related events may
+    // be keyed by either the artifact_id (stream_id) or a session_id
+    // whose session row points back to the artifact. The OR covers
+    // both shapes without forcing the dashboard to issue two queries.
+    if let Some(rid) = params.run_id.as_deref() {
+        qb.push(" AND (stream_id = ");
+        qb.push_bind(rid.to_string());
+        qb.push(" OR data->>'artifact_id' = ");
+        qb.push_bind(rid.to_string());
+        qb.push(" OR stream_id IN (SELECT id FROM sessions WHERE artifact_id = ");
+        qb.push_bind(rid.to_string());
+        qb.push("))");
     }
     qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
 

--- a/crates/onsager-portal/src/handlers/spine.rs
+++ b/crates/onsager-portal/src/handlers/spine.rs
@@ -36,10 +36,12 @@ pub struct EventsQuery {
     /// one entity without scanning the whole table client-side.
     pub stream_id: Option<String>,
     /// Filter to events tied to a specific run (spec #303). A "run" id
-    /// is an artifact_id; events join via either `stream_id = run_id`
-    /// (artifact-keyed) or via `data->>'artifact_id' = run_id` /
-    /// `data->>'session_id'` for session-keyed events linked back to
-    /// the artifact through the `sessions` table.
+    /// is an artifact_id; events match via any of:
+    /// - `stream_id = run_id` (artifact-keyed events), or
+    /// - `data->>'artifact_id' = run_id` (events that carry the artifact
+    ///   id in their payload), or
+    /// - `stream_id IN (SELECT id FROM sessions WHERE artifact_id = run_id)`
+    ///   (session-keyed events whose session points back to the artifact).
     pub run_id: Option<String>,
     pub limit: Option<i64>,
 }

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -13,8 +13,8 @@ use crate::handlers::{
     installations as installation_handlers, live_data as live_data_handlers,
     nodes as node_handlers, pats as pat_handlers, projects as project_handlers,
     registry_events as registry_event_handlers, registry_triggers as registry_trigger_handlers,
-    sessions as session_handlers, spine as spine_handlers, tasks as task_handlers,
-    telegram_webhook, triggers as trigger_handlers, webhook,
+    runs as run_handlers, sessions as session_handlers, spine as spine_handlers,
+    tasks as task_handlers, telegram_webhook, triggers as trigger_handlers, webhook,
     workflow_kinds as workflow_kind_handlers, workflows as workflow_handlers,
     workspaces as workspace_handlers,
 };
@@ -294,6 +294,15 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             "/api/sessions/{id}/logs",
             get(session_handlers::session_logs),
         )
+        .route(
+            "/api/sessions/{id}/cancel",
+            post(session_handlers::cancel_session),
+        )
+        // Run detail hub (spec #303). One artifact == one run; this
+        // endpoint joins it with its parent workflow + stage chain +
+        // linked sessions so the dashboard's RunDetailPage tabs render
+        // off a single fetch.
+        .route("/api/runs/{id}", get(run_handlers::get_run))
         .route("/api/nodes", get(node_handlers::list_nodes))
         .route("/api/tasks", post(task_handlers::create_task))
         // Manual / replay trigger endpoints (#241 — Category 4 of the

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -279,6 +279,15 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: None,
             description: "Dashboard task request from portal; stiglab dispatches the session to an agent node.",
         },
+        EventDefinition {
+            kind: "portal.session_cancel_requested",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Stiglab],
+            diagnostic_only: false,
+            reason: None,
+            description: "Dashboard cancel-session request from portal (spec #303); stiglab forwards a CancelSession to the session's agent node.",
+        },
         // -- Synodic events -------------------------------------------------
         // Per spec #285: the redundant `synodic.gate_evaluated` /
         // `gate_denied` / `gate_modified` summary variants were dropped;

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -243,6 +243,18 @@ pub enum FactoryEventKind {
     /// agent node (spec #222 Follow-up 3).
     PortalSessionRequested { session_id: String },
 
+    /// Dashboard cancel-session request from portal (spec #303). Stiglab's
+    /// `session_cancel_requested_listener` looks up the session's node and
+    /// forwards a `ServerMessage::CancelSession` to the agent. Best-effort:
+    /// if the node is offline or the session is already terminal, the
+    /// cancel is a no-op.
+    PortalSessionCancelRequested {
+        session_id: String,
+        /// Actor identifier captured for audit / debugging.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
+    },
+
     // -- Synodic events (governance) ----------------------------------------
     /// Full gate verdict issued by Synodic in response to a
     /// `forge.gate_requested` event. Carries the complete `GateVerdict`
@@ -522,6 +534,7 @@ impl FactoryEventKind {
             Self::StiglabSessionFailed { .. } => "stiglab.session_failed",
             Self::StiglabSessionAborted { .. } => "stiglab.session_aborted",
             Self::PortalSessionRequested { .. } => "portal.session_requested",
+            Self::PortalSessionCancelRequested { .. } => "portal.session_cancel_requested",
             Self::SynodicGateVerdict { .. } => "synodic.gate_verdict",
             Self::SynodicEscalationStarted { .. } => "synodic.escalation_started",
             Self::SynodicEscalationResolved { .. } => "synodic.escalation_resolved",
@@ -569,7 +582,9 @@ impl FactoryEventKind {
             | Self::StiglabSessionResultReady { .. }
             | Self::StiglabSessionFailed { .. }
             | Self::StiglabSessionAborted { .. } => "stiglab",
-            Self::PortalSessionRequested { .. } => "portal",
+            Self::PortalSessionRequested { .. } | Self::PortalSessionCancelRequested { .. } => {
+                "portal"
+            }
             Self::SynodicGateVerdict { .. }
             | Self::SynodicEscalationStarted { .. }
             | Self::SynodicEscalationResolved { .. }
@@ -619,7 +634,8 @@ impl FactoryEventKind {
             | Self::StiglabSessionFailed { session_id, .. }
             | Self::StiglabSessionAborted { session_id, .. } => session_id.clone(),
             Self::StiglabSessionResultReady { artifact_id, .. } => artifact_id.to_string(),
-            Self::PortalSessionRequested { session_id, .. } => session_id.clone(),
+            Self::PortalSessionRequested { session_id, .. }
+            | Self::PortalSessionCancelRequested { session_id, .. } => session_id.clone(),
             Self::SynodicGateVerdict { gate_id, .. } => gate_id.clone(),
             Self::SynodicEscalationStarted { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicEscalationResolved { escalation_id, .. } => escalation_id.clone(),

--- a/crates/stiglab/src/main.rs
+++ b/crates/stiglab/src/main.rs
@@ -201,6 +201,34 @@ async fn run_server(
                 }
             });
         }
+        // portal.session_cancel_requested listener (spec #303).
+        // Portal owns POST /api/sessions/:id/cancel; this listener
+        // forwards CancelSession to the agent WebSocket.
+        {
+            let listener_store = spine.store_clone();
+            let listener_state = state.clone();
+            tokio::spawn(async move {
+                let since = match listener_store.max_event_id().await {
+                    Ok(cursor) => cursor,
+                    Err(e) => {
+                        tracing::warn!(
+                            "stiglab: max_event_id lookup failed ({e}); starting \
+                             session_cancel_requested listener from the beginning"
+                        );
+                        None
+                    }
+                };
+                if let Err(e) = stiglab::server::session_cancel_requested_listener::run(
+                    listener_store,
+                    listener_state,
+                    since,
+                )
+                .await
+                {
+                    tracing::error!("stiglab: session_cancel_requested listener exited: {e}");
+                }
+            });
+        }
     }
 
     // Start built-in runner if enabled

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod github_app;
 pub mod handler;
 pub mod routes;
+pub mod session_cancel_requested_listener;
 pub mod session_requested_listener;
 pub mod shaping_listener;
 pub mod spine;

--- a/crates/stiglab/src/server/session_cancel_requested_listener.rs
+++ b/crates/stiglab/src/server/session_cancel_requested_listener.rs
@@ -80,8 +80,12 @@ impl Canceller {
             }
         };
 
-        // Idempotency: terminal sessions are no-ops. Pending sessions
-        // never dispatched, so just mark them aborted locally.
+        // Idempotency: terminal sessions are no-ops — no agent message
+        // to send and no state to update. Non-terminal sessions get a
+        // best-effort CancelSession forwarded below; the agent owns the
+        // actual state transition (it emits `stiglab.session_aborted`
+        // when the local process exits, which the rest of the system
+        // observes via the spine).
         if matches!(session.state, SessionState::Done | SessionState::Failed) {
             tracing::debug!(
                 session_id = %payload.session_id,

--- a/crates/stiglab/src/server/session_cancel_requested_listener.rs
+++ b/crates/stiglab/src/server/session_cancel_requested_listener.rs
@@ -1,0 +1,137 @@
+//! Spine listener that consumes `portal.session_cancel_requested` events
+//! (spec #303) and forwards a `ServerMessage::CancelSession` to the
+//! session's agent over the WebSocket.
+//!
+//! Portal owns `POST /api/sessions/:id/cancel` and emits this event after
+//! authorizing the caller; stiglab is the only consumer. Best-effort —
+//! if the node isn't connected, or the session is already terminal, the
+//! cancel is dropped with a warn log. The agent decides locally what to
+//! do (its session_manager already exposes `cancel_session`).
+
+use async_trait::async_trait;
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+use serde::Deserialize;
+
+use crate::core::{ServerMessage, SessionState};
+use crate::server::db;
+use crate::server::state::AppState;
+
+#[derive(Debug, Deserialize)]
+struct CancelPayload {
+    session_id: String,
+    #[serde(default)]
+    actor: Option<String>,
+}
+
+pub async fn run(store: EventStore, app_state: AppState, since: Option<i64>) -> anyhow::Result<()> {
+    let handler = Canceller {
+        store: store.clone(),
+        app_state,
+    };
+    Listener::new(store).with_since(since).run(handler).await
+}
+
+struct Canceller {
+    store: EventStore,
+    app_state: AppState,
+}
+
+#[async_trait]
+impl EventHandler for Canceller {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "portal.session_cancel_requested" {
+            return Ok(());
+        }
+        if notification.table != "events_ext" {
+            return Ok(());
+        }
+
+        let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+            return Ok(());
+        };
+
+        let payload: CancelPayload = match serde_json::from_value(row.data) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    id = notification.id,
+                    "stiglab: portal.session_cancel_requested parse failed: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        self.dispatch(payload).await
+    }
+}
+
+impl Canceller {
+    async fn dispatch(&self, payload: CancelPayload) -> anyhow::Result<()> {
+        let state = &self.app_state;
+
+        let session = match db::get_session(&state.db, &payload.session_id).await? {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    session_id = %payload.session_id,
+                    "stiglab: cancel — session not found, skipping"
+                );
+                return Ok(());
+            }
+        };
+
+        // Idempotency: terminal sessions are no-ops. Pending sessions
+        // never dispatched, so just mark them aborted locally.
+        if matches!(session.state, SessionState::Done | SessionState::Failed) {
+            tracing::debug!(
+                session_id = %payload.session_id,
+                state = ?session.state,
+                "stiglab: cancel — session already terminal, skipping"
+            );
+            return Ok(());
+        }
+
+        let agents = state.agents.read().await;
+        if let Some(agent) = agents.get(&session.node_id) {
+            let msg = ServerMessage::CancelSession {
+                session_id: payload.session_id.clone(),
+            };
+            match serde_json::to_string(&msg) {
+                Ok(json) => {
+                    if agent
+                        .sender
+                        .send(axum::extract::ws::Message::Text(json.into()))
+                        .is_ok()
+                    {
+                        tracing::info!(
+                            session_id = %payload.session_id,
+                            node_id = %session.node_id,
+                            actor = ?payload.actor,
+                            "stiglab: forwarded CancelSession to agent"
+                        );
+                    } else {
+                        tracing::warn!(
+                            session_id = %payload.session_id,
+                            node_id = %session.node_id,
+                            "stiglab: cancel — agent WS send failed"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        session_id = %payload.session_id,
+                        "stiglab: cancel — serialize failed: {e}"
+                    );
+                }
+            }
+        } else {
+            tracing::warn!(
+                session_id = %payload.session_id,
+                node_id = %session.node_id,
+                "stiglab: cancel — agent not connected"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -251,6 +251,7 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::WorkflowManualTriggered { .. }
         | FactoryEventKind::GateCheckUpdated { .. }
         | FactoryEventKind::GateManualApprovalSignal { .. }
-        | FactoryEventKind::PortalSessionRequested { .. } => None,
+        | FactoryEventKind::PortalSessionRequested { .. }
+        | FactoryEventKind::PortalSessionCancelRequested { .. } => None,
     }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -56,7 +56,7 @@ that requires a coordinated rollout.
 | `git` | onsager-portal (GitHub webhooks) | 4 |
 | `forge` | forge | 6 |
 | `stiglab` | stiglab | 4 |
-| `portal` | (unknown — update `stream_producer` in xtask) | 1 |
+| `portal` | (unknown — update `stream_producer` in xtask) | 2 |
 | `synodic` | synodic | 9 |
 | `ising` | ising | 6 |
 | `refract` | refract | 3 |
@@ -317,6 +317,18 @@ Dashboard task request from portal. Stiglab's `session_requested_listener` dispa
 | Field | Type | Description |
 |---|---|---|
 | `session_id` | `String` |  |
+
+### `portal.session_cancel_requested`
+
+- Variant: `FactoryEventKind::PortalSessionCancelRequested`
+- Stream: `portal`
+
+Dashboard cancel-session request from portal (spec #303). Stiglab's `session_cancel_requested_listener` looks up the session's node and forwards a `ServerMessage::CancelSession` to the agent. Best-effort: if the node is offline or the session is already terminal, the cancel is a no-op.
+
+| Field | Type | Description |
+|---|---|---|
+| `session_id` | `String` |  |
+| `actor` | `Option<String>` | Actor identifier captured for audit / debugging. _(optional)_ |
 
 ## `synodic` events
 


### PR DESCRIPTION
## Summary

PR 3 of the #289 two-surface IA. Adds a flat-routed run detail hub at `/workspaces/:slug/runs/:runId` with Overview / Stages / Artifacts / Verdicts / Events tabs.

### Frontend (apps/dashboard)
- `RunDetailPage.tsx` with 5 tabs; hash persistence keeps deep-links to a specific tab working.
- Stages tab: per-stage accordion. Each open panel lists linked sessions (deep-link to `/sessions/:id`) with a Cancel button.
- Verdicts + Events tabs reuse the new `run_id` filter on the spine events route.
- `WorkflowDetailPage` run rows now link to `/runs/:runId`.

### Backend (onsager-portal)
- `GET /api/runs/:id` — projected run + parent workflow + stages + linked sessions; auth-gated by the artifact's workspace.
- `POST /api/sessions/:id/cancel` — emits `portal.session_cancel_requested` onto the spine (202 Accepted).
- `GET /api/spine/events` — new `run_id` filter (joins on `stream_id`, `data->>'artifact_id'`, and `sessions.artifact_id`).

### Cross-subsystem (#303 cancel wiring)
- New `FactoryEventKind::PortalSessionCancelRequested` variant + manifest row (producer: portal, consumer: stiglab). Answers spec's "kill stuck session" open question.
- Stiglab gains `session_cancel_requested_listener` that forwards `ServerMessage::CancelSession` to the session's agent over the WebSocket.

## Test plan
- [ ] `xtask check-events`, `check-api-contract`, `lint-seams`, `check-file-budget` all clean locally.
- [ ] Workflows → workflow → runs row → lands on `/runs/:runId` with Overview tab; hash deep-links to other tabs work.
- [ ] Stages accordion expands; Cancel button fires `POST /api/sessions/:id/cancel`.
- [ ] Events tab shows only events for this run.
- [ ] Mobile (360px): tabs + accordion behave.

Closes #303
Part of #289

https://claude.ai/code/session_01UE463Rd9YJBTP1TkKW27EN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UE463Rd9YJBTP1TkKW27EN)_