### PR TITLE
design: chat-to-workflow HTML prototype

### DIFF
--- a/.agents/skills/frontend-design/LICENSE.txt
+++ b/.agents/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+../../.agents/skills/frontend-design

--- a/.claude/skills/web-design-guidelines
+++ b/.claude/skills/web-design-guidelines
@@ -1,0 +1,1 @@
+../../.agents/skills/web-design-guidelines

--- a/design/chat-workflow-prototype.html
+++ b/design/chat-workflow-prototype.html
@@ -549,12 +549,15 @@ prompt: |
     if (!text) return;
     ta.value = ''; ta.style.height = 'auto';
 
-    // User bubble
+    // User bubble — use textContent to avoid XSS from typed input
     const feed = document.getElementById('feed');
     const userDiv = document.createElement('div');
     userDiv.className = 'msg-enter flex justify-end';
-    userDiv.innerHTML = `<div class="max-w-xs rounded-2xl rounded-tr-sm px-3.5 py-2.5 text-sm"
-      style="background:#1a2033; color:var(--text-hi); border:1px solid var(--border-hi);">${text}</div>`;
+    const bubble = document.createElement('div');
+    bubble.className = 'max-w-xs rounded-2xl rounded-tr-sm px-3.5 py-2.5 text-sm';
+    bubble.style.cssText = 'background:#1a2033; color:var(--text-hi); border:1px solid var(--border-hi);';
+    bubble.textContent = text;
+    userDiv.appendChild(bubble);
     feed.appendChild(userDiv);
 
     // Streaming assistant reply

--- a/design/chat-workflow-prototype.html
+++ b/design/chat-workflow-prototype.html
@@ -1,0 +1,745 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Onsager — Chat to Workflow</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/base16/one-dark-pro.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
+<style>
+  :root {
+    --bg:        #0b0d11;
+    --surface:   #13161c;
+    --border:    #1e222d;
+    --border-hi: #2a2f3d;
+    --muted:     #4a5068;
+    --text:      #c8cdd8;
+    --text-hi:   #e8ecf4;
+    --accent:    #00d4aa;
+    --accent-dim:#00d4aa22;
+    /* gate kinds */
+    --agent:     #3b82f6;
+    --external:  #a855f7;
+    --governance:#f59e0b;
+    --approval:  #22c55e;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; background: var(--bg); color: var(--text);
+    font-family: 'Geist', sans-serif; font-size: 14px; -webkit-font-smoothing: antialiased; }
+  /* dot grid background */
+  .dot-grid {
+    background-image: radial-gradient(circle, #1e222d 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  .mono { font-family: 'IBM Plex Mono', monospace; }
+
+  /* scrollbars */
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-hi); border-radius: 2px; }
+
+  /* streaming cursor */
+  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+  .cursor::after { content:'▋'; color: var(--accent); animation: blink 0.9s step-end infinite; font-size: 0.85em; }
+
+  /* HITL card glow states */
+  @keyframes pulse-amber { 0%,100%{box-shadow:0 0 0 0 #f59e0b22} 50%{box-shadow:0 0 0 4px #f59e0b11} }
+  .hitl-pending { animation: pulse-amber 2.5s ease-in-out infinite; }
+
+  /* edge animation */
+  @keyframes dash { to { stroke-dashoffset: -20; } }
+  .edge-animated { stroke-dasharray: 5 4; animation: dash 0.6s linear infinite; }
+
+  /* fade-in for messages */
+  @keyframes fadeUp { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
+  .msg-enter { animation: fadeUp 0.25s ease-out forwards; }
+
+  /* node hover */
+  .dag-node { transition: filter 0.15s; cursor: pointer; }
+  .dag-node:hover { filter: brightness(1.25); }
+
+  /* tab indicator */
+  .tab-active { color: var(--text-hi); border-bottom: 2px solid var(--accent); }
+  .tab-inactive { color: var(--muted); border-bottom: 2px solid transparent; }
+
+  /* code block overrides */
+  .hljs { background: #090b0f !important; border-radius: 6px; font-size: 12px; line-height: 1.6; }
+
+  /* collapse prose highlight */
+  mark { background: var(--accent-dim); color: var(--accent); padding: 0 3px; border-radius: 3px; }
+
+  /* info block */
+  .info-block { border-left: 2px solid var(--border-hi); padding-left: 10px; }
+
+  /* scrollable feed */
+  .feed { overflow-y: auto; overscroll-behavior: contain; }
+
+  /* button base */
+  .btn { display:inline-flex; align-items:center; gap:6px; padding: 5px 12px; border-radius: 5px;
+    font-size: 12px; font-weight: 500; cursor: pointer; border: 1px solid transparent;
+    transition: background 0.12s, border-color 0.12s, color 0.12s; white-space: nowrap; }
+  .btn-ghost { background: transparent; border-color: var(--border-hi); color: var(--muted); }
+  .btn-ghost:hover { border-color: var(--border-hi); color: var(--text); background: var(--border); }
+  .btn-accept { background: #16261f; border-color: #22c55e44; color: #4ade80; }
+  .btn-accept:hover { background: #1d3228; border-color: #22c55e88; }
+  .btn-reject { background: #26181b; border-color: #f8717144; color: #f87171; }
+  .btn-reject:hover { background: #2f1e21; border-color: #f8717188; }
+  .btn-primary { background: var(--accent); border-color: var(--accent); color: #000; font-weight:600; }
+  .btn-primary:hover { background: #00bfa0; }
+  .btn-primary:disabled { opacity:0.4; cursor:not-allowed; }
+
+  textarea { resize: none; outline: none; background: transparent; color: var(--text-hi); width:100%;
+    font-family: inherit; font-size: 13px; line-height: 1.5; }
+  textarea::placeholder { color: var(--muted); }
+
+  /* accepted/rejected states */
+  .hitl-accepted { border-color: #22c55e33 !important; }
+  .hitl-rejected { border-color: #f8717133 !important; opacity: 0.65; }
+
+  /* stage badge */
+  .badge { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:3px;
+    font-size: 10px; font-weight:500; font-family:'IBM Plex Mono',monospace; text-transform:uppercase;
+    letter-spacing:0.05em; }
+</style>
+</head>
+<body class="h-full">
+
+<!-- APP SHELL -->
+<div id="app" class="flex flex-col h-full">
+
+  <!-- TOPBAR -->
+  <header style="border-bottom:1px solid var(--border); background:var(--surface);"
+          class="flex items-center justify-between px-4 h-11 shrink-0">
+    <div class="flex items-center gap-3">
+      <!-- logo mark -->
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <circle cx="10" cy="10" r="9" stroke="#00d4aa" stroke-width="1.5"/>
+        <path d="M6 10h8M10 6v8" stroke="#00d4aa" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+      <span class="mono text-xs" style="color:var(--text-hi); letter-spacing:0.12em;">ONSAGER</span>
+      <span style="color:var(--border-hi)">·</span>
+      <span class="text-xs" style="color:var(--muted)">Chat</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <span class="badge" style="background:#0d2a1e; color:var(--accent); border:1px solid #00d4aa22;">
+        <svg width="6" height="6" viewBox="0 0 6 6"><circle cx="3" cy="3" r="3" fill="#00d4aa"/></svg>
+        MCP · 11 tools
+      </span>
+    </div>
+  </header>
+
+  <!-- MOBILE TABS (hidden on desktop) -->
+  <div id="mobile-tabs" class="md:hidden flex shrink-0" style="border-bottom:1px solid var(--border); background:var(--surface);">
+    <button onclick="switchTab('chat')" id="tab-chat"
+      class="flex-1 tab-active py-2.5 text-xs font-medium transition-all" style="background:transparent;border:none;cursor:pointer;">
+      Chat
+    </button>
+    <button onclick="switchTab('dag')" id="tab-dag"
+      class="flex-1 tab-inactive py-2.5 text-xs font-medium transition-all" style="background:transparent;border:none;cursor:pointer;">
+      Workflow DAG
+    </button>
+  </div>
+
+  <!-- MAIN CONTENT -->
+  <div class="flex flex-1 min-h-0">
+
+    <!-- ═══════════════════════════════ LEFT PANEL: CHAT ═══════════════════════════════ -->
+    <div id="panel-chat" class="flex flex-col flex-1 md:flex-none min-h-0"
+         style="width:100%; border-right:1px solid var(--border);"
+         data-panel="chat">
+
+      <!-- conversation feed -->
+      <div id="feed" class="feed flex-1 min-h-0 px-4 py-5 space-y-5">
+
+        <!-- 1. User message -->
+        <div class="msg-enter flex justify-end">
+          <div class="max-w-xs rounded-2xl rounded-tr-sm px-3.5 py-2.5 text-sm"
+               style="background:#1a2033; color:var(--text-hi); border:1px solid var(--border-hi);">
+            Create a workflow that auto-labels GitHub issues and runs an AI triage on them.
+          </div>
+        </div>
+
+        <!-- 2. Assistant streaming bubble -->
+        <div class="msg-enter flex gap-2.5">
+          <div class="shrink-0 w-7 h-7 rounded-full flex items-center justify-center mt-0.5"
+               style="background:#0d1a15; border:1px solid #00d4aa33;">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <circle cx="6" cy="6" r="5" stroke="#00d4aa" stroke-width="1.2"/>
+              <path d="M3.5 6h5M6 3.5v5" stroke="#00d4aa" stroke-width="1.2" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="flex-1 text-sm leading-relaxed" style="color:var(--text);">
+            <p class="mb-2">Here's what I'll build for you:</p>
+            <ol class="list-decimal list-inside space-y-1 mb-3" style="color:var(--text);">
+              <li>A <mark>trigger</mark> that fires on new GitHub issues</li>
+              <li>An <mark>agent-session</mark> stage that classifies the issue</li>
+              <li>An <mark>external-check</mark> stage that applies labels via API</li>
+              <li>A <mark>manual-approval</mark> gate for escalations</li>
+            </ol>
+            <p class="mb-2">Let me propose this workflow — you can review the details below.</p>
+          </div>
+        </div>
+
+        <!-- 3. HITL card: constructive (propose_workflow) — PENDING -->
+        <div id="hitl-1" class="msg-enter ml-9 hitl-pending rounded-xl overflow-hidden transition-all"
+             style="border:1px solid #f59e0b44; background:var(--surface);">
+          <!-- card header -->
+          <div class="flex items-center justify-between px-4 py-2.5"
+               style="border-bottom:1px solid var(--border); background:#16120a;">
+            <div class="flex items-center gap-2">
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                <path d="M6.5 1.5v5l3 2" stroke="#f59e0b" stroke-width="1.3" stroke-linecap="round"/>
+                <circle cx="6.5" cy="6.5" r="5.5" stroke="#f59e0b" stroke-width="1.2"/>
+              </svg>
+              <span class="mono text-xs font-medium" style="color:#fbbf24;">propose_workflow</span>
+            </div>
+            <span class="badge" style="background:#16120a; color:#f59e0b; border:1px solid #f59e0b33;">
+              review required
+            </span>
+          </div>
+          <!-- card body -->
+          <div class="px-4 py-3 space-y-2.5">
+            <div>
+              <div class="mono text-xs mb-1" style="color:var(--muted);">name</div>
+              <div class="text-sm font-medium" style="color:var(--text-hi);">GitHub Issue Triage &amp; Auto-Label</div>
+            </div>
+            <div>
+              <div class="mono text-xs mb-1" style="color:var(--muted);">trigger</div>
+              <div class="flex items-center gap-1.5">
+                <span class="badge" style="background:#0e1520; color:#60a5fa; border:1px solid #3b82f622;">issues.opened</span>
+                <span class="text-xs" style="color:var(--muted);">onsager-ai/onsager</span>
+              </div>
+            </div>
+            <div>
+              <div class="mono text-xs mb-2" style="color:var(--muted);">stages (3)</div>
+              <div class="space-y-1.5">
+                <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md"
+                     style="background:#0e1520; border:1px solid var(--border);">
+                  <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--agent)"></span>
+                  <span class="text-xs" style="color:var(--text);">1 — AI classify &amp; summarise</span>
+                  <span class="mono text-xs ml-auto" style="color:var(--muted);">agent-session</span>
+                </div>
+                <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md"
+                     style="background:#0e1520; border:1px solid var(--border);">
+                  <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--external)"></span>
+                  <span class="text-xs" style="color:var(--text);">2 — Apply labels via GitHub API</span>
+                  <span class="mono text-xs ml-auto" style="color:var(--muted);">external-check</span>
+                </div>
+                <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md"
+                     style="background:#0e1520; border:1px solid var(--border);">
+                  <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--approval)"></span>
+                  <span class="text-xs" style="color:var(--text);">3 — Escalation approval</span>
+                  <span class="mono text-xs ml-auto" style="color:var(--muted);">manual-approval</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- card actions -->
+          <div class="flex items-center justify-between px-4 py-2.5"
+               style="border-top:1px solid var(--border);">
+            <button class="btn btn-ghost text-xs" onclick="editCard()">Edit</button>
+            <div class="flex gap-2">
+              <button class="btn btn-reject" onclick="rejectCard('hitl-1')">
+                <svg width="10" height="10" viewBox="0 0 10 10"><path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+                Reject
+              </button>
+              <button class="btn btn-accept" onclick="acceptCard('hitl-1')">
+                <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 5l2.5 3 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Accept
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- 4. Info block: list_workflows result -->
+        <div class="msg-enter ml-9">
+          <div class="flex items-center gap-2 mb-2">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <circle cx="6" cy="6" r="5" stroke="#4a5068" stroke-width="1.2"/>
+              <path d="M6 5v4M6 3.5v.5" stroke="#4a5068" stroke-width="1.2" stroke-linecap="round"/>
+            </svg>
+            <span class="mono text-xs" style="color:var(--muted);">list_workflows</span>
+          </div>
+          <div class="info-block text-xs space-y-1" style="color:var(--muted);">
+            <div>2 workflows in <span class="mono" style="color:var(--text);">onsager-ai</span> workspace</div>
+            <div class="mono" style="color:var(--text-hi);">→ PR Review Gate (active)</div>
+            <div class="mono" style="color:var(--text-hi);">→ Deploy Notification (paused)</div>
+          </div>
+        </div>
+
+        <!-- 5. HITL card: destructive variant -->
+        <div id="hitl-2" class="msg-enter ml-9 hitl-pending rounded-xl overflow-hidden"
+             style="border:1px solid #f8717144; background:var(--surface);">
+          <div class="flex items-center justify-between px-4 py-2.5"
+               style="border-bottom:1px solid var(--border); background:#1a0e0e;">
+            <div class="flex items-center gap-2">
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                <path d="M6.5 4v3M6.5 8.5v.5" stroke="#f87171" stroke-width="1.3" stroke-linecap="round"/>
+                <path d="M1.5 11L6.5 2l5 9H1.5z" stroke="#f87171" stroke-width="1.2" stroke-linejoin="round"/>
+              </svg>
+              <span class="mono text-xs font-medium" style="color:#f87171;">cancel_run</span>
+            </div>
+            <span class="badge" style="background:#1a0e0e; color:#f87171; border:1px solid #f8717133;">
+              destructive
+            </span>
+          </div>
+          <div class="px-4 py-3">
+            <p class="text-xs mb-2" style="color:var(--muted);">This will terminate the active run and mark it <span class="mono" style="color:#f87171;">cancelled</span>.</p>
+            <div class="mono text-xs px-2.5 py-1.5 rounded" style="background:#0f0a0a; color:#f87171; border:1px solid #f8717122;">
+              run_id: run_01JX4MN8KP2Q
+            </div>
+          </div>
+          <div class="flex items-center justify-end gap-2 px-4 py-2.5"
+               style="border-top:1px solid var(--border);">
+            <button class="btn btn-ghost" onclick="rejectCard('hitl-2')">Cancel</button>
+            <button class="btn btn-reject" onclick="acceptCard('hitl-2')">
+              <svg width="10" height="10" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4" stroke="currentColor" stroke-width="1.2"/><path d="M3.5 5h3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+              Confirm Cancel Run
+            </button>
+          </div>
+        </div>
+
+        <!-- 6. Streaming message with code block -->
+        <div class="msg-enter flex gap-2.5">
+          <div class="shrink-0 w-7 h-7 rounded-full flex items-center justify-center mt-0.5"
+               style="background:#0d1a15; border:1px solid #00d4aa33;">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <circle cx="6" cy="6" r="5" stroke="#00d4aa" stroke-width="1.2"/>
+              <path d="M3.5 6h5M6 3.5v5" stroke="#00d4aa" stroke-width="1.2" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="flex-1 text-sm leading-relaxed" style="color:var(--text);">
+            <p class="mb-2">Here's the stage prompt template for the classifier:</p>
+            <pre><code class="language-yaml rounded-lg" style="display:block;">name: classify-issue
+gate_kind: agent-session
+prompt: |
+  You are a GitHub issue triage assistant.
+  Analyze the issue below and output JSON:
+
+  {
+    "labels": ["bug" | "feature" | "question"],
+    "severity": "low" | "medium" | "high",
+    "summary": "one-line description"
+  }
+
+  Issue title: {{issue.title}}
+  Issue body: {{issue.body}}</code></pre>
+            <p class="mt-2 cursor">The governance stage will run if severity is</p>
+          </div>
+        </div>
+
+      </div><!-- /feed -->
+
+      <!-- PINNED COMPOSER -->
+      <div class="shrink-0 px-4 py-3" style="border-top:1px solid var(--border); background:var(--surface);">
+        <div class="flex gap-2 items-end rounded-xl px-3 py-2.5"
+             style="background:var(--bg); border:1px solid var(--border-hi);">
+          <textarea id="composer" rows="1" placeholder="Refine or ask a follow-up…"
+            oninput="autosize(this)" onkeydown="handleKey(event)"
+            style="min-height:20px; max-height:120px;"></textarea>
+          <button id="send-btn" class="btn btn-primary shrink-0" style="height:30px;" onclick="sendDemo()">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M10 6H2M7 3l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Send
+          </button>
+        </div>
+        <div class="flex items-center justify-between mt-1.5 px-0.5">
+          <span class="text-xs" style="color:var(--muted);">11 tools · claude-opus-4-7</span>
+          <span class="text-xs" style="color:var(--muted);">⏎ send · ⇧⏎ newline</span>
+        </div>
+      </div>
+
+    </div><!-- /chat panel -->
+
+    <!-- ═══════════════════════════════ RIGHT PANEL: DAG ═══════════════════════════════ -->
+    <div id="panel-dag" class="hidden md:flex flex-col min-h-0"
+         style="width: 58%; border-left:1px solid var(--border);"
+         data-panel="dag">
+
+      <!-- DAG header -->
+      <div class="flex items-center justify-between px-4 h-11 shrink-0"
+           style="border-bottom:1px solid var(--border); background:var(--surface);">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-medium" style="color:var(--text-hi);">Workflow Preview</span>
+          <span id="dag-status-badge" class="badge" style="background:var(--accent-dim); color:var(--accent); border:1px solid #00d4aa22;">
+            draft
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="mono text-xs" style="color:var(--muted);">GitHub Issue Triage</span>
+          <button class="btn btn-ghost" style="height:24px; font-size:11px;">Export</button>
+        </div>
+      </div>
+
+      <!-- DAG canvas -->
+      <div id="dag-canvas" class="dot-grid flex-1 min-h-0 overflow-auto relative"
+           style="background:var(--bg);">
+        <svg id="dag-svg" xmlns="http://www.w3.org/2000/svg"
+             style="width:100%; min-height:100%; overflow:visible; display:block;">
+
+          <defs>
+            <marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+              <path d="M0,0 L0,6 L6,3 z" fill="#2a2f3d"/>
+            </marker>
+            <marker id="arrow-accent" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+              <path d="M0,0 L0,6 L6,3 z" fill="#00d4aa66"/>
+            </marker>
+          </defs>
+
+          <!-- ── EDGES ── -->
+          <!-- trigger → classify -->
+          <line x1="50%" y1="116" x2="50%" y2="180"
+                stroke="#2a2f3d" stroke-width="1.5" marker-end="url(#arrow)"/>
+          <!-- classify → label -->
+          <line x1="50%" y1="276" x2="50%" y2="340"
+                stroke="#2a2f3d" stroke-width="1.5" marker-end="url(#arrow)"/>
+          <!-- label → escalation -->
+          <line x1="50%" y1="436" x2="50%" y2="500"
+                stroke="#2a2f3d" stroke-width="1.5" marker-end="url(#arrow)"/>
+          <!-- escalation → end -->
+          <line x1="50%" y1="596" x2="50%" y2="640"
+                stroke="#2a2f3d" stroke-width="1.5" marker-end="url(#arrow)"/>
+        </svg>
+
+        <!-- Nodes rendered as HTML on top of SVG background -->
+        <div style="position:absolute; top:0; left:0; right:0; display:flex; flex-direction:column; align-items:center; padding:40px 32px;">
+
+          <!-- TRIGGER NODE -->
+          <div class="dag-node" style="width:260px; margin-bottom:64px;" onclick="selectNode('trigger')">
+            <div class="rounded-xl overflow-hidden" style="border:1.5px solid #3b82f644; background:#0d1520;">
+              <div class="flex items-center gap-2 px-3 py-2"
+                   style="background:#0a1018; border-bottom:1px solid #3b82f622;">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M6 1l1.3 3.9H11L8.3 6.9l1 3.1L6 8l-3.3 2 1-3.1L1 4.9h3.7z"
+                        fill="#3b82f6" opacity="0.8"/>
+                </svg>
+                <span class="mono text-xs" style="color:#60a5fa;">trigger</span>
+                <span class="mono text-xs ml-auto" style="color:var(--muted);">issues.opened</span>
+              </div>
+              <div class="px-3 py-2.5 text-xs" style="color:var(--text);">
+                <div class="font-medium mb-1" style="color:var(--text-hi);">GitHub Issue Opened</div>
+                <div style="color:var(--muted);">onsager-ai/onsager · all labels</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- STAGE 1: agent-session -->
+          <div class="dag-node" style="width:260px; margin-bottom:64px;" onclick="selectNode('s1')">
+            <div class="rounded-xl overflow-hidden" style="border:1.5px solid #3b82f666; background:#0a1020;">
+              <div class="flex items-center gap-2 px-3 py-2"
+                   style="background:#080d1a; border-bottom:1px solid #3b82f633;">
+                <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--agent)"></span>
+                <span class="mono text-xs" style="color:#93c5fd;">Stage 1</span>
+                <span class="badge ml-auto" style="background:#0e1830; color:#60a5fa; border:1px solid #3b82f633;">agent-session</span>
+              </div>
+              <div class="px-3 py-2.5 text-xs" style="color:var(--text);">
+                <div class="font-medium mb-1" style="color:var(--text-hi);">AI Classify &amp; Summarise</div>
+                <div style="color:var(--muted);">claude-opus-4-7 · max_tokens 512</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- STAGE 2: external-check -->
+          <div class="dag-node" style="width:260px; margin-bottom:64px;" onclick="selectNode('s2')">
+            <div class="rounded-xl overflow-hidden" style="border:1.5px solid #a855f766; background:#120a20;">
+              <div class="flex items-center gap-2 px-3 py-2"
+                   style="background:#0d0618; border-bottom:1px solid #a855f733;">
+                <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--external)"></span>
+                <span class="mono text-xs" style="color:#c084fc;">Stage 2</span>
+                <span class="badge ml-auto" style="background:#180e2a; color:#c084fc; border:1px solid #a855f733;">external-check</span>
+              </div>
+              <div class="px-3 py-2.5 text-xs" style="color:var(--text);">
+                <div class="font-medium mb-1" style="color:var(--text-hi);">Apply GitHub Labels</div>
+                <div style="color:var(--muted);">POST /repos/:owner/:repo/issues/:n/labels</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- STAGE 3: manual-approval -->
+          <div class="dag-node" style="width:260px; margin-bottom:64px;" onclick="selectNode('s3')">
+            <div class="rounded-xl overflow-hidden" style="border:1.5px solid #22c55e66; background:#0a1a10;">
+              <div class="flex items-center gap-2 px-3 py-2"
+                   style="background:#061210; border-bottom:1px solid #22c55e33;">
+                <span class="w-2 h-2 rounded-full shrink-0" style="background:var(--approval)"></span>
+                <span class="mono text-xs" style="color:#86efac;">Stage 3</span>
+                <span class="badge ml-auto" style="background:#0c1e10; color:#4ade80; border:1px solid #22c55e33;">manual-approval</span>
+              </div>
+              <div class="px-3 py-2.5 text-xs" style="color:var(--text);">
+                <div class="font-medium mb-1" style="color:var(--text-hi);">Escalation Approval</div>
+                <div style="color:var(--muted);">Required when severity = high</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- END NODE -->
+          <div style="width:260px;">
+            <div class="rounded-xl flex items-center justify-center py-2.5 gap-2"
+                 style="border:1.5px solid var(--border-hi); background:var(--surface);">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                <circle cx="6" cy="6" r="5" stroke="#4a5068" stroke-width="1.2"/>
+                <path d="M3.5 6l2 2 3-3.5" stroke="#4a5068" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="mono text-xs" style="color:var(--muted);">end</span>
+            </div>
+          </div>
+
+        </div>
+      </div><!-- /dag-canvas -->
+
+      <!-- DAG footer: legend -->
+      <div class="flex items-center gap-5 px-4 py-2 shrink-0"
+           style="border-top:1px solid var(--border); background:var(--surface);">
+        <span class="text-xs" style="color:var(--muted);">Gate kinds:</span>
+        <span class="flex items-center gap-1.5 text-xs" style="color:var(--muted);">
+          <span class="w-2 h-2 rounded-full" style="background:var(--agent)"></span>agent-session
+        </span>
+        <span class="flex items-center gap-1.5 text-xs" style="color:var(--muted);">
+          <span class="w-2 h-2 rounded-full" style="background:var(--external)"></span>external-check
+        </span>
+        <span class="flex items-center gap-1.5 text-xs" style="color:var(--muted);">
+          <span class="w-2 h-2 rounded-full" style="background:var(--governance)"></span>governance
+        </span>
+        <span class="flex items-center gap-1.5 text-xs" style="color:var(--muted);">
+          <span class="w-2 h-2 rounded-full" style="background:var(--approval)"></span>manual-approval
+        </span>
+      </div>
+
+    </div><!-- /dag panel -->
+
+  </div><!-- /main -->
+</div><!-- /app -->
+
+<!-- NODE DETAIL DRAWER (hidden initially) -->
+<div id="node-drawer" class="fixed bottom-0 left-0 right-0 md:left-auto md:top-0 md:bottom-0 md:w-72 z-50 transition-transform"
+     style="background:var(--surface); border-top:1px solid var(--border-hi); transform:translateY(100%);">
+  <div class="flex items-center justify-between px-4 py-3"
+       style="border-bottom:1px solid var(--border);">
+    <span id="drawer-title" class="text-sm font-medium" style="color:var(--text-hi);">Node Details</span>
+    <button class="btn btn-ghost" style="height:24px;font-size:11px;" onclick="closeDrawer()">✕</button>
+  </div>
+  <div id="drawer-body" class="p-4 text-xs space-y-3" style="color:var(--text);"></div>
+</div>
+
+<script>
+  // ── Syntax highlight ──────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('pre code').forEach(el => hljs.highlightElement(el));
+  });
+
+  // ── Autosize textarea ─────────────────────────────────────────────
+  function autosize(el) {
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 120) + 'px';
+  }
+
+  // ── Key handler ───────────────────────────────────────────────────
+  function handleKey(e) {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendDemo(); }
+  }
+
+  // ── Send demo ─────────────────────────────────────────────────────
+  function sendDemo() {
+    const ta = document.getElementById('composer');
+    const text = ta.value.trim();
+    if (!text) return;
+    ta.value = ''; ta.style.height = 'auto';
+
+    // User bubble
+    const feed = document.getElementById('feed');
+    const userDiv = document.createElement('div');
+    userDiv.className = 'msg-enter flex justify-end';
+    userDiv.innerHTML = `<div class="max-w-xs rounded-2xl rounded-tr-sm px-3.5 py-2.5 text-sm"
+      style="background:#1a2033; color:var(--text-hi); border:1px solid var(--border-hi);">${text}</div>`;
+    feed.appendChild(userDiv);
+
+    // Streaming assistant reply
+    setTimeout(() => {
+      const msgs = [
+        "Got it. Updating the workflow to add a governance stage after the agent-session. This ensures high-severity issues route through your compliance check before labeling.",
+        "I've also tightened the prompt to output structured JSON so the external-check stage can read `labels` directly without parsing."
+      ];
+      const reply = msgs[Math.floor(Math.random() * msgs.length)];
+
+      const aDiv = document.createElement('div');
+      aDiv.className = 'msg-enter flex gap-2.5';
+      aDiv.innerHTML = `
+        <div class="shrink-0 w-7 h-7 rounded-full flex items-center justify-center mt-0.5"
+             style="background:#0d1a15; border:1px solid #00d4aa33;">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <circle cx="6" cy="6" r="5" stroke="#00d4aa" stroke-width="1.2"/>
+            <path d="M3.5 6h5M6 3.5v5" stroke="#00d4aa" stroke-width="1.2" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div class="flex-1 text-sm leading-relaxed" style="color:var(--text);">
+          <span id="stream-target"></span><span class="cursor"></span>
+        </div>`;
+      feed.appendChild(aDiv);
+      feed.scrollTop = feed.scrollHeight;
+
+      streamText(document.getElementById('stream-target'), reply, () => {
+        // remove cursor after done
+        aDiv.querySelector('.cursor').remove();
+        feed.scrollTop = feed.scrollHeight;
+      });
+    }, 400);
+
+    feed.scrollTop = feed.scrollHeight;
+  }
+
+  // ── Streaming text animation ──────────────────────────────────────
+  function streamText(el, text, onDone, i = 0) {
+    if (i >= text.length) { onDone?.(); return; }
+    el.textContent += text[i];
+    el.closest('.feed')?.scrollTo({ top: 99999 });
+    setTimeout(() => streamText(el, text, onDone, i + 1), 18 + Math.random() * 14);
+  }
+
+  // ── HITL accept / reject ──────────────────────────────────────────
+  function acceptCard(id) {
+    const card = document.getElementById(id);
+    card.classList.remove('hitl-pending');
+    card.classList.add('hitl-accepted');
+    card.querySelector('.btn-accept')?.remove();
+    card.querySelector('.btn-reject')?.remove();
+    card.querySelector('.btn-ghost')?.remove();
+
+    const footer = card.querySelector('[style*="border-top"]');
+    footer.innerHTML = `<div class="flex items-center gap-1.5 text-xs" style="color:#4ade80;">
+      <svg width="11" height="11" viewBox="0 0 11 11"><path d="M1.5 5.5l2.5 3 5-6" stroke="#4ade80" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      Accepted
+    </div>`;
+
+    // update DAG badge
+    document.getElementById('dag-status-badge').textContent = 'pending save';
+    document.getElementById('dag-status-badge').style.cssText = 'background:#1a2033; color:#60a5fa; border:1px solid #3b82f633;';
+  }
+
+  function rejectCard(id) {
+    const card = document.getElementById(id);
+    card.classList.remove('hitl-pending');
+    card.classList.add('hitl-rejected');
+    const footer = card.querySelector('[style*="border-top"]');
+    footer.innerHTML = `<div class="flex items-center gap-1.5 text-xs" style="color:#f87171;">
+      <svg width="11" height="11" viewBox="0 0 11 11"><path d="M2 2l7 7M9 2l-7 7" stroke="#f87171" stroke-width="1.4" stroke-linecap="round"/></svg>
+      Rejected
+    </div>`;
+  }
+
+  function editCard() {
+    alert('Edit mode: in production this would open an inline JSON editor.');
+  }
+
+  // ── Mobile tab switching ──────────────────────────────────────────
+  function switchTab(tab) {
+    const chatPanel = document.getElementById('panel-chat');
+    const dagPanel  = document.getElementById('panel-dag');
+    const tabChat   = document.getElementById('tab-chat');
+    const tabDag    = document.getElementById('tab-dag');
+
+    if (tab === 'chat') {
+      chatPanel.classList.remove('hidden'); chatPanel.classList.add('flex');
+      dagPanel.classList.add('hidden');    dagPanel.classList.remove('flex');
+      tabChat.className = 'flex-1 tab-active py-2.5 text-xs font-medium transition-all';
+      tabDag.className  = 'flex-1 tab-inactive py-2.5 text-xs font-medium transition-all';
+    } else {
+      dagPanel.classList.remove('hidden'); dagPanel.classList.add('flex');
+      chatPanel.classList.add('hidden');   chatPanel.classList.remove('flex');
+      tabDag.className  = 'flex-1 tab-active py-2.5 text-xs font-medium transition-all';
+      tabChat.className = 'flex-1 tab-inactive py-2.5 text-xs font-medium transition-all';
+    }
+    // fix tab styles (no background/border from btn)
+    [tabChat, tabDag].forEach(t => { t.style.background='transparent'; t.style.border='none'; });
+  }
+
+  // ── Desktop: fix panel widths ─────────────────────────────────────
+  function applyDesktopLayout() {
+    const chatPanel = document.getElementById('panel-chat');
+    const dagPanel  = document.getElementById('panel-dag');
+    if (window.innerWidth >= 768) {
+      chatPanel.style.width = '42%';
+      chatPanel.classList.remove('hidden');
+      chatPanel.classList.add('flex');
+      dagPanel.classList.remove('hidden');
+      dagPanel.classList.add('flex');
+    } else {
+      chatPanel.style.width = '100%';
+      dagPanel.classList.add('hidden');
+      dagPanel.classList.remove('flex');
+    }
+  }
+  window.addEventListener('resize', applyDesktopLayout);
+  applyDesktopLayout();
+
+  // ── Node detail drawer ─────────────────────────────────────────────
+  const nodeData = {
+    trigger: {
+      title: 'Trigger: issues.opened',
+      body: `<div class="space-y-2.5">
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">repository</div>
+          <div style="color:var(--text-hi);">onsager-ai/onsager</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">event</div>
+          <div class="mono" style="color:#60a5fa;">issues.opened</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">install_id</div>
+          <div class="mono" style="color:var(--text-hi);">58231940</div></div>
+      </div>`
+    },
+    s1: {
+      title: 'Stage 1 — Agent Session',
+      body: `<div class="space-y-2.5">
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">gate_kind</div>
+          <span class="badge" style="background:#0e1830;color:#60a5fa;border:1px solid #3b82f633;">agent-session</span></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">model</div>
+          <div style="color:var(--text-hi);">claude-opus-4-7</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">max_tokens</div>
+          <div class="mono" style="color:var(--text-hi);">512</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">timeout</div>
+          <div class="mono" style="color:var(--text-hi);">30s</div></div>
+      </div>`
+    },
+    s2: {
+      title: 'Stage 2 — External Check',
+      body: `<div class="space-y-2.5">
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">gate_kind</div>
+          <span class="badge" style="background:#180e2a;color:#c084fc;border:1px solid #a855f733;">external-check</span></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">endpoint</div>
+          <div class="mono" style="color:var(--text-hi); word-break:break-all;">POST /repos/{owner}/{repo}/issues/{n}/labels</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">auth</div>
+          <div style="color:var(--text-hi);">GitHub App credential</div></div>
+      </div>`
+    },
+    s3: {
+      title: 'Stage 3 — Manual Approval',
+      body: `<div class="space-y-2.5">
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">gate_kind</div>
+          <span class="badge" style="background:#0c1e10;color:#4ade80;border:1px solid #22c55e33;">manual-approval</span></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">condition</div>
+          <div class="mono" style="color:var(--text-hi);">severity == "high"</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">assignee</div>
+          <div style="color:var(--text-hi);">workspace admins</div></div>
+        <div><div class="mono" style="color:var(--muted);margin-bottom:3px;">timeout</div>
+          <div class="mono" style="color:var(--text-hi);">48h</div></div>
+      </div>`
+    }
+  };
+
+  function selectNode(id) {
+    const data = nodeData[id];
+    if (!data) return;
+    document.getElementById('drawer-title').textContent = data.title;
+    document.getElementById('drawer-body').innerHTML = data.body;
+    const drawer = document.getElementById('node-drawer');
+    drawer.style.transform = 'translateY(0)';
+    drawer.style.borderRight = '1px solid var(--border-hi)';
+  }
+
+  function closeDrawer() {
+    document.getElementById('node-drawer').style.transform = 'translateY(100%)';
+  }
+</script>
+</body>
+</html>

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,23 @@
 {
   "version": 1,
   "skills": {
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/frontend-design/SKILL.md",
+      "computedHash": "063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67"
+    },
     "plan-dag": {
       "source": "onsager-ai/onsager-skills",
       "sourceType": "github",
       "skillPath": "skills/plan-dag/SKILL.md",
       "computedHash": "448edc2a6042bfab30d3a8efbe70ef3f8e2dcd633286beb826fb73eb2f78fce4"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/web-design-guidelines/SKILL.md",
+      "computedHash": "a6a44d5498f7e8f68289902f3dedfc6f38ae0cee1e96527c80724cf27f727c2a"
     }
   }
 }


### PR DESCRIPTION
## Summary

Design prototype for the proper Onsager chat surface. Self-contained HTML file — open `design/chat-workflow-prototype.html` directly in a browser or view via the Railway preview.

**Covers:**
- Split-panel layout (42% chat / 58% DAG) with fullBleed scroll model
- Streaming assistant bubbles (character-by-character animation)
- HITL cards: constructive (`propose_workflow`, amber glow) and destructive (`cancel_run`, red) variants with accept/reject state transitions
- Info blocks for read-only tool results
- Workflow DAG: trigger → stage nodes (color-coded by gate kind) → end, SVG edges, click-to-open node detail drawer
- Mobile: tab strip switching between Chat and DAG views
- `highlight.js` One Dark Pro theme for code blocks
- Aesthetic: dark industrial (`#0b0d11` + dot grid + `#00d4aa` cyan accent), IBM Plex Mono + Geist

## Purpose

This is a **design alignment artifact** — review and give feedback before we implement the proper React version. Try:
1. Type a message in the composer and press Enter → streaming reply animation
2. Click Accept/Reject on the HITL cards
3. Click any DAG node → detail drawer
4. Resize to mobile width → tab strip

Part of #330

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHQZoiKPcMoQjQM1jndTgX)_