### PR TITLE
feat(skills): four public skills + bundle scaffolding

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,6 +97,10 @@ jobs:
         run: cargo run -p xtask --quiet -- check-events
       - name: File-budget check (spec #261)
         run: cargo run -p xtask --quiet -- check-file-budget --mode=fail
+      - name: MCP tools ↔ public-skills cross-check (ADR 0007 / spec #310)
+        run: cargo run -p xtask --quiet -- check-tools-and-skills
+        env:
+          ONSAGER_SKILLS_DIR: public-skills
       - name: Apply database migrations
         run: |
           for f in crates/onsager-spine/migrations/*.sql; do

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,14 @@ jobs:
               # re-trigger the xtask job.
               - 'apps/dashboard/src/lib/api.ts'
               - 'apps/dashboard/src/lib/sse.ts'
+              # Spec #310 — check-tools-and-skills cross-references the
+              # MCP tool registry against the public skills bundle. The
+              # registry lives under crates/onsager-portal (already
+              # covered by `workspace`/path triggers); add the staging
+              # bundle dir and this workflow itself so a skill-only
+              # change still re-triggers the lint.
+              - 'public-skills/**'
+              - '.github/workflows/rust.yml'
 
   check:
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,18 +295,24 @@ Layers landing in stages (#288):
   v1 stub returning log pointers; server-side AI reasoning is a
   follow-up), Caddyfile `/mcp/*` block, `xtask
   check-tools-and-skills` lint, ADR 0007 flipped to Accepted.
-- **Skills bundle** — `onsager-ai/onsager-skills` (sibling repo)
-  carries the four initial public skills. Follow-up.
+- **Skills bundle (#310)** — the four initial public skills
+  (`onsager-design-workflow`, `onsager-run-workflow`,
+  `onsager-triage-run`, `onsager-explore-artifacts`) live in
+  `public-skills/` while the cross-repo migration to
+  `onsager-ai/onsager-skills` is in flight. See
+  [`public-skills/README.md`](public-skills/README.md) for install
+  (`npx skills add onsager-ai/onsager-skills`), the trigger-phrase
+  matrix, and how the four skills compose into one product loop.
 - **Dashboard MCP client + HitlCard primitive** — `ChatBuilder.tsx`
   migration + the `HitlCard` constructive/diff/destructive primitive
   + `xtask check-hitl-coverage`. Follow-up.
 
 `xtask check-tools-and-skills` is the enforcement counterpart of
 ADR 0007's dev-process clause (every public tool has a skill
-grant; every skill grant references a real tool). The skills
-cross-check activates when `ONSAGER_SKILLS_DIR` points at a local
-checkout of the bundle repo; CI wires this in once the bundle is
-populated.
+grant; every skill grant references a real tool). It runs in CI
+with `ONSAGER_SKILLS_DIR=public-skills` (staging) and is part of
+`just lint`; once the bundle moves to the sibling repo, CI swaps
+the env var to a `git clone` checkout.
 
 ## The seam rule (canonical)
 

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ lint-rust:
     cargo run -p xtask --quiet -- lint-seams
     cargo run -p xtask --quiet -- check-api-contract
     cargo run -p xtask --quiet -- check-file-budget --mode=fail
+    ONSAGER_SKILLS_DIR=public-skills cargo run -p xtask --quiet -- check-tools-and-skills
 
 lint-ui:
     pnpm --filter dashboard lint

--- a/public-skills/LICENSE
+++ b/public-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Onsager AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/public-skills/README.md
+++ b/public-skills/README.md
@@ -1,0 +1,74 @@
+# onsager-skills
+
+Public **skills bundle** for [Onsager](https://github.com/onsager-ai/onsager) — the operating-procedures knowledge layer that pairs with portal's MCP server (the action layer). Together they are clause 1 of [ADR 0007](https://github.com/onsager-ai/onsager/blob/main/docs/adr/0007-tools-and-skills-as-the-public-contract.md): the **two-layer public contract** Onsager exposes to AI runtimes.
+
+Tools are *what* you can call. Skills are *when to call which tool*, *how to sequence them*, and *what shapes the arguments expect*. Without the skills, an LLM staring at 11 tool descriptions has to guess the workflow; with them, the LLM sees a trigger phrase → tool sequence → example shape, and ships the right call on the first try.
+
+> **Staging note.** This bundle is currently staged inside the main `onsager-ai/onsager` repo at `public-skills/` while the cross-repo migration to `onsager-ai/onsager-skills` is in flight. The `xtask check-tools-and-skills` lint picks it up via `ONSAGER_SKILLS_DIR=public-skills`. Once it lands in the sibling repo, this README is the canonical entry point and the staging copy goes away.
+
+## Install
+
+In a Claude Code session:
+
+```bash
+npx skills add onsager-ai/onsager-skills
+```
+
+This drops the four skills below into your local `~/.claude/skills/` so Claude Code triggers them automatically when their phrases match.
+
+### Prerequisites
+
+The skills call the portal MCP server. You need:
+
+- An Onsager portal URL (default `https://your-org.onsager.dev`; for local dev, `http://localhost:3002`).
+- A Personal Access Token with workspace access. Create one in the dashboard at **Settings → Tokens**.
+- Your MCP client configured to point at `<portal-url>/mcp/messages` with the PAT in the `Authorization: Bearer <token>` header.
+
+## The four skills
+
+Each skill is a `SKILL.md` with YAML frontmatter — `name`, `description`, trigger-phrase list, and `allowed_tools`. The body is the operating procedure: when the trigger fires, here is the sequence of MCP tool calls to make, the argument shapes to use, and the failure modes to watch for.
+
+| Skill | Triggers (sample) | Tools it grants |
+| --- | --- | --- |
+| [`onsager-design-workflow`](skills/onsager-design-workflow/SKILL.md) | "design a workflow", "create an automation", "build a pipeline" | `propose_workflow`, `edit_workflow`, `list_workflows`, `schedule_workflow` |
+| [`onsager-run-workflow`](skills/onsager-run-workflow/SKILL.md) | "run this workflow", "execute the pipeline", "trigger a run" | `run_workflow`, `list_workflows`, `inspect_run` |
+| [`onsager-triage-run`](skills/onsager-triage-run/SKILL.md) | "the run failed", "diagnose this", "why did it fail" | `inspect_run`, `get_stage_logs`, `propose_remediation`, `cancel_run` |
+| [`onsager-explore-artifacts`](skills/onsager-explore-artifacts/SKILL.md) | "show me the artifacts", "what did this run produce" | `get_artifact`, `list_runs` |
+
+### How the skills compose
+
+The four skills cover one product loop:
+
+1. **Design** a workflow (`onsager-design-workflow`).
+2. **Run** it manually or wait for its trigger to fire (`onsager-run-workflow`).
+3. **Explore** the artifacts a run produced (`onsager-explore-artifacts`).
+4. **Triage** a run that failed or got stuck (`onsager-triage-run`).
+
+You can hold the whole loop in one chat — the trigger phrases are designed not to collide, so "design me a workflow, run it once, and show me what it produced" cleanly chains three skills back-to-back.
+
+## Cross-repo contract
+
+The MCP tool registry is the single source of truth: [`crates/onsager-portal/src/mcp/registry.rs`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-portal/src/mcp/registry.rs) in the main repo. Two invariants are mechanically enforced by `xtask check-tools-and-skills`:
+
+1. Every tool name listed in any skill's `allowed_tools` is a real, registered MCP tool.
+2. Every registered MCP tool appears in `allowed_tools` of at least one skill — no orphan tools, no orphan grants.
+
+That cross-check is exactly the [half-wired drift pattern](https://github.com/onsager-ai/onsager/blob/main/CLAUDE.md#architectural-drift-patterns-to-watch) caught for tools/skills, the way `check-events` catches producer-without-consumer for spine events.
+
+To run the cross-check locally, with both repos checked out side-by-side:
+
+```bash
+cd onsager
+ONSAGER_SKILLS_DIR=../onsager-skills cargo run -p xtask -- check-tools-and-skills
+```
+
+While the bundle is staged inside the main repo, point at the staging dir instead:
+
+```bash
+cd onsager
+ONSAGER_SKILLS_DIR=public-skills cargo run -p xtask -- check-tools-and-skills
+```
+
+## License
+
+[MIT](LICENSE)

--- a/public-skills/package.json
+++ b/public-skills/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "onsager-skills",
+  "version": "0.1.0",
+  "description": "Public skills bundle for Onsager — operating-procedures knowledge paired with the portal MCP server's tool surface (ADR 0007).",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onsager-ai/onsager-skills.git"
+  },
+  "homepage": "https://github.com/onsager-ai/onsager-skills",
+  "bugs": {
+    "url": "https://github.com/onsager-ai/onsager/issues"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "skills",
+    "mcp",
+    "onsager"
+  ],
+  "files": [
+    "skills",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/public-skills/skills/onsager-design-workflow/SKILL.md
+++ b/public-skills/skills/onsager-design-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onsager-design-workflow
-description: Design a new Onsager workflow — pick a trigger, chain ordered stages, and create the workflow inactive via the portal MCP server. Triggers include "design a workflow", "create an automation", "build a pipeline", "set up a workflow that runs on every issue comment", "schedule a workflow to run every morning", "deactivate this workflow". Allowed tools cover the full create/list/edit/schedule surface; activation runs through the REST PATCH endpoint, not MCP.
+description: Design a new Onsager workflow — pick a trigger, chain ordered stages, and create the workflow inactive via the portal MCP server. Triggers include "design a workflow", "create an automation", "build a pipeline", "set up a workflow that fires on issue webhooks", "schedule a workflow to run every morning", "deactivate this workflow". Allowed tools cover the full create/list/edit/schedule surface; activation runs through the REST PATCH endpoint, not MCP.
 allowed_tools:
 - propose_workflow
 - edit_workflow
@@ -10,17 +10,17 @@ allowed_tools:
 
 # onsager-design-workflow
 
-A **workflow** in Onsager is a trigger plus an ordered chain of stages. The trigger says when to fire; the stages say what to do, in order, until something gates the artifact or releases it. This skill creates and shapes those blueprints. Running a workflow lives in `onsager-run-workflow`; triaging a stuck run lives in `onsager-triage-run`.
+A **workflow** in Onsager is a trigger plus an ordered chain of stages. The trigger says when to fire; the stages say what to do, in order, until something parks the artifact or releases it. This skill creates and shapes those blueprints. Running a workflow lives in `onsager-run-workflow`; triaging a stuck run lives in `onsager-triage-run`.
 
 ## When this skill triggers
 
 Phrases that should route here:
 
-- "design a workflow that runs on every issue comment"
-- "create an automation for new pull requests"
+- "design a workflow that runs on a GitHub issue label"
+- "create an automation for merged pull requests"
 - "build a pipeline that triages incoming issues"
 - "schedule a workflow to run every morning at 09:00"
-- "deactivate the spec-link workflow"
+- "deactivate the morning-digest workflow"
 - "list the workflows in this workspace"
 
 If the user is asking to *fire* an existing workflow ("run this", "trigger a run"), hand off to `onsager-run-workflow`.
@@ -33,38 +33,56 @@ Every tool here takes a `workspace_id`. If the user hasn't named one, call `list
 
 ### Step 2 — pick a trigger
 
-The portal MCP server accepts these trigger kinds (canonical list in [`onsager-spine::TriggerKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-spine/src/trigger.rs)):
+The portal MCP server accepts the trigger kinds defined in [`onsager-spine::TriggerKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-spine/src/trigger.rs). The wire form is `{ "kind": "<snake_case_tag>", … }` with the variant's fields alongside.
 
-- `manual` — fires only on `run_workflow`.
-- `cron` — fires on a cron schedule.
-- `interval` — fires every `N` seconds/minutes/hours.
-- `delay` — fires once, after a delay.
-- `github_issue_opened`, `github_issue_commented`, `github_pull_request_opened`, `github_pull_request_review`, `github_pr_comment`, `github_check_run` — fire on the named GitHub webhook.
-- `spine_event` — fires on a spine event kind (e.g. `artifact.registered`). **Forbidden case**: `spine_event { event_kind: "trigger.fired" }` self-amplifies and the tool rejects it.
+External (webhook) kinds:
 
-GitHub triggers need an `install_id` (the GitHub App installation row id). For schedule and manual triggers, pass `install_id: 0`.
+- `github_issue_webhook` — fires on `issues.labeled` whose label matches. Fields: `repo` (`"owner/name"`), `label`.
+- `github_pull_request_closed` — fires on `pull_request.closed`. Fields: `repo`, optional `predicate.merged` (`true` for merged-only, `false` for closed-without-merge, omit for any close).
+- `github_workflow_run_completed` — fires on `workflow_run.completed`. Fields: `repo`, `workflow_name`, optional `event`, `head_branch`, `conclusion`.
+- `telegram_webhook` — fires on a Telegram bot update. Fields: `bot_username`, optional `chat_id_allowlist`, optional `command_prefix` (e.g. `/onsager`).
+
+Schedule kinds:
+
+- `cron` — cron schedule. Fields: `expression` (5- or 6-field cron string), optional `timezone` (IANA name; defaults to UTC).
+- `delay` — fire once after a delay. Fields: `seconds`, optional `anchor` (v1 only `workflow_activated_at`).
+- `interval` — periodic. Fields: `period_seconds`.
+
+Event kinds:
+
+- `spine_event` — fire on a `FactoryEventKind` whose `type` matches. Fields: `event_kind`, optional `filter.equals` (JSON-shape predicate). **Forbidden**: `event_kind: "trigger.fired"` self-amplifies and the tool rejects it.
+- `pg_notify` — fire on a Postgres `NOTIFY <channel>`. Fields: `channel`, optional `filter`.
+- `outbox_row` — fire when a row matching `where_clause` is inserted into `table`. Fields: `table`, `where_clause`.
+
+Manual kinds:
+
+- `manual` — fire on demand. Fields: `name` (the button label).
+- `replay` — re-emit a past `TriggerFired` event by id. Fields: `source_event_id`.
+
+`install_id` is the GitHub App installation row id. Required for `github_*` triggers; pass `0` for schedule / manual / event-bus triggers.
 
 ### Step 3 — chain stages
 
-Each stage is a `{ gate_kind, params? }` pair. Gate kinds are registered in [`onsager-portal::workflow::GateKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-portal/src/workflow.rs). The most common today:
+Each stage is a `{ gate_kind, params? }` pair. `gate_kind` is a **kebab-case** string from [`onsager-portal::workflow::GateKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-portal/src/workflow.rs):
 
-- `agent_session` — dispatches a stiglab agent session with a prompt. `params: { prompt: "..." }`.
-- `spec_link_check` — passes only if the linked spec issue is in a valid state.
-- `synodic_review` — sends the artifact to the synodic gate for human/governance review.
+- `agent-session` — dispatches a stiglab agent session with a prompt. `params: { "prompt": "…" }`.
+- `external-check` — an external pass/fail check (e.g. spec-link validation). `params` defines the check.
+- `governance` — sends the artifact to the synodic gate for governance review.
+- `manual-approval` — parks for a human click in the dashboard.
 
-The order matters: stage `0` runs first, then `1`, then `2`. A stage failing parks the artifact at that stage with a `parked_reason`; the workflow only releases when every stage passes.
+The order matters: stage `0` runs first, then `1`, then `2`. A stage that doesn't pass parks the artifact at that stage with a `workflow_parked_reason`; the workflow only releases when every stage passes (artifact state → `released`).
 
 ### Step 4 — call `propose_workflow`
 
 ```json
 {
   "workspace_id": "ws_<uuid>",
-  "name": "Triage every new issue",
-  "trigger": { "kind": "github_issue_opened" },
+  "name": "Triage every labeled issue",
+  "trigger": { "kind": "github_issue_webhook", "repo": "acme/widgets", "label": "needs-triage" },
   "install_id": 12345,
   "stages": [
-    { "gate_kind": "agent_session", "params": { "prompt": "Classify this issue and add labels." } },
-    { "gate_kind": "synodic_review" }
+    { "gate_kind": "agent-session", "params": { "prompt": "Classify this issue and add labels." } },
+    { "gate_kind": "governance" }
   ]
 }
 ```
@@ -78,7 +96,10 @@ After the call succeeds, tell the user: "Created workflow `<name>` (id `<wf_…>
 To change an existing workflow's trigger (e.g. swap cron expressions, or move from manual to cron), use `schedule_workflow`:
 
 ```json
-{ "workflow_id": "wf_…", "trigger": { "kind": "cron", "expr": "0 9 * * *" } }
+{
+  "workflow_id": "wf_…",
+  "trigger": { "kind": "cron", "expression": "0 9 * * *", "timezone": "UTC" }
+}
 ```
 
 `schedule_workflow` replaces the trigger atomically. It validates the kind against the registry manifest and rejects the self-amplifying `spine_event { event_kind: "trigger.fired" }` case for the same reason `propose_workflow` does.
@@ -93,16 +114,20 @@ To change an existing workflow's trigger (e.g. swap cron expressions, or move fr
 
 ## Common shapes (copy-paste templates)
 
-### "Run a stage on every new PR"
+### "Run a stage on every merged PR"
 
 ```json
 {
   "workspace_id": "<ws>",
-  "name": "PR review pass",
-  "trigger": { "kind": "github_pull_request_opened" },
+  "name": "Merged-PR review pass",
+  "trigger": {
+    "kind": "github_pull_request_closed",
+    "repo": "acme/widgets",
+    "predicate": { "merged": true }
+  },
   "install_id": <install_id>,
   "stages": [
-    { "gate_kind": "agent_session", "params": { "prompt": "Review this PR for spec drift." } }
+    { "gate_kind": "agent-session", "params": { "prompt": "Review this PR for spec drift." } }
   ]
 }
 ```
@@ -113,10 +138,10 @@ To change an existing workflow's trigger (e.g. swap cron expressions, or move fr
 {
   "workspace_id": "<ws>",
   "name": "Morning digest",
-  "trigger": { "kind": "cron", "expr": "0 9 * * *" },
+  "trigger": { "kind": "cron", "expression": "0 9 * * *", "timezone": "UTC" },
   "install_id": 0,
   "stages": [
-    { "gate_kind": "agent_session", "params": { "prompt": "Summarise yesterday's merged PRs." } }
+    { "gate_kind": "agent-session", "params": { "prompt": "Summarise yesterday's merged PRs." } }
   ]
 }
 ```
@@ -130,7 +155,25 @@ To change an existing workflow's trigger (e.g. swap cron expressions, or move fr
   "trigger": { "kind": "manual", "name": "go" },
   "install_id": 0,
   "stages": [
-    { "gate_kind": "agent_session", "params": { "prompt": "Backfill missing labels on open issues." } }
+    { "gate_kind": "agent-session", "params": { "prompt": "Backfill missing labels on open issues." } }
+  ]
+}
+```
+
+### "Run on a spine event"
+
+```json
+{
+  "workspace_id": "<ws>",
+  "name": "On artifact registration",
+  "trigger": {
+    "kind": "spine_event",
+    "event_kind": "artifact.registered",
+    "filter": { "equals": { "$.payload.kind": "pull_request" } }
+  },
+  "install_id": 0,
+  "stages": [
+    { "gate_kind": "agent-session", "params": { "prompt": "Welcome the artifact author." } }
   ]
 }
 ```
@@ -140,6 +183,7 @@ To change an existing workflow's trigger (e.g. swap cron expressions, or move fr
 - **`InvalidParams: MCP propose_workflow cannot activate inline …`** — you passed `active: true`. Drop it and tell the user to activate from the dashboard.
 - **`InvalidParams: trigger kind `…` is not in the registry manifest`** — typo in the trigger kind, or the kind hasn't shipped yet. Fall back to `manual` while the user files a spec for the new kind.
 - **`InvalidParams: spine_event workflow cannot listen for `trigger.fired` …`** — the requested workflow would self-amplify. Suggest a different event kind (e.g. `artifact.registered`).
+- **Schema validation error on `gate_kind`** — `gate_kind` is kebab-case (`agent-session`, not `agent_session`). Same for `trigger.kind` — snake_case (`github_issue_webhook`, not `githubIssueWebhook`).
 - **`Unauthorized`** — the PAT doesn't have access to the workspace the user named. Have them re-issue the PAT scoped to that workspace.
 
 ## Related skills

--- a/public-skills/skills/onsager-design-workflow/SKILL.md
+++ b/public-skills/skills/onsager-design-workflow/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: onsager-design-workflow
+description: Design a new Onsager workflow — pick a trigger, chain ordered stages, and create the workflow inactive via the portal MCP server. Triggers include "design a workflow", "create an automation", "build a pipeline", "set up a workflow that runs on every issue comment", "schedule a workflow to run every morning", "deactivate this workflow". Allowed tools cover the full create/list/edit/schedule surface; activation runs through the REST PATCH endpoint, not MCP.
+allowed_tools:
+- propose_workflow
+- edit_workflow
+- list_workflows
+- schedule_workflow
+---
+
+# onsager-design-workflow
+
+A **workflow** in Onsager is a trigger plus an ordered chain of stages. The trigger says when to fire; the stages say what to do, in order, until something gates the artifact or releases it. This skill creates and shapes those blueprints. Running a workflow lives in `onsager-run-workflow`; triaging a stuck run lives in `onsager-triage-run`.
+
+## When this skill triggers
+
+Phrases that should route here:
+
+- "design a workflow that runs on every issue comment"
+- "create an automation for new pull requests"
+- "build a pipeline that triages incoming issues"
+- "schedule a workflow to run every morning at 09:00"
+- "deactivate the spec-link workflow"
+- "list the workflows in this workspace"
+
+If the user is asking to *fire* an existing workflow ("run this", "trigger a run"), hand off to `onsager-run-workflow`.
+
+## Operating procedure
+
+### Step 1 — confirm the workspace
+
+Every tool here takes a `workspace_id`. If the user hasn't named one, call `list_workflows` against the workspace they're working in (the chat surface usually has this in scope; otherwise ask). Never invent a workspace id.
+
+### Step 2 — pick a trigger
+
+The portal MCP server accepts these trigger kinds (canonical list in [`onsager-spine::TriggerKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-spine/src/trigger.rs)):
+
+- `manual` — fires only on `run_workflow`.
+- `cron` — fires on a cron schedule.
+- `interval` — fires every `N` seconds/minutes/hours.
+- `delay` — fires once, after a delay.
+- `github_issue_opened`, `github_issue_commented`, `github_pull_request_opened`, `github_pull_request_review`, `github_pr_comment`, `github_check_run` — fire on the named GitHub webhook.
+- `spine_event` — fires on a spine event kind (e.g. `artifact.registered`). **Forbidden case**: `spine_event { event_kind: "trigger.fired" }` self-amplifies and the tool rejects it.
+
+GitHub triggers need an `install_id` (the GitHub App installation row id). For schedule and manual triggers, pass `install_id: 0`.
+
+### Step 3 — chain stages
+
+Each stage is a `{ gate_kind, params? }` pair. Gate kinds are registered in [`onsager-portal::workflow::GateKind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-portal/src/workflow.rs). The most common today:
+
+- `agent_session` — dispatches a stiglab agent session with a prompt. `params: { prompt: "..." }`.
+- `spec_link_check` — passes only if the linked spec issue is in a valid state.
+- `synodic_review` — sends the artifact to the synodic gate for human/governance review.
+
+The order matters: stage `0` runs first, then `1`, then `2`. A stage failing parks the artifact at that stage with a `parked_reason`; the workflow only releases when every stage passes.
+
+### Step 4 — call `propose_workflow`
+
+```json
+{
+  "workspace_id": "ws_<uuid>",
+  "name": "Triage every new issue",
+  "trigger": { "kind": "github_issue_opened" },
+  "install_id": 12345,
+  "stages": [
+    { "gate_kind": "agent_session", "params": { "prompt": "Classify this issue and add labels." } },
+    { "gate_kind": "synodic_review" }
+  ]
+}
+```
+
+Important: **do not pass `active: true`**. The MCP entry point doesn't plumb the request headers the activation pipeline needs (it does the GitHub label-create + webhook-register side-effects), so the tool returns `InvalidParams` if you ask for inline activation. Workflows always land inactive; the user activates them via the dashboard or REST PATCH.
+
+After the call succeeds, tell the user: "Created workflow `<name>` (id `<wf_…>`), currently inactive. Activate it in the dashboard at **Workflows → <name> → Activate**." Don't try to activate it through MCP.
+
+### Step 5 — schedule changes
+
+To change an existing workflow's trigger (e.g. swap cron expressions, or move from manual to cron), use `schedule_workflow`:
+
+```json
+{ "workflow_id": "wf_…", "trigger": { "kind": "cron", "expr": "0 9 * * *" } }
+```
+
+`schedule_workflow` replaces the trigger atomically. It validates the kind against the registry manifest and rejects the self-amplifying `spine_event { event_kind: "trigger.fired" }` case for the same reason `propose_workflow` does.
+
+### Step 6 — deactivate
+
+`edit_workflow` can deactivate (`active: false`). Re-activation is **not** supported via MCP today — same headers issue as `propose_workflow`. If the user asks to re-activate, point them at the dashboard or REST PATCH.
+
+```json
+{ "workflow_id": "wf_…", "active": false }
+```
+
+## Common shapes (copy-paste templates)
+
+### "Run a stage on every new PR"
+
+```json
+{
+  "workspace_id": "<ws>",
+  "name": "PR review pass",
+  "trigger": { "kind": "github_pull_request_opened" },
+  "install_id": <install_id>,
+  "stages": [
+    { "gate_kind": "agent_session", "params": { "prompt": "Review this PR for spec drift." } }
+  ]
+}
+```
+
+### "Run something every morning"
+
+```json
+{
+  "workspace_id": "<ws>",
+  "name": "Morning digest",
+  "trigger": { "kind": "cron", "expr": "0 9 * * *" },
+  "install_id": 0,
+  "stages": [
+    { "gate_kind": "agent_session", "params": { "prompt": "Summarise yesterday's merged PRs." } }
+  ]
+}
+```
+
+### "A one-shot workflow I'll fire by hand"
+
+```json
+{
+  "workspace_id": "<ws>",
+  "name": "Ad-hoc backfill",
+  "trigger": { "kind": "manual", "name": "go" },
+  "install_id": 0,
+  "stages": [
+    { "gate_kind": "agent_session", "params": { "prompt": "Backfill missing labels on open issues." } }
+  ]
+}
+```
+
+## Failure modes to watch for
+
+- **`InvalidParams: MCP propose_workflow cannot activate inline …`** — you passed `active: true`. Drop it and tell the user to activate from the dashboard.
+- **`InvalidParams: trigger kind `…` is not in the registry manifest`** — typo in the trigger kind, or the kind hasn't shipped yet. Fall back to `manual` while the user files a spec for the new kind.
+- **`InvalidParams: spine_event workflow cannot listen for `trigger.fired` …`** — the requested workflow would self-amplify. Suggest a different event kind (e.g. `artifact.registered`).
+- **`Unauthorized`** — the PAT doesn't have access to the workspace the user named. Have them re-issue the PAT scoped to that workspace.
+
+## Related skills
+
+- `onsager-run-workflow` — fire a workflow once it's active.
+- `onsager-explore-artifacts` — inspect what a run produced.
+- `onsager-triage-run` — diagnose a run that failed or got stuck.

--- a/public-skills/skills/onsager-explore-artifacts/SKILL.md
+++ b/public-skills/skills/onsager-explore-artifacts/SKILL.md
@@ -45,7 +45,7 @@ Response shape:
       "artifact_id": "art_…",
       "status": "passed" | "failed" | "blocked" | "pending",
       "current_stage_index": 2,
-      "parked_reason": null | "spec_link_check: no spec issue linked",
+      "parked_reason": null | "external-check: no spec issue linked",
       "started_at": "2026-…",
       "updated_at": "2026-…"
     },
@@ -73,7 +73,7 @@ Surface to the user as a table or a tight list. The dashboard's run-detail URL i
 
 Response shape includes:
 
-- `id`, `workspace_id`, `kind` (`issue` / `pull_request` / `agent_session` / `deployment` / …), `name`, `state`.
+- `id`, `workspace_id`, `kind` (`github_issue` / `pull_request` / `code` / `document` / or a custom workspace-defined string — see [`onsager-artifact::Kind`](https://github.com/onsager-ai/onsager/blob/main/crates/onsager-artifact/src/artifact.rs)), `name`, `state` (one of `draft` / `in_progress` / `under_review` / `released` / `archived`).
 - `owner`, `current_version`, `consumers` (downstream artifacts), `external_ref` (e.g. `github.com/org/repo/issues/42`).
 - `workflow_id`, `current_stage_index`, `workflow_parked_reason`.
 - `created_at`, `updated_at`, `last_observed_at`.

--- a/public-skills/skills/onsager-explore-artifacts/SKILL.md
+++ b/public-skills/skills/onsager-explore-artifacts/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: onsager-explore-artifacts
+description: Browse the artifacts an Onsager workflow has produced — list recent runs for a workflow, then drill into a specific artifact's metadata and current state. Triggers include "show me the artifacts", "what did this run produce", "list recent runs of the workflow", "what artifacts has this workflow created", "show me artifact `art_…`", "what's the state of run `art_…`". Read-only — no mutations. For diagnosis when something failed, use `onsager-triage-run`.
+allowed_tools:
+- get_artifact
+- list_runs
+---
+
+# onsager-explore-artifacts
+
+Workflows produce **artifacts** — issues, PRs, agent sessions, deployments, anything with a lifecycle. This skill is the read-only browse surface: list the runs of a workflow, drill into one artifact. No mutations. If something failed and the user wants a fix, that's `onsager-triage-run`.
+
+## When this skill triggers
+
+Phrases that should route here:
+
+- "show me the artifacts this workflow has produced"
+- "list recent runs of the morning-digest workflow"
+- "what's the state of artifact `art_…`?"
+- "show me the metadata for run `<id>`"
+- "what artifacts has my PR-review workflow created this week?"
+
+If the user wants to fire a run, that's `onsager-run-workflow`. If they want to fix one that failed, that's `onsager-triage-run`.
+
+## Operating procedure
+
+### Step 1 — listing runs
+
+`list_runs` returns the recent runs for a single workflow. One artifact == one run (per the workflow runtime), so the response is the artifact list with a derived `status`:
+
+```json
+{ "workflow_id": "wf_…", "limit": 50 }
+```
+
+`limit` is optional, defaults to 50, clamped to `[1, 500]`.
+
+Response shape:
+
+```json
+{
+  "runs": [
+    {
+      "id": "art_…",
+      "workflow_id": "wf_…",
+      "artifact_id": "art_…",
+      "status": "passed" | "failed" | "blocked" | "pending",
+      "current_stage_index": 2,
+      "parked_reason": null | "spec_link_check: no spec issue linked",
+      "started_at": "2026-…",
+      "updated_at": "2026-…"
+    },
+    …
+  ]
+}
+```
+
+`status` derivations:
+
+- `passed` — artifact `state == 'released'` (every stage passed).
+- `failed` — artifact `state == 'archived'` (cancelled or terminally failed).
+- `blocked` — `workflow_parked_reason` is non-null (stuck at a gate).
+- `pending` — anything else (in-flight).
+
+Surface to the user as a table or a tight list. The dashboard's run-detail URL is `<portal-url>/runs/<artifact_id>` — link each row when you can.
+
+### Step 2 — drilling into one artifact
+
+`get_artifact` returns the full row for a single artifact:
+
+```json
+{ "artifact_id": "art_…" }
+```
+
+Response shape includes:
+
+- `id`, `workspace_id`, `kind` (`issue` / `pull_request` / `agent_session` / `deployment` / …), `name`, `state`.
+- `owner`, `current_version`, `consumers` (downstream artifacts), `external_ref` (e.g. `github.com/org/repo/issues/42`).
+- `workflow_id`, `current_stage_index`, `workflow_parked_reason`.
+- `created_at`, `updated_at`, `last_observed_at`.
+
+`external_ref` is the most useful field for surfacing to the user — if the artifact is a GitHub issue or PR, that's the link they actually want to click.
+
+`consumers` is a JSON array of downstream artifact ids. If the user asks "what did this produce?", drill into each `consumer` with another `get_artifact` call. Don't fan out beyond two levels without asking — the consumer graph can be deep.
+
+## Common shapes
+
+### "What's running for workflow X right now?"
+
+1. `list_runs { "workflow_id": "wf_…", "limit": 20 }`.
+2. Filter client-side for `status == 'pending'` or `status == 'blocked'`.
+3. Report.
+
+### "Show me the last 5 runs of workflow X"
+
+```json
+{ "workflow_id": "wf_…", "limit": 5 }
+```
+
+### "What's the state of artifact `art_…`?"
+
+```json
+{ "artifact_id": "art_…" }
+```
+
+### "What did run `art_…` produce?"
+
+1. `get_artifact { "artifact_id": "art_…" }`.
+2. Read the `consumers` array.
+3. For each entry, `get_artifact { "artifact_id": "<consumer_id>" }` and report the `kind` + `external_ref`.
+
+## Failure modes to watch for
+
+- **`NotFound: artifact `…` not found`** — typo in the id, or the artifact was hard-deleted (rare). Confirm the id with the user.
+- **`NotFound: workflow `…` not found`** — typo in the workflow id. Use `list_workflows` (from `onsager-design-workflow`) to find the right one.
+- **`Unauthorized`** — PAT doesn't have workspace access.
+
+## Related skills
+
+- `onsager-design-workflow` — list and edit the workflows themselves.
+- `onsager-run-workflow` — fire a new run.
+- `onsager-triage-run` — diagnose when `status` is `failed` or `blocked`.

--- a/public-skills/skills/onsager-run-workflow/SKILL.md
+++ b/public-skills/skills/onsager-run-workflow/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: onsager-run-workflow
-description: Fire an Onsager workflow's manual trigger to start a new run and watch its first few stages. Triggers include "run this workflow", "execute the pipeline", "trigger a run", "kick off the digest workflow", "fire the backfill once", "run the manual workflow named go". Allowed tools cover the manual-trigger fire and the initial inspection step; deep diagnosis lives in `onsager-triage-run`.
+description: Fire an Onsager workflow's manual trigger to start a new run and surface the resulting artifact. Triggers include "run this workflow", "execute the pipeline", "trigger a run", "kick off the digest workflow", "fire the backfill once", "run the manual workflow named go". Allowed tools cover the manual-trigger fire, recent-runs lookup (to discover the artifact the runtime materialises asynchronously), and an initial inspection. Deep diagnosis lives in `onsager-triage-run`.
 allowed_tools:
 - run_workflow
 - list_workflows
+- list_runs
 - inspect_run
 ---
 
 # onsager-run-workflow
 
-A workflow's `manual` trigger is a named door — fire it with `run_workflow` and one new run starts. This skill covers the "I want this workflow to run *now*" path. Scheduled / webhook-triggered runs fire on their own; you don't need this skill for them.
+A workflow's `manual` trigger is a named door — fire it with `run_workflow` and the workflow runtime materialises a new artifact (one artifact == one run). This skill covers the "I want this workflow to run *now*" path. Scheduled / webhook-triggered runs fire on their own; you don't need this skill for them.
 
 ## When this skill triggers
 
@@ -35,11 +36,11 @@ If the user names the workflow by id (`wf_…`), use it directly. Otherwise call
 
 The response is `{ "workflows": [ { "id": "wf_…", "name": "…", "active": true, "trigger": { … } }, … ] }`. Pick the row whose `name` matches and confirm `active: true` (an inactive workflow can't fire — point the user at the dashboard's activate switch).
 
-Also confirm the trigger is `manual`. If it's `cron` / `github_*` / `spine_event`, this skill doesn't apply — runs of that workflow happen on their own schedule or in response to external events. Tell the user that and don't call `run_workflow`.
+Also confirm the trigger is `manual`. If it's `cron` / `github_*` / `spine_event` / etc., this skill doesn't apply — runs of that workflow happen on their own schedule or in response to external events. Tell the user that and don't call `run_workflow`.
 
 ### Step 2 — pick the trigger name
 
-`manual` triggers have a `name` field (set when the workflow was designed). The default is `go`. If the user said "fire the `nightly` trigger", pass `trigger_name: "nightly"`. If they didn't name one, try `"go"` first.
+`manual` triggers have a `name` field (set when the workflow was designed). If the user said "fire the `nightly` trigger", pass `trigger_name: "nightly"`. Otherwise read the workflow's trigger payload from step 1 — `trigger.kind == "manual"` carries a `name` field; use exactly that string.
 
 ### Step 3 — call `run_workflow`
 
@@ -53,11 +54,33 @@ Also confirm the trigger is `manual`. If it's `cron` / `github_*` / `spine_event
 
 `payload` is optional. Canonical fields (`workflow_id`, `workspace_id`, `name`, `actor`, `source`, `fired_at`, `trigger_kind`) always override any colliding keys, so you can pass arbitrary structured data without worrying about clobbering the trigger's own metadata.
 
-The tool returns the new artifact id — that's your `run_id`. Surface it to the user with the dashboard's run-detail deep-link: `<portal-url>/runs/<artifact_id>`.
+The tool returns:
 
-### Step 4 — first-look inspection
+```json
+{
+  "workflow_id": "wf_…",
+  "trigger_event_id": 123456,
+  "fired_at": "2026-…"
+}
+```
 
-Right after firing, call `inspect_run` with the returned artifact id and a small `event_limit`:
+Note: `run_workflow` does **not** return an `artifact_id`. It emits the `workflow.trigger.fired` event onto the spine; the workflow runtime materialises the artifact asynchronously a moment later (typically <1s). The `trigger_event_id` is the audit pointer back to the fire — useful for log searches, not for deep-linking the run.
+
+### Step 4 — discover the new artifact
+
+Call `list_runs` against the workflow to find the artifact the runtime just materialised:
+
+```json
+{ "workflow_id": "wf_…", "limit": 5 }
+```
+
+Look for the newest row whose `started_at` is at or after the `fired_at` you got back from `run_workflow`. That's the new run; its `artifact_id` is the deep-link target — surface it as `<portal-url>/runs/<artifact_id>` to the user.
+
+If the newest row's `started_at` is still earlier than `fired_at`, the runtime hasn't materialised the artifact yet (rare; usually <1s lag). Tell the user the fire succeeded and to refresh the dashboard in a moment; don't loop polling.
+
+### Step 5 — first-look inspection
+
+Once you have the artifact id, call `inspect_run`:
 
 ```json
 { "artifact_id": "<artifact_id>", "event_limit": 20 }
@@ -65,12 +88,12 @@ Right after firing, call `inspect_run` with the returned artifact id and a small
 
 The response carries:
 
-- `artifact.state` — usually `registered` immediately after fire, then transitions through `provisioning` / `running` as stages start.
+- `artifact.state` — one of `draft`, `in_progress`, `under_review`, `released`, `archived`. Right after fire the runtime advances the artifact through these as stages enter/exit (`in_progress` for `agent-session` stages, `under_review` for `external-check` / `governance` / `manual-approval` stages).
 - `artifact.current_stage_index` — 0 right after fire; advances as stages pass.
-- `artifact.workflow_parked_reason` — `null` for a healthy run. If non-null, the artifact is parked at the current stage and this is **not** a fire-success path: hand off to `onsager-triage-run`.
-- `recent_events` — newest first. Look for `trigger.fired` (your fire), then `stage.entered` events as the workflow advances.
+- `artifact.workflow_parked_reason` — `null` for a healthy run. **Non-null means the run is parked at the current stage** (and is **not** a fire-success path): hand off to `onsager-triage-run`.
+- `recent_events` — newest first. Look for `workflow.trigger.fired` (your fire) and the subsequent `stage.entered` events as the workflow advances.
 
-Report back to the user: "Started run `<artifact_id>`, currently on stage `<index>` (`<gate_kind>`). Open the run at `/runs/<artifact_id>`." Don't loop polling `inspect_run` — one read is enough; the user opens the dashboard for live state.
+Report back to the user: "Started run `<artifact_id>`, currently on stage `<index>` (`<gate_kind>`). Open the run at `/runs/<artifact_id>`." Don't loop polling — one read is enough; the user opens the dashboard for live state.
 
 ## Common shapes
 
@@ -95,10 +118,10 @@ Report back to the user: "Started run `<artifact_id>`, currently on stage `<inde
 
 ## Failure modes to watch for
 
-- **`InvalidParams: workflow has no manual trigger named <name>`** — the workflow's trigger is scheduled or webhook-driven, or `trigger_name` doesn't match. Re-read the workflow's `trigger` field from `list_workflows`; if it's not `manual`, this skill doesn't apply.
-- **`InvalidParams: workflow is inactive`** — workflow exists but `active: false`. Tell the user to activate it in the dashboard first; this skill cannot activate it (per `onsager-design-workflow`'s headers limitation).
+- **`InvalidParams: workflow <id> does not declare manual trigger `<name>` …`** — the workflow's trigger is scheduled or webhook-driven, or `trigger_name` doesn't match the configured `name`. Re-read the workflow's `trigger` field from `list_workflows`; if it's not `manual`, this skill doesn't apply.
+- **`InvalidParams: workflow is inactive — activate before firing`** — workflow exists but `active: false`. Tell the user to activate it in the dashboard first; this skill cannot activate it (per `onsager-design-workflow`'s headers limitation).
 - **`Unauthorized`** — PAT doesn't have workspace access.
-- **`artifact.workflow_parked_reason` non-null on first inspect** — handed off to `onsager-triage-run`.
+- **`artifact.workflow_parked_reason` non-null on first inspect** — hand off to `onsager-triage-run`.
 
 ## Related skills
 

--- a/public-skills/skills/onsager-run-workflow/SKILL.md
+++ b/public-skills/skills/onsager-run-workflow/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: onsager-run-workflow
+description: Fire an Onsager workflow's manual trigger to start a new run and watch its first few stages. Triggers include "run this workflow", "execute the pipeline", "trigger a run", "kick off the digest workflow", "fire the backfill once", "run the manual workflow named go". Allowed tools cover the manual-trigger fire and the initial inspection step; deep diagnosis lives in `onsager-triage-run`.
+allowed_tools:
+- run_workflow
+- list_workflows
+- inspect_run
+---
+
+# onsager-run-workflow
+
+A workflow's `manual` trigger is a named door — fire it with `run_workflow` and one new run starts. This skill covers the "I want this workflow to run *now*" path. Scheduled / webhook-triggered runs fire on their own; you don't need this skill for them.
+
+## When this skill triggers
+
+Phrases that should route here:
+
+- "run the morning-digest workflow"
+- "fire the backfill once"
+- "trigger a run of the PR-review pipeline"
+- "kick off the workflow named `nightly`"
+- "execute the manual workflow `go`"
+
+If the user wants to *design* a workflow, hand off to `onsager-design-workflow`. If they want to *triage* a failing run, hand off to `onsager-triage-run`.
+
+## Operating procedure
+
+### Step 1 — find the workflow
+
+If the user names the workflow by id (`wf_…`), use it directly. Otherwise call `list_workflows` against the workspace and match by name:
+
+```json
+{ "workspace_id": "<ws>" }
+```
+
+The response is `{ "workflows": [ { "id": "wf_…", "name": "…", "active": true, "trigger": { … } }, … ] }`. Pick the row whose `name` matches and confirm `active: true` (an inactive workflow can't fire — point the user at the dashboard's activate switch).
+
+Also confirm the trigger is `manual`. If it's `cron` / `github_*` / `spine_event`, this skill doesn't apply — runs of that workflow happen on their own schedule or in response to external events. Tell the user that and don't call `run_workflow`.
+
+### Step 2 — pick the trigger name
+
+`manual` triggers have a `name` field (set when the workflow was designed). The default is `go`. If the user said "fire the `nightly` trigger", pass `trigger_name: "nightly"`. If they didn't name one, try `"go"` first.
+
+### Step 3 — call `run_workflow`
+
+```json
+{
+  "workflow_id": "wf_…",
+  "trigger_name": "go",
+  "payload": { "user_note": "manual fire from chat" }
+}
+```
+
+`payload` is optional. Canonical fields (`workflow_id`, `workspace_id`, `name`, `actor`, `source`, `fired_at`, `trigger_kind`) always override any colliding keys, so you can pass arbitrary structured data without worrying about clobbering the trigger's own metadata.
+
+The tool returns the new artifact id — that's your `run_id`. Surface it to the user with the dashboard's run-detail deep-link: `<portal-url>/runs/<artifact_id>`.
+
+### Step 4 — first-look inspection
+
+Right after firing, call `inspect_run` with the returned artifact id and a small `event_limit`:
+
+```json
+{ "artifact_id": "<artifact_id>", "event_limit": 20 }
+```
+
+The response carries:
+
+- `artifact.state` — usually `registered` immediately after fire, then transitions through `provisioning` / `running` as stages start.
+- `artifact.current_stage_index` — 0 right after fire; advances as stages pass.
+- `artifact.workflow_parked_reason` — `null` for a healthy run. If non-null, the artifact is parked at the current stage and this is **not** a fire-success path: hand off to `onsager-triage-run`.
+- `recent_events` — newest first. Look for `trigger.fired` (your fire), then `stage.entered` events as the workflow advances.
+
+Report back to the user: "Started run `<artifact_id>`, currently on stage `<index>` (`<gate_kind>`). Open the run at `/runs/<artifact_id>`." Don't loop polling `inspect_run` — one read is enough; the user opens the dashboard for live state.
+
+## Common shapes
+
+### "Fire workflow X now"
+
+```json
+{ "workflow_id": "wf_abc", "trigger_name": "go" }
+```
+
+### "Fire workflow X with some context"
+
+```json
+{
+  "workflow_id": "wf_abc",
+  "trigger_name": "go",
+  "payload": {
+    "reason": "ad-hoc backfill, requested by @alice",
+    "scope": "open issues created before 2026-01-01"
+  }
+}
+```
+
+## Failure modes to watch for
+
+- **`InvalidParams: workflow has no manual trigger named <name>`** — the workflow's trigger is scheduled or webhook-driven, or `trigger_name` doesn't match. Re-read the workflow's `trigger` field from `list_workflows`; if it's not `manual`, this skill doesn't apply.
+- **`InvalidParams: workflow is inactive`** — workflow exists but `active: false`. Tell the user to activate it in the dashboard first; this skill cannot activate it (per `onsager-design-workflow`'s headers limitation).
+- **`Unauthorized`** — PAT doesn't have workspace access.
+- **`artifact.workflow_parked_reason` non-null on first inspect** — handed off to `onsager-triage-run`.
+
+## Related skills
+
+- `onsager-design-workflow` — create or modify the workflow blueprint.
+- `onsager-explore-artifacts` — list past runs or fetch a specific artifact.
+- `onsager-triage-run` — diagnose a run that failed or got stuck.

--- a/public-skills/skills/onsager-triage-run/SKILL.md
+++ b/public-skills/skills/onsager-triage-run/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: onsager-triage-run
+description: Diagnose why an Onsager run failed, got stuck, or parked unexpectedly — pull the artifact summary, fetch agent-session logs, surface log pointers from the v1 stub, and (when there's no path forward) cancel the run. Triggers include "the run failed", "diagnose this", "why did it fail", "this workflow is stuck", "the artifact is parked", "look at the logs for run X", "cancel run X". This skill does the *reasoning* client-side because `propose_remediation` is a v1 stub that only returns pointers — server-side AI reasoning is a follow-up to ADR 0007.
+allowed_tools:
+- inspect_run
+- get_stage_logs
+- propose_remediation
+- cancel_run
+---
+
+# onsager-triage-run
+
+A run failed, got stuck at a stage, or parked with a reason the user can't decode at a glance. This skill walks the inspection chain — artifact summary → log pointers → stage logs → client-side reasoning → optional cancellation.
+
+**Heads-up:** `propose_remediation` is a v1 **stub**. It does not call an LLM server-side; it returns the failed run's state plus structured log pointers and a fixed `suggested_next_tools` list. The reasoning happens here, in this skill, in the client. The Full version is a follow-up to [ADR 0007](https://github.com/onsager-ai/onsager/blob/main/docs/adr/0007-tools-and-skills-as-the-public-contract.md). Until then, treat the stub's response as a starting point and chain `get_stage_logs` yourself.
+
+## When this skill triggers
+
+Phrases that should route here:
+
+- "the run failed"
+- "why did this workflow fail?"
+- "diagnose this run"
+- "the artifact is parked at stage 2"
+- "look at the logs for session `sess_…`"
+- "cancel the run for artifact `art_…`"
+- "this workflow is stuck and I don't know why"
+
+## Operating procedure
+
+### Step 1 — summary
+
+Start with `inspect_run` on the artifact:
+
+```json
+{ "artifact_id": "<artifact_id>", "event_limit": 50 }
+```
+
+Read these fields:
+
+- `artifact.state` — `archived` means the run was cancelled or hit a terminal failure. `released` means it actually finished. `provisioning` / `running` means in-flight; `parked` means stuck at a gate.
+- `artifact.workflow_parked_reason` — non-null means parked. This string is the **first thing to surface** to the user; it's often the whole answer ("`spec_link_check: no spec issue linked`").
+- `artifact.current_stage_index` — which stage parked / failed.
+- `recent_events` — newest first. Scan for the last `stage.entered`, `stage.exited`, `synodic.gate_verdict`, `stiglab.session_*` events. Each `stiglab.session_*` event carries a `session_id` you'll need below.
+
+If `workflow_parked_reason` plus the recent events make the failure obvious (e.g. "spec_link_check parked because no `Closes #N` in the PR body"), tell the user and stop. Don't fetch logs you don't need.
+
+### Step 2 — gather log pointers
+
+If the failure was inside an `agent_session` stage, call `propose_remediation`:
+
+```json
+{ "artifact_id": "<artifact_id>" }
+```
+
+The v1 response shape:
+
+```json
+{
+  "v1_stub": true,
+  "stub_reason": "v1 returns log pointers; server-side AI reasoning is a follow-up.",
+  "failure_summary": { … same as inspect_run … },
+  "log_pointers": [
+    { "session_id": "sess_…", "event_type": "stiglab.session_failed", "created_at": "…" },
+    …
+  ],
+  "suggested_next_tools": ["get_stage_logs"]
+}
+```
+
+`log_pointers` is the input you need for step 3. Each entry's `session_id` corresponds to one agent-session stage execution; the newest (first in the list) is usually the one that failed.
+
+### Step 3 — read the logs
+
+For the failing session, call `get_stage_logs`:
+
+```json
+{ "session_id": "sess_…", "since_seq": 0 }
+```
+
+The response carries:
+
+- `state` — `failed`, `completed`, `cancelled`, etc.
+- `chunks` — ordered log chunks, each with `seq`, `stream` (`stdout` / `stderr` / `tool`), and `chunk` (the text). Read from the **end** — the failure tail is usually in the last few chunks.
+
+If the session is long-running and you only want the tail, pass `since_seq` larger than 0. The lint accepts any non-negative integer.
+
+### Step 4 — reason about the failure (client-side)
+
+Combine:
+
+- The `workflow_parked_reason` (if any) — the gate's own diagnosis.
+- The session `state` — terminal failure vs. interrupted.
+- The last ~20 chunks of the failing session — what the agent was doing when it died.
+- The `recent_events` from step 1 — what the workflow runtime saw.
+
+Surface to the user **one** of:
+
+- **Mechanical failure** ("the agent timed out", "rate-limited by GitHub") — tell them what the failure was and that re-running often fixes it.
+- **Prompt / data failure** ("the agent didn't see a spec issue to link") — tell them which input was missing.
+- **Workflow design failure** ("`spec_link_check` is gating a PR that legitimately has no spec because it's a docs-only change") — suggest the workflow needs a different gate, and hand off to `onsager-design-workflow` for a fix.
+
+Don't fabricate a fix you can't verify. If the logs don't tell you, say so explicitly.
+
+### Step 5 — optional cancellation
+
+If the user wants to stop the run (it's not going to recover on its own, or they want a clean slate before re-firing), use `cancel_run`:
+
+```json
+{ "artifact_id": "<artifact_id>", "reason": "manual cancel after triage — root cause: <one-line summary>" }
+```
+
+`cancel_run` is **destructive and irreversible at the artifact level**: it sets `state = 'archived'` and emits `artifact.archived` on the `forge:<artifact_id>` stream. Confirm with the user before firing it. After cancel, the same trigger event won't re-run the workflow automatically — the user has to re-fire via `onsager-run-workflow` (if manual) or re-trigger upstream (if webhook-driven).
+
+If the artifact is already `archived`, `cancel_run` returns `InvalidParams: artifact already archived`. Just tell the user — no further action.
+
+## Common failure shapes
+
+### `workflow_parked_reason = "spec_link_check: no spec issue linked"`
+
+The PR body doesn't have `Closes #N` or `Part of #N`. Tell the user; if they want, suggest a one-line edit to the PR body and that the workflow will re-evaluate on the next push.
+
+### `workflow_parked_reason = "synodic_review: pending"`
+
+A human needs to approve via the dashboard's governance surface. Not a bug — just waiting.
+
+### `stiglab.session_failed` with `chunks` showing `RATE_LIMITED`
+
+Anthropic API rate limit or GitHub rate limit. Suggest re-firing in a few minutes.
+
+### `stiglab.session_failed` with `chunks` showing the agent looping on the same tool
+
+Prompt design bug — the agent's prompt has no exit condition. Hand off to `onsager-design-workflow` to revise the stage's `params.prompt`.
+
+## Related skills
+
+- `onsager-design-workflow` — when triage points at a workflow-design fix.
+- `onsager-run-workflow` — when you cancel and want to re-fire.
+- `onsager-explore-artifacts` — when you want to see what *did* land before the failure.

--- a/public-skills/skills/onsager-triage-run/SKILL.md
+++ b/public-skills/skills/onsager-triage-run/SKILL.md
@@ -38,16 +38,16 @@ Start with `inspect_run` on the artifact:
 
 Read these fields:
 
-- `artifact.state` — `archived` means the run was cancelled or hit a terminal failure. `released` means it actually finished. `provisioning` / `running` means in-flight; `parked` means stuck at a gate.
-- `artifact.workflow_parked_reason` — non-null means parked. This string is the **first thing to surface** to the user; it's often the whole answer ("`spec_link_check: no spec issue linked`").
+- `artifact.state` — one of `draft`, `in_progress`, `under_review`, `released`, `archived`. `archived` means the run was cancelled or hit a terminal failure. `released` means every stage passed. `under_review` is the typical resting state for a parked artifact at an `external-check` / `governance` / `manual-approval` stage; `in_progress` is the typical state for an artifact mid-`agent-session`.
+- `artifact.workflow_parked_reason` — non-null means **parked**. This string is the **first thing to surface** to the user; it's often the whole answer ("`external-check: no spec issue linked`"). The state alone (e.g. `under_review`) does not tell you parked-vs-progressing — always read `workflow_parked_reason` for that.
 - `artifact.current_stage_index` — which stage parked / failed.
 - `recent_events` — newest first. Scan for the last `stage.entered`, `stage.exited`, `synodic.gate_verdict`, `stiglab.session_*` events. Each `stiglab.session_*` event carries a `session_id` you'll need below.
 
-If `workflow_parked_reason` plus the recent events make the failure obvious (e.g. "spec_link_check parked because no `Closes #N` in the PR body"), tell the user and stop. Don't fetch logs you don't need.
+If `workflow_parked_reason` plus the recent events make the failure obvious (e.g. "`external-check` parked because no `Closes #N` in the PR body"), tell the user and stop. Don't fetch logs you don't need.
 
 ### Step 2 — gather log pointers
 
-If the failure was inside an `agent_session` stage, call `propose_remediation`:
+If the failure was inside an `agent-session` stage, call `propose_remediation`:
 
 ```json
 { "artifact_id": "<artifact_id>" }
@@ -64,11 +64,11 @@ The v1 response shape:
     { "session_id": "sess_…", "event_type": "stiglab.session_failed", "created_at": "…" },
     …
   ],
-  "suggested_next_tools": ["get_stage_logs"]
+  "suggested_next_tools": ["get_stage_logs", "get_artifact", "inspect_run"]
 }
 ```
 
-`log_pointers` is the input you need for step 3. Each entry's `session_id` corresponds to one agent-session stage execution; the newest (first in the list) is usually the one that failed.
+`log_pointers` is the input you need for step 3. Each entry's `session_id` corresponds to one agent-session stage execution; the newest (first in the list) is usually the one that failed. The `suggested_next_tools` list is a fixed hint at the diagnostic chain; clients may rely on it when sequencing follow-up calls, so don't synthesise it differently in the body of your response.
 
 ### Step 3 — read the logs
 
@@ -98,7 +98,7 @@ Surface to the user **one** of:
 
 - **Mechanical failure** ("the agent timed out", "rate-limited by GitHub") — tell them what the failure was and that re-running often fixes it.
 - **Prompt / data failure** ("the agent didn't see a spec issue to link") — tell them which input was missing.
-- **Workflow design failure** ("`spec_link_check` is gating a PR that legitimately has no spec because it's a docs-only change") — suggest the workflow needs a different gate, and hand off to `onsager-design-workflow` for a fix.
+- **Workflow design failure** ("an `external-check` gate is parking a PR that legitimately has no spec because it's a docs-only change") — suggest the workflow needs a different gate, and hand off to `onsager-design-workflow` for a fix.
 
 Don't fabricate a fix you can't verify. If the logs don't tell you, say so explicitly.
 
@@ -116,13 +116,17 @@ If the artifact is already `archived`, `cancel_run` returns `InvalidParams: arti
 
 ## Common failure shapes
 
-### `workflow_parked_reason = "spec_link_check: no spec issue linked"`
+### `workflow_parked_reason = "external-check: no spec issue linked"`
 
 The PR body doesn't have `Closes #N` or `Part of #N`. Tell the user; if they want, suggest a one-line edit to the PR body and that the workflow will re-evaluate on the next push.
 
-### `workflow_parked_reason = "synodic_review: pending"`
+### `workflow_parked_reason = "governance: pending"`
 
-A human needs to approve via the dashboard's governance surface. Not a bug — just waiting.
+A human needs to approve via the dashboard's governance surface (the `governance` gate kind). Not a bug — just waiting.
+
+### `workflow_parked_reason = "manual-approval: pending"`
+
+A human needs to click the approve button in the dashboard. Same shape as `governance` but a different gate kind.
 
 ### `stiglab.session_failed` with `chunks` showing `RATE_LIMITED`
 


### PR DESCRIPTION
## Summary

Stages the public skills bundle from ADR 0007 / spec #310 inside this repo at `public-skills/` while the cross-repo migration to `onsager-ai/onsager-skills` is in flight. Adds the four initial `SKILL.md` files, bundle-level `package.json` / `README.md` / `LICENSE`, and wires `xtask check-tools-and-skills` into CI + `just lint` against the staging directory.

- **`public-skills/skills/onsager-design-workflow/SKILL.md`** — grants `propose_workflow`, `edit_workflow`, `list_workflows`, `schedule_workflow`. Documents trigger-shape templates, the "no inline activation" headers limitation, and the self-amplifying `spine_event { trigger.fired }` rejection.
- **`public-skills/skills/onsager-run-workflow/SKILL.md`** — grants `run_workflow`, `list_workflows`, `inspect_run`. Covers the manual-fire path with optional payload and a single first-look `inspect_run` (no polling loop).
- **`public-skills/skills/onsager-triage-run/SKILL.md`** — grants `inspect_run`, `get_stage_logs`, `propose_remediation`, `cancel_run`. Explicit that `propose_remediation` is a v1 stub and the reasoning happens client-side until the Full version lands.
- **`public-skills/skills/onsager-explore-artifacts/SKILL.md`** — grants `get_artifact`, `list_runs`. Read-only browse surface; drills into `consumers` for the "what did this produce" question.

Cross-check coverage is exact: every registered MCP tool (11 total) is granted by ≥1 skill; no skill grants a tool that isn't in the registry. Frontmatter uses **unindented** YAML list items so the lint's hand-rolled `parse_allowed_tools` (which only does `trim_end` on lines) actually picks them up.

CI: `.github/workflows/rust.yml` gets a new `cargo run -p xtask -- check-tools-and-skills` step with `ONSAGER_SKILLS_DIR=public-skills`. `justfile`'s `lint-rust` recipe gets the same. Root `CLAUDE.md`'s "MCP server + public skills bundle" section updated to point at the populated `public-skills/README.md` and explain the staging arrangement.

## Cross-repo note

Spec #310 names `onsager-ai/onsager-skills` as the canonical home for these artifacts. The Claude Code session implementing this PR is scoped to `onsager-ai/onsager` only, so the artifacts are staged here instead. A follow-up `git mv` PR (run from a session with access to both repos) moves `public-skills/*` into the sibling repo and updates `ONSAGER_SKILLS_DIR` to a `git clone` checkout in CI. The README at `public-skills/README.md` calls out the staging arrangement so it doesn't read as the permanent home.

## Test plan

- [x] Manual replay of the lint's `parse_allowed_tools` + `cross_check` against the four SKILL.md files: every registered tool granted, no orphan grants.
- [ ] CI runs `cargo run -p xtask -- check-tools-and-skills` with `ONSAGER_SKILLS_DIR=public-skills` — confirms the lint passes on a real toolchain (couldn't run locally; crates.io unreachable from this env).
- [ ] `npx skills add onsager-ai/onsager-skills` end-to-end test (blocked on the cross-repo migration landing in the sibling repo).
- [ ] "Design me a workflow that runs on every issue comment" produces a valid `propose_workflow` call shape (manual test against a local dev MCP server, blocked on a later session with the bundle wired into Claude Code).

Closes #310

https://claude.ai/code/session_01C7r8FPunbcYHiqrBZYQ5FX

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7r8FPunbcYHiqrBZYQ5FX)_