### PR TITLE
feat(portal): full propose_remediation with server-side AI reasoning

### DIFF
--- a/crates/onsager-portal/migrations/008_portal_remediation_calls.sql
+++ b/crates/onsager-portal/migrations/008_portal_remediation_calls.sql
@@ -1,0 +1,31 @@
+-- Onsager #312: portal-owned cost ledger for `propose_remediation`'s
+-- server-side AI call.
+--
+-- One row per AI call. Used for:
+--   1. Per-workspace monthly budget enforcement (sum cost_usd over the
+--      current calendar month; refuse new calls past the cap).
+--   2. Observability — `SELECT workspace_id, SUM(cost_usd) ... GROUP BY`
+--      tells operators which workspaces are paying for remediation.
+--
+-- Schema is intentionally narrow: token counts so we can recompute cost
+-- if the upstream price changes, plus a denormalized `cost_usd` snapshot
+-- captured at call time using the price table compiled into the binary.
+-- No FK on workspace_id — same pattern as the rest of portal's tables,
+-- which join back to spine.workspaces at the app layer.
+
+CREATE TABLE IF NOT EXISTS portal_remediation_calls (
+    id                          TEXT        PRIMARY KEY,
+    workspace_id                TEXT        NOT NULL,
+    user_id                     TEXT        NOT NULL,
+    artifact_id                 TEXT        NOT NULL,
+    model                       TEXT        NOT NULL,
+    input_tokens                INTEGER     NOT NULL DEFAULT 0,
+    output_tokens               INTEGER     NOT NULL DEFAULT 0,
+    cache_creation_input_tokens INTEGER     NOT NULL DEFAULT 0,
+    cache_read_input_tokens     INTEGER     NOT NULL DEFAULT 0,
+    cost_usd                    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_portal_remediation_calls_workspace_month
+    ON portal_remediation_calls (workspace_id, created_at DESC);

--- a/crates/onsager-portal/migrations/008_portal_remediation_calls.sql
+++ b/crates/onsager-portal/migrations/008_portal_remediation_calls.sql
@@ -19,10 +19,10 @@ CREATE TABLE IF NOT EXISTS portal_remediation_calls (
     user_id                     TEXT        NOT NULL,
     artifact_id                 TEXT        NOT NULL,
     model                       TEXT        NOT NULL,
-    input_tokens                INTEGER     NOT NULL DEFAULT 0,
-    output_tokens               INTEGER     NOT NULL DEFAULT 0,
-    cache_creation_input_tokens INTEGER     NOT NULL DEFAULT 0,
-    cache_read_input_tokens     INTEGER     NOT NULL DEFAULT 0,
+    input_tokens                BIGINT      NOT NULL DEFAULT 0,
+    output_tokens               BIGINT      NOT NULL DEFAULT 0,
+    cache_creation_input_tokens BIGINT      NOT NULL DEFAULT 0,
+    cache_read_input_tokens     BIGINT      NOT NULL DEFAULT 0,
     cost_usd                    DOUBLE PRECISION NOT NULL DEFAULT 0,
     created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/crates/onsager-portal/src/anthropic.rs
+++ b/crates/onsager-portal/src/anthropic.rs
@@ -1,0 +1,332 @@
+//! Minimal Anthropic Messages API client for portal's server-side AI
+//! features. Today's only caller is `propose_remediation` (#312) —
+//! kept narrow to that surface intentionally; if a second caller
+//! appears, generalize then, not now.
+//!
+//! Why a hand-rolled client (vs. an SDK):
+//!
+//! - reqwest is already a portal dep; pulling in `anthropic-sdk` for
+//!   one call would be a fresh trust surface plus extra build cost.
+//! - We need fine-grained control over `cache_control` blocks (prompt
+//!   caching) and `usage.cache_creation_input_tokens` /
+//!   `cache_read_input_tokens` (cost ledger). The shape is small
+//!   enough that the SDK's abstractions would obscure rather than help.
+//!
+//! Mirrors the pattern in `synodic/src/core/llm.rs` (also direct
+//! reqwest), kept independent because synodic is a sibling subsystem
+//! that the seam rule forbids portal from importing.
+//!
+//! ## Prompt caching
+//!
+//! Anthropic prompt caching keys on the exact bytes of the cached
+//! prefix. To keep the cache warm across `propose_remediation` calls
+//! within a workspace, the **system** block carries the workspace-
+//! invariant context (tool registry summary, response-format
+//! instructions, naming conventions) and is marked
+//! `{"type":"text", "text":"...", "cache_control":{"type":"ephemeral"}}`.
+//! The per-call failure summary rides in the **user** message and is
+//! not cached.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com/v1";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Default Claude model — the "Sonnet for cost" branch from spec #312.
+/// Callers can override via `ProposeRemediationArgs::model`.
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+
+/// Higher-reasoning model — the "Opus for hard cases" branch.
+pub const OPUS_MODEL: &str = "claude-opus-4-7";
+
+/// Maximum tokens we'll request from the model. Remediation responses
+/// are tool-call JSON plus a short rationale per action; 2k is
+/// comfortably above what real responses need without budget surprises.
+pub const MAX_OUTPUT_TOKENS: u32 = 2048;
+
+/// Resolve a caller-supplied model string to a canonical model id.
+/// `"sonnet"` and `"opus"` are convenience aliases; anything else is
+/// passed through so callers can pin to a specific dated revision.
+pub fn resolve_model(requested: Option<&str>) -> &str {
+    match requested.map(str::trim).filter(|s| !s.is_empty()) {
+        Some("sonnet") => DEFAULT_MODEL,
+        Some("opus") => OPUS_MODEL,
+        Some(other) => match other {
+            // Reject anything that doesn't look like a Claude model
+            // string. Caller falls through to default; this guards
+            // against the model-name being a vehicle for prompt
+            // injection-via-config.
+            s if s.starts_with("claude-") => s,
+            _ => DEFAULT_MODEL,
+        },
+        None => DEFAULT_MODEL,
+    }
+}
+
+// ── Request / response shapes ───────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct MessagesRequest<'a> {
+    pub model: &'a str,
+    pub max_tokens: u32,
+    pub system: Vec<SystemBlock<'a>>,
+    pub messages: Vec<UserMessage<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SystemBlock<'a> {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub text: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+}
+
+impl CacheControl {
+    pub const EPHEMERAL: Self = CacheControl { kind: "ephemeral" };
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserMessage<'a> {
+    pub role: &'static str,
+    pub content: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessagesResponse {
+    #[serde(default)]
+    pub content: Vec<ContentBlock>,
+    #[serde(default)]
+    pub usage: Usage,
+    #[serde(default)]
+    pub model: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentBlock {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: u32,
+    #[serde(default)]
+    pub output_tokens: u32,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+}
+
+/// Concatenate all text content blocks. Anthropic returns content as a
+/// list of typed blocks (text, tool_use, ...); for our request shape
+/// we expect text-only.
+pub fn collect_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter(|c| c.kind == "text")
+        .filter_map(|c| c.text.clone())
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+// ── Pricing ────────────────────────────────────────────────────────
+
+/// Per-million-token pricing snapshot (USD). Updated alongside model
+/// releases. Sonnet 4.6 / Opus 4.7 prices are the published list as of
+/// 2026-05. Cache writes are billed at ~1.25x input; cache reads at
+/// ~0.1x input. We charge per Anthropic's documented rates rather than
+/// the wire data because the wire usage object doesn't carry the price.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelPricing {
+    pub input_per_mtok_usd: f64,
+    pub output_per_mtok_usd: f64,
+    pub cache_write_per_mtok_usd: f64,
+    pub cache_read_per_mtok_usd: f64,
+}
+
+impl ModelPricing {
+    pub const SONNET_4_6: Self = Self {
+        input_per_mtok_usd: 3.0,
+        output_per_mtok_usd: 15.0,
+        cache_write_per_mtok_usd: 3.75,
+        cache_read_per_mtok_usd: 0.30,
+    };
+    pub const OPUS_4_7: Self = Self {
+        input_per_mtok_usd: 15.0,
+        output_per_mtok_usd: 75.0,
+        cache_write_per_mtok_usd: 18.75,
+        cache_read_per_mtok_usd: 1.50,
+    };
+
+    pub fn for_model(model: &str) -> Self {
+        if model.contains("opus") {
+            Self::OPUS_4_7
+        } else {
+            // Default to Sonnet pricing for anything we don't recognize.
+            // Worst case the cost is slightly under-reported for a more
+            // expensive model; the call still completes and the workspace
+            // still pays the upstream bill.
+            Self::SONNET_4_6
+        }
+    }
+
+    pub fn estimate_usd(&self, usage: &Usage) -> f64 {
+        let m = 1_000_000.0;
+        (usage.input_tokens as f64 * self.input_per_mtok_usd
+            + usage.output_tokens as f64 * self.output_per_mtok_usd
+            + usage.cache_creation_input_tokens as f64 * self.cache_write_per_mtok_usd
+            + usage.cache_read_input_tokens as f64 * self.cache_read_per_mtok_usd)
+            / m
+    }
+}
+
+// ── Client ─────────────────────────────────────────────────────────
+
+pub struct AnthropicClient {
+    api_key: String,
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl AnthropicClient {
+    pub fn new(api_key: String) -> Result<Self> {
+        let base_url =
+            std::env::var("ANTHROPIC_API_BASE").unwrap_or_else(|_| ANTHROPIC_API_BASE.to_string());
+        let http = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .context("build anthropic http client")?;
+        Ok(Self {
+            api_key,
+            base_url,
+            http,
+        })
+    }
+
+    pub async fn messages(&self, req: &MessagesRequest<'_>) -> Result<MessagesResponse> {
+        let url = format!("{}/messages", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(req)
+            .send()
+            .await
+            .context("anthropic request failed")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("anthropic API returned {status}: {body}");
+        }
+
+        let parsed: MessagesResponse = resp.json().await.context("decode anthropic response")?;
+        Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_model_aliases() {
+        assert_eq!(resolve_model(Some("sonnet")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("opus")), OPUS_MODEL);
+        assert_eq!(resolve_model(None), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("  ")), DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn resolve_model_passes_through_canonical_ids() {
+        assert_eq!(resolve_model(Some("claude-opus-4-7")), "claude-opus-4-7");
+        assert_eq!(
+            resolve_model(Some("claude-sonnet-4-20250514")),
+            "claude-sonnet-4-20250514"
+        );
+    }
+
+    #[test]
+    fn resolve_model_rejects_non_claude_strings() {
+        // Guards against `model` being weaponized to point at an
+        // attacker-controlled / unrelated model id.
+        assert_eq!(resolve_model(Some("gpt-4o")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("../etc/passwd")), DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn estimate_usd_handles_all_token_kinds() {
+        let usage = Usage {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        let cost = ModelPricing::SONNET_4_6.estimate_usd(&usage);
+        assert!((cost - 3.0).abs() < 1e-9);
+
+        let usage = Usage {
+            input_tokens: 0,
+            output_tokens: 1_000_000,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        let cost = ModelPricing::SONNET_4_6.estimate_usd(&usage);
+        assert!((cost - 15.0).abs() < 1e-9);
+
+        let usage = Usage {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: 1_000_000,
+            cache_read_input_tokens: 1_000_000,
+        };
+        let cost = ModelPricing::SONNET_4_6.estimate_usd(&usage);
+        // 3.75 + 0.30
+        assert!((cost - 4.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pricing_picks_opus_table_for_opus_models() {
+        let p = ModelPricing::for_model("claude-opus-4-7");
+        assert_eq!(p.input_per_mtok_usd, 15.0);
+        let p = ModelPricing::for_model("claude-sonnet-4-6");
+        assert_eq!(p.input_per_mtok_usd, 3.0);
+    }
+
+    #[test]
+    fn collect_text_concatenates_text_blocks_only() {
+        let blocks = vec![
+            ContentBlock {
+                kind: "text".into(),
+                text: Some("hello ".into()),
+            },
+            ContentBlock {
+                kind: "tool_use".into(),
+                text: Some("ignored".into()),
+            },
+            ContentBlock {
+                kind: "text".into(),
+                text: Some("world".into()),
+            },
+        ];
+        assert_eq!(collect_text(&blocks), "hello world");
+    }
+}

--- a/crates/onsager-portal/src/anthropic.rs
+++ b/crates/onsager-portal/src/anthropic.rs
@@ -233,8 +233,17 @@ impl AnthropicClient {
 
         if !resp.status().is_success() {
             let status = resp.status();
+            // Pull the body for server-side diagnostics only — callers
+            // surface this through `stub_reason`, so we keep the
+            // bubbled-up error short and stable instead of leaking
+            // raw provider output.
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("anthropic API returned {status}: {body}");
+            tracing::warn!(
+                status = %status,
+                body = %body,
+                "anthropic API returned non-2xx"
+            );
+            anyhow::bail!("anthropic API returned {status}");
         }
 
         let parsed: MessagesResponse = resp.json().await.context("decode anthropic response")?;

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -51,7 +51,20 @@ pub struct Config {
     /// `503` — the trigger kind is registered but the receiver is
     /// disabled. Set via `TELEGRAM_WEBHOOK_SECRET` (#240).
     pub telegram_webhook_secret: Option<String>,
+    /// Per-workspace per-month USD spend cap for `propose_remediation`
+    /// AI calls (#312). When a workspace's spend in the current
+    /// calendar month reaches this value, further calls short-circuit
+    /// to the stub envelope with `stub_reason: budget_exceeded`.
+    /// Defaults to a conservative double-digit dollar value; override
+    /// via `PORTAL_REMEDIATION_MONTHLY_CAP_USD`.
+    pub remediation_monthly_cap_usd: f64,
 }
+
+/// Default monthly per-workspace cap for `propose_remediation` AI
+/// spend. Sized to absorb a steady stream of failed-run analyses at
+/// Sonnet pricing without an operator surprise; revisit when real
+/// usage data exists.
+pub const DEFAULT_REMEDIATION_MONTHLY_CAP_USD: f64 = 10.0;
 
 impl Config {
     /// Classify the process's role in the SSO flow. `None` means no GitHub
@@ -130,6 +143,7 @@ mod tests {
             sso_auth_domain: None,
             dev_login_enabled: false,
             telegram_webhook_secret: None,
+            remediation_monthly_cap_usd: DEFAULT_REMEDIATION_MONTHLY_CAP_USD,
         }
     }
 

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -54,7 +54,8 @@ pub struct Config {
     /// Per-workspace per-month USD spend cap for `propose_remediation`
     /// AI calls (#312). When a workspace's spend in the current
     /// calendar month reaches this value, further calls short-circuit
-    /// to the stub envelope with `stub_reason: budget_exceeded`.
+    /// to the stub envelope with `stub_reason = "budget_exceeded"`
+    /// and a `details` object carrying `{spent_usd, cap_usd}`.
     /// Defaults to a conservative double-digit dollar value; override
     /// via `PORTAL_REMEDIATION_MONTHLY_CAP_USD`.
     pub remediation_monthly_cap_usd: f64,

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -26,6 +26,7 @@
 //! are migrated at startup; everything else (tenant / installation / project /
 //! events / artifacts / lineage) is owned by stiglab and the spine.
 
+pub mod anthropic;
 pub mod auth;
 pub mod auth_db;
 pub mod backfill;
@@ -44,6 +45,7 @@ pub mod migrate;
 pub mod pat_db;
 pub mod preset;
 pub mod proxy_cache;
+pub mod remediation_db;
 pub mod server;
 pub mod session_db;
 pub mod sso;

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -74,6 +74,12 @@ enum Command {
         /// 503. (#240 Category 3)
         #[arg(long, env = "TELEGRAM_WEBHOOK_SECRET")]
         telegram_webhook_secret: Option<String>,
+        /// Per-workspace per-month USD spend cap for `propose_remediation`
+        /// AI calls (#312). Calls past the cap fall back to the stub
+        /// envelope. Defaults to the code-side
+        /// `DEFAULT_REMEDIATION_MONTHLY_CAP_USD`.
+        #[arg(long, env = "PORTAL_REMEDIATION_MONTHLY_CAP_USD")]
+        remediation_monthly_cap_usd: Option<f64>,
     },
     /// Backfill issues + PRs for an existing project.
     Backfill {
@@ -120,6 +126,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             sso_auth_domain,
             dev_login_enabled,
             telegram_webhook_secret,
+            remediation_monthly_cap_usd,
         } => {
             let allowlist = sso_return_host_allowlist
                 .as_deref()
@@ -155,6 +162,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     .map(|s| s.trim_end_matches('/').to_string()),
                 dev_login_enabled: dev_login_enabled || is_railway_preview,
                 telegram_webhook_secret: telegram_webhook_secret.filter(|s| !s.is_empty()),
+                remediation_monthly_cap_usd: remediation_monthly_cap_usd
+                    .unwrap_or(onsager_portal::config::DEFAULT_REMEDIATION_MONTHLY_CAP_USD),
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/mcp/registry.rs
+++ b/crates/onsager-portal/src/mcp/registry.rs
@@ -174,7 +174,7 @@ fn build_registry() -> Vec<ToolDescriptor> {
         },
         ToolDescriptor {
             name: "propose_remediation",
-            description: "v1 stub: returns the failed run's state + structured log pointers so the *client-side* AI can reason about remediation. No server-side AI call; the Full version (server-side prompt + cost model) is filed as a follow-up.",
+            description: "Server-side AI analysis of a failed run. Reads the artifact's state, recent spine events, and trailing session logs, then asks Claude for `proposed_actions` (registered tool names + concrete arguments) the operator can review via HitlCard. Requires an `ANTHROPIC_API_KEY` workspace credential; falls back to the v1 stub envelope (state + log pointers, no AI call) when the credential is missing, the per-workspace monthly budget is exhausted, or the model call errors. Pass `model: \"opus\"` for hard cases (cost: ~5x sonnet); defaults to Sonnet.",
             category: ToolCategory::ReadOnly,
             input_schema: super::input_schema::<tools::diagnostics::ProposeRemediationArgs>(),
             invoke: |state, user, args| {

--- a/crates/onsager-portal/src/mcp/tools/diagnostics.rs
+++ b/crates/onsager-portal/src/mcp/tools/diagnostics.rs
@@ -291,32 +291,35 @@ pub async fn propose_remediation(
         .collect();
 
     // Decide whether to go to the model. Each guard returns the stub
-    // envelope with a specific `stub_reason` so the dashboard can
-    // tell the user why their request degraded.
+    // envelope with a stable machine-readable `stub_reason` code so
+    // the dashboard can branch on the reason; detailed error context
+    // is logged server-side rather than embedded in the client
+    // payload (security: avoids leaking SQL errors / provider bodies
+    // through the chat surface).
     let api_key = match load_workspace_anthropic_key(state, auth_user, &workspace_id).await {
         Ok(Some(k)) => k,
         Ok(None) => {
             return Ok(stub_envelope(
                 &summary,
                 &log_pointers,
-                "no ANTHROPIC_API_KEY credential set for this workspace",
+                stub_reason::NO_CREDENTIAL,
+                None,
             ));
         }
-        Err(reason) => {
-            return Ok(stub_envelope(&summary, &log_pointers, &reason));
+        Err(code) => {
+            return Ok(stub_envelope(&summary, &log_pointers, code, None));
         }
     };
 
     let cap_usd = state.config.remediation_monthly_cap_usd;
     match remediation_db::check_budget(&state.pool, &workspace_id, cap_usd).await {
         Ok(BudgetStatus::OverCap { spent_usd, cap_usd }) => {
-            return Ok(stub_envelope(
+            return Ok(stub_envelope_with_budget(
                 &summary,
                 &log_pointers,
-                &format!(
-                    "workspace monthly remediation budget exceeded ({:.2} USD / {:.2} USD cap)",
-                    spent_usd, cap_usd
-                ),
+                stub_reason::BUDGET_EXCEEDED,
+                spent_usd,
+                cap_usd,
             ));
         }
         Ok(BudgetStatus::Ok { .. }) => {}
@@ -338,10 +341,12 @@ pub async fn propose_remediation(
     let client = match AnthropicClient::new(api_key) {
         Ok(c) => c,
         Err(e) => {
+            tracing::warn!("propose_remediation anthropic client init failed: {e}");
             return Ok(stub_envelope(
                 &summary,
                 &log_pointers,
-                &format!("anthropic client init failed: {e}"),
+                stub_reason::ANTHROPIC_INIT_FAILED,
+                None,
             ));
         }
     };
@@ -367,7 +372,8 @@ pub async fn propose_remediation(
             return Ok(stub_envelope(
                 &summary,
                 &log_pointers,
-                &format!("anthropic call failed: {e}"),
+                stub_reason::ANTHROPIC_CALL_FAILED,
+                None,
             ));
         }
     };
@@ -481,16 +487,23 @@ fn build_user_prompt(
 }
 
 /// Pull the most recent log tails for up to three distinct sessions
-/// surfaced in the artifact's `stiglab.*` events. Each tail is capped
-/// to ~1500 characters to keep the prompt bounded; we keep the last
-/// N chars rather than the first, because failure messages live at
-/// the end of the log.
+/// surfaced in the artifact's `stiglab.*` events. We pull only the
+/// last N chunks per session at the SQL layer (failure messages live
+/// at the end of the log), then trim the joined text to a char
+/// budget. Bounded SQL + bounded post-processing keeps tool latency
+/// independent of session size.
 async fn collect_recent_log_tails(
     state: &AppState,
     pointers: &[SessionPointer],
 ) -> Vec<(String, String)> {
     const MAX_SESSIONS: usize = 3;
     const MAX_TAIL_CHARS: usize = 1500;
+    const TAIL_CHUNK_LIMIT: i64 = 64;
+
+    #[derive(FromRow)]
+    struct ChunkRow {
+        chunk: String,
+    }
 
     let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut out = Vec::new();
@@ -504,7 +517,18 @@ async fn collect_recent_log_tails(
         if !seen.insert(sid.to_string()) {
             continue;
         }
-        let chunks = match session_db::get_session_logs_after(&state.pool, sid, 0).await {
+        // Fetch only the last TAIL_CHUNK_LIMIT chunks, then reverse
+        // into ascending order for the prompt. Bounded SQL work —
+        // a 10k-chunk session costs the same as a 64-chunk one.
+        let chunks = match sqlx::query_as::<_, ChunkRow>(
+            "SELECT chunk FROM session_logs WHERE session_id = $1 \
+             ORDER BY seq DESC LIMIT $2",
+        )
+        .bind(sid)
+        .bind(TAIL_CHUNK_LIMIT)
+        .fetch_all(&state.pool)
+        .await
+        {
             Ok(c) => c,
             Err(e) => {
                 tracing::debug!(session_id = sid, "log tail fetch failed: {e}");
@@ -515,7 +539,7 @@ async fn collect_recent_log_tails(
             continue;
         }
         let mut joined = String::new();
-        for c in &chunks {
+        for c in chunks.iter().rev() {
             joined.push_str(&c.chunk);
         }
         let tail = if joined.len() > MAX_TAIL_CHARS {
@@ -536,19 +560,20 @@ async fn collect_recent_log_tails(
 
 /// Resolve the caller's `ANTHROPIC_API_KEY` for `workspace_id`.
 /// Returns `Ok(None)` when the user has no such credential (clean
-/// stub fallback); `Err(reason)` when the credential exists but
-/// can't be decrypted (something is wrong server-side and we should
-/// surface a different stub_reason).
+/// stub fallback); `Err(stable_code)` on operational failures
+/// (lookup error, missing decryption key, decrypt failure). The
+/// detailed error context is logged here — only the stable
+/// `stub_reason` code travels back to the caller.
 async fn load_workspace_anthropic_key(
     state: &AppState,
     auth_user: &AuthUser,
     workspace_id: &str,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, &'static str> {
     #[derive(FromRow)]
     struct EncRow {
         encrypted_value: String,
     }
-    let row = sqlx::query_as::<_, EncRow>(
+    let row = match sqlx::query_as::<_, EncRow>(
         "SELECT encrypted_value FROM user_credentials \
          WHERE workspace_id = $1 AND user_id = $2 AND name = 'ANTHROPIC_API_KEY'",
     )
@@ -556,23 +581,55 @@ async fn load_workspace_anthropic_key(
     .bind(&auth_user.user_id)
     .fetch_optional(&state.pool)
     .await
-    .map_err(|e| format!("credential lookup failed: {e}"))?;
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("propose_remediation credential lookup failed: {e}");
+            return Err(stub_reason::CREDENTIAL_LOOKUP_FAILED);
+        }
+    };
 
     let Some(row) = row else { return Ok(None) };
     let Some(key) = state.config.credential_key.as_deref() else {
-        return Err("portal credential_key is not configured; cannot decrypt".into());
+        tracing::warn!("propose_remediation: portal credential_key not configured");
+        return Err(stub_reason::CREDENTIAL_KEY_MISSING);
     };
-    decrypt_credential(key, &row.encrypted_value)
-        .map(Some)
-        .map_err(|e| format!("ANTHROPIC_API_KEY decryption failed: {e}"))
+    match decrypt_credential(key, &row.encrypted_value) {
+        Ok(v) => Ok(Some(v)),
+        Err(e) => {
+            tracing::warn!("propose_remediation ANTHROPIC_API_KEY decrypt failed: {e}");
+            Err(stub_reason::CREDENTIAL_DECRYPT_FAILED)
+        }
+    }
+}
+
+/// Stable machine-readable codes for the stub envelope's
+/// `stub_reason` field. The dashboard branches on these to render a
+/// targeted degraded experience (e.g. "go set ANTHROPIC_API_KEY in
+/// Settings → Credentials" for `no_credential`, "your workspace hit
+/// the monthly cap" for `budget_exceeded`). Operational details
+/// (SQL errors, provider response bodies) stay in server logs —
+/// these strings are part of the public tool contract.
+mod stub_reason {
+    pub const NO_CREDENTIAL: &str = "no_credential";
+    pub const CREDENTIAL_LOOKUP_FAILED: &str = "credential_lookup_failed";
+    pub const CREDENTIAL_KEY_MISSING: &str = "credential_key_missing";
+    pub const CREDENTIAL_DECRYPT_FAILED: &str = "credential_decrypt_failed";
+    pub const BUDGET_EXCEEDED: &str = "budget_exceeded";
+    pub const ANTHROPIC_INIT_FAILED: &str = "anthropic_init_failed";
+    pub const ANTHROPIC_CALL_FAILED: &str = "anthropic_call_failed";
 }
 
 /// Parse the model's response. The system prompt asks for a JSON
-/// object with `rationale` + `proposed_actions`; we accept either
-/// that shape directly or any JSON object found inside the response.
-/// On parse failure we surface the raw text as rationale and an
-/// empty actions list — clients render the rationale and the user
-/// can decide.
+/// object with `rationale` + `proposed_actions`; the parser is
+/// intentionally narrow — it trims whitespace, peels off an
+/// accidental ```json ... ``` markdown fence if present, and then
+/// requires the remaining text to be a complete JSON value. On
+/// parse failure we surface the raw text as rationale and an empty
+/// actions list so the client renders something the user can decide
+/// against. (Extracting an embedded object from mixed prose is a
+/// possible follow-up — today the system prompt forbids surrounding
+/// commentary, so the strict path is sufficient.)
 fn parse_remediation_response(raw: &str) -> (Vec<Value>, String) {
     let trimmed = raw.trim();
     // Strip an accidental markdown code fence if the model emitted one.
@@ -607,10 +664,17 @@ fn parse_remediation_response(raw: &str) -> (Vec<Value>, String) {
 }
 
 /// Stub envelope shared by every short-circuit path. Mirrors the v1
-/// shape so existing clients keep working — only the `stub_reason`
-/// string changes.
-fn stub_envelope(summary: &Value, log_pointers: &[Value], reason: &str) -> Value {
-    serde_json::json!({
+/// shape so existing clients keep working — `stub_reason` is a
+/// stable machine-readable code from the `stub_reason` module;
+/// optional `details` carries structured extras (e.g. budget numbers
+/// for `budget_exceeded`).
+fn stub_envelope(
+    summary: &Value,
+    log_pointers: &[Value],
+    reason: &str,
+    details: Option<Value>,
+) -> Value {
+    let mut env = serde_json::json!({
         "v1_stub": true,
         "stub_reason": reason,
         "failure_summary": summary,
@@ -620,7 +684,29 @@ fn stub_envelope(summary: &Value, log_pointers: &[Value], reason: &str) -> Value
             "get_artifact",
             "inspect_run",
         ],
-    })
+    });
+    if let Some(d) = details {
+        env["details"] = d;
+    }
+    env
+}
+
+fn stub_envelope_with_budget(
+    summary: &Value,
+    log_pointers: &[Value],
+    reason: &str,
+    spent_usd: f64,
+    cap_usd: f64,
+) -> Value {
+    stub_envelope(
+        summary,
+        log_pointers,
+        reason,
+        Some(serde_json::json!({
+            "spent_usd": spent_usd,
+            "cap_usd": cap_usd,
+        })),
+    )
 }
 
 #[cfg(test)]
@@ -656,14 +742,47 @@ mod propose_remediation_tests {
     fn stub_envelope_carries_reason_and_pointers() {
         let summary = serde_json::json!({"artifact": {"workspace_id":"w1"}});
         let pointers = vec![serde_json::json!({"session_id":"s1"})];
-        let env = stub_envelope(&summary, &pointers, "no key");
+        let env = stub_envelope(&summary, &pointers, stub_reason::NO_CREDENTIAL, None);
         assert_eq!(env["v1_stub"], true);
-        assert_eq!(env["stub_reason"], "no key");
+        assert_eq!(env["stub_reason"], "no_credential");
         assert_eq!(env["failure_summary"]["artifact"]["workspace_id"], "w1");
         assert_eq!(env["log_pointers"][0]["session_id"], "s1");
+        assert!(env.get("details").is_none());
         // Stub keeps the legacy suggested_next_tools so degraded
         // clients can still chain.
         assert!(env["suggested_next_tools"].is_array());
+    }
+
+    #[test]
+    fn stub_envelope_with_budget_carries_numeric_details() {
+        let summary = serde_json::json!({});
+        let env =
+            stub_envelope_with_budget(&summary, &[], stub_reason::BUDGET_EXCEEDED, 12.34, 10.0);
+        assert_eq!(env["stub_reason"], "budget_exceeded");
+        assert_eq!(env["details"]["spent_usd"], 12.34);
+        assert_eq!(env["details"]["cap_usd"], 10.0);
+    }
+
+    #[test]
+    fn stub_reason_codes_are_snake_case_identifiers() {
+        // Stability check — these are part of the public tool
+        // contract. If you rename one, downstream clients break.
+        for code in [
+            stub_reason::NO_CREDENTIAL,
+            stub_reason::CREDENTIAL_LOOKUP_FAILED,
+            stub_reason::CREDENTIAL_KEY_MISSING,
+            stub_reason::CREDENTIAL_DECRYPT_FAILED,
+            stub_reason::BUDGET_EXCEEDED,
+            stub_reason::ANTHROPIC_INIT_FAILED,
+            stub_reason::ANTHROPIC_CALL_FAILED,
+        ] {
+            assert!(
+                code.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                "stub_reason `{code}` must be lowercase snake_case"
+            );
+            assert!(!code.is_empty());
+        }
     }
 
     #[test]

--- a/crates/onsager-portal/src/mcp/tools/diagnostics.rs
+++ b/crates/onsager-portal/src/mcp/tools/diagnostics.rs
@@ -2,23 +2,32 @@
 //! failed runs without dead-ending in "something went wrong" (ADR
 //! 0007's first-class diagnostic-surface commitment).
 //!
-//! Three real tools plus a v1 stub:
+//! Four tools:
 //!
 //! - `inspect_run` — structured snapshot of an artifact's current
 //!   state plus recent spine events touching it.
 //! - `get_stage_logs` — ordered log chunks from an agent-session
 //!   stage's `sessions` row.
-//! - `propose_remediation` — v1 stub: returns the same data
-//!   `inspect_run` and `get_stage_logs` would, in a single envelope,
-//!   with `suggested_next_tools` pointing the client AI at the next
-//!   step. Server-side AI reasoning is deferred to a follow-up.
+//! - `propose_remediation` — server-side AI reasoning over the failed
+//!   run's state and logs (#312). Reads the caller's
+//!   `ANTHROPIC_API_KEY` workspace credential, calls the Anthropic
+//!   Messages API with prompt caching, and returns `proposed_actions`
+//!   the client AI can review via HitlCard. Falls back to the v1 stub
+//!   envelope when the call short-circuits (no credential, monthly
+//!   budget exhausted, model error) so clients can detect the degraded
+//!   path instead of dead-ending.
 
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 use sqlx::FromRow;
 
-use crate::auth::AuthUser;
+use crate::anthropic::{
+    AnthropicClient, CacheControl, MAX_OUTPUT_TOKENS, MessagesRequest, ModelPricing, SystemBlock,
+    UserMessage, collect_text, resolve_model,
+};
+use crate::auth::{AuthUser, decrypt_credential};
+use crate::remediation_db::{self, BudgetStatus};
 use crate::session_db;
 use crate::state::AppState;
 
@@ -182,26 +191,51 @@ pub async fn get_stage_logs(state: &AppState, auth_user: &AuthUser, args: Value)
 }
 
 // =============================================================================
-// propose_remediation (v1 stub)
+// propose_remediation
 // =============================================================================
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ProposeRemediationArgs {
     /// Artifact id for the failed (or stuck) run.
     pub artifact_id: String,
+    /// Optional model selector. Accepts the convenience aliases
+    /// `"sonnet"` / `"opus"`, or a canonical Anthropic model id like
+    /// `"claude-opus-4-7"`. Defaults to Sonnet for cost — Opus is the
+    /// "hard cases" escape hatch.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
-/// Stub remediation tool — returns the same shape `inspect_run` does,
-/// plus pointers to log-bearing sessions and a fixed
-/// `suggested_next_tools` list. The *client-side* AI reads this and
-/// decides what to do; the Full version (server-side prompt design,
-/// Anthropic SDK call, cost model) is filed as a follow-up to #288.
+/// Pointer to a session attached to the failed run's artifact stream.
+/// Surfaced verbatim in both the AI-success and stub fallback envelopes
+/// so clients can chain `get_stage_logs` with no special-casing.
+#[derive(FromRow)]
+struct SessionPointer {
+    session_id: Option<String>,
+    event_type: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Server-side remediation tool.
 ///
-/// This is intentionally not "AI on the server with no prompt design"
-/// — that would lock in cost + provider choices that deserve their own
-/// conversation. The stub keeps the architecture honest (every tool
-/// in the registry is reachable; the diagnostic surface is complete)
-/// without those locks.
+/// Reads the failed run's state via `inspect_run`, gathers recent log
+/// tails for the artifact's most recent agent sessions, and asks
+/// Claude what the next step should be. The response is a
+/// `proposed_actions` array — each entry names a registered MCP tool
+/// plus concrete arguments — which the client surfaces as `HitlCard`s
+/// for the user to commit.
+///
+/// Short-circuits to the v1 stub envelope when:
+///   1. The workspace has no `ANTHROPIC_API_KEY` credential.
+///   2. The credential is unreadable (no encryption key configured;
+///      decryption fails).
+///   3. The workspace's per-month spend cap has been reached.
+///   4. The Anthropic call errors.
+///
+/// In every short-circuit the client sees the same shape
+/// (`v1_stub: true`, populated `failure_summary` and `log_pointers`,
+/// `suggested_next_tools` to chain), so the chat experience degrades
+/// instead of dead-ending.
 pub async fn propose_remediation(
     state: &AppState,
     auth_user: &AuthUser,
@@ -210,27 +244,26 @@ pub async fn propose_remediation(
     let args: ProposeRemediationArgs = serde_json::from_value(args)
         .map_err(|e| ToolError::InvalidParams(format!("invalid propose_remediation args: {e}")))?;
 
-    // Reuse inspect_run's payload as the failure_summary. The client AI
-    // chains `get_stage_logs` next via the surfaced session_ids.
+    // Workspace authz happens inside inspect_run; reuse it for the
+    // canonical failure-summary payload and the workspace_id lookup.
     let summary = inspect_run(
         state,
         auth_user,
         serde_json::json!({
             "artifact_id": args.artifact_id,
+            "event_limit": 100,
         }),
     )
     .await?;
 
-    // Pull log-pointers (session_ids) from `stiglab.session_*` events
-    // on the artifact stream. The client AI uses these as the input to
-    // `get_stage_logs`.
+    let workspace_id = summary
+        .get("artifact")
+        .and_then(|a| a.get("workspace_id"))
+        .and_then(|w| w.as_str())
+        .ok_or_else(|| ToolError::Internal("inspect_run did not return a workspace_id".into()))?
+        .to_string();
+
     let spine = state.spine.pool();
-    #[derive(FromRow)]
-    struct SessionPointer {
-        session_id: Option<String>,
-        event_type: String,
-        created_at: chrono::DateTime<chrono::Utc>,
-    }
     let pointers = sqlx::query_as::<_, SessionPointer>(
         "SELECT data->>'session_id' AS session_id, event_type, created_at \
          FROM events_ext \
@@ -246,7 +279,7 @@ pub async fn propose_remediation(
     })?;
 
     let log_pointers: Vec<Value> = pointers
-        .into_iter()
+        .iter()
         .filter(|p| p.session_id.is_some())
         .map(|p| {
             serde_json::json!({
@@ -257,9 +290,329 @@ pub async fn propose_remediation(
         })
         .collect();
 
+    // Decide whether to go to the model. Each guard returns the stub
+    // envelope with a specific `stub_reason` so the dashboard can
+    // tell the user why their request degraded.
+    let api_key = match load_workspace_anthropic_key(state, auth_user, &workspace_id).await {
+        Ok(Some(k)) => k,
+        Ok(None) => {
+            return Ok(stub_envelope(
+                &summary,
+                &log_pointers,
+                "no ANTHROPIC_API_KEY credential set for this workspace",
+            ));
+        }
+        Err(reason) => {
+            return Ok(stub_envelope(&summary, &log_pointers, &reason));
+        }
+    };
+
+    let cap_usd = state.config.remediation_monthly_cap_usd;
+    match remediation_db::check_budget(&state.pool, &workspace_id, cap_usd).await {
+        Ok(BudgetStatus::OverCap { spent_usd, cap_usd }) => {
+            return Ok(stub_envelope(
+                &summary,
+                &log_pointers,
+                &format!(
+                    "workspace monthly remediation budget exceeded ({:.2} USD / {:.2} USD cap)",
+                    spent_usd, cap_usd
+                ),
+            ));
+        }
+        Ok(BudgetStatus::Ok { .. }) => {}
+        Err(e) => {
+            tracing::warn!("propose_remediation budget check failed: {e}");
+            // Fail open — budget query failures shouldn't deny a
+            // tool call. The next call after the next successful
+            // ledger insert will re-check.
+        }
+    }
+
+    // Pull log tails for the most recent agent sessions. Keep this
+    // bounded — the prompt is the cost driver.
+    let recent_logs = collect_recent_log_tails(state, &pointers).await;
+
+    let model = resolve_model(args.model.as_deref()).to_string();
+    let user_prompt = build_user_prompt(&args.artifact_id, &summary, &log_pointers, &recent_logs);
+
+    let client = match AnthropicClient::new(api_key) {
+        Ok(c) => c,
+        Err(e) => {
+            return Ok(stub_envelope(
+                &summary,
+                &log_pointers,
+                &format!("anthropic client init failed: {e}"),
+            ));
+        }
+    };
+
+    let messages_req = MessagesRequest {
+        model: &model,
+        max_tokens: MAX_OUTPUT_TOKENS,
+        system: vec![SystemBlock {
+            kind: "text",
+            text: REMEDIATION_SYSTEM_PROMPT,
+            cache_control: Some(CacheControl::EPHEMERAL),
+        }],
+        messages: vec![UserMessage {
+            role: "user",
+            content: &user_prompt,
+        }],
+    };
+
+    let response = match client.messages(&messages_req).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("propose_remediation anthropic call failed: {e}");
+            return Ok(stub_envelope(
+                &summary,
+                &log_pointers,
+                &format!("anthropic call failed: {e}"),
+            ));
+        }
+    };
+
+    let pricing = ModelPricing::for_model(&model);
+    let cost_usd = pricing.estimate_usd(&response.usage);
+    if let Err(e) = remediation_db::record_call(
+        &state.pool,
+        &workspace_id,
+        &auth_user.user_id,
+        &args.artifact_id,
+        &model,
+        &response.usage,
+        cost_usd,
+    )
+    .await
+    {
+        // Ledger failure is logged but doesn't block the response —
+        // the AI call already happened and the user is waiting on it.
+        tracing::warn!("propose_remediation ledger insert failed: {e}");
+    }
+
+    let raw_text = collect_text(&response.content);
+    let (proposed_actions, ai_rationale) = parse_remediation_response(&raw_text);
+
     Ok(serde_json::json!({
+        "v1_stub": false,
+        "failure_summary": summary,
+        "log_pointers": log_pointers,
+        "proposed_actions": proposed_actions,
+        "rationale": ai_rationale,
+        "model": model,
+        "usage": {
+            "input_tokens": response.usage.input_tokens,
+            "output_tokens": response.usage.output_tokens,
+            "cache_creation_input_tokens": response.usage.cache_creation_input_tokens,
+            "cache_read_input_tokens": response.usage.cache_read_input_tokens,
+            "estimated_cost_usd": cost_usd,
+        },
+    }))
+}
+
+/// System prompt — workspace-invariant, prompt-cached. Carries the
+/// tool registry summary and the response-shape contract. Any change
+/// here invalidates the cache for every workspace; keep it stable.
+const REMEDIATION_SYSTEM_PROMPT: &str = r#"You are an operations agent for Onsager, an AI factory that drives software-engineering artifacts (GitHub issues, pull requests, etc.) through workflows. A "run" is one workflow execution against an artifact; runs can park on a stage failure, an agent-session error, or a gate verdict.
+
+You will receive a JSON blob describing a failed or stuck run: its artifact state, the most recent spine events, structured pointers to agent sessions, and trailing log excerpts. Your job is to recommend concrete next actions the operator can review and commit.
+
+Available MCP tools the operator can invoke. Recommend by tool name plus concrete arguments:
+- get_stage_logs(session_id, since_seq?) — fetch more session log chunks when the failure cause is not yet clear.
+- inspect_run(artifact_id, event_limit?) — re-read the run's state, useful after another action runs.
+- get_artifact(artifact_id) — read a specific artifact's metadata.
+- list_runs(workflow_id, limit?) — list recent runs of a workflow to spot patterns.
+- list_workflows(workspace_id) — list workflows when the failure looks like a workflow-shape problem.
+- cancel_run(artifact_id) — archive the artifact; irreversible. Use only when the run cannot be recovered and the operator should abandon it.
+- propose_workflow(...) / edit_workflow(...) / schedule_workflow(...) — mutate workflow definitions. Use only when the failure is rooted in the workflow definition itself, not a transient session error.
+- run_workflow(workflow_id, trigger_name) — fire a manual trigger to retry, when the failure looked transient and the workflow has a manual trigger.
+
+Respond with a single JSON object, no surrounding markdown, no prose outside the JSON. Shape:
+{
+  "rationale": "1-3 sentences naming the failure cause as you read it",
+  "proposed_actions": [
+    {
+      "tool": "<one of the tool names above>",
+      "arguments": { <concrete JSON args matching that tool> },
+      "reason": "1 sentence — why this action, what it tells us"
+    },
+    ...
+  ]
+}
+
+Rules:
+- Prefer diagnostic actions (get_stage_logs, inspect_run) before destructive ones (cancel_run).
+- Never invent tool names or arguments not listed above.
+- Two or three actions is typical; one is fine if the cause is obvious; never more than five.
+- If you cannot tell what happened, propose a get_stage_logs call against the most recent session.
+- If the run is clearly unrecoverable (agent crashed deterministically; the underlying GitHub artifact is gone), propose cancel_run as the sole action.
+- Output ONLY the JSON object. No code fences, no commentary."#;
+
+/// Build the per-call user prompt — failure summary + log tails. Not
+/// cached; this is the bit that varies per artifact.
+fn build_user_prompt(
+    artifact_id: &str,
+    summary: &Value,
+    log_pointers: &[Value],
+    recent_logs: &[(String, String)],
+) -> String {
+    let mut out = String::with_capacity(2048);
+    out.push_str("Failed run report:\n\n");
+    out.push_str(&format!("artifact_id: {}\n\n", artifact_id));
+    out.push_str("=== Artifact + recent spine events (from inspect_run) ===\n");
+    out.push_str(
+        &serde_json::to_string_pretty(summary)
+            .unwrap_or_else(|_| "<summary serialization failed>".into()),
+    );
+    out.push_str("\n\n=== Session pointers ===\n");
+    out.push_str(&serde_json::to_string_pretty(log_pointers).unwrap_or_else(|_| "[]".into()));
+    if recent_logs.is_empty() {
+        out.push_str("\n\n=== Session log tails ===\n(none available)\n");
+    } else {
+        out.push_str("\n\n=== Session log tails (most recent first) ===\n");
+        for (session_id, tail) in recent_logs {
+            out.push_str(&format!("--- session {session_id} (tail) ---\n"));
+            out.push_str(tail);
+            out.push_str("\n\n");
+        }
+    }
+    out.push_str("\nReturn the JSON object as instructed.");
+    out
+}
+
+/// Pull the most recent log tails for up to three distinct sessions
+/// surfaced in the artifact's `stiglab.*` events. Each tail is capped
+/// to ~1500 characters to keep the prompt bounded; we keep the last
+/// N chars rather than the first, because failure messages live at
+/// the end of the log.
+async fn collect_recent_log_tails(
+    state: &AppState,
+    pointers: &[SessionPointer],
+) -> Vec<(String, String)> {
+    const MAX_SESSIONS: usize = 3;
+    const MAX_TAIL_CHARS: usize = 1500;
+
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut out = Vec::new();
+    for p in pointers {
+        if out.len() >= MAX_SESSIONS {
+            break;
+        }
+        let Some(sid) = p.session_id.as_deref() else {
+            continue;
+        };
+        if !seen.insert(sid.to_string()) {
+            continue;
+        }
+        let chunks = match session_db::get_session_logs_after(&state.pool, sid, 0).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(session_id = sid, "log tail fetch failed: {e}");
+                continue;
+            }
+        };
+        if chunks.is_empty() {
+            continue;
+        }
+        let mut joined = String::new();
+        for c in &chunks {
+            joined.push_str(&c.chunk);
+        }
+        let tail = if joined.len() > MAX_TAIL_CHARS {
+            joined
+                .char_indices()
+                .rev()
+                .nth(MAX_TAIL_CHARS)
+                .map(|(idx, _)| &joined[idx..])
+                .unwrap_or(&joined)
+                .to_string()
+        } else {
+            joined
+        };
+        out.push((sid.to_string(), tail));
+    }
+    out
+}
+
+/// Resolve the caller's `ANTHROPIC_API_KEY` for `workspace_id`.
+/// Returns `Ok(None)` when the user has no such credential (clean
+/// stub fallback); `Err(reason)` when the credential exists but
+/// can't be decrypted (something is wrong server-side and we should
+/// surface a different stub_reason).
+async fn load_workspace_anthropic_key(
+    state: &AppState,
+    auth_user: &AuthUser,
+    workspace_id: &str,
+) -> Result<Option<String>, String> {
+    #[derive(FromRow)]
+    struct EncRow {
+        encrypted_value: String,
+    }
+    let row = sqlx::query_as::<_, EncRow>(
+        "SELECT encrypted_value FROM user_credentials \
+         WHERE workspace_id = $1 AND user_id = $2 AND name = 'ANTHROPIC_API_KEY'",
+    )
+    .bind(workspace_id)
+    .bind(&auth_user.user_id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(|e| format!("credential lookup failed: {e}"))?;
+
+    let Some(row) = row else { return Ok(None) };
+    let Some(key) = state.config.credential_key.as_deref() else {
+        return Err("portal credential_key is not configured; cannot decrypt".into());
+    };
+    decrypt_credential(key, &row.encrypted_value)
+        .map(Some)
+        .map_err(|e| format!("ANTHROPIC_API_KEY decryption failed: {e}"))
+}
+
+/// Parse the model's response. The system prompt asks for a JSON
+/// object with `rationale` + `proposed_actions`; we accept either
+/// that shape directly or any JSON object found inside the response.
+/// On parse failure we surface the raw text as rationale and an
+/// empty actions list — clients render the rationale and the user
+/// can decide.
+fn parse_remediation_response(raw: &str) -> (Vec<Value>, String) {
+    let trimmed = raw.trim();
+    // Strip an accidental markdown code fence if the model emitted one.
+    let stripped = if let Some(rest) = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+    {
+        rest.trim_start_matches('\n')
+            .strip_suffix("```")
+            .unwrap_or(rest)
+            .trim()
+    } else {
+        trimmed
+    };
+
+    match serde_json::from_str::<Value>(stripped) {
+        Ok(v) => {
+            let actions = v
+                .get("proposed_actions")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            let rationale = v
+                .get("rationale")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            (actions, rationale)
+        }
+        Err(_) => (Vec::new(), trimmed.to_string()),
+    }
+}
+
+/// Stub envelope shared by every short-circuit path. Mirrors the v1
+/// shape so existing clients keep working — only the `stub_reason`
+/// string changes.
+fn stub_envelope(summary: &Value, log_pointers: &[Value], reason: &str) -> Value {
+    serde_json::json!({
         "v1_stub": true,
-        "stub_reason": "v1 returns log pointers; server-side AI reasoning is a follow-up. See #288 Notes.",
+        "stub_reason": reason,
         "failure_summary": summary,
         "log_pointers": log_pointers,
         "suggested_next_tools": [
@@ -267,5 +620,72 @@ pub async fn propose_remediation(
             "get_artifact",
             "inspect_run",
         ],
-    }))
+    })
+}
+
+#[cfg(test)]
+mod propose_remediation_tests {
+    use super::*;
+
+    #[test]
+    fn parse_handles_clean_json_object() {
+        let raw = r#"{"rationale": "cause", "proposed_actions": [{"tool":"inspect_run","arguments":{"artifact_id":"a"},"reason":"r"}]}"#;
+        let (actions, rat) = parse_remediation_response(raw);
+        assert_eq!(rat, "cause");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0]["tool"], "inspect_run");
+    }
+
+    #[test]
+    fn parse_strips_markdown_fence() {
+        let raw = "```json\n{\"rationale\": \"x\", \"proposed_actions\": []}\n```";
+        let (actions, rat) = parse_remediation_response(raw);
+        assert_eq!(rat, "x");
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn parse_falls_back_to_rationale_on_garbage() {
+        let raw = "I think you should restart everything";
+        let (actions, rat) = parse_remediation_response(raw);
+        assert!(actions.is_empty());
+        assert!(rat.contains("restart"));
+    }
+
+    #[test]
+    fn stub_envelope_carries_reason_and_pointers() {
+        let summary = serde_json::json!({"artifact": {"workspace_id":"w1"}});
+        let pointers = vec![serde_json::json!({"session_id":"s1"})];
+        let env = stub_envelope(&summary, &pointers, "no key");
+        assert_eq!(env["v1_stub"], true);
+        assert_eq!(env["stub_reason"], "no key");
+        assert_eq!(env["failure_summary"]["artifact"]["workspace_id"], "w1");
+        assert_eq!(env["log_pointers"][0]["session_id"], "s1");
+        // Stub keeps the legacy suggested_next_tools so degraded
+        // clients can still chain.
+        assert!(env["suggested_next_tools"].is_array());
+    }
+
+    #[test]
+    fn build_user_prompt_includes_required_sections() {
+        let summary = serde_json::json!({"artifact": {"state": "parked"}});
+        let pointers = vec![serde_json::json!({"session_id":"s1"})];
+        let logs = vec![("s1".to_string(), "boom".to_string())];
+        let p = build_user_prompt("a-1", &summary, &pointers, &logs);
+        assert!(p.contains("artifact_id: a-1"));
+        assert!(p.contains("=== Artifact"));
+        assert!(p.contains("=== Session pointers"));
+        assert!(p.contains("=== Session log tails"));
+        assert!(p.contains("session s1"));
+        assert!(p.contains("boom"));
+    }
+
+    #[test]
+    fn build_user_prompt_marks_empty_logs() {
+        let summary = serde_json::json!({});
+        let pointers: Vec<Value> = vec![];
+        let logs: Vec<(String, String)> = vec![];
+        let p = build_user_prompt("a-1", &summary, &pointers, &logs);
+        assert!(p.contains("(none available)"));
+    }
 }

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -54,6 +54,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "006_user_credentials",
         include_str!("../migrations/006_user_credentials.sql"),
     ),
+    (
+        "008_portal_remediation_calls",
+        include_str!("../migrations/008_portal_remediation_calls.sql"),
+    ),
 ];
 
 /// Apply all portal-owned table migrations. Idempotent — safe to call on

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -54,6 +54,15 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "006_user_credentials",
         include_str!("../migrations/006_user_credentials.sql"),
     ),
+    // 007_github_app_installations was historically applied via
+    // stiglab's runtime CREATE TABLE IF NOT EXISTS path; the `.sql`
+    // file is the canonical schema. Wire it here so the apply order
+    // matches filename order — the SQL is idempotent so a deploy
+    // where stiglab migrated first is unaffected.
+    (
+        "007_github_app_installations",
+        include_str!("../migrations/007_github_app_installations.sql"),
+    ),
     (
         "008_portal_remediation_calls",
         include_str!("../migrations/008_portal_remediation_calls.sql"),

--- a/crates/onsager-portal/src/remediation_db.rs
+++ b/crates/onsager-portal/src/remediation_db.rs
@@ -17,8 +17,10 @@ use crate::anthropic::Usage;
 /// Outcome of the per-workspace budget check.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BudgetStatus {
-    /// At least one more call fits under the monthly cap. Carries the
-    /// remaining headroom so the caller can surface it.
+    /// At least one more call fits under the monthly cap. Carries
+    /// `spent_usd` and `cap_usd` so the caller can compute remaining
+    /// headroom (`cap_usd - spent_usd`) and surface a warning when
+    /// the workspace is approaching the limit.
     Ok { spent_usd: f64, cap_usd: f64 },
     /// Over the monthly cap — the call must short-circuit to stub.
     OverCap { spent_usd: f64, cap_usd: f64 },
@@ -92,10 +94,10 @@ pub async fn record_call(
     .bind(user_id)
     .bind(artifact_id)
     .bind(model)
-    .bind(usage.input_tokens as i32)
-    .bind(usage.output_tokens as i32)
-    .bind(usage.cache_creation_input_tokens as i32)
-    .bind(usage.cache_read_input_tokens as i32)
+    .bind(usage.input_tokens as i64)
+    .bind(usage.output_tokens as i64)
+    .bind(usage.cache_creation_input_tokens as i64)
+    .bind(usage.cache_read_input_tokens as i64)
     .bind(cost_usd)
     .execute(pool)
     .await?;

--- a/crates/onsager-portal/src/remediation_db.rs
+++ b/crates/onsager-portal/src/remediation_db.rs
@@ -1,0 +1,143 @@
+//! Cost ledger + budget enforcement for `propose_remediation`'s
+//! server-side AI calls (spec #312).
+//!
+//! Cost lives in `portal_remediation_calls` (migration 008). One row
+//! per AI call; the budget check sums `cost_usd` across the current
+//! calendar month (UTC) for the workspace and refuses new calls past
+//! the configured cap. The cap defaults to a low double-digit dollar
+//! amount in code; per-workspace overrides are a future dashboard
+//! Settings concern and are deliberately not modeled in this slice.
+
+use chrono::{DateTime, Datelike, TimeZone, Utc};
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+use crate::anthropic::Usage;
+
+/// Outcome of the per-workspace budget check.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BudgetStatus {
+    /// At least one more call fits under the monthly cap. Carries the
+    /// remaining headroom so the caller can surface it.
+    Ok { spent_usd: f64, cap_usd: f64 },
+    /// Over the monthly cap — the call must short-circuit to stub.
+    OverCap { spent_usd: f64, cap_usd: f64 },
+}
+
+impl BudgetStatus {
+    pub fn is_over(&self) -> bool {
+        matches!(self, BudgetStatus::OverCap { .. })
+    }
+}
+
+/// Sum `cost_usd` for the current calendar month (UTC) and compare
+/// against `cap_usd`. The cap is the **soft pre-call gate**: a call
+/// that pushes spend over the cap mid-flight still completes (we
+/// charge per Anthropic's invoice either way); the next call after it
+/// will be refused.
+pub async fn check_budget(
+    pool: &PgPool,
+    workspace_id: &str,
+    cap_usd: f64,
+) -> anyhow::Result<BudgetStatus> {
+    let start = month_start(Utc::now());
+    let spent: Option<f64> = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(cost_usd), 0) FROM portal_remediation_calls \
+         WHERE workspace_id = $1 AND created_at >= $2",
+    )
+    .bind(workspace_id)
+    .bind(start)
+    .fetch_one(pool)
+    .await?;
+    let spent = spent.unwrap_or(0.0);
+    Ok(if spent >= cap_usd {
+        BudgetStatus::OverCap {
+            spent_usd: spent,
+            cap_usd,
+        }
+    } else {
+        BudgetStatus::Ok {
+            spent_usd: spent,
+            cap_usd,
+        }
+    })
+}
+
+/// Insert one row into `portal_remediation_calls`. Best-effort —
+/// the AI call has already happened by the time we get here, so a
+/// ledger failure is logged but doesn't propagate to the caller.
+/// The next budget check will under-count by one row; that's
+/// acceptable for the soft-cap semantics.
+#[allow(clippy::too_many_arguments)]
+pub async fn record_call(
+    pool: &PgPool,
+    workspace_id: &str,
+    user_id: &str,
+    artifact_id: &str,
+    model: &str,
+    usage: &Usage,
+    cost_usd: f64,
+) -> anyhow::Result<()> {
+    let id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO portal_remediation_calls (\
+            id, workspace_id, user_id, artifact_id, model, \
+            input_tokens, output_tokens, \
+            cache_creation_input_tokens, cache_read_input_tokens, \
+            cost_usd \
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(&id)
+    .bind(workspace_id)
+    .bind(user_id)
+    .bind(artifact_id)
+    .bind(model)
+    .bind(usage.input_tokens as i32)
+    .bind(usage.output_tokens as i32)
+    .bind(usage.cache_creation_input_tokens as i32)
+    .bind(usage.cache_read_input_tokens as i32)
+    .bind(cost_usd)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn month_start(now: DateTime<Utc>) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(now.year(), now.month(), 1, 0, 0, 0)
+        .single()
+        .expect("month-start datetime is well-defined")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    #[test]
+    fn month_start_is_first_of_month_at_midnight() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 11, 23, 59, 59).unwrap();
+        let start = month_start(now);
+        assert_eq!(start.year(), 2026);
+        assert_eq!(start.month(), 5);
+        assert_eq!(start.day(), 1);
+        assert_eq!(start.hour(), 0);
+    }
+
+    #[test]
+    fn budget_status_is_over_predicate() {
+        assert!(
+            !BudgetStatus::Ok {
+                spent_usd: 1.0,
+                cap_usd: 10.0
+            }
+            .is_over()
+        );
+        assert!(
+            BudgetStatus::OverCap {
+                spent_usd: 10.5,
+                cap_usd: 10.0
+            }
+            .is_over()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the MCP `propose_remediation` tool from its v1 stub (log pointers + `suggested_next_tools`) to a server-side Anthropic Messages call that returns concrete `proposed_actions` for the dashboard's `HitlCard` to render. Closes #312.

## What changed

- **`crates/onsager-portal/src/anthropic.rs`** — minimal Anthropic Messages client (reqwest-based, no new SDK). Supports prompt-caching `cache_control` blocks, parses `usage.cache_creation_input_tokens` / `cache_read_input_tokens`, and carries a Sonnet/Opus pricing table for cost estimation.
- **`crates/onsager-portal/src/remediation_db.rs`** + **`migrations/008_portal_remediation_calls.sql`** — per-workspace cost ledger and monthly budget check. One row per AI call (model, token counts, `cost_usd`); `check_budget` sums the current calendar month and refuses new calls past the cap.
- **`crates/onsager-portal/src/mcp/tools/diagnostics.rs`** — `propose_remediation` replaced. Resolves the artifact's workspace, looks up the caller's `ANTHROPIC_API_KEY` credential, runs the budget gate, gathers `inspect_run` payload + recent session log tails, asks Claude (cached system prompt + per-call user blob) for a JSON envelope with `rationale` + `proposed_actions`, parses the result, records the call to the ledger, and returns the envelope.
- **`crates/onsager-portal/src/config.rs`** + **`main.rs`** — `remediation_monthly_cap_usd` config field, default $10, override via `PORTAL_REMEDIATION_MONTHLY_CAP_USD`.
- **Registry description** updated to advertise the new shape.

## Design choices baked in (Plan items from #312)

- **Model**: defaults to Sonnet 4.6 (cost); caller can pass `model: "opus"` for hard cases (~5x cost). Unknown / non-`claude-*` model strings fall back to the default — guards against the model name being a prompt-injection vehicle.
- **Caching**: one ephemeral cache block on the system prompt (tool registry summary + response-format contract). The per-call failure summary is uncached.
- **Cost model**: default $10/workspace/month. The cap is a soft pre-call gate — a call already in flight completes; the next call after the limit is refused.
- **Fallback**: every short-circuit (no credential, budget exhausted, model error, decryption failure) returns the v1 stub envelope with a populated `stub_reason` so the dashboard can render a degraded experience instead of dead-ending.

## What's not done (deferred from #312's Plan)

- **Prompt iteration on 10 real failed runs** — requires production data; the prompt as shipped is the initial design and will be tuned in a follow-up against real `events_ext WHERE workspace_parked_reason IS NOT NULL` samples.
- **Per-workspace budget overrides** — code-side default only; per-workspace dashboard Settings is a future surface.
- **`HitlCard` rendering on the dashboard** — the tool surface returns `proposed_actions` in the documented shape; the dashboard side lands separately per #288.

## Test plan

- [x] `cargo build -p onsager-portal` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p onsager-portal --lib` — 137 tests pass, 8 new unit tests covering model alias resolution, pricing math, response parsing (clean JSON / markdown-fenced / garbage), stub envelope shape, prompt builder, month-start math, and budget-status predicate
- [x] `xtask check-tools-and-skills` — registry self-check passes (11 tools)
- [x] `xtask lint-seams` / `check-events` / `check-api-contract` / `check-file-budget` — all clean
- [ ] Smoke test against 10 real failed runs (production data; follow-up)
- [ ] Cost guardrail end-to-end (requires running portal against Postgres; follow-up)

Closes #312

https://claude.ai/code/session_011qK4KUNZZoNGNH2oMmBkk9

---
_Generated by [Claude Code](https://claude.ai/code/session_011qK4KUNZZoNGNH2oMmBkk9)_