### PR TITLE
Add guardrail blocking direct edits to synced skills

### DIFF
--- a/.claude/hooks/check-skill-edit.sh
+++ b/.claude/hooks/check-skill-edit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Blocks direct edits to skills synced from an upstream repo.
+# To change a shared skill: edit it in its upstream repo, merge the PR,
+# then re-run: npx skills add <upstream>
+
+input=$(cat)
+path=$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null) || path=""
+
+[[ -z "$path" ]] && exit 0
+
+# Match absolute or relative paths containing .claude/skills/<skill>/
+if [[ "$path" =~ (^|/)(\.claude/skills/([^/]+))/ ]]; then
+  skill="${BASH_REMATCH[3]}"
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  marker="${repo_root}/.claude/skills/${skill}/.upstream-source"
+  if [[ -f "$marker" ]]; then
+    upstream=$(cat "$marker")
+    echo "BLOCKED: .claude/skills/${skill}/ is synced from ${upstream}." >&2
+    echo "  Edit it there → merge → npx skills add ${upstream}" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-skill-edit.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/plan-dag/.upstream-source
+++ b/.claude/skills/plan-dag/.upstream-source
@@ -1,0 +1,1 @@
+onsager-ai/onsager-skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,19 @@ via a transient `git clone` of `onsager-ai/onsager-skills` (spec
 override, `just lint` clones the sibling into `target/onsager-skills/`
 automatically.
 
+**Shared skill editing.** Skills installed under `.claude/skills/` via
+`npx skills add onsager-ai/onsager-skills` are read-only copies — do not
+edit them directly. A `PreToolUse` hook (`.claude/hooks/check-skill-edit.sh`)
+blocks direct edits to any skill directory that carries a `.upstream-source`
+marker file. To change a shared skill:
+
+1. Edit it in `onsager-ai/onsager-skills`.
+2. Open a PR there, get it reviewed, and merge it.
+3. Re-run `npx skills add onsager-ai/onsager-skills` in this repo.
+
+Editing the installed copy is blocked by the hook and wrong — a future
+`npx skills add` run would silently overwrite the change.
+
 ## The seam rule (canonical)
 
 > HTTP APIs exist only at external boundaries:


### PR DESCRIPTION
## Summary

Follows up on the accidental direct-edit pattern from #325 (which modified `.claude/skills/plan-dag/` in this repo instead of going through `onsager-ai/onsager-skills` first).

- **`.claude/hooks/check-skill-edit.sh`** — `PreToolUse` hook that reads the tool input JSON, extracts `file_path`, and blocks `Edit`/`Write` to any `.claude/skills/<name>/` directory that contains a `.upstream-source` marker. Exits 2 with a clear message: edit upstream → merge → `npx skills add`.
- **`.claude/skills/plan-dag/.upstream-source`** — marks `plan-dag` as canonical in `onsager-ai/onsager-skills`. Adding this file to a skill directory is all that's needed to opt it in to the guardrail.
- **`.claude/settings.json`** — wires `check-skill-edit.sh` into `PreToolUse` on `Edit|Write`.
- **`CLAUDE.md`** — documents the shared-skill editing process in the MCP server / skills bundle section.

## Correct process going forward

1. Edit the skill in `onsager-ai/onsager-skills`.
2. Open a PR there, get it reviewed, merge it.
3. Re-run `npx skills add onsager-ai/onsager-skills` in this repo to pull the updated copy.

https://claude.ai/code/session_015tPPTgJSaSxGvJzazad9gt