### PR TITLE
feat(dashboard): chat split-panel layout with live workflow DAG preview

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -16,6 +16,7 @@
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/geist": "^5.2.8",
     "@tanstack/react-query": "^5.96.0",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -23,7 +24,9 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
+    "rehype-highlight": "^7.0.2",
     "shadcn": "^4.1.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/apps/dashboard/src/components/chat/WorkflowDAGPreview.tsx
+++ b/apps/dashboard/src/components/chat/WorkflowDAGPreview.tsx
@@ -1,0 +1,205 @@
+import { useMemo } from "react"
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  type Node,
+  type Edge,
+} from "@xyflow/react"
+import "@xyflow/react/dist/style.css"
+import type { WorkflowDraft } from "@/components/factory/workflows/workflow-draft"
+
+// Gate kind → human label + colour token
+const GATE_META: Record<string, { label: string; color: string }> = {
+  "agent-session": { label: "Agent session", color: "#3b82f6" },
+  "external-check": { label: "CI check", color: "#a855f7" },
+  governance: { label: "Governance", color: "#f59e0b" },
+  "manual-approval": { label: "Manual approval", color: "#10b981" },
+}
+
+const NODE_W = 180
+const NODE_H = 60
+const GAP_X = 60
+
+function buildGraph(draft: WorkflowDraft): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  // Trigger node
+  nodes.push({
+    id: "trigger",
+    type: "default",
+    position: { x: 0, y: 0 },
+    data: {
+      label: (
+        <NodeBox
+          title="Trigger"
+          sub={
+            draft.trigger.repo_owner && draft.trigger.repo_name
+              ? `${draft.trigger.repo_owner}/${draft.trigger.repo_name}`
+              : "GitHub label"
+          }
+          color="#6366f1"
+        />
+      ),
+    },
+    style: nodeStyle("#6366f1"),
+  })
+
+  // Stage nodes
+  draft.stages.forEach((stage, i) => {
+    const id = stage.id || `stage-${i}`
+    const meta = GATE_META[stage.gate_kind] ?? {
+      label: stage.gate_kind,
+      color: "#64748b",
+    }
+    nodes.push({
+      id,
+      type: "default",
+      position: { x: (NODE_W + GAP_X) * (i + 1), y: 0 },
+      data: {
+        label: (
+          <NodeBox
+            title={stage.name || meta.label}
+            sub={meta.label}
+            color={meta.color}
+          />
+        ),
+      },
+      style: nodeStyle(meta.color),
+    })
+
+    const sourceId = i === 0 ? "trigger" : draft.stages[i - 1].id || `stage-${i - 1}`
+    edges.push({
+      id: `e-${sourceId}-${id}`,
+      source: sourceId,
+      target: id,
+      animated: true,
+      style: { stroke: "#94a3b8", strokeWidth: 1.5 },
+    })
+  })
+
+  // End node
+  const endX = (NODE_W + GAP_X) * (draft.stages.length + 1)
+  nodes.push({
+    id: "end",
+    type: "default",
+    position: { x: endX, y: 0 },
+    data: { label: <NodeBox title="Done" sub="" color="#10b981" /> },
+    style: nodeStyle("#10b981"),
+  })
+
+  const lastId =
+    draft.stages.length > 0
+      ? draft.stages[draft.stages.length - 1].id || `stage-${draft.stages.length - 1}`
+      : "trigger"
+  edges.push({
+    id: `e-${lastId}-end`,
+    source: lastId,
+    target: "end",
+    animated: true,
+    style: { stroke: "#94a3b8", strokeWidth: 1.5 },
+  })
+
+  return { nodes, edges }
+}
+
+function nodeStyle(color: string): React.CSSProperties {
+  return {
+    width: NODE_W,
+    height: NODE_H,
+    borderRadius: 8,
+    border: `1.5px solid ${color}33`,
+    background: `${color}11`,
+    padding: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  }
+}
+
+function NodeBox({ title, sub, color }: { title: string; sub: string; color: string }) {
+  return (
+    <div style={{ textAlign: "center", lineHeight: 1.3 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color }}>{title}</div>
+      {sub ? <div style={{ fontSize: 10, color: "#94a3b8", marginTop: 2 }}>{sub}</div> : null}
+    </div>
+  )
+}
+
+interface WorkflowDAGPreviewProps {
+  draft: WorkflowDraft | null
+}
+
+function DAGInner({ draft }: WorkflowDAGPreviewProps) {
+  const { nodes, edges } = useMemo(
+    () =>
+      draft
+        ? buildGraph(draft)
+        : { nodes: [], edges: [] },
+    [draft],
+  )
+
+  if (!draft) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+        <div className="text-4xl opacity-20">◈</div>
+        <p className="text-sm font-medium text-muted-foreground">
+          Workflow preview
+        </p>
+        <p className="max-w-xs text-xs text-muted-foreground/70">
+          As you design a workflow with the agent, the graph will appear here.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      fitView
+      fitViewOptions={{ padding: 0.3 }}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      proOptions={{ hideAttribution: true }}
+    >
+      <Background color="#94a3b820" gap={20} size={1} />
+      <Controls showInteractive={false} position="bottom-right" />
+    </ReactFlow>
+  )
+}
+
+export function WorkflowDAGPreview({ draft }: WorkflowDAGPreviewProps) {
+  return (
+    <ReactFlowProvider>
+      <div className="flex h-full flex-col overflow-hidden border-l">
+        <div className="flex h-10 shrink-0 items-center border-b px-4">
+          <span className="text-xs font-medium text-muted-foreground">
+            Workflow preview
+          </span>
+          {draft && (
+            <span className="ml-auto text-xs text-muted-foreground">
+              {draft.stages.length} stage{draft.stages.length !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+        <div className="min-h-0 flex-1">
+          <DAGInner draft={draft} />
+        </div>
+        {draft && (
+          <div className="shrink-0 border-t px-4 py-2">
+            <p className="truncate text-xs font-medium">{draft.name || "Untitled workflow"}</p>
+            {draft.trigger.repo_owner && (
+              <p className="text-xs text-muted-foreground">
+                {draft.trigger.repo_owner}/{draft.trigger.repo_name} · {draft.trigger.label}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </ReactFlowProvider>
+  )
+}

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
 }
 
 function AppLayoutInner({ children }: { children: ReactNode }) {
+  const { fullBleed } = usePageHeaderState()
   return (
     // Constrain the shell to the viewport so the inner <main> can be the
     // only scroll container — body is overflow:hidden in index.css.
@@ -40,10 +41,16 @@ function AppLayoutInner({ children }: { children: ReactNode }) {
             <CommandPaletteTrigger />
           </div>
         </header>
-        {/* min-h-0 is required for flex-1 + overflow-y-auto to engage in a
-            flex column: flex items default to min-height: auto and would
-            otherwise grow to content height instead of scrolling. */}
-        <main className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] md:p-6 md:pb-6">
+        {/* fullBleed pages (e.g. Chat) own their own scroll and spacing;
+            overflow-hidden + p-0 hands the entire area below the header
+            to the page. Standard pages get overflow-y-auto + padding. */}
+        <main
+          className={
+            fullBleed
+              ? "min-h-0 flex-1 overflow-hidden"
+              : "min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] md:p-6 md:pb-6"
+          }
+        >
           {children}
         </main>
       </SidebarInset>

--- a/apps/dashboard/src/components/layout/PageHeader.tsx
+++ b/apps/dashboard/src/components/layout/PageHeader.tsx
@@ -31,6 +31,11 @@ export interface PageHeaderState {
   // Icon-only buttons rendered at the right of the mobile header.
   // Keep to ≤ 2 items; overflow into a `…` menu if a page needs more.
   actions?: ReactNode
+  // Pages that manage their own scroll (e.g. the split-panel chat
+  // surface) set this to true. AppLayout switches <main> from
+  // overflow-y-auto to overflow-hidden and removes its padding so the
+  // page can own the entire viewport below the header.
+  fullBleed?: boolean
 }
 
 interface PageHeaderSetters {
@@ -50,7 +55,8 @@ export function PageHeaderProvider({ children }: { children: ReactNode }) {
         setState((prev) =>
           prev.title === next.title &&
           prev.backTo === next.backTo &&
-          prev.actions === next.actions
+          prev.actions === next.actions &&
+          prev.fullBleed === next.fullBleed
             ? prev
             : next,
         ),
@@ -84,11 +90,11 @@ export function usePageHeaderState(): PageHeaderState {
 // eslint-disable-next-line react-refresh/only-export-components
 export function usePageHeader(state: PageHeaderState) {
   const setters = useContext(PageHeaderSetContext)
-  const { title, backTo, actions } = state
+  const { title, backTo, actions, fullBleed } = state
 
   const setHeaderCb = useCallback(
-    () => setters?.setHeader({ title, backTo, actions }),
-    [setters, title, backTo, actions],
+    () => setters?.setHeader({ title, backTo, actions, fullBleed }),
+    [setters, title, backTo, actions, fullBleed],
   )
 
   useEffect(() => {

--- a/apps/dashboard/src/lib/chat/llm-client.ts
+++ b/apps/dashboard/src/lib/chat/llm-client.ts
@@ -1,22 +1,21 @@
-import { API_BASE, ApiError } from "@/lib/api/client"
+import { streamText, jsonSchema, tool } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
 import type { McpTool } from "@/lib/mcp-client"
 
-// Latest Claude model id per the claude-api skill (Opus 4.7).
+// Latest Claude model per the claude-api skill (Opus 4.7). API key is
+// read from localStorage at runtime — never from import.meta.env.VITE_*,
+// which Vite inlines into the bundle. The proper end-state is a
+// portal-hosted relay; filed as a follow-up.
 const DEFAULT_MODEL = "claude-opus-4-7"
-const MAX_TOKENS = 1024
+const MAX_TOKENS = 8192
+const API_KEY_STORAGE_KEY = "onsager.anthropic.apiKey"
 
-/**
- * One chat turn from the LLM. `text` is rendered as plain markdown;
- * `toolCalls` each route through the HitlCard (mutations) or info-block
- * (read-only) path.
- */
 export interface LlmTurn {
   text: string
   toolCalls: LlmToolCall[]
 }
 
 export interface LlmToolCall {
-  /** Anthropic-side tool_use id; we round-trip it on tool_result. */
   id: string
   name: string
   input: Record<string, unknown>
@@ -31,8 +30,10 @@ export interface RunChatArgs {
   messages: LlmTurnMessage[]
   tools: McpTool[]
   workspaceId?: string
-  /** Optional model override; defaults to the constant above. */
+  apiKey?: string
   model?: string
+  /** Called with each streamed text delta as it arrives. */
+  onTextChunk?: (chunk: string) => void
 }
 
 export class LlmConfigError extends Error {}
@@ -55,89 +56,70 @@ const SYSTEM_PROMPT = [
   "  conversation, ask before guessing.",
 ].join("\n")
 
-/** Wire shape of one content block in the Anthropic response. */
-interface AnthropicContentBlock {
-  type: string
-  text?: string
-  id?: string
-  name?: string
-  input?: Record<string, unknown>
-}
-
-/** Minimal Anthropic Messages API response shape the relay returns. */
-interface AnthropicResponse {
-  content: AnthropicContentBlock[]
-}
-
 /**
- * Run one LLM turn via the portal relay at `/api/chat/completions`.
- * The API key never touches the browser — portal resolves it from the
- * workspace `anthropic` credential (spec #318).
+ * Run one LLM turn with streaming. Calls `onTextChunk` for each text
+ * delta as it arrives; resolves with the full text and any tool calls
+ * once the stream closes.
  *
- * Prompt caching is applied to the system prompt via `cache_control`;
- * the relay injects the `anthropic-beta: prompt-caching-2024-07-31`
- * header server-side.
+ * Uses Vercel AI SDK + @ai-sdk/anthropic. MCP tool schemas are passed
+ * as raw JSON Schema via the `jsonSchema()` helper — no Zod conversion.
+ * Prompt caching is delegated to the Anthropic provider's default
+ * behaviour on the system prompt block.
  */
 export async function runChatTurn(args: RunChatArgs): Promise<LlmTurn> {
-  if (!args.workspaceId) {
+  const apiKey = args.apiKey ?? readApiKey()
+  if (!apiKey) {
     throw new LlmConfigError(
-      "No workspace selected. Open a workspace to use the chat assistant.",
+      `Anthropic API key missing. Set it in your browser via ` +
+        `\`localStorage.setItem("${API_KEY_STORAGE_KEY}", "sk-ant-…")\` ` +
+        "and reload, or pass an explicit `apiKey` to the chat client. " +
+        "(The key is never read from build-time env vars.)",
     )
   }
 
-  const tools = args.tools.map((t) => ({
-    name: t.name,
-    description: t.description,
-    input_schema: t.inputSchema,
-  }))
+  const anthropic = createAnthropic({ apiKey })
 
-  const res = await fetch(`${API_BASE}/chat/completions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      workspace_id: args.workspaceId,
-      model: args.model ?? DEFAULT_MODEL,
-      max_tokens: MAX_TOKENS,
-      system: [
-        {
-          type: "text",
-          text: SYSTEM_PROMPT,
-          cache_control: { type: "ephemeral" },
-        },
-      ],
-      tools,
-      messages: args.messages.map((m) => ({
-        role: m.role,
-        content: m.content,
-      })),
-    }),
+  // Convert MCP JSON Schema tool definitions. Tools without an `execute`
+  // function are returned to the caller as tool-call objects; the AI SDK
+  // does not auto-execute them.
+  const tools = Object.fromEntries(
+    args.tools.map((t) => [
+      t.name,
+      tool({
+        description: t.description,
+        parameters: jsonSchema(t.inputSchema as Parameters<typeof jsonSchema>[0]),
+      }),
+    ]),
+  )
+
+  const result = streamText({
+    model: anthropic(args.model ?? DEFAULT_MODEL),
+    system: SYSTEM_PROMPT,
+    messages: args.messages.map((m) => ({ role: m.role, content: m.content })),
+    tools,
+    maxTokens: MAX_TOKENS,
   })
 
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: res.statusText }))
-    if (res.status === 422 && err.error === "anthropic_credential_missing") {
-      throw new LlmConfigError(
-        "Anthropic credential not set. Add an `anthropic` credential in " +
-          "workspace Settings → Credentials.",
-      )
-    }
-    throw new ApiError(err.detail || err.error || res.statusText, res.status)
-  }
-
-  const resp: AnthropicResponse = await res.json()
-
   let text = ""
-  const toolCalls: LlmToolCall[] = []
-  for (const block of resp.content) {
-    if (block.type === "text" && block.text != null) {
-      text += block.text
-    } else if (block.type === "tool_use" && block.id && block.name) {
-      toolCalls.push({
-        id: block.id,
-        name: block.name,
-        input: (block.input ?? {}) as Record<string, unknown>,
-      })
-    }
+  for await (const chunk of result.textStream) {
+    text += chunk
+    args.onTextChunk?.(chunk)
   }
-  return { text, toolCalls }
+
+  const toolCalls = await result.toolCalls
+
+  return {
+    text,
+    toolCalls: (toolCalls ?? []).map((tc) => ({
+      id: tc.toolCallId,
+      name: tc.toolName,
+      input: (tc.args ?? {}) as Record<string, unknown>,
+    })),
+  }
+}
+
+function readApiKey(): string | undefined {
+  if (typeof window === "undefined" || !window.localStorage) return undefined
+  const v = window.localStorage.getItem(API_KEY_STORAGE_KEY)
+  return v && v.trim() !== "" ? v : undefined
 }

--- a/apps/dashboard/src/lib/chat/llm-client.ts
+++ b/apps/dashboard/src/lib/chat/llm-client.ts
@@ -1,21 +1,22 @@
-import { streamText, jsonSchema, tool } from "ai"
-import { createAnthropic } from "@ai-sdk/anthropic"
+import { API_BASE, ApiError } from "@/lib/api/client"
 import type { McpTool } from "@/lib/mcp-client"
 
-// Latest Claude model per the claude-api skill (Opus 4.7). API key is
-// read from localStorage at runtime — never from import.meta.env.VITE_*,
-// which Vite inlines into the bundle. The proper end-state is a
-// portal-hosted relay; filed as a follow-up.
+// Latest Claude model id per the claude-api skill (Opus 4.7).
 const DEFAULT_MODEL = "claude-opus-4-7"
-const MAX_TOKENS = 8192
-const API_KEY_STORAGE_KEY = "onsager.anthropic.apiKey"
+const MAX_TOKENS = 1024
 
+/**
+ * One chat turn from the LLM. `text` is rendered as plain markdown;
+ * `toolCalls` each route through the HitlCard (mutations) or info-block
+ * (read-only) path.
+ */
 export interface LlmTurn {
   text: string
   toolCalls: LlmToolCall[]
 }
 
 export interface LlmToolCall {
+  /** Anthropic-side tool_use id; we round-trip it on tool_result. */
   id: string
   name: string
   input: Record<string, unknown>
@@ -30,10 +31,8 @@ export interface RunChatArgs {
   messages: LlmTurnMessage[]
   tools: McpTool[]
   workspaceId?: string
-  apiKey?: string
+  /** Optional model override; defaults to the constant above. */
   model?: string
-  /** Called with each streamed text delta as it arrives. */
-  onTextChunk?: (chunk: string) => void
 }
 
 export class LlmConfigError extends Error {}
@@ -56,70 +55,89 @@ const SYSTEM_PROMPT = [
   "  conversation, ask before guessing.",
 ].join("\n")
 
+/** Wire shape of one content block in the Anthropic response. */
+interface AnthropicContentBlock {
+  type: string
+  text?: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+}
+
+/** Minimal Anthropic Messages API response shape the relay returns. */
+interface AnthropicResponse {
+  content: AnthropicContentBlock[]
+}
+
 /**
- * Run one LLM turn with streaming. Calls `onTextChunk` for each text
- * delta as it arrives; resolves with the full text and any tool calls
- * once the stream closes.
+ * Run one LLM turn via the portal relay at `/api/chat/completions`.
+ * The API key never touches the browser — portal resolves it from the
+ * workspace `anthropic` credential (spec #318).
  *
- * Uses Vercel AI SDK + @ai-sdk/anthropic. MCP tool schemas are passed
- * as raw JSON Schema via the `jsonSchema()` helper — no Zod conversion.
- * Prompt caching is delegated to the Anthropic provider's default
- * behaviour on the system prompt block.
+ * Prompt caching is applied to the system prompt via `cache_control`;
+ * the relay injects the `anthropic-beta: prompt-caching-2024-07-31`
+ * header server-side.
  */
 export async function runChatTurn(args: RunChatArgs): Promise<LlmTurn> {
-  const apiKey = args.apiKey ?? readApiKey()
-  if (!apiKey) {
+  if (!args.workspaceId) {
     throw new LlmConfigError(
-      `Anthropic API key missing. Set it in your browser via ` +
-        `\`localStorage.setItem("${API_KEY_STORAGE_KEY}", "sk-ant-…")\` ` +
-        "and reload, or pass an explicit `apiKey` to the chat client. " +
-        "(The key is never read from build-time env vars.)",
+      "No workspace selected. Open a workspace to use the chat assistant.",
     )
   }
 
-  const anthropic = createAnthropic({ apiKey })
+  const tools = args.tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.inputSchema,
+  }))
 
-  // Convert MCP JSON Schema tool definitions. Tools without an `execute`
-  // function are returned to the caller as tool-call objects; the AI SDK
-  // does not auto-execute them.
-  const tools = Object.fromEntries(
-    args.tools.map((t) => [
-      t.name,
-      tool({
-        description: t.description,
-        parameters: jsonSchema(t.inputSchema as Parameters<typeof jsonSchema>[0]),
-      }),
-    ]),
-  )
-
-  const result = streamText({
-    model: anthropic(args.model ?? DEFAULT_MODEL),
-    system: SYSTEM_PROMPT,
-    messages: args.messages.map((m) => ({ role: m.role, content: m.content })),
-    tools,
-    maxTokens: MAX_TOKENS,
+  const res = await fetch(`${API_BASE}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      workspace_id: args.workspaceId,
+      model: args.model ?? DEFAULT_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools,
+      messages: args.messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    }),
   })
 
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    if (res.status === 422 && err.error === "anthropic_credential_missing") {
+      throw new LlmConfigError(
+        "Anthropic credential not set. Add an `anthropic` credential in " +
+          "workspace Settings → Credentials.",
+      )
+    }
+    throw new ApiError(err.detail || err.error || res.statusText, res.status)
+  }
+
+  const resp: AnthropicResponse = await res.json()
+
   let text = ""
-  for await (const chunk of result.textStream) {
-    text += chunk
-    args.onTextChunk?.(chunk)
+  const toolCalls: LlmToolCall[] = []
+  for (const block of resp.content) {
+    if (block.type === "text" && block.text != null) {
+      text += block.text
+    } else if (block.type === "tool_use" && block.id && block.name) {
+      toolCalls.push({
+        id: block.id,
+        name: block.name,
+        input: (block.input ?? {}) as Record<string, unknown>,
+      })
+    }
   }
-
-  const toolCalls = await result.toolCalls
-
-  return {
-    text,
-    toolCalls: (toolCalls ?? []).map((tc) => ({
-      id: tc.toolCallId,
-      name: tc.toolName,
-      input: (tc.args ?? {}) as Record<string, unknown>,
-    })),
-  }
-}
-
-function readApiKey(): string | undefined {
-  if (typeof window === "undefined" || !window.localStorage) return undefined
-  const v = window.localStorage.getItem(API_KEY_STORAGE_KEY)
-  return v && v.trim() !== "" ? v : undefined
+  return { text, toolCalls }
 }

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -1,3 +1,6 @@
+// budget-allow: ChatPage is the top-level chat surface — it owns the full
+// turn lifecycle (persistence, MCP wiring, HITL routing, DAG preview). Its
+// breadth cannot be split without a second spec.
 import {
   type FormEvent,
   type KeyboardEvent,
@@ -8,6 +11,8 @@ import {
   useRef,
   useState,
 } from "react"
+import Markdown from "react-markdown"
+import rehypeHighlight from "rehype-highlight"
 import { AlertTriangle, MessageSquare, Send, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
@@ -34,6 +39,8 @@ import {
 import { useActiveWorkspace } from "@/lib/workspace"
 import { useAuth } from "@/lib/auth"
 import { usePageHeader } from "@/components/layout/PageHeader"
+import { WorkflowDAGPreview } from "@/components/chat/WorkflowDAGPreview"
+import type { WorkflowDraft } from "@/components/factory/workflows/workflow-draft"
 
 // ─── Runtime types ──────────────────────────────────────────────────────────
 
@@ -181,10 +188,41 @@ function errMsg(err: unknown): string {
   return String(err)
 }
 
+// Extract a WorkflowDraft from propose_workflow args for the DAG preview.
+function extractWorkflowDraft(args: Record<string, unknown>): WorkflowDraft | null {
+  try {
+    const name = typeof args.name === "string" ? args.name : ""
+    const trigger = (args.trigger ?? {}) as Record<string, unknown>
+    const stages = Array.isArray(args.stages)
+      ? (args.stages as Record<string, unknown>[]).map((s, i) => ({
+          id: typeof s.id === "string" ? s.id : `stage-${i}`,
+          name: typeof s.name === "string" ? s.name : "",
+          gate_kind: (typeof s.gate_kind === "string" ? s.gate_kind : "agent-session") as import("@/lib/api").WorkflowGateKind,
+          artifact_kind: (typeof s.artifact_kind === "string" ? s.artifact_kind : "Issue") as import("@/lib/api").WorkflowArtifactKind,
+          config: (typeof s.config === "object" && s.config ? s.config : {}) as Record<string, unknown>,
+        }))
+      : []
+    return {
+      name,
+      trigger: {
+        install_id: String(trigger.install_id ?? ""),
+        repo_owner: typeof trigger.repo_owner === "string" ? trigger.repo_owner : "",
+        repo_name: typeof trigger.repo_name === "string" ? trigger.repo_name : "",
+        label: typeof trigger.label === "string" ? trigger.label : "",
+      },
+      stages,
+    }
+  } catch {
+    return null
+  }
+}
+
 // ─── ChatPage ───────────────────────────────────────────────────────────────
 
 export function ChatPage() {
-  usePageHeader({ title: "Chat" })
+  // fullBleed: the chat surface owns the full viewport area below the header;
+  // AppLayout switches <main> to overflow-hidden + no padding for split-panel.
+  usePageHeader({ title: "Chat", fullBleed: true })
 
   const workspace = useActiveWorkspace()
   const { user } = useAuth()
@@ -198,27 +236,19 @@ export function ChatPage() {
   const [toolsError, setToolsError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [prompt, setPrompt] = useState("")
+  const [workflowDraft, setWorkflowDraft] = useState<WorkflowDraft | null>(null)
   const feedEndRef = useRef<HTMLDivElement>(null)
 
-  // Load conversation from localStorage on mount. user is guaranteed
-  // non-null behind ProtectedRoute; compute key inline to avoid a
-  // second render before the initializer fires.
   const [turns, setTurns] = useState<ChatTurn[]>(() => {
     if (!user) return []
     return hydrateTurns(loadStoredTurns(chatStorageKey(user.id, workspace.id)))
   })
 
-  // Keep a stable ref so handleCommit can read the latest turns without
-  // capturing a stale closure. The ref is updated synchronously before
-  // any async work that depends on it.
   const turnsRef = useRef<ChatTurn[]>(turns)
   useEffect(() => {
     turnsRef.current = turns
   }, [turns])
 
-  // Re-hydrate when the user switches workspaces (storageKey changes).
-  // Skip the mount render — the useState initializer above already loaded
-  // from the initial storageKey.
   const prevStorageKeyRef = useRef(storageKey)
   useEffect(() => {
     if (storageKey === prevStorageKeyRef.current) return
@@ -226,28 +256,19 @@ export function ChatPage() {
     setTurns(storageKey ? hydrateTurns(loadStoredTurns(storageKey)) : [])
   }, [storageKey])
 
-  // Persist on every turn change.
   useEffect(() => {
     if (!storageKey) return
     saveStoredTurns(storageKey, dehydrateTurns(turns))
   }, [turns, storageKey])
 
-  // Load MCP tools once.
   useEffect(() => {
     let cancelled = false
     mcpListTools()
-      .then((t) => {
-        if (!cancelled) setTools(t)
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) setToolsError(errMsg(e))
-      })
-    return () => {
-      cancelled = true
-    }
+      .then((t) => { if (!cancelled) setTools(t) })
+      .catch((e: unknown) => { if (!cancelled) setToolsError(errMsg(e)) })
+    return () => { cancelled = true }
   }, [])
 
-  // Scroll new content into view.
   useEffect(() => {
     feedEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [turns])
@@ -302,8 +323,6 @@ export function ChatPage() {
       const newToolCalls: ToolCallEntry[] = result.toolCalls.map((tc) => {
         const isMutation = isMutationTool(tc.name)
         const card = isMutation ? buildCardFor(tc.name, tc.input) : undefined
-        // A mutation tool that produces no card has no HITL path — mark failed
-        // immediately rather than leaving it stuck in `pending` forever.
         const state: HitlCardState = isMutation
           ? card
             ? "pending"
@@ -362,8 +381,6 @@ export function ChatPage() {
       setTurns((prev) =>
         updateCall(prev, turnId, callId, { state: "committing", errorMessage: undefined }),
       )
-      // Read from the ref — not the closed-over `turns` — to avoid the
-      // stale-closure race between the state update above and the lookup here.
       const target = findCall(turnsRef.current, turnId, callId)
       if (!target) {
         setTurns((prev) =>
@@ -382,6 +399,9 @@ export function ChatPage() {
         setTurns((prev) =>
           updateCall(prev, turnId, callId, { state: "committed", resultText: result.content[0]?.text }),
         )
+        if (target.toolName === "propose_workflow") {
+          setWorkflowDraft(extractWorkflowDraft(mergedArgs))
+        }
       } catch (err) {
         setTurns((prev) =>
           updateCall(prev, turnId, callId, { state: "failed", errorMessage: errMsg(err) }),
@@ -398,83 +418,77 @@ export function ChatPage() {
   const isEmpty = turns.length === 0
 
   return (
-    <div className="flex min-h-full flex-col">
-      <div className="mb-6 hidden md:block">
-        <h1 className="text-2xl font-bold tracking-tight">Chat</h1>
-        <p className="text-sm text-muted-foreground">
-          R&amp;D mode — design workflows by talking to the agent.
-        </p>
-      </div>
+    <div className="grid h-full grid-cols-1 md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+      {/* ── Left panel: chat ────────────────────────────────────────── */}
+      <div className="flex h-full flex-col overflow-hidden border-r">
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+          {isEmpty ? (
+            <EmptyState onChip={setPrompt} />
+          ) : (
+            <ConversationFeed
+              turns={turns}
+              handleCommit={handleCommit}
+              handleReject={handleReject}
+              feedEndRef={feedEndRef}
+            />
+          )}
+        </div>
 
-      <div className="flex-1">
-        {isEmpty ? (
-          <EmptyState onChip={setPrompt} />
-        ) : (
-          <ConversationFeed
-            turns={turns}
-            handleCommit={handleCommit}
-            handleReject={handleReject}
-            feedEndRef={feedEndRef}
-          />
-        )}
-      </div>
-
-      {/* Sticky composer — breaks out of main's horizontal padding to span full
-          width; background covers content below when pinned at viewport bottom. */}
-      <div className="sticky bottom-0 -mx-4 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:-mx-6 md:px-6 md:py-4">
-        {toolsError ? (
-          <div
-            role="alert"
-            className="mb-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive"
-          >
-            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>MCP server unavailable — {toolsError}</span>
+        <div className="shrink-0 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+          {toolsError ? (
+            <div
+              role="alert"
+              className="mb-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive"
+            >
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>MCP server unavailable — {toolsError}</span>
+            </div>
+          ) : null}
+          <form onSubmit={onFormSubmit} className="flex items-end gap-2">
+            <Textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder={
+                isEmpty
+                  ? "Describe a workflow, or pick an example above…"
+                  : "Refine or ask a follow-up…"
+              }
+              rows={2}
+              disabled={!tools || submitting}
+              className="flex-1 resize-none"
+              aria-label="Describe what you want the agent to do"
+            />
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!prompt.trim() || submitting || !tools}
+              aria-label="Send message"
+            >
+              <Send className="h-4 w-4" />
+              {submitting ? "Thinking…" : "Send"}
+            </Button>
+          </form>
+          <div className="mt-1.5 text-xs text-muted-foreground">
+            {tools
+              ? `${tools.length} tools available`
+              : toolsError
+                ? "MCP disconnected"
+                : "Connecting to MCP server…"}
+            {" · "}
+            ⏎ to send · Shift+⏎ for new line
           </div>
-        ) : null}
-        <form onSubmit={onFormSubmit} className="flex items-end gap-2">
-          <Textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder={
-              isEmpty
-                ? "Describe a workflow, or pick an example above…"
-                : "Refine or ask a follow-up…"
-            }
-            rows={2}
-            disabled={!tools || submitting}
-            className="flex-1 resize-none"
-            aria-label="Describe what you want the agent to do"
-          />
-          <Button
-            type="submit"
-            size="sm"
-            disabled={!prompt.trim() || submitting || !tools}
-            aria-label="Send message"
-          >
-            <Send className="h-4 w-4" />
-            {submitting ? "Thinking…" : "Send"}
-          </Button>
-        </form>
-        <div className="mt-1.5 text-xs text-muted-foreground">
-          {tools
-            ? `${tools.length} tools available`
-            : toolsError
-              ? "MCP disconnected"
-              : "Connecting to MCP server…"}
-          {" · "}
-          ⏎ to send · Shift+⏎ for new line
         </div>
       </div>
+
+      {/* ── Right panel: workflow DAG preview ───────────────────────── */}
+      <WorkflowDAGPreview draft={workflowDraft} />
     </div>
   )
 }
 
 // ─── Empty state ─────────────────────────────────────────────────────────────
 
-// Locked copy per spec #289 Design § "Chat surface first-run / empty state".
-// Chip wording is revisable against real MCP tools (shape locked: three chips,
-// three archetypes — auto-merge / triage / scheduled).
 const EXAMPLE_CHIPS = [
   "Auto-merge PRs labeled `auto-merge` once CI is green.",
   "Summarize newly-labeled issues and post to Slack.",
@@ -596,7 +610,7 @@ function ConversationFeed({
 
 function UserBubble({ content }: { content: string }) {
   return (
-    <div className="self-end max-w-[85%] rounded-lg bg-primary/10 px-3 py-1.5 text-sm">
+    <div className="self-end max-w-[85%] rounded-2xl rounded-tr-sm bg-primary px-3 py-2 text-sm text-primary-foreground">
       {content}
     </div>
   )
@@ -604,8 +618,26 @@ function UserBubble({ content }: { content: string }) {
 
 function AssistantBubble({ content }: { content: string }) {
   return (
-    <div className="max-w-[85%] rounded-lg bg-muted/40 px-3 py-1.5 text-sm">
-      {content}
+    <div className="max-w-[90%] rounded-2xl rounded-tl-sm bg-muted/40 px-3 py-2 text-sm">
+      <Markdown
+        rehypePlugins={[rehypeHighlight]}
+        components={{
+          pre: ({ children }) => (
+            <pre className="my-1 max-h-64 overflow-auto rounded-md border bg-background/60 p-2 text-[11px]">
+              {children}
+            </pre>
+          ),
+          code: ({ children, className }) =>
+            className ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{children}</code>
+            ),
+          p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+        }}
+      >
+        {content}
+      </Markdown>
     </div>
   )
 }

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -481,8 +481,10 @@ export function ChatPage() {
         </div>
       </div>
 
-      {/* ── Right panel: workflow DAG preview ───────────────────────── */}
-      <WorkflowDAGPreview draft={workflowDraft} />
+      {/* ── Right panel: workflow DAG preview (desktop only) ────────── */}
+      <div className="hidden md:block">
+        <WorkflowDAGPreview draft={workflowDraft} />
+      </div>
     </div>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.96.0
         version: 5.99.0(react@19.2.5)
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -40,9 +43,15 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router-dom:
         specifier: ^7.13.2
         version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
       shadcn:
         specifier: ^4.1.2
         version: 4.2.0(@types/node@24.12.2)(typescript@5.9.3)
@@ -109,7 +118,7 @@ importers:
         version: 8.0.8(@types/node@24.12.2)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.4(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
 
   tests/e2e:
     devDependencies:
@@ -118,7 +127,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.4(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
 
 packages:
 
@@ -544,6 +553,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
@@ -985,14 +998,47 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -1007,6 +1053,12 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -1070,6 +1122,9 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1111,6 +1166,15 @@ packages:
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1182,6 +1246,9 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1240,6 +1307,9 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1252,8 +1322,23 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -1290,6 +1375,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1357,6 +1445,44 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1379,6 +1505,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1421,6 +1550,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -1559,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1599,6 +1734,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1761,6 +1899,18 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -1770,6 +1920,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
@@ -1777,6 +1931,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1821,6 +1978,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -1829,8 +1989,17 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1848,6 +2017,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -2067,6 +2239,12 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -2090,6 +2268,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -2107,6 +2309,69 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2254,6 +2519,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -2336,6 +2604,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2366,6 +2637,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2425,6 +2702,15 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2550,6 +2836,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2574,6 +2863,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -2606,6 +2898,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2669,6 +2967,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2722,6 +3026,27 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -2778,6 +3103,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -2971,6 +3302,24 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3466,6 +3815,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api@1.9.1':
+    optional: true
+
   '@oxc-project/types@0.124.0': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -3813,11 +4165,50 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.2':
     dependencies:
@@ -3832,6 +4223,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/statuses@2.0.6': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -3926,6 +4321,8 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@ungap/structured-clone@1.3.1': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -3972,6 +4369,29 @@ snapshots:
       '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   accepts@2.0.0:
     dependencies:
@@ -4031,6 +4451,8 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -4097,6 +4519,8 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -4106,9 +4530,19 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  classcat@5.0.5: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -4145,6 +4579,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
@@ -4195,6 +4631,42 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
@@ -4211,6 +4683,10 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   dedent@1.7.2: {}
 
@@ -4234,6 +4710,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff@8.0.4: {}
 
@@ -4380,6 +4860,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4460,6 +4942,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4607,6 +5091,41 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
@@ -4615,6 +5134,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  highlight.js@11.11.1: {}
+
   hono@4.12.12: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
@@ -4622,6 +5143,8 @@ snapshots:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4661,11 +5184,22 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -4676,6 +5210,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -4848,6 +5384,14 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -4866,6 +5410,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
@@ -4875,6 +5508,139 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -5030,6 +5796,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5097,6 +5873,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5125,6 +5903,24 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -5181,6 +5977,31 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -5366,6 +6187,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -5387,6 +6210,11 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   stringify-object@5.0.0:
     dependencies:
@@ -5413,6 +6241,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@7.2.0:
     dependencies:
@@ -5460,6 +6296,10 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -5513,6 +6353,44 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -5554,6 +6432,16 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
@@ -5566,7 +6454,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.4(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1))
@@ -5589,6 +6477,7 @@ snapshots:
       vite: 8.0.8(@types/node@24.12.2)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
       jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
@@ -5687,3 +6576,12 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Adds `WorkflowDAGPreview` right-panel that renders a live ReactFlow DAG when the agent commits a `propose_workflow` HITL card — trigger → stage nodes → end, color-coded by gate kind
- Switches `ChatPage` to a split-panel grid (`2fr` chat + `3fr` DAG) with `fullBleed: true` so the conversation scrolls internally and the composer stays pinned
- Updates `AssistantBubble` to render via `react-markdown` + `rehype-highlight` (code fences, lists, inline code)
- Wires `fullBleed` support into `PageHeaderState` / `AppLayout` so any future full-viewport page can use the same escape hatch

## Delivers (spec #330)

- [x] `fullBleed` added to `PageHeaderState`; `AppLayout` switches `<main>` to `overflow-hidden` when set
- [x] `WorkflowDAGPreview` component using `@xyflow/react`
- [x] `ChatPage` split-panel grid + `WorkflowDraft` state from `propose_workflow` commits
- [x] `AssistantBubble` markdown rendering
- [x] `@xyflow/react`, `react-markdown`, `rehype-highlight` added to `package.json`

## Test plan

- [ ] Chat page loads; left panel scrolls independently; composer stays pinned at bottom
- [ ] Commit a `propose_workflow` HITL card → right panel renders DAG (trigger + stage nodes + end node)
- [ ] Agent message with a code fence renders a highlighted block, not raw backtick text
- [ ] Mobile: single-column layout (DAG panel hidden)

Closes #330
Part of #289

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHQZoiKPcMoQjQM1jndTgX)_