### PR TITLE
feat(portal): workflow-scoped artifacts + verdicts routes

### DIFF
--- a/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowArtifactsTab.tsx
@@ -1,56 +1,28 @@
-import { useMemo } from "react"
 import { Link } from "react-router-dom"
-import { useQueries } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { Package } from "lucide-react"
-import { api, type WorkflowRun } from "@/lib/api"
+import { api } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArtifactBadge } from "./ArtifactBadge"
 import { useActiveWorkspace } from "@/lib/workspace"
 
-// Derived from the runs list: every run produces (at most) one artifact, so
-// the unique set of artifact ids on this workflow's runs is the artifact
-// inventory for the workflow. PR 2b replaces this with a dedicated backend
-// route; this PR keeps the surface shape stable so the swap is a data-source
-// change only.
-export function WorkflowArtifactsTab({ runs }: { runs: WorkflowRun[] }) {
+// Workflow-scoped artifact list from the dedicated backend route (#302).
+// Replaces the per-run artifact fan-out we used to do client-side; one
+// request, server-side filter, and we can poll without scaling the
+// request count with the number of runs.
+export function WorkflowArtifactsTab({ workflowId }: { workflowId: string }) {
   const workspace = useActiveWorkspace()
-  const artifactIds = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          runs
-            .map((r) => r.artifact_id)
-            .filter((id): id is string => !!id),
-        ),
-      ),
-    [runs],
-  )
-
-  // Artifacts move slowly compared to runs — kind/state/version churn on
-  // human timescales. Up to 50 runs means up to 50 parallel artifact
-  // fetches per interval, so we poll at 30s and pause when the tab isn't
-  // visible. PR 2b's workflow-scoped artifact route folds this into one
-  // request and lets us drop the per-item polling entirely.
-  const queries = useQueries({
-    queries: artifactIds.map((id) => ({
-      queryKey: ["artifact", id],
-      queryFn: () => api.getArtifact(id),
-      refetchInterval: 30000,
-      refetchIntervalInBackground: false,
-    })),
+  const { data, isLoading } = useQuery({
+    queryKey: ["workflow-artifacts", workflowId],
+    queryFn: () => api.getWorkflowArtifacts(workflowId),
+    refetchInterval: 30000,
+    refetchIntervalInBackground: false,
   })
 
-  const loading = queries.some((q) => q.isLoading)
-  const items = useMemo(
-    () =>
-      queries
-        .map((q, i) => ({ id: artifactIds[i], artifact: q.data?.artifact }))
-        .filter((row) => !!row.artifact),
-    [queries, artifactIds],
-  )
+  const artifacts = data?.artifacts ?? []
 
-  if (artifactIds.length === 0) {
+  if (!isLoading && artifacts.length === 0) {
     return <EmptyState />
   }
 
@@ -60,34 +32,32 @@ export function WorkflowArtifactsTab({ runs }: { runs: WorkflowRun[] }) {
         <CardTitle className="text-base">Artifacts</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2 px-4 pb-4 md:px-6">
-        {loading && items.length === 0 ? (
+        {isLoading && artifacts.length === 0 ? (
           <p className="py-4 text-center text-sm text-muted-foreground">
             Loading…
           </p>
         ) : (
-          items.map(({ id, artifact }) =>
-            artifact ? (
-              <Link
-                key={id}
-                to={`/workspaces/${workspace.slug}/artifacts/${id}`}
-                className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
+          artifacts.map((artifact) => (
+            <Link
+              key={artifact.id}
+              to={`/workspaces/${workspace.slug}/artifacts/${artifact.id}`}
+              className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
+            >
+              <ArtifactBadge kind={artifact.kind} />
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {artifact.name ?? artifact.id}
+              </span>
+              <Badge
+                variant={artifact.state === "released" ? "default" : "outline"}
+                className="shrink-0"
               >
-                <ArtifactBadge kind={artifact.kind} />
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {artifact.name ?? id}
-                </span>
-                <Badge
-                  variant={artifact.state === "released" ? "default" : "outline"}
-                  className="shrink-0"
-                >
-                  {artifact.state}
-                </Badge>
-                <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
-                  v{artifact.current_version}
-                </span>
-              </Link>
-            ) : null,
-          )
+                {artifact.state}
+              </Badge>
+              <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                v{artifact.current_version}
+              </span>
+            </Link>
+          ))
         )}
       </CardContent>
     </Card>

--- a/apps/dashboard/src/components/factory/workflows/WorkflowVerdictsTab.tsx
+++ b/apps/dashboard/src/components/factory/workflows/WorkflowVerdictsTab.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Gavel } from "lucide-react"
-import { api, type GovernanceEvent, type WorkflowRun } from "@/lib/api"
+import { api } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
@@ -15,61 +14,23 @@ const SEVERITY_VARIANT: Record<
   low: "secondary",
 }
 
-// Does this governance event reference one of the workflow's artifact IDs?
-// PR 2b replaces this with a workflow-scoped backend route; until then we
-// pull the workspace-wide list and filter on whatever artifact-id reference
-// the event happens to carry. Synodic events vary in shape, so we probe
-// the common locations (`metadata.artifact_id`, `event.source`) and a
-// last-ditch scan of metadata string values.
-function referencesArtifact(
-  event: GovernanceEvent,
-  artifactIds: Set<string>,
-): boolean {
-  if (artifactIds.size === 0) return false
-  const meta = event.metadata ?? {}
-  const direct = meta["artifact_id"]
-  if (typeof direct === "string" && artifactIds.has(direct)) return true
-  if (event.source && artifactIds.has(event.source)) return true
-  for (const value of Object.values(meta)) {
-    if (typeof value === "string" && artifactIds.has(value)) return true
-  }
-  return false
-}
-
 export function WorkflowVerdictsTab({
-  workspaceId,
-  runs,
+  workflowId,
   stages,
 }: {
-  workspaceId: string
-  runs: WorkflowRun[]
+  workflowId: string
   stages: { gate_kind: string }[]
 }) {
-  const { data, isLoading } = useQuery({
-    queryKey: ["governance-events", workspaceId],
-    queryFn: () => api.getGovernanceEvents(workspaceId),
-    refetchInterval: 5000,
-  })
-
-  const artifactIds = useMemo(
-    () =>
-      new Set(
-        runs
-          .map((r) => r.artifact_id)
-          .filter((id): id is string => !!id),
-      ),
-    [runs],
-  )
-
-  const filtered = useMemo(
-    () =>
-      (data ?? []).filter((e) => referencesArtifact(e, artifactIds)),
-    [data, artifactIds],
-  )
-
   const hasGovernanceStage = stages.some(
     (s) => s.gate_kind === "governance",
   )
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["workflow-verdicts", workflowId],
+    queryFn: () => api.getWorkflowVerdicts(workflowId),
+    refetchInterval: 5000,
+    enabled: hasGovernanceStage,
+  })
 
   if (!hasGovernanceStage) {
     return (
@@ -90,7 +51,9 @@ export function WorkflowVerdictsTab({
     )
   }
 
-  if (filtered.length === 0) {
+  const verdicts = data?.verdicts ?? []
+
+  if (verdicts.length === 0) {
     return (
       <EmptyState
         title="No verdicts yet"
@@ -105,7 +68,7 @@ export function WorkflowVerdictsTab({
         <CardTitle className="text-base">Verdicts</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2 px-4 pb-4 md:px-6">
-        {filtered.map((e) => (
+        {verdicts.map((e) => (
           <div
             key={e.id}
             className="space-y-1 rounded-md border px-3 py-2"

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -1,5 +1,7 @@
 import { ApiError, request } from './client';
 import type {
+  GovernanceEvent,
+  SpineArtifact,
   Workflow,
   WorkflowStage,
   WorkflowGateKind,
@@ -198,6 +200,17 @@ export const workflows = {
   getWorkflowRuns: (id: string, limit = 20) =>
     request<{ runs: WorkflowRun[] }>(
       `/workflows/${encodeURIComponent(id)}/runs?limit=${limit}`,
+    ),
+  // Workflow-scoped artifacts + verdicts (#302). One round-trip
+  // replaces the dashboard's per-run artifact fan-out fetch and the
+  // workspace-wide governance-events filter.
+  getWorkflowArtifacts: (id: string) =>
+    request<{ artifacts: SpineArtifact[] }>(
+      `/workflows/${encodeURIComponent(id)}/artifacts`,
+    ),
+  getWorkflowVerdicts: (id: string) =>
+    request<{ verdicts: GovernanceEvent[] }>(
+      `/workflows/${encodeURIComponent(id)}/verdicts`,
     ),
   // Run detail hub (#303). Backend returns the projected run alongside
   // the parent workflow's backend shape; reuse `workflowFromBackend` so

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -203,14 +203,15 @@ export const workflows = {
     ),
   // Workflow-scoped artifacts + verdicts (#302). One round-trip
   // replaces the dashboard's per-run artifact fan-out fetch and the
-  // workspace-wide governance-events filter.
-  getWorkflowArtifacts: (id: string) =>
+  // workspace-wide governance-events filter. Backend clamps `limit`
+  // to [1, 500]; default 50 matches `/workflows/:id/runs`.
+  getWorkflowArtifacts: (id: string, limit = 50) =>
     request<{ artifacts: SpineArtifact[] }>(
-      `/workflows/${encodeURIComponent(id)}/artifacts`,
+      `/workflows/${encodeURIComponent(id)}/artifacts?limit=${limit}`,
     ),
-  getWorkflowVerdicts: (id: string) =>
+  getWorkflowVerdicts: (id: string, limit = 50) =>
     request<{ verdicts: GovernanceEvent[] }>(
-      `/workflows/${encodeURIComponent(id)}/verdicts`,
+      `/workflows/${encodeURIComponent(id)}/verdicts?limit=${limit}`,
     ),
   // Run detail hub (#303). Backend returns the projected run alongside
   // the parent workflow's backend shape; reuse `workflowFromBackend` so

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -187,13 +187,12 @@ export function WorkflowDetailPage() {
         </TabsContent>
 
         <TabsContent value="artifacts" className="space-y-4 pt-4 md:space-y-6">
-          <WorkflowArtifactsTab runs={runs} />
+          <WorkflowArtifactsTab workflowId={workflow.id} />
         </TabsContent>
 
         <TabsContent value="verdicts" className="space-y-4 pt-4 md:space-y-6">
           <WorkflowVerdictsTab
-            workspaceId={workspace.id}
-            runs={runs}
+            workflowId={workflow.id}
             stages={workflow.stages}
           />
         </TabsContent>

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -24,5 +24,6 @@ pub mod telegram_webhook;
 pub mod triggers;
 pub mod webhook;
 pub mod workflow_kinds;
+pub mod workflow_views;
 pub mod workflows;
 pub mod workspaces;

--- a/crates/onsager-portal/src/handlers/workflow_views.rs
+++ b/crates/onsager-portal/src/handlers/workflow_views.rs
@@ -1,0 +1,158 @@
+//! Workflow-scoped read views (spec #302 — #289 PR 2b).
+//!
+//! Dedicated list endpoints that replace the dashboard's derived
+//! client-side filters: a workflow's artifacts (formerly a per-run
+//! artifact fan-out from `GET /api/spine/artifacts/:id`) and verdicts
+//! (formerly the workspace-wide `GET /api/governance/events` filtered
+//! on the client). One round-trip per tab, server-side workspace
+//! gating, and `check-api-contract`-clean.
+//!
+//! Same workspace-access model as `handlers/workflows.rs` — caller must
+//! be a member of the workflow's workspace (404 otherwise).
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::auth::AuthUser;
+use crate::handlers::workspaces::require_workspace_access;
+use crate::state::AppState;
+use crate::workflow_db;
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct WorkflowArtifactRow {
+    id: String,
+    kind: String,
+    name: Option<String>,
+    state: String,
+    owner: Option<String>,
+    current_version: i32,
+    consumers: serde_json::Value,
+    external_ref: Option<String>,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    last_observed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// GET /api/workflows/:id/artifacts — artifacts produced by runs of
+/// this workflow. Same `SpineArtifact` shape as
+/// `GET /api/spine/artifacts`, filtered by `artifacts.workflow_id`.
+pub async fn list_workflow_artifacts(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workflow_id): Path<String>,
+) -> Response {
+    let spine = state.spine.pool();
+    let workflow = match workflow_db::get_workflow(spine, &workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return not_found("workflow not found"),
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workflow.workspace_id).await
+    {
+        return r;
+    }
+
+    match sqlx::query_as::<_, WorkflowArtifactRow>(
+        "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
+                consumers, external_ref, created_at, updated_at, last_observed_at \
+         FROM artifacts \
+         WHERE workflow_id = $1 \
+         ORDER BY updated_at DESC",
+    )
+    .bind(&workflow_id)
+    .fetch_all(spine)
+    .await
+    {
+        Ok(artifacts) => Json(serde_json::json!({ "artifacts": artifacts })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to load workflow artifacts: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load artifacts" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct WorkflowVerdictRow {
+    id: String,
+    event_type: String,
+    title: String,
+    severity: String,
+    source: String,
+    metadata: serde_json::Value,
+    resolved: bool,
+    resolution_notes: Option<String>,
+    created_at: chrono::DateTime<chrono::Utc>,
+    resolved_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// GET /api/workflows/:id/verdicts — governance verdicts on this
+/// workflow's runs. Filters `governance_events` by
+/// `metadata->>'artifact_id'` against the artifacts owned by this
+/// workflow.
+///
+/// Synodic and portal share the spine Postgres in production
+/// (`deploy/docker-compose.yml`) and via the `migrate` service in
+/// `just dev`, so this is a direct SQL read — same pattern as
+/// portal's other shared-table reads (`artifacts`, `events_ext`,
+/// `sessions`).
+pub async fn list_workflow_verdicts(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(workflow_id): Path<String>,
+) -> Response {
+    let spine = state.spine.pool();
+    let workflow = match workflow_db::get_workflow(spine, &workflow_id).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return not_found("workflow not found"),
+        Err(e) => {
+            tracing::error!("failed to load workflow: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, &workflow.workspace_id).await
+    {
+        return r;
+    }
+
+    match sqlx::query_as::<_, WorkflowVerdictRow>(
+        "SELECT id, event_type, title, severity, source, metadata, resolved, \
+                resolution_notes, created_at, resolved_at \
+         FROM governance_events \
+         WHERE metadata->>'artifact_id' IN ( \
+             SELECT artifact_id FROM artifacts WHERE workflow_id = $1 \
+         ) \
+         ORDER BY created_at DESC",
+    )
+    .bind(&workflow_id)
+    .fetch_all(spine)
+    .await
+    {
+        Ok(verdicts) => Json(serde_json::json!({ "verdicts": verdicts })).into_response(),
+        Err(e) => {
+            tracing::error!("failed to load workflow verdicts: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to load verdicts" })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/onsager-portal/src/handlers/workflow_views.rs
+++ b/crates/onsager-portal/src/handlers/workflow_views.rs
@@ -11,10 +11,10 @@
 //! be a member of the workflow's workspace (404 otherwise).
 
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthUser;
 use crate::handlers::workspaces::require_workspace_access;
@@ -27,6 +27,19 @@ fn not_found(msg: &str) -> Response {
         Json(serde_json::json!({ "error": msg })),
     )
         .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LimitQuery {
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+/// Default page size + hard cap for the workflow-scoped list endpoints.
+/// Matches `GET /api/workflows/:id/runs` so the three workflow tabs poll
+/// the same shape.
+fn clamp_limit(limit: Option<i64>) -> i64 {
+    limit.unwrap_or(50).clamp(1, 500)
 }
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
@@ -47,10 +60,14 @@ struct WorkflowArtifactRow {
 /// GET /api/workflows/:id/artifacts — artifacts produced by runs of
 /// this workflow. Same `SpineArtifact` shape as
 /// `GET /api/spine/artifacts`, filtered by `artifacts.workflow_id`.
+///
+/// `?limit=` (default 50, clamped to 500) keeps the polled response
+/// bounded as a workflow accumulates artifacts.
 pub async fn list_workflow_artifacts(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(workflow_id): Path<String>,
+    Query(q): Query<LimitQuery>,
 ) -> Response {
     let spine = state.spine.pool();
     let workflow = match workflow_db::get_workflow(spine, &workflow_id).await {
@@ -66,14 +83,17 @@ pub async fn list_workflow_artifacts(
         return r;
     }
 
+    let limit = clamp_limit(q.limit);
     match sqlx::query_as::<_, WorkflowArtifactRow>(
         "SELECT artifact_id AS id, kind, name, state, owner, current_version, \
                 consumers, external_ref, created_at, updated_at, last_observed_at \
          FROM artifacts \
          WHERE workflow_id = $1 \
-         ORDER BY updated_at DESC",
+         ORDER BY updated_at DESC \
+         LIMIT $2",
     )
     .bind(&workflow_id)
+    .bind(limit)
     .fetch_all(spine)
     .await
     {
@@ -108,6 +128,9 @@ struct WorkflowVerdictRow {
 /// `metadata->>'artifact_id'` against the artifacts owned by this
 /// workflow.
 ///
+/// `?limit=` (default 50, clamped to 500) bounds the polled response;
+/// the dashboard hits this every 5s when a governance stage exists.
+///
 /// Synodic and portal share the spine Postgres in production
 /// (`deploy/docker-compose.yml`) and via the `migrate` service in
 /// `just dev`, so this is a direct SQL read — same pattern as
@@ -117,6 +140,7 @@ pub async fn list_workflow_verdicts(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(workflow_id): Path<String>,
+    Query(q): Query<LimitQuery>,
 ) -> Response {
     let spine = state.spine.pool();
     let workflow = match workflow_db::get_workflow(spine, &workflow_id).await {
@@ -132,6 +156,7 @@ pub async fn list_workflow_verdicts(
         return r;
     }
 
+    let limit = clamp_limit(q.limit);
     match sqlx::query_as::<_, WorkflowVerdictRow>(
         "SELECT id, event_type, title, severity, source, metadata, resolved, \
                 resolution_notes, created_at, resolved_at \
@@ -139,9 +164,11 @@ pub async fn list_workflow_verdicts(
          WHERE metadata->>'artifact_id' IN ( \
              SELECT artifact_id FROM artifacts WHERE workflow_id = $1 \
          ) \
-         ORDER BY created_at DESC",
+         ORDER BY created_at DESC \
+         LIMIT $2",
     )
     .bind(&workflow_id)
+    .bind(limit)
     .fetch_all(spine)
     .await
     {

--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -523,6 +523,7 @@ struct ArtifactRunRow {
     updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+
 /// Project a single artifact row + its workflow's stage chain into the
 /// dashboard `WorkflowRun` shape.
 ///

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -15,8 +15,8 @@ use crate::handlers::{
     registry_events as registry_event_handlers, registry_triggers as registry_trigger_handlers,
     runs as run_handlers, sessions as session_handlers, spine as spine_handlers,
     tasks as task_handlers, telegram_webhook, triggers as trigger_handlers, webhook,
-    workflow_kinds as workflow_kind_handlers, workflows as workflow_handlers,
-    workspaces as workspace_handlers,
+    workflow_kinds as workflow_kind_handlers, workflow_views as workflow_view_handlers,
+    workflows as workflow_handlers, workspaces as workspace_handlers,
 };
 use crate::proxy_cache::ProxyCache;
 use crate::state::AppState;
@@ -191,6 +191,19 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/workflows/{id}/runs",
             get(workflow_handlers::list_workflow_runs),
+        )
+        // Workflow-scoped artifacts + verdicts (spec #302 — #289 PR 2b).
+        // Dedicated routes replace the dashboard's per-run artifact
+        // fan-out fetch and the workspace-wide governance-events
+        // filter. Same workspace-access gating as the rest of
+        // `/api/workflows/*`.
+        .route(
+            "/api/workflows/{id}/artifacts",
+            get(workflow_view_handlers::list_workflow_artifacts),
+        )
+        .route(
+            "/api/workflows/{id}/verdicts",
+            get(workflow_view_handlers::list_workflow_verdicts),
         )
         // Workflow artifact-kind catalog (issue #102 / #222 Slice 4) —
         // public registry pass-through; the dashboard fetches this


### PR DESCRIPTION
## Summary

- New `GET /api/workflows/:id/artifacts` — server-side filter on `artifacts.workflow_id`, returns the `SpineArtifact` list shape. Replaces the dashboard's per-run artifact fan-out fetch.
- New `GET /api/workflows/:id/verdicts` — filters `governance_events.metadata->>'artifact_id'` against the workflow's artifacts. Replaces the workspace-wide governance fetch + client-side filter in `WorkflowVerdictsTab`.
- Handlers live in a new `crates/onsager-portal/src/handlers/workflow_views.rs` to keep `workflows.rs` under the file-budget ceiling. Same `require_workspace_access` (404 on non-member) gating as the rest of `/api/workflows/*`.
- Dashboard tabs collapse to a single `useQuery` each. `WorkflowVerdictsTab` keeps the governance-stage gate so the query stays disabled when no governance gate is configured. The Workflow detail page no longer passes `runs` / `workspaceId` into either tab.
- The spec text mentions stiglab as the owner; workflow CRUD has moved to portal under #222 Slice 4, so the routes land alongside the existing `/api/workflows/*` handlers in portal.

## Test plan

- [x] `cargo build -p onsager-portal`
- [x] `cargo clippy -p onsager-portal --all-targets -- -D warnings`
- [x] `cargo test -p onsager-portal --lib` (123 passed)
- [x] `cargo run -p xtask -- lint-seams`
- [x] `cargo run -p xtask -- check-api-contract` (clean — both routes have dashboard callers)
- [x] `cargo run -p xtask -- check-events`
- [x] `cargo run -p xtask -- check-file-budget`
- [x] `pnpm --filter dashboard build`
- [x] `pnpm --filter dashboard lint`
- [x] `pnpm --filter dashboard test` (109 passed)
- [ ] Integration smoke: create workflow → kick off run → produce artifact → endpoint returns it. Same for a verdict via an overridden gate.
- [ ] Mobile + desktop: Workflow detail Artifacts/Verdicts tabs render the same shape as before, now powered by the dedicated routes.

Closes #302
Part of #289

https://claude.ai/code/session_01KV3VLvibSsU2FSJwkc5FRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV3VLvibSsU2FSJwkc5FRK)_