### PR TITLE
docs(claude.md) + test(portal): pin reference-only contract (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,14 +567,19 @@ the same PR that introduces them.
   system owns. Provider-authored fields (title, body, labels, author)
   are hydrated live by the dashboard through a portal proxy
   (`crates/onsager-portal/src/handlers/live_data.rs`) backed by a short-
-  TTL per-installation cache (`proxy_cache.rs`). New external integrations
-  inherit this by default: ship a proxy, not a denormalizer.
+  TTL process-local cache (`proxy_cache.rs`, keyed by project/resource,
+  shared across all installations in a replica). New external integrations
+  inherit this by default: ship a proxy, not a denormalizer. Enforced
+  today by review and `crates/onsager-portal/tests/reference_only_artifacts.rs`,
+  which pins the existing PR/issue helpers; a mechanical lint for new
+  external-origin write paths is a follow-up.
 
 The strategy spec #131 captures the full reasoning and the six-lever plan
-that made these contracts enforced. The patterns above are now caught
-mechanically by `lint-seams`, `check-api-contract`, and `check-events`;
-the bullets stay as a glossary of the failure modes those checks were
-designed against.
+that made these contracts enforced. The first five bullets above are now
+caught mechanically by `lint-seams`, `check-api-contract`, and
+`check-events`; the bullets stay as a glossary of the failure modes those
+checks were designed against. The denormalized-external-state bullet is
+the exception — review + contract test today, mechanical check pending.
 
 ## Workspace layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,6 +556,19 @@ the same PR that introduces them.
   to outlive their intended window. Land the rename and the alias removal
   in the same PR; don't open a removal-date window. `lint-seams` hard-fails
   on new `serde(alias)` and on legacy type aliases.
+- **Denormalized external state.** When an external system (GitHub, Linear,
+  Slack, …) is the author of a field, copying it into the spine creates a
+  drift surface — every retitle, label edit, author transfer, body rewrite
+  is either a webhook we have to chase or a row that quietly goes stale.
+  Per spec #170, external-origin artifacts are **reference-only**: the
+  spine row carries identity (`external_ref`), *our* derived lifecycle
+  (`state`, `current_version`, `last_observed_at`), and *our* relationships
+  (lineage, governance verdicts, ising signals) — nothing the external
+  system owns. Provider-authored fields (title, body, labels, author)
+  are hydrated live by the dashboard through a portal proxy
+  (`crates/onsager-portal/src/handlers/live_data.rs`) backed by a short-
+  TTL per-installation cache (`proxy_cache.rs`). New external integrations
+  inherit this by default: ship a proxy, not a denormalizer.
 
 The strategy spec #131 captures the full reasoning and the six-lever plan
 that made these contracts enforced. The patterns above are now caught

--- a/crates/onsager-portal/tests/reference_only_artifacts.rs
+++ b/crates/onsager-portal/tests/reference_only_artifacts.rs
@@ -1,0 +1,219 @@
+//! Umbrella contract test for spec #170 (reference-only external artifacts).
+//!
+//! The umbrella's invariant is single-sentence: the spine never copies
+//! provider-authored fields. For both `Kind::PullRequest` (child #171) and
+//! `Kind::GithubIssue` (child #167), `upsert_pr_artifact_ref` /
+//! `upsert_issue_artifact_ref` write identity + our derived lifecycle and
+//! nothing else — `name` and `owner` stay NULL on every insert and every
+//! subsequent state transition. A PR retitle / author transfer / label edit
+//! on GitHub does not touch the spine row because there is no field to
+//! drift; the dashboard hydrates the live title via the portal proxy
+//! (`live_data.rs` + `proxy_cache.rs`) instead of off the artifact row.
+//!
+//! This test pins that contract end-to-end against a real Postgres so the
+//! invariant cannot regress to "we wrote NULL today but a future PR
+//! quietly starts populating it again". The PR-side and issue-side cases
+//! are kept symmetrical on purpose — the umbrella's whole point is that
+//! the two external-origin kinds share one shape.
+//!
+//! Skipped when `DATABASE_URL` is unset — the contract lives in the spine
+//! schema, which only the Postgres-backed harness exercises.
+
+use onsager_portal::db::{
+    self, IssueLifecycleState, PrLifecycleState, issue_external_ref, pr_external_ref,
+};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+async fn fetch_columns(
+    spine: &PgPool,
+    artifact_id: &str,
+) -> (Option<String>, Option<String>, String, i32, Option<String>) {
+    let row = sqlx::query(
+        "SELECT name, owner, state, current_version, external_ref \
+           FROM artifacts WHERE artifact_id = $1",
+    )
+    .bind(artifact_id)
+    .fetch_one(spine)
+    .await
+    .expect("artifact row");
+    (
+        row.try_get("name").unwrap(),
+        row.try_get("owner").unwrap(),
+        row.get("state"),
+        row.get("current_version"),
+        row.try_get("external_ref").unwrap(),
+    )
+}
+
+async fn cleanup(spine: &PgPool, artifact_id: &str) {
+    let _ = sqlx::query("DELETE FROM artifacts WHERE artifact_id = $1")
+        .bind(artifact_id)
+        .execute(spine)
+        .await;
+}
+
+#[tokio::test]
+async fn pr_skeleton_never_writes_name_or_owner() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let pr_number: u64 = 42;
+
+    // First webhook (pull_request.opened): skeleton row created.
+    let created =
+        db::upsert_pr_artifact_ref(&spine, &project_id, pr_number, PrLifecycleState::InProgress)
+            .await
+            .expect("initial upsert");
+
+    let (name, owner, state, version, external_ref) =
+        fetch_columns(&spine, &created.artifact_id).await;
+    assert!(name.is_none(), "PR skeleton must not store GitHub title");
+    assert!(owner.is_none(), "PR skeleton must not store GitHub author");
+    assert_eq!(state, "in_progress");
+    assert_eq!(version, 1);
+    assert_eq!(
+        external_ref.as_deref(),
+        Some(pr_external_ref(&project_id, pr_number).as_str())
+    );
+
+    // pull_request.edited (title rename on GitHub): the umbrella's headline
+    // test — the row must not drift even when the upstream renames. The
+    // PR webhook handler only re-runs the upsert with the current lifecycle
+    // state, so we model that here.
+    let renamed =
+        db::upsert_pr_artifact_ref(&spine, &project_id, pr_number, PrLifecycleState::InProgress)
+            .await
+            .expect("re-upsert after rename");
+    assert_eq!(
+        renamed.artifact_id, created.artifact_id,
+        "idempotent on external_ref"
+    );
+
+    let (name_after, owner_after, _, _, _) = fetch_columns(&spine, &created.artifact_id).await;
+    assert!(
+        name_after.is_none(),
+        "rename must not surface a title on the spine row"
+    );
+    assert!(
+        owner_after.is_none(),
+        "rename must not surface an author on the spine row"
+    );
+
+    // pull_request.closed → state flips to released, name/owner stay NULL.
+    db::upsert_pr_artifact_ref(&spine, &project_id, pr_number, PrLifecycleState::Released)
+        .await
+        .expect("close upsert");
+    let (name_closed, owner_closed, state_closed, _, _) =
+        fetch_columns(&spine, &created.artifact_id).await;
+    assert!(name_closed.is_none());
+    assert!(owner_closed.is_none());
+    assert_eq!(state_closed, "released");
+
+    cleanup(&spine, &created.artifact_id).await;
+}
+
+#[tokio::test]
+async fn issue_skeleton_never_writes_name_or_owner() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let issue_number: u64 = 7;
+
+    let created = db::upsert_issue_artifact_ref(
+        &spine,
+        &project_id,
+        issue_number,
+        IssueLifecycleState::Draft,
+    )
+    .await
+    .expect("initial upsert");
+
+    let (name, owner, state, version, external_ref) =
+        fetch_columns(&spine, &created.artifact_id).await;
+    assert!(name.is_none(), "issue skeleton must not store GitHub title");
+    assert!(
+        owner.is_none(),
+        "issue skeleton must not store GitHub author"
+    );
+    assert_eq!(state, "draft");
+    assert_eq!(version, 1);
+    assert_eq!(
+        external_ref.as_deref(),
+        Some(issue_external_ref(&project_id, issue_number).as_str())
+    );
+
+    // issues.closed → archived; issues.reopened → draft; no name/author churn.
+    db::upsert_issue_artifact_ref(
+        &spine,
+        &project_id,
+        issue_number,
+        IssueLifecycleState::Archived,
+    )
+    .await
+    .expect("close upsert");
+    let (_, _, state_closed, _, _) = fetch_columns(&spine, &created.artifact_id).await;
+    assert_eq!(state_closed, "archived");
+
+    db::upsert_issue_artifact_ref(
+        &spine,
+        &project_id,
+        issue_number,
+        IssueLifecycleState::Draft,
+    )
+    .await
+    .expect("reopen upsert");
+    let (name_reopen, owner_reopen, state_reopen, _, _) =
+        fetch_columns(&spine, &created.artifact_id).await;
+    assert!(name_reopen.is_none());
+    assert!(owner_reopen.is_none());
+    assert_eq!(state_reopen, "draft");
+
+    cleanup(&spine, &created.artifact_id).await;
+}
+
+#[tokio::test]
+async fn touch_artifact_bumps_version_but_leaves_provider_fields_null() {
+    // `issues.edited` / `issues.labeled` flow through `touch_artifact`,
+    // which bumps `current_version` + `last_observed_at`. The umbrella's
+    // contract is that this path also never writes provider-authored
+    // fields — even when GitHub fires an edit/label event, the spine row
+    // shape doesn't move.
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let issue_number: u64 = 99;
+
+    let created = db::upsert_issue_artifact_ref(
+        &spine,
+        &project_id,
+        issue_number,
+        IssueLifecycleState::Draft,
+    )
+    .await
+    .expect("seed");
+
+    let new_version = db::touch_artifact(&spine, &created.artifact_id)
+        .await
+        .expect("touch");
+    assert_eq!(new_version, 2, "touch_artifact bumps current_version");
+
+    let (name, owner, state, version, _) = fetch_columns(&spine, &created.artifact_id).await;
+    assert!(name.is_none(), "touch_artifact must not surface a title");
+    assert!(owner.is_none(), "touch_artifact must not surface an author");
+    assert_eq!(state, "draft", "touch_artifact leaves state alone");
+    assert_eq!(version, 2);
+
+    cleanup(&spine, &created.artifact_id).await;
+}


### PR DESCRIPTION
## Summary

Lands the umbrella's two direct artifacts from spec #170:

- **CLAUDE.md drift-patterns catalogue** gains a "Denormalized external state" entry that points at the reference-only principle so future external integrations (Linear, Slack, Sentry, …) inherit "ship a proxy, not a denormalizer" by default. Cross-references `live_data.rs` + `proxy_cache.rs` as the enforcement surface.
- **Postgres-backed contract test** at `crates/onsager-portal/tests/reference_only_artifacts.rs` pins the umbrella's headline invariant: `upsert_pr_artifact_ref` / `upsert_issue_artifact_ref` / `touch_artifact` never populate `name` or `owner` on insert, re-upsert (the GitHub retitle path), or state transitions (close / reopen). The PR-side and issue-side cases are kept symmetrical on purpose — the umbrella's whole point is that the two external-origin kinds share one shape, so the regression check shares one shape too.

The schema migration (`011_artifacts_external_ref_only.sql`) and both children's code paths (`upsert_pr_artifact_ref` for #171, `upsert_issue_artifact_ref` for #167) had already landed; this PR closes out the umbrella by adding the doc + the contract gate.

Closes #170.

## Test plan

- [x] `cargo build -p onsager-portal --tests` — compiles
- [x] `cargo test -p onsager-portal --test reference_only_artifacts` — all 3 tests pass (skip cleanly without `DATABASE_URL`, mirroring `workflow_delete.rs`)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo run -p xtask --quiet -- lint-seams` — clean
- [x] `cargo run -p xtask --quiet -- check-api-contract` — clean
- [x] `cargo run -p xtask --quiet -- check-file-budget --mode=fail` — clean (CLAUDE.md not in the .rs/.ts/.tsx scope)
- [ ] When `DATABASE_URL` is set in CI, the three contract tests exercise insert / re-upsert / state-transition / touch paths against the live spine schema.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3KyF73SqbYkUHmNxNYSf9)_