### PR TITLE
feat(portal,forge): close the session→PR loop (spec #273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,6 +700,11 @@ do not wait to be asked:
 
    This is the upstream answer to the bot's `<!-- pr-spec-sync:no-spec-link -->`
    reminder — answering it at PR creation keeps the bot silent.
+
+   **Always pass `body` as a plain inline string.** Never wrap it in shell
+   heredoc syntax (`$(cat <<'EOF'...EOF)`) — that is Bash substitution and
+   produces a literal `$(cat <<'EOF'...` in the PR description when passed
+   to an MCP tool parameter.
 3. Subscribe to PR activity so CI failures and review comments are auto-fixed.
 
 Skip this for branches that don't start with `claude/` (local/manual work).

--- a/crates/forge/src/cmd/serve.rs
+++ b/crates/forge/src/cmd/serve.rs
@@ -584,6 +584,33 @@ pub fn run(database_url: &str, tick_ms: u64) {
             }
         });
 
+        // Spawn the git.pr_merged → archive listener (spec #273).
+        // Warm-start at max_event_id so boot doesn't replay all history.
+        let pr_merged_shared = shared.clone();
+        tokio::spawn(async move {
+            let store = {
+                let state = pr_merged_shared.read().await;
+                state.spine.clone()
+            };
+            let Some(store) = store else {
+                tracing::info!("forge: pr_merged listener disabled (no spine connection)");
+                return;
+            };
+            let since = match store.max_event_id().await {
+                Ok(cursor) => cursor,
+                Err(e) => {
+                    tracing::warn!(
+                        "forge: max_event_id lookup failed ({e}); starting pr_merged \
+                         listener from the beginning"
+                    );
+                    None
+                }
+            };
+            if let Err(e) = crate::core::pr_merged_listener::run(store, since).await {
+                tracing::error!("forge: pr_merged listener exited: {e}");
+            }
+        });
+
         // Run the HTTP server.
         axum::serve(listener, app).await.unwrap();
     });

--- a/crates/forge/src/core/mod.rs
+++ b/crates/forge/src/core/mod.rs
@@ -9,6 +9,7 @@ pub mod kernel;
 pub mod pending;
 pub mod persistence;
 pub mod pipeline;
+pub mod pr_merged_listener;
 pub mod scheduler;
 pub mod session_listener;
 pub mod session_result_listener;

--- a/crates/forge/src/core/pr_merged_listener.rs
+++ b/crates/forge/src/core/pr_merged_listener.rs
@@ -1,0 +1,165 @@
+//! Spine listener for `git.pr_merged` → archive originating issue artifact
+//! (spec #273, PR 2).
+//!
+//! When a PR is merged:
+//! 1. Look up the `Kind::PullRequest` artifact from the event.
+//! 2. Follow the `horizontal_lineage` back to the originating issue artifact.
+//! 3. Archive the issue artifact (state → `archived`).
+//! 4. Emit `artifact.archived` on the spine.
+//!
+//! If there is no lineage row (PR was not opened by the factory, or was
+//! opened before spec #273 landed), archival is skipped silently.
+
+use async_trait::async_trait;
+use onsager_artifact::ArtifactId;
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventHandler, EventMetadata, EventNotification, EventStore, Listener};
+
+/// Run the pr-merged → archive listener forever. Returns only when the
+/// pg_notify channel closes.
+pub async fn run(store: EventStore, since: Option<i64>) -> anyhow::Result<()> {
+    let handler = PrMergedHandler {
+        store: store.clone(),
+    };
+    Listener::new(store).with_since(since).run(handler).await
+}
+
+struct PrMergedHandler {
+    store: EventStore,
+}
+
+impl PrMergedHandler {
+    async fn handle_pr_merged(&self, pr_artifact_id: &ArtifactId) -> anyhow::Result<()> {
+        let pool = self.store.pool();
+
+        // Find the issue artifact linked to this PR via horizontal_lineage.
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT hl.source_artifact_id, a.workspace_id \
+               FROM horizontal_lineage hl \
+               JOIN artifacts a ON a.artifact_id = hl.source_artifact_id \
+              WHERE hl.artifact_id = $1 AND hl.role = 'derived_from' \
+              ORDER BY hl.id DESC LIMIT 1",
+        )
+        .bind(pr_artifact_id.as_str())
+        .fetch_optional(pool)
+        .await?;
+
+        let Some((issue_artifact_id, workspace_id)) = row else {
+            // PR was not opened by the factory (no lineage row); skip silently.
+            return Ok(());
+        };
+
+        // Archive the issue artifact. The UPDATE returns the row only when
+        // the state actually changed (not already archived), so we can use
+        // the result to decide whether to emit the event.
+        let archived: Option<(String,)> = sqlx::query_as(
+            "UPDATE artifacts SET state = 'archived', updated_at = NOW() \
+              WHERE artifact_id = $1 AND state != 'archived' \
+          RETURNING artifact_id",
+        )
+        .bind(&issue_artifact_id)
+        .fetch_optional(pool)
+        .await?;
+
+        let Some(_) = archived else {
+            // Already archived or not found — no-op.
+            return Ok(());
+        };
+
+        // Emit artifact.archived.
+        let event = FactoryEventKind::ArtifactArchived {
+            artifact_id: ArtifactId::new(issue_artifact_id.clone()),
+            reason: "pr_merged".to_string(),
+        };
+        let metadata = EventMetadata {
+            actor: "forge".into(),
+            ..Default::default()
+        };
+        if let Err(e) = self
+            .store
+            .append_ext(
+                &workspace_id,
+                &issue_artifact_id,
+                "forge",
+                "artifact.archived",
+                serde_json::to_value(&event)?,
+                &metadata,
+                None,
+            )
+            .await
+        {
+            tracing::warn!(
+                artifact_id = %issue_artifact_id,
+                error = %e,
+                "pr_merged_listener: failed to emit artifact.archived"
+            );
+        } else {
+            tracing::info!(
+                pr_artifact_id = %pr_artifact_id,
+                issue_artifact_id = %issue_artifact_id,
+                "pr_merged_listener: issue artifact archived"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EventHandler for PrMergedHandler {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "git.pr_merged" {
+            return Ok(());
+        }
+
+        let kind = match notification.table.as_str() {
+            "events" => {
+                let Some(row) = self.store.get_event_by_id(notification.id).await? else {
+                    return Ok(());
+                };
+                let envelope: FactoryEvent = serde_json::from_value(row.data)?;
+                envelope.event
+            }
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(());
+                };
+                serde_json::from_value::<FactoryEventKind>(row.data)?
+            }
+            _ => return Ok(()),
+        };
+
+        let FactoryEventKind::GitPrMerged { artifact_id, .. } = kind else {
+            return Ok(());
+        };
+
+        if let Err(e) = self.handle_pr_merged(&artifact_id).await {
+            tracing::warn!(
+                pr_artifact_id = %artifact_id,
+                error = %e,
+                "pr_merged_listener: handler error"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_spine::factory_event::FactoryEventKind;
+
+    #[test]
+    fn event_type_filter_literal_present() {
+        // Smoke-test: the event type string used in the listener matches the
+        // check-events lint pattern. The guard `if notification.event_type !=
+        // "git.pr_merged"` is what check-events scans for.
+        let expected = "git.pr_merged";
+        let kind = FactoryEventKind::GitPrMerged {
+            artifact_id: ArtifactId::new("art_test"),
+            pr_number: 1,
+            merge_sha: "abc".into(),
+        };
+        assert_eq!(kind.event_type(), expected);
+    }
+}

--- a/crates/forge/src/core/pr_merged_listener.rs
+++ b/crates/forge/src/core/pr_merged_listener.rs
@@ -37,7 +37,7 @@ impl PrMergedHandler {
             "SELECT hl.source_artifact_id, a.workspace_id \
                FROM horizontal_lineage hl \
                JOIN artifacts a ON a.artifact_id = hl.source_artifact_id \
-              WHERE hl.artifact_id = $1 AND hl.role = 'derived_from' \
+              WHERE hl.artifact_id = $1 AND hl.role = 'closes_issue' \
               ORDER BY hl.id DESC LIMIT 1",
         )
         .bind(pr_artifact_id.as_str())
@@ -75,11 +75,12 @@ impl PrMergedHandler {
             actor: "forge".into(),
             ..Default::default()
         };
+        let stream_id = format!("forge:{issue_artifact_id}");
         if let Err(e) = self
             .store
             .append_ext(
                 &workspace_id,
-                &issue_artifact_id,
+                &stream_id,
                 "forge",
                 "artifact.archived",
                 serde_json::to_value(&event)?,

--- a/crates/ising/src/cmd/serve.rs
+++ b/crates/ising/src/cmd/serve.rs
@@ -286,6 +286,18 @@ fn parse_forge_event(event_type: &str, data: &serde_json::Value) -> Option<Facto
                 outcome,
             })
         }
+        "artifact.archived" => {
+            let artifact_id = data.get("artifact_id")?.as_str()?;
+            let reason = data
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(FactoryEventKind::ArtifactArchived {
+                artifact_id: ArtifactId::new(artifact_id),
+                reason,
+            })
+        }
         _ => None,
     }
 }

--- a/crates/ising/src/core/model.rs
+++ b/crates/ising/src/core/model.rs
@@ -236,6 +236,10 @@ impl FactoryModel {
                 }
             }
 
+            FactoryEventKind::ArtifactArchived { artifact_id, .. } => {
+                self.artifacts.remove(artifact_id.as_str());
+            }
+
             _ => {}
         }
     }

--- a/crates/onsager-github/src/api/pulls.rs
+++ b/crates/onsager-github/src/api/pulls.rs
@@ -96,6 +96,78 @@ impl CheckConclusion {
     }
 }
 
+/// Create a pull request. Returns `(pr_number, html_url)`.
+pub async fn create_pull_request(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+    head: &str,
+    base: &str,
+) -> Result<(u64, String), GithubError> {
+    let url = format!("{GITHUB_API}/repos/{owner}/{repo}/pulls");
+    let payload = serde_json::json!({
+        "title": title,
+        "body": body,
+        "head": head,
+        "base": base,
+    });
+    let resp = client()
+        .post(&url)
+        .bearer_auth(token)
+        .json(&payload)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let v: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    let number = v
+        .get("number")
+        .and_then(|n| n.as_u64())
+        .ok_or_else(|| GithubError::Decode("missing pr number".into()))?;
+    let html_url = v
+        .get("html_url")
+        .and_then(|u| u.as_str())
+        .unwrap_or_default()
+        .to_string();
+    Ok((number, html_url))
+}
+
+/// Find an open pull request whose head branch matches `head`. Returns
+/// `Some((pr_number, html_url))` when one exists; `None` otherwise.
+pub async fn find_open_pr_for_branch(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    head: &str,
+) -> Result<Option<(u64, String)>, GithubError> {
+    let url = format!(
+        "{GITHUB_API}/repos/{owner}/{repo}/pulls?state=open&head={owner}:{head}&per_page=1"
+    );
+    let resp = client().get(&url).bearer_auth(token).send().await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let list: Vec<serde_json::Value> = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(list.first().and_then(|pr| {
+        let number = pr.get("number")?.as_u64()?;
+        let url = pr
+            .get("html_url")
+            .and_then(|u| u.as_str())
+            .unwrap_or_default()
+            .to_string();
+        Some((number, url))
+    }))
+}
+
 /// Post a check run on a head SHA. Returns the created check-run id.
 pub async fn create_check_run(
     token: Option<&str>,

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -593,33 +593,40 @@ pub async fn find_artifact_info(
     pool: &PgPool,
     artifact_id: &str,
 ) -> anyhow::Result<Option<ArtifactInfo>> {
-    let row: Option<(String, String, Option<String>, String, Option<serde_json::Value>)> =
-        sqlx::query_as(
-            "SELECT artifact_id, kind, name, workspace_id, metadata \
+    let row: Option<(
+        String,
+        String,
+        Option<String>,
+        String,
+        Option<serde_json::Value>,
+    )> = sqlx::query_as(
+        "SELECT artifact_id, kind, name, workspace_id, metadata \
              FROM artifacts WHERE artifact_id = $1",
-        )
-        .bind(artifact_id)
-        .fetch_optional(pool)
-        .await?;
-    Ok(row.map(|(artifact_id, kind, name, workspace_id, metadata)| {
-        let project_id = metadata
-            .as_ref()
-            .and_then(|m| m.get("project_id"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        let issue_number = metadata
-            .as_ref()
-            .and_then(|m| m.get("issue_number"))
-            .and_then(|v| v.as_i64());
-        ArtifactInfo {
-            artifact_id,
-            kind,
-            name,
-            workspace_id,
-            project_id,
-            issue_number,
-        }
-    }))
+    )
+    .bind(artifact_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(
+        row.map(|(artifact_id, kind, name, workspace_id, metadata)| {
+            let project_id = metadata
+                .as_ref()
+                .and_then(|m| m.get("project_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let issue_number = metadata
+                .as_ref()
+                .and_then(|m| m.get("issue_number"))
+                .and_then(|v| v.as_i64());
+            ArtifactInfo {
+                artifact_id,
+                kind,
+                name,
+                workspace_id,
+                project_id,
+                issue_number,
+            }
+        }),
+    )
 }
 
 /// Check for an existing open PR for `(project_id, branch)` — used by the
@@ -639,9 +646,7 @@ pub async fn find_pr_for_branch(
     .bind(branch)
     .fetch_optional(pool)
     .await?;
-    Ok(row
-        .and_then(|(pr_number,)| pr_number)
-        .map(|n| n as u64))
+    Ok(row.and_then(|(pr_number,)| pr_number).map(|n| n as u64))
 }
 
 /// Record a horizontal lineage row linking `child_artifact_id` (the new PR
@@ -688,10 +693,7 @@ pub async fn find_issue_artifact_for_pr(
 
 /// Archive an artifact and return its workspace_id. Used by the PR-merged
 /// listener to terminate the originating issue artifact's lifecycle.
-pub async fn archive_artifact(
-    pool: &PgPool,
-    artifact_id: &str,
-) -> anyhow::Result<Option<String>> {
+pub async fn archive_artifact(pool: &PgPool, artifact_id: &str) -> anyhow::Result<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as(
         "UPDATE artifacts SET state = 'archived', updated_at = NOW() \
           WHERE artifact_id = $1 AND state != 'archived' \

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -579,6 +579,7 @@ pub struct ArtifactInfo {
     pub kind: String,
     pub name: Option<String>,
     pub workspace_id: String,
+    pub current_version: i32,
     /// `project_id` extracted from `metadata->>'project_id'` (set by
     /// `upsert_issue_artifact_ref` and forge's `insert_artifact_row`).
     pub project_id: Option<String>,
@@ -587,27 +588,30 @@ pub struct ArtifactInfo {
     pub issue_number: Option<i64>,
 }
 
+type ArtifactInfoRow = (
+    String,
+    String,
+    Option<String>,
+    String,
+    i32,
+    Option<serde_json::Value>,
+);
+
 /// Look up the artifact info for `artifact_id`. Returns `None` when the
 /// artifact does not exist.
 pub async fn find_artifact_info(
     pool: &PgPool,
     artifact_id: &str,
 ) -> anyhow::Result<Option<ArtifactInfo>> {
-    let row: Option<(
-        String,
-        String,
-        Option<String>,
-        String,
-        Option<serde_json::Value>,
-    )> = sqlx::query_as(
-        "SELECT artifact_id, kind, name, workspace_id, metadata \
+    let row: Option<ArtifactInfoRow> = sqlx::query_as(
+        "SELECT artifact_id, kind, name, workspace_id, current_version, metadata \
              FROM artifacts WHERE artifact_id = $1",
     )
     .bind(artifact_id)
     .fetch_optional(pool)
     .await?;
-    Ok(
-        row.map(|(artifact_id, kind, name, workspace_id, metadata)| {
+    Ok(row.map(
+        |(artifact_id, kind, name, workspace_id, current_version, metadata)| {
             let project_id = metadata
                 .as_ref()
                 .and_then(|m| m.get("project_id"))
@@ -622,11 +626,12 @@ pub async fn find_artifact_info(
                 kind,
                 name,
                 workspace_id,
+                current_version,
                 project_id,
                 issue_number,
             }
-        }),
-    )
+        },
+    ))
 }
 
 /// Check for an existing open PR for `(project_id, branch)` — used by the
@@ -661,8 +666,7 @@ pub async fn record_horizontal_lineage(
     sqlx::query(
         "INSERT INTO horizontal_lineage \
              (artifact_id, source_artifact_id, source_version, role) \
-         VALUES ($1, $2, $3, 'derived_from') \
-         ON CONFLICT DO NOTHING",
+         VALUES ($1, $2, $3, 'closes_issue')",
     )
     .bind(child_artifact_id)
     .bind(parent_artifact_id)
@@ -682,7 +686,7 @@ pub async fn find_issue_artifact_for_pr(
         "SELECT hl.source_artifact_id, a.current_version \
            FROM horizontal_lineage hl \
            JOIN artifacts a ON a.artifact_id = hl.source_artifact_id \
-          WHERE hl.artifact_id = $1 AND hl.role = 'derived_from' \
+          WHERE hl.artifact_id = $1 AND hl.role = 'closes_issue' \
           ORDER BY hl.id DESC LIMIT 1",
     )
     .bind(pr_artifact_id)

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -569,3 +569,136 @@ pub async fn link_session_to_pr_artifact(
     .await?;
     Ok(())
 }
+
+// ── Session-completed → PR listener helpers (spec #273) ───────────────────
+
+/// Core info about an artifact needed by the session-completed listener.
+#[derive(Debug, Clone)]
+pub struct ArtifactInfo {
+    pub artifact_id: String,
+    pub kind: String,
+    pub name: Option<String>,
+    pub workspace_id: String,
+    /// `project_id` extracted from `metadata->>'project_id'` (set by
+    /// `upsert_issue_artifact_ref` and forge's `insert_artifact_row`).
+    pub project_id: Option<String>,
+    /// `issue_number` extracted from `metadata->>'issue_number'` (set by
+    /// `upsert_issue_artifact_ref`).
+    pub issue_number: Option<i64>,
+}
+
+/// Look up the artifact info for `artifact_id`. Returns `None` when the
+/// artifact does not exist.
+pub async fn find_artifact_info(
+    pool: &PgPool,
+    artifact_id: &str,
+) -> anyhow::Result<Option<ArtifactInfo>> {
+    let row: Option<(String, String, Option<String>, String, Option<serde_json::Value>)> =
+        sqlx::query_as(
+            "SELECT artifact_id, kind, name, workspace_id, metadata \
+             FROM artifacts WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.map(|(artifact_id, kind, name, workspace_id, metadata)| {
+        let project_id = metadata
+            .as_ref()
+            .and_then(|m| m.get("project_id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let issue_number = metadata
+            .as_ref()
+            .and_then(|m| m.get("issue_number"))
+            .and_then(|v| v.as_i64());
+        ArtifactInfo {
+            artifact_id,
+            kind,
+            name,
+            workspace_id,
+            project_id,
+            issue_number,
+        }
+    }))
+}
+
+/// Check for an existing open PR for `(project_id, branch)` — used by the
+/// session-completed listener for idempotent re-entry. Returns the PR number
+/// when a match is found in `pr_branch_links`.
+pub async fn find_pr_for_branch(
+    pool: &PgPool,
+    project_id: &str,
+    branch: &str,
+) -> anyhow::Result<Option<u64>> {
+    let row: Option<(Option<i64>,)> = sqlx::query_as(
+        "SELECT pr_number FROM pr_branch_links \
+         WHERE project_id = $1 AND branch = $2 AND pr_number IS NOT NULL \
+         ORDER BY recorded_at DESC LIMIT 1",
+    )
+    .bind(project_id)
+    .bind(branch)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row
+        .and_then(|(pr_number,)| pr_number)
+        .map(|n| n as u64))
+}
+
+/// Record a horizontal lineage row linking `child_artifact_id` (the new PR
+/// artifact) back to `parent_artifact_id` (the issue artifact it was derived
+/// from). Idempotent — duplicate inserts are silently ignored.
+pub async fn record_horizontal_lineage(
+    pool: &PgPool,
+    child_artifact_id: &str,
+    parent_artifact_id: &str,
+    parent_version: i32,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO horizontal_lineage \
+             (artifact_id, source_artifact_id, source_version, role) \
+         VALUES ($1, $2, $3, 'derived_from') \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(child_artifact_id)
+    .bind(parent_artifact_id)
+    .bind(parent_version)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Look up the issue artifact linked to `pr_artifact_id` via
+/// `horizontal_lineage`. Returns the issue artifact's id and current version.
+pub async fn find_issue_artifact_for_pr(
+    pool: &PgPool,
+    pr_artifact_id: &str,
+) -> anyhow::Result<Option<(String, i32)>> {
+    let row: Option<(String, i32)> = sqlx::query_as(
+        "SELECT hl.source_artifact_id, a.current_version \
+           FROM horizontal_lineage hl \
+           JOIN artifacts a ON a.artifact_id = hl.source_artifact_id \
+          WHERE hl.artifact_id = $1 AND hl.role = 'derived_from' \
+          ORDER BY hl.id DESC LIMIT 1",
+    )
+    .bind(pr_artifact_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Archive an artifact and return its workspace_id. Used by the PR-merged
+/// listener to terminate the originating issue artifact's lifecycle.
+pub async fn archive_artifact(
+    pool: &PgPool,
+    artifact_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "UPDATE artifacts SET state = 'archived', updated_at = NOW() \
+          WHERE artifact_id = $1 AND state != 'archived' \
+      RETURNING workspace_id",
+    )
+    .bind(artifact_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(w,)| w))
+}

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -27,7 +27,6 @@
 //! events / artifacts / lineage) is owned by stiglab and the spine.
 
 pub mod anthropic;
-pub mod listeners;
 pub mod auth;
 pub mod auth_db;
 pub mod backfill;
@@ -41,6 +40,7 @@ pub mod gate;
 pub mod handlers;
 pub mod installation;
 pub mod installation_db;
+pub mod listeners;
 pub mod mcp;
 pub mod migrate;
 pub mod pat_db;

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -27,6 +27,7 @@
 //! events / artifacts / lineage) is owned by stiglab and the spine.
 
 pub mod anthropic;
+pub mod listeners;
 pub mod auth;
 pub mod auth_db;
 pub mod backfill;

--- a/crates/onsager-portal/src/listeners/mod.rs
+++ b/crates/onsager-portal/src/listeners/mod.rs
@@ -1,0 +1,1 @@
+pub mod session_completed;

--- a/crates/onsager-portal/src/listeners/session_completed.rs
+++ b/crates/onsager-portal/src/listeners/session_completed.rs
@@ -77,18 +77,20 @@ impl SessionPrOpener {
             return Ok(());
         };
 
-        // Empty branch pushed — error signal.
+        // Empty branch pushed — error signal. Resolve workspace_id via artifact
+        // lookup so the diagnostic event is scoped correctly; skip if unavailable.
         if branch.trim().is_empty() {
-            let workspace_id = event_artifact_id
-                .as_deref()
-                .and_then(|_aid| {
-                    // best-effort: we may not have workspace_id at this point;
-                    // use artifact lookup below if needed
-                    None::<String>
-                })
-                .unwrap_or_default();
-            self.emit_pr_open_failed(None, Some(&branch), &workspace_id, "empty_branch")
+            if let Some(ref art_id) = event_artifact_id
+                && let Ok(Some(art)) = db::find_artifact_info(&self.pool, art_id).await
+            {
+                self.emit_pr_open_failed(
+                    Some(art_id),
+                    Some(&branch),
+                    &art.workspace_id,
+                    "empty_branch",
+                )
                 .await;
+            }
             return Ok(());
         }
 
@@ -162,6 +164,7 @@ impl SessionPrOpener {
             self.record_lineage_and_link(
                 &pr_art.artifact_id,
                 issue_artifact_id,
+                art.current_version,
                 &session_id,
                 &branch,
                 project_id,
@@ -245,6 +248,7 @@ impl SessionPrOpener {
                 self.record_lineage_and_link(
                     &pr_art.artifact_id,
                     issue_artifact_id,
+                    art.current_version,
                     &session_id,
                     &branch,
                     project_id,
@@ -355,6 +359,7 @@ impl SessionPrOpener {
         self.record_lineage_and_link(
             &pr_art.artifact_id,
             issue_artifact_id,
+            art.current_version,
             &session_id,
             &branch,
             project_id,
@@ -399,18 +404,25 @@ impl SessionPrOpener {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn record_lineage_and_link(
         &self,
         pr_artifact_id: &str,
         issue_artifact_id: &str,
+        issue_version: i32,
         session_id: &str,
         branch: &str,
         project_id: &str,
         pr_number: u64,
     ) -> anyhow::Result<()> {
         // Horizontal lineage: PR artifact → issue artifact.
-        if let Err(e) =
-            db::record_horizontal_lineage(&self.pool, pr_artifact_id, issue_artifact_id, 1).await
+        if let Err(e) = db::record_horizontal_lineage(
+            &self.pool,
+            pr_artifact_id,
+            issue_artifact_id,
+            issue_version,
+        )
+        .await
         {
             tracing::warn!(error = %e, "failed to record horizontal lineage");
         }
@@ -490,6 +502,6 @@ mod tests {
     /// signature drift without needing a live DB.
     #[allow(dead_code)]
     fn _type_check_run_signature(pool: PgPool, store: EventStore) {
-        let _ = run(pool, store);
+        std::mem::drop(run(pool, store));
     }
 }

--- a/crates/onsager-portal/src/listeners/session_completed.rs
+++ b/crates/onsager-portal/src/listeners/session_completed.rs
@@ -1,0 +1,490 @@
+//! Spine listener for `stiglab.session_completed` → GitHub PR (spec #273).
+//!
+//! Portal is the only subsystem that holds GitHub App credentials, so it
+//! owns the outbound GitHub API call. The happy-path sequence:
+//!
+//! 1. Consume `stiglab.session_completed`; extract `branch` + `artifact_id`.
+//! 2. Look up the originating issue artifact to get project, repo, issue number.
+//! 3. Mint an installation token via the GitHub App.
+//! 4. Open a PR (`Closes #N`); materialize a `Kind::PullRequest` artifact in
+//!    the spine; emit `git.pr_opened`; record horizontal lineage.
+//!
+//! Error and edge-case handling:
+//! - No branch → silent skip (session did no git work).
+//! - Empty branch → emit `portal.pr_open_failed` (`empty_branch`).
+//! - `pr_number` already set on the event → session opened the PR itself;
+//!   upsert the artifact and record lineage, no new GitHub call.
+//! - Existing PR for (project, branch) → silent no-op per spec.
+//! - GitHub API failure → emit `portal.pr_open_failed` (`github_api_error`).
+//! - App not configured → emit `portal.pr_open_failed` (`app_not_configured`).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use onsager_artifact::ArtifactId;
+use onsager_github::api::app::{AppConfig, mint_app_jwt, mint_installation_token};
+use onsager_github::api::pulls::{create_pull_request, find_open_pr_for_branch};
+use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::{EventHandler, EventMetadata, EventNotification, EventStore, Listener};
+use sqlx::postgres::PgPool;
+
+use crate::db::{self, PrLifecycleState};
+
+/// Run the session-completed → PR listener forever. Returns only when the
+/// pg_notify channel closes.
+pub async fn run(pool: PgPool, store: EventStore) -> anyhow::Result<()> {
+    let handler = SessionPrOpener {
+        pool: Arc::new(pool),
+        store: store.clone(),
+    };
+    Listener::new(store).run(handler).await
+}
+
+struct SessionPrOpener {
+    pool: Arc<PgPool>,
+    store: EventStore,
+}
+
+impl SessionPrOpener {
+    async fn handle_session_completed(
+        &self,
+        notification: &EventNotification,
+    ) -> anyhow::Result<()> {
+        // Load the typed event.
+        let kind = match notification.table.as_str() {
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(());
+                };
+                serde_json::from_value::<FactoryEventKind>(row.data)?
+            }
+            _ => return Ok(()),
+        };
+
+        let FactoryEventKind::StiglabSessionCompleted {
+            session_id,
+            artifact_id: event_artifact_id,
+            branch,
+            pr_number: event_pr_number,
+            ..
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        // No git work — skip silently.
+        let Some(branch) = branch else {
+            return Ok(());
+        };
+
+        // Empty branch pushed — error signal.
+        if branch.trim().is_empty() {
+            let workspace_id = event_artifact_id
+                .as_deref()
+                .and_then(|_aid| {
+                    // best-effort: we may not have workspace_id at this point;
+                    // use artifact lookup below if needed
+                    None::<String>
+                })
+                .unwrap_or_default();
+            self.emit_pr_open_failed(
+                None,
+                Some(&branch),
+                &workspace_id,
+                "empty_branch",
+            )
+            .await;
+            return Ok(());
+        }
+
+        // Resolve the issue artifact. Without it we cannot find the repo.
+        let Some(ref issue_artifact_id) = event_artifact_id else {
+            tracing::debug!(
+                session_id = %session_id,
+                branch = %branch,
+                "session_completed: no artifact_id, cannot open PR"
+            );
+            return Ok(());
+        };
+
+        let Some(art) = db::find_artifact_info(&self.pool, issue_artifact_id).await? else {
+            tracing::warn!(
+                session_id = %session_id,
+                artifact_id = %issue_artifact_id,
+                "session_completed: artifact not found"
+            );
+            return Ok(());
+        };
+        let workspace_id = art.workspace_id.clone();
+
+        let Some(ref project_id) = art.project_id else {
+            tracing::warn!(
+                artifact_id = %issue_artifact_id,
+                "session_completed: artifact has no project_id in metadata"
+            );
+            return Ok(());
+        };
+
+        let Some(project) = db::get_project(&self.pool, project_id).await? else {
+            tracing::warn!(
+                project_id = %project_id,
+                "session_completed: project not found"
+            );
+            return Ok(());
+        };
+
+        let installation =
+            crate::installation_db::get_installation(&self.pool, &project.github_app_installation_id)
+                .await?;
+        let Some(install) = installation else {
+            tracing::warn!(
+                install_row_id = %project.github_app_installation_id,
+                "session_completed: installation not found"
+            );
+            self.emit_pr_open_failed(
+                Some(issue_artifact_id),
+                Some(&branch),
+                &workspace_id,
+                "no_installation",
+            )
+            .await;
+            return Ok(());
+        };
+
+        // If the event already carries a pr_number the agent opened the PR
+        // itself during the session. Upsert the artifact and record lineage
+        // without making a new GitHub API call.
+        if let Some(pr_number) = event_pr_number {
+            let pr_art =
+                db::upsert_pr_artifact_ref(&self.pool, project_id, pr_number, PrLifecycleState::InProgress)
+                    .await?;
+            self.record_lineage_and_link(
+                &pr_art.artifact_id,
+                issue_artifact_id,
+                &session_id,
+                &branch,
+                project_id,
+                pr_number,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        // Idempotency: if a PR for this branch already exists in pr_branch_links,
+        // silent no-op.
+        if db::find_pr_for_branch(&self.pool, project_id, &branch)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        // Mint an installation token.
+        let Some(app_cfg) = AppConfig::from_env() else {
+            tracing::warn!("session_completed: GitHub App not configured, cannot open PR");
+            self.emit_pr_open_failed(
+                Some(issue_artifact_id),
+                Some(&branch),
+                &workspace_id,
+                "app_not_configured",
+            )
+            .await;
+            return Ok(());
+        };
+        let app_jwt = match mint_app_jwt(&app_cfg) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::warn!(error = %e, "session_completed: failed to mint GitHub App JWT");
+                self.emit_pr_open_failed(
+                    Some(issue_artifact_id),
+                    Some(&branch),
+                    &workspace_id,
+                    "app_not_configured",
+                )
+                .await;
+                return Ok(());
+            }
+        };
+        let token = match mint_installation_token(&app_jwt, install.install_id).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "session_completed: failed to mint installation token");
+                self.emit_pr_open_failed(
+                    Some(issue_artifact_id),
+                    Some(&branch),
+                    &workspace_id,
+                    "github_api_error",
+                )
+                .await;
+                return Ok(());
+            }
+        };
+
+        // Before creating a new PR, check if GitHub already has an open PR for
+        // this branch (handles the case where the previous listener run created
+        // the PR but crashed before updating pr_branch_links).
+        let existing = find_open_pr_for_branch(
+            &token.token,
+            &project.repo_owner,
+            &project.repo_name,
+            &branch,
+        )
+        .await;
+
+        let (pr_number, pr_url) = match existing {
+            Ok(Some(pr)) => {
+                // PR already exists — no event emitted per spec.
+                let pr_art = db::upsert_pr_artifact_ref(
+                    &self.pool,
+                    project_id,
+                    pr.0,
+                    PrLifecycleState::InProgress,
+                )
+                .await?;
+                self.record_lineage_and_link(
+                    &pr_art.artifact_id,
+                    issue_artifact_id,
+                    &session_id,
+                    &branch,
+                    project_id,
+                    pr.0,
+                )
+                .await?;
+                return Ok(());
+            }
+            Ok(None) => {
+                // Build the PR title and body.
+                let title = art
+                    .name
+                    .clone()
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or_else(|| {
+                        art.issue_number
+                            .map(|n| format!("Update for issue #{n}"))
+                            .unwrap_or_else(|| "Update from Onsager agent".to_string())
+                    });
+                let body = art
+                    .issue_number
+                    .map(|n| format!("Closes #{n}\n\n"))
+                    .unwrap_or_default();
+
+                match create_pull_request(
+                    &token.token,
+                    &project.repo_owner,
+                    &project.repo_name,
+                    &title,
+                    &body,
+                    &branch,
+                    &project.default_branch,
+                )
+                .await
+                {
+                    Ok(pr) => pr,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            branch = %branch,
+                            repo = %format!("{}/{}", project.repo_owner, project.repo_name),
+                            "session_completed: GitHub create_pull_request failed"
+                        );
+                        self.emit_pr_open_failed(
+                            Some(issue_artifact_id),
+                            Some(&branch),
+                            &workspace_id,
+                            "github_api_error",
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "session_completed: find_open_pr_for_branch failed");
+                // Proceed with creation attempt; GitHub will 422 if it already exists.
+                let title = art
+                    .name
+                    .clone()
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or_else(|| {
+                        art.issue_number
+                            .map(|n| format!("Update for issue #{n}"))
+                            .unwrap_or_else(|| "Update from Onsager agent".to_string())
+                    });
+                let body = art
+                    .issue_number
+                    .map(|n| format!("Closes #{n}\n\n"))
+                    .unwrap_or_default();
+
+                match create_pull_request(
+                    &token.token,
+                    &project.repo_owner,
+                    &project.repo_name,
+                    &title,
+                    &body,
+                    &branch,
+                    &project.default_branch,
+                )
+                .await
+                {
+                    Ok(pr) => pr,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "session_completed: create_pull_request failed");
+                        self.emit_pr_open_failed(
+                            Some(issue_artifact_id),
+                            Some(&branch),
+                            &workspace_id,
+                            "github_api_error",
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                }
+            }
+        };
+
+        // Materialize the PR artifact and record lineage.
+        let pr_art =
+            db::upsert_pr_artifact_ref(&self.pool, project_id, pr_number, PrLifecycleState::InProgress)
+                .await?;
+
+        self.record_lineage_and_link(
+            &pr_art.artifact_id,
+            issue_artifact_id,
+            &session_id,
+            &branch,
+            project_id,
+            pr_number,
+        )
+        .await?;
+
+        // Emit git.pr_opened.
+        let event = FactoryEventKind::GitPrOpened {
+            artifact_id: ArtifactId::new(pr_art.artifact_id.clone()),
+            repo: format!("{}/{}", project.repo_owner, project.repo_name),
+            pr_number,
+            url: pr_url.clone(),
+        };
+        let stream_id = crate::handlers::pull_request::pr_stream_id(project_id, pr_number);
+        let metadata = EventMetadata {
+            actor: "onsager-portal".into(),
+            ..Default::default()
+        };
+        if let Err(e) = self
+            .store
+            .append_ext(
+                &workspace_id,
+                &stream_id,
+                "git",
+                event.event_type(),
+                serde_json::to_value(&event)?,
+                &metadata,
+                None,
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "session_completed: failed to emit git.pr_opened");
+        }
+
+        tracing::info!(
+            session_id = %session_id,
+            pr_number,
+            pr_url = %pr_url,
+            "session_completed: PR opened"
+        );
+        Ok(())
+    }
+
+    async fn record_lineage_and_link(
+        &self,
+        pr_artifact_id: &str,
+        issue_artifact_id: &str,
+        session_id: &str,
+        branch: &str,
+        project_id: &str,
+        pr_number: u64,
+    ) -> anyhow::Result<()> {
+        // Horizontal lineage: PR artifact → issue artifact.
+        if let Err(e) =
+            db::record_horizontal_lineage(&self.pool, pr_artifact_id, issue_artifact_id, 1).await
+        {
+            tracing::warn!(error = %e, "failed to record horizontal lineage");
+        }
+        // Session↔PR branch link for idempotency on retries.
+        if let Err(e) = db::record_session_branch(
+            &self.pool,
+            session_id,
+            Some(project_id),
+            branch,
+            Some(pr_number),
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "failed to record session branch link");
+        }
+        Ok(())
+    }
+
+    async fn emit_pr_open_failed(
+        &self,
+        artifact_id: Option<&str>,
+        branch: Option<&str>,
+        workspace_id: &str,
+        reason: &str,
+    ) {
+        let event = FactoryEventKind::PortalPrOpenFailed {
+            artifact_id: artifact_id.map(|id| ArtifactId::new(id.to_string())),
+            branch: branch.map(|b| b.to_string()),
+            workspace_id: workspace_id.to_string(),
+            reason: reason.to_string(),
+        };
+        let stream_id = event.stream_id();
+        let metadata = EventMetadata {
+            actor: "onsager-portal".into(),
+            ..Default::default()
+        };
+        if let Err(e) = self
+            .store
+            .append_ext(
+                workspace_id,
+                &stream_id,
+                "portal",
+                event.event_type(),
+                serde_json::to_value(&event).unwrap_or_default(),
+                &metadata,
+                None,
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "failed to emit portal.pr_open_failed");
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for SessionPrOpener {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "stiglab.session_completed" {
+            return Ok(());
+        }
+        if let Err(e) = self.handle_session_completed(&notification).await {
+            tracing::warn!(
+                error = %e,
+                event_id = notification.id,
+                "session_completed listener: handler error"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `run` function accepts the correct types; compiling this catches
+    /// signature drift without needing a live DB.
+    #[allow(dead_code)]
+    fn _type_check_run_signature(pool: PgPool, store: EventStore) {
+        let _ = run(pool, store);
+    }
+}

--- a/crates/onsager-portal/src/listeners/session_completed.rs
+++ b/crates/onsager-portal/src/listeners/session_completed.rs
@@ -87,13 +87,8 @@ impl SessionPrOpener {
                     None::<String>
                 })
                 .unwrap_or_default();
-            self.emit_pr_open_failed(
-                None,
-                Some(&branch),
-                &workspace_id,
-                "empty_branch",
-            )
-            .await;
+            self.emit_pr_open_failed(None, Some(&branch), &workspace_id, "empty_branch")
+                .await;
             return Ok(());
         }
 
@@ -133,9 +128,11 @@ impl SessionPrOpener {
             return Ok(());
         };
 
-        let installation =
-            crate::installation_db::get_installation(&self.pool, &project.github_app_installation_id)
-                .await?;
+        let installation = crate::installation_db::get_installation(
+            &self.pool,
+            &project.github_app_installation_id,
+        )
+        .await?;
         let Some(install) = installation else {
             tracing::warn!(
                 install_row_id = %project.github_app_installation_id,
@@ -155,9 +152,13 @@ impl SessionPrOpener {
         // itself during the session. Upsert the artifact and record lineage
         // without making a new GitHub API call.
         if let Some(pr_number) = event_pr_number {
-            let pr_art =
-                db::upsert_pr_artifact_ref(&self.pool, project_id, pr_number, PrLifecycleState::InProgress)
-                    .await?;
+            let pr_art = db::upsert_pr_artifact_ref(
+                &self.pool,
+                project_id,
+                pr_number,
+                PrLifecycleState::InProgress,
+            )
+            .await?;
             self.record_lineage_and_link(
                 &pr_art.artifact_id,
                 issue_artifact_id,
@@ -343,9 +344,13 @@ impl SessionPrOpener {
         };
 
         // Materialize the PR artifact and record lineage.
-        let pr_art =
-            db::upsert_pr_artifact_ref(&self.pool, project_id, pr_number, PrLifecycleState::InProgress)
-                .await?;
+        let pr_art = db::upsert_pr_artifact_ref(
+            &self.pool,
+            project_id,
+            pr_number,
+            PrLifecycleState::InProgress,
+        )
+        .await?;
 
         self.record_lineage_and_link(
             &pr_art.artifact_id,

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -353,7 +353,22 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         app
     };
 
+    // Clone handles needed by background listeners before consuming state.
+    let listener_pool = state.pool.clone();
+    let listener_spine = state.spine.clone();
+
     let app = app.with_state(state);
+
+    // Spawn the session-completed → PR listener (spec #273). Runs as a
+    // background task; errors are logged and the task exits, but they never
+    // crash the HTTP server.
+    tokio::spawn(async move {
+        if let Err(e) =
+            crate::listeners::session_completed::run(listener_pool, listener_spine).await
+        {
+            tracing::error!("portal: session_completed listener exited: {e}");
+        }
+    });
 
     let listener = tokio::net::TcpListener::bind(&config.bind).await?;
     tracing::info!(bind = %config.bind, "onsager-portal listening");

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -132,12 +132,10 @@ pub const EVENTS: EventManifest = EventManifest {
         EventDefinition {
             kind: "artifact.archived",
             schema_version: 1,
-            producers: &[Subsystem::Portal],
-            consumers: &[],
-            diagnostic_only: true,
-            reason: Some(
-                "forge consumer in flight per spec #273; remains diagnostic-only until that PR lands",
-            ),
+            producers: &[Subsystem::Portal, Subsystem::Forge],
+            consumers: &[Subsystem::Ising],
+            diagnostic_only: false,
+            reason: None,
             description: "Artifact reached terminal state (archived).",
         },
         // -- Git lifecycle (onsager-portal webhooks) ------------------------
@@ -287,6 +285,17 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             description: "Dashboard cancel-session request from portal (spec #303); stiglab forwards a CancelSession to the session's agent node.",
+        },
+        EventDefinition {
+            kind: "portal.pr_open_failed",
+            schema_version: 1,
+            producers: &[Subsystem::Portal],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "observable in dashboard event timeline for operator troubleshooting when portal cannot open a PR for a completed session",
+            ),
+            description: "Portal failed to open a GitHub PR for a completed session (empty branch, GitHub API error, or missing App config).",
         },
         // -- Synodic events -------------------------------------------------
         // Per spec #285: the redundant `synodic.gate_evaluated` /

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -243,6 +243,25 @@ pub enum FactoryEventKind {
     /// agent node (spec #222 Follow-up 3).
     PortalSessionRequested { session_id: String },
 
+    /// Portal failed to open a GitHub PR for a completed session (spec #273).
+    /// Emitted as a diagnostic signal when the GitHub API call fails, the
+    /// session pushed an empty branch, or the GitHub App is not configured.
+    /// No retry is attempted inside the listener — the operator investigates
+    /// via the dashboard event timeline.
+    PortalPrOpenFailed {
+        /// Issue artifact the session was shaping, if known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact_id: Option<ArtifactId>,
+        /// Branch the session pushed to, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+        /// Workspace the session belongs to.
+        workspace_id: String,
+        /// Short reason code: `"empty_branch"`, `"github_api_error"`,
+        /// `"no_installation"`, `"app_not_configured"`, etc.
+        reason: String,
+    },
+
     /// Dashboard cancel-session request from portal (spec #303). Stiglab's
     /// `session_cancel_requested_listener` looks up the session's node and
     /// forwards a `ServerMessage::CancelSession` to the agent. Best-effort:
@@ -535,6 +554,7 @@ impl FactoryEventKind {
             Self::StiglabSessionAborted { .. } => "stiglab.session_aborted",
             Self::PortalSessionRequested { .. } => "portal.session_requested",
             Self::PortalSessionCancelRequested { .. } => "portal.session_cancel_requested",
+            Self::PortalPrOpenFailed { .. } => "portal.pr_open_failed",
             Self::SynodicGateVerdict { .. } => "synodic.gate_verdict",
             Self::SynodicEscalationStarted { .. } => "synodic.escalation_started",
             Self::SynodicEscalationResolved { .. } => "synodic.escalation_resolved",
@@ -582,9 +602,9 @@ impl FactoryEventKind {
             | Self::StiglabSessionResultReady { .. }
             | Self::StiglabSessionFailed { .. }
             | Self::StiglabSessionAborted { .. } => "stiglab",
-            Self::PortalSessionRequested { .. } | Self::PortalSessionCancelRequested { .. } => {
-                "portal"
-            }
+            Self::PortalSessionRequested { .. }
+            | Self::PortalSessionCancelRequested { .. }
+            | Self::PortalPrOpenFailed { .. } => "portal",
             Self::SynodicGateVerdict { .. }
             | Self::SynodicEscalationStarted { .. }
             | Self::SynodicEscalationResolved { .. }
@@ -636,6 +656,14 @@ impl FactoryEventKind {
             Self::StiglabSessionResultReady { artifact_id, .. } => artifact_id.to_string(),
             Self::PortalSessionRequested { session_id, .. }
             | Self::PortalSessionCancelRequested { session_id, .. } => session_id.clone(),
+            Self::PortalPrOpenFailed {
+                workspace_id,
+                branch,
+                ..
+            } => branch
+                .as_deref()
+                .map(|b| format!("portal:pr_open_failed:{b}"))
+                .unwrap_or_else(|| format!("portal:pr_open_failed:{workspace_id}")),
             Self::SynodicGateVerdict { gate_id, .. } => gate_id.clone(),
             Self::SynodicEscalationStarted { escalation_id, .. } => escalation_id.clone(),
             Self::SynodicEscalationResolved { escalation_id, .. } => escalation_id.clone(),

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -252,6 +252,7 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::GateCheckUpdated { .. }
         | FactoryEventKind::GateManualApprovalSignal { .. }
         | FactoryEventKind::PortalSessionRequested { .. }
-        | FactoryEventKind::PortalSessionCancelRequested { .. } => None,
+        | FactoryEventKind::PortalSessionCancelRequested { .. }
+        | FactoryEventKind::PortalPrOpenFailed { .. } => None,
     }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -56,7 +56,7 @@ that requires a coordinated rollout.
 | `git` | onsager-portal (GitHub webhooks) | 4 |
 | `forge` | forge | 6 |
 | `stiglab` | stiglab | 4 |
-| `portal` | (unknown — update `stream_producer` in xtask) | 2 |
+| `portal` | (unknown — update `stream_producer` in xtask) | 3 |
 | `synodic` | synodic | 9 |
 | `ising` | ising | 6 |
 | `refract` | refract | 3 |
@@ -317,6 +317,20 @@ Dashboard task request from portal. Stiglab's `session_requested_listener` dispa
 | Field | Type | Description |
 |---|---|---|
 | `session_id` | `String` |  |
+
+### `portal.pr_open_failed`
+
+- Variant: `FactoryEventKind::PortalPrOpenFailed`
+- Stream: `portal`
+
+Portal failed to open a GitHub PR for a completed session (spec #273). Emitted as a diagnostic signal when the GitHub API call fails, the session pushed an empty branch, or the GitHub App is not configured. No retry is attempted inside the listener — the operator investigates via the dashboard event timeline.
+
+| Field | Type | Description |
+|---|---|---|
+| `artifact_id` | `Option<ArtifactId>` | Issue artifact the session was shaping, if known. _(optional)_ |
+| `branch` | `Option<String>` | Branch the session pushed to, if any. _(optional)_ |
+| `workspace_id` | `String` | Workspace the session belongs to. |
+| `reason` | `String` | Short reason code: `"empty_branch"`, `"github_api_error"`, `"no_installation"`, `"app_not_configured"`, etc. |
 
 ### `portal.session_cancel_requested`
 


### PR DESCRIPTION
Closes #273

Implements the two-listener golden path described in spec #273:

- **Portal `session_completed` listener** — consumes `stiglab.session_completed`, mints a GitHub App installation token, opens a PR (`Closes #N`), materialises a `Kind::PullRequest` artifact in the spine, emits `git.pr_opened`, and records horizontal lineage (PR artifact → issue artifact with role `closes_issue`). Handles crash-restart idempotency by checking `pr_branch_links` and calling `find_open_pr_for_branch` before creation. Error paths emit `portal.pr_open_failed` (diagnostic-only).

- **Forge `pr_merged` listener** — consumes `git.pr_merged`, follows the `horizontal_lineage` (`closes_issue` role) back to the originating issue artifact, archives it (`state → archived`), and emits `artifact.archived` on stream `forge:{artifact_id}`.

Supporting changes across crates:
- `onsager-github`: `create_pull_request` + `find_open_pr_for_branch` helpers
- `onsager-spine`: `PortalPrOpenFailed` variant added to `FactoryEventKind`
- `onsager-registry`: `artifact.archived` promoted to real (Ising consumer added); `portal.pr_open_failed` added as `diagnostic_only`
- `ising`: `parse_forge_event` + `ingest_at` updated to consume `artifact.archived`
- `stiglab/spine.rs`: exhaustive match updated for `PortalPrOpenFailed`
- `docs/events.md`: regenerated

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask check-events` clean — 44 events, 4 subsystems scanned
- [x] `cargo run -p xtask -- gen-event-docs --check` clean
- [ ] `cargo test --workspace` passes in CI
- [ ] Spec #273 Test section: session completes with a branch → PR opened, `git.pr_opened` emitted, horizontal lineage recorded; PR merged → issue artifact state becomes `archived`, `artifact.archived` emitted