### PR TITLE
chore: cut v0.1.0, bump to 0.2.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ project does not yet publish numbered releases.
 
 ## [Unreleased]
 
+### Changed
+- Begin 0.2 substrate re-foundation (see milestone `0.2-refoundation`)
+- Workspace version bumped to `0.2.0-alpha.1`
+
+## [0.1.0] - 2026-05-15
+
 ### Added
 - **Stiglab + Railway**: cross-env SSO delegation so per-PR preview
   environments can piggy-back off prod's single registered GitHub
@@ -461,3 +467,7 @@ project does not yet publish numbered releases.
 - Root `README.md` and `apps/dashboard/README.md` rewritten to match the
   current monorepo layout (forge, ising) and `just dev` workflow.
 - Outdated specs archived; spec indexes updated.
+
+### Frozen
+- Final state of 5-subsystem era: forge / synodic / stiglab / ising / refract
+- This is the last release of the pre-substrate code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1323,7 +1323,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "ising"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1626,11 +1626,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onsager"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 
 [[package]]
 name = "onsager-artifact"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "onsager-github"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "onsager-portal"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "onsager-registry"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "onsager-spine"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "onsager-trigger"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "refract"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2736,7 +2736,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stiglab"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "synodic"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3954,7 +3954,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/onsager-ai/onsager"


### PR DESCRIPTION
Anchors the 5-subsystem era as `v0.1.0`. Begins 0.2 substrate re-foundation.

## Changes
- `CHANGELOG.md`: moves all `[Unreleased]` content into a new `[0.1.0] - 2026-05-15` section; adds `### Frozen` note at bottom marking end of 5-subsystem era; adds new empty `[Unreleased]` with the 0.2 re-foundation entry
- `Cargo.toml`: bumps workspace `version` from `0.1.0` → `0.2.0-alpha.1`
- `Cargo.lock`: regenerated

## Post-merge action
After squash-merge, tag `v0.1.0` at the resulting main commit:
```
git checkout main && git pull
git tag -a v0.1.0 -m "5-subsystem era final state"
git push origin v0.1.0
```

`trivial`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLtCoELs8uTbXVdLpZbMMD)_