### PR TITLE
chore(skills): sync plan-dag PNG target from onsager-skills

### DIFF
--- a/.claude/skills/plan-dag/SKILL.md
+++ b/.claude/skills/plan-dag/SKILL.md
@@ -29,7 +29,7 @@ Skip when:
 |-----------|----------|
 | **Scope** | Inferred — current branch's spec, the umbrella the user named, or the open issues just surveyed. |
 | **Granularity** | Spec-level; drop to sub-issue / PR level for an umbrella that has fanned out. |
-| **Output format** | Monospace text (Unicode box-drawing) laid out top-to-bottom via graphviz (default). `--as=ascii` for a pure-ASCII tree; `--as=dot` for raw DOT. |
+| **Output format** | Monospace text (Unicode box-drawing) laid out top-to-bottom via graphviz (default). `--as=png --out <path>` for a high-DPI image (preferred on image-capable chat surfaces — see below); `--as=ascii` for a pure-ASCII tree; `--as=dot` for raw DOT. |
 
 ## Workflow
 
@@ -104,7 +104,7 @@ Emit a JSON IR matching the schema below, then invoke the renderer. **Do not han
 - Every `from` / `to` resolves to a declared node id, or the literal `"close"`.
 - `critical_path` is optional; renderer appends it as a callout under the box-drawing and ASCII targets.
 
-**Invocation.** Default emits top-to-bottom box-drawing via graphviz (requires `dot` on PATH — `apt install graphviz`, or `brew install graphviz`) and is the right choice for normal use. `--as=ascii` produces a pure-ASCII indented tree with no external dependency — used explicitly for restricted terminals, and selected automatically (with a stderr note) when `dot` is missing. `--as=dot` emits raw DOT source for piping or debugging.
+**Invocation.** Default emits top-to-bottom box-drawing via graphviz (requires `dot` on PATH — `apt install graphviz`, or `brew install graphviz`) and is the right choice for terminal-only surfaces. `--as=png --out <path>` rasterises the same DOT through `dot -Tsvg` and a headless Chromium screenshot at deviceScaleFactor=2 — sharper than `dot -Tpng` and the preferred output when the chat surface can show inline images (see Response handling below). Needs `dot`, `node`, and Playwright Chromium on PATH. `--as=ascii` produces a pure-ASCII indented tree with no external dependency — used explicitly for restricted terminals, and selected automatically (with a stderr note) when `dot` is missing. `--as=dot` emits raw DOT source for piping or debugging.
 
 The renderer ships inside the skill. Use the path that matches how the skill was installed:
 
@@ -119,6 +119,9 @@ SCRIPT=.claude/skills/plan-dag/scripts/plan-dag-render.py   # project install
 
 # default: top-to-bottom box-drawing via graphviz
 "$SCRIPT" /tmp/plan.json
+
+# high-DPI PNG (preferred on image-capable surfaces; then SendUserFile)
+"$SCRIPT" /tmp/plan.json --as=png --out /tmp/plan-dag.png
 
 # pure ASCII tree (no external deps; auto-selected when `dot` is missing)
 "$SCRIPT" /tmp/plan.json --as=ascii
@@ -135,8 +138,9 @@ If the renderer aborts with `IR validation failed`, fix the IR — do not work a
 - Do **not** retype or paraphrase the renderer output. Copy the tool result verbatim. A single shifted character destroys column alignment, and the AI's spatial reasoning is the failure mode the script was introduced to eliminate.
 - Surface rules:
   - **Claude Code (terminal runtime):** the stdout is already visible in the terminal pane. Do not duplicate it in the reply. Add commentary only — critical path summary, next pickable node, sequencing rationale.
-  - **claude.ai web / mobile (no terminal pane):** echo the stdout once, fenced as ` ```text `, then add commentary below.
-- For very wide graphs (>10 nodes with cross-edges) where the default box-drawing is unwieldy, split the plan into per-track DAGs (one renderer call per track) and render the cross-edges as a final short prose list, per the existing "Cross-edges" convention in §3.
+  - **claude.ai web / mobile, Claude Code on the web (image-capable, no real terminal pane):** prefer the PNG path. Render with `--as=png --out /tmp/plan-dag.png` and send the file via `SendUserFile` so the user sees a rasterised image instead of a wall of glyphs that may reflow under proportional fonts. Add prose commentary below the file — critical path, next pickable node — but don't echo the text-art version too.
+  - **No image surface available (raw terminals, restricted runtimes):** the default stdout box-drawing remains the right output. PR descriptions also prefer the text version since GitHub renders ` ```text ` blocks faithfully.
+- For very wide graphs (>10 nodes with cross-edges) where the default box-drawing is unwieldy, split the plan into per-track DAGs (one renderer call per track) and render the cross-edges as a final short prose list, per the existing "Cross-edges" convention in §3. The PNG target scales further before it becomes unwieldy than the text target does.
 
 ## Conventions
 

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.py
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.py
@@ -456,16 +456,70 @@ def render_ascii(ir):
     return out
 
 
+def render_png(ir, out_path):
+    """Render the IR as a high-quality PNG.
+
+    Pipeline: dot -Tsvg → headless Chromium (via Playwright) → PNG. Going
+    through the browser instead of `dot -Tpng` gives sharper text and
+    correct anti-aliasing at high DPI, which matters when the PNG is
+    surfaced to the user as an inline chat image.
+    """
+    if shutil.which("dot") is None:
+        sys.exit(
+            "--as=png requires `dot` (graphviz) on PATH. "
+            "Install: apt install graphviz, or brew install graphviz."
+        )
+    if shutil.which("node") is None:
+        sys.exit(
+            "--as=png requires Node (node ≥18) on PATH for Playwright."
+        )
+    script_dir = Path(__file__).resolve().parent
+    svg_to_png = script_dir / "svg-to-png.mjs"
+    if not svg_to_png.exists():
+        sys.exit(f"--as=png: missing helper {svg_to_png}")
+
+    dot_src = render_dot(ir)
+    try:
+        svg_res = subprocess.run(
+            ["dot", "-Tsvg"], input=dot_src,
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit("`dot -Tsvg` timed out after 10s.")
+    if svg_res.returncode != 0:
+        sys.stderr.write(svg_res.stderr)
+        sys.exit(svg_res.returncode)
+
+    try:
+        png_res = subprocess.run(
+            ["node", str(svg_to_png), out_path],
+            input=svg_res.stdout, capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit("svg-to-png.mjs timed out after 30s.")
+    if png_res.returncode != 0:
+        sys.stderr.write(png_res.stderr)
+        sys.exit(png_res.returncode)
+    sys.stderr.write(png_res.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser(description="Render plan DAG IR.")
     ap.add_argument("ir", help="path to JSON IR, or '-' for stdin")
     ap.add_argument(
         "--as", dest="target", default=None,
-        choices=["ascii", "dot"],
+        choices=["ascii", "dot", "png"],
         help="output target. Default: top-to-bottom box-drawing via graphviz "
              "(requires `dot`; auto-falls back to --as=ascii when missing). "
+             "--as=png: high-quality PNG via graphviz SVG + headless "
+             "Chromium (requires `dot`, `node`, and Playwright Chromium; "
+             "use --out to set the path). "
              "--as=ascii: pure-ASCII tree, no external deps. "
              "--as=dot: raw DOT source.",
+    )
+    ap.add_argument(
+        "--out", default=None,
+        help="output file path. Required for --as=png; ignored otherwise.",
     )
     args = ap.parse_args()
 
@@ -495,6 +549,10 @@ def main():
         print(render_dot(ir))
     elif target == "ascii":
         print(render_ascii(ir))
+    elif target == "png":
+        if not args.out:
+            sys.exit("--as=png requires --out <path>")
+        render_png(ir, args.out)
     else:
         print(render_tb_boxart(ir))
         cp = ir.get("critical_path")

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.py
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.py
@@ -488,7 +488,7 @@ def render_png(ir, out_path):
         sys.exit("`dot -Tsvg` timed out after 10s.")
     if svg_res.returncode != 0:
         sys.stderr.write(svg_res.stderr)
-        sys.exit(svg_res.returncode)
+        sys.exit(svg_res.returncode or 1)
 
     try:
         png_res = subprocess.run(
@@ -499,7 +499,7 @@ def render_png(ir, out_path):
         sys.exit("svg-to-png.mjs timed out after 30s.")
     if png_res.returncode != 0:
         sys.stderr.write(png_res.stderr)
-        sys.exit(png_res.returncode)
+        sys.exit(png_res.returncode or 1)
     sys.stderr.write(png_res.stderr)
 
 

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
@@ -120,13 +120,17 @@ for tgt in tb ascii; do
 done
 
 echo "--as=png smoke (skipped without node + Playwright Chromium)"
+# Skip markers — any of these in the helper's stderr means the local env is
+# missing a Playwright/Chromium piece and the test should be skipped rather
+# than fail loudly.
+png_skip_re='cannot load Playwright|Executable doesn.t exist|browserType\.launch|playwright install'
 if command -v node >/dev/null 2>&1; then
     png_out="$tmp/happy.png"
     "$SCRIPT" "$FIX/happy.json" --as=png --out "$png_out" >"$tmp/png.out" 2>"$tmp/png.err"
     rc=$?
     if [ "$rc" -ne 0 ]; then
-        if grep -q 'cannot load Playwright' "$tmp/png.err"; then
-            printf '  skip --as=png (Playwright not installed)\n'
+        if grep -qE "$png_skip_re" "$tmp/png.err"; then
+            printf '  skip --as=png (Playwright/Chromium not available)\n'
         else
             fail=$((fail + 1))
             printf '  FAIL --as=png exited %d\n' "$rc"
@@ -135,9 +139,10 @@ if command -v node >/dev/null 2>&1; then
     elif [ ! -s "$png_out" ]; then
         fail=$((fail + 1))
         printf '  FAIL --as=png produced empty output\n'
-    elif ! head -c 8 "$png_out" | grep -q 'PNG'; then
+    elif ! file "$png_out" 2>/dev/null | grep -q 'PNG image'; then
         fail=$((fail + 1))
-        printf '  FAIL --as=png output is not a PNG\n'
+        printf '  FAIL --as=png output is not a PNG (file: %s)\n' \
+            "$(file "$png_out" 2>/dev/null || echo unknown)"
     else
         pass=$((pass + 1))
         printf '  ok  --as=png produced a PNG\n'

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
@@ -119,6 +119,47 @@ for tgt in tb ascii; do
     assert_eq "stdin $tgt matches file-arg" "$tmp/stdin.$tgt" "$EXP/happy.$tgt"
 done
 
+echo "--as=png smoke (skipped without node + Playwright Chromium)"
+if command -v node >/dev/null 2>&1; then
+    png_out="$tmp/happy.png"
+    "$SCRIPT" "$FIX/happy.json" --as=png --out "$png_out" >"$tmp/png.out" 2>"$tmp/png.err"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        if grep -q 'cannot load Playwright' "$tmp/png.err"; then
+            printf '  skip --as=png (Playwright not installed)\n'
+        else
+            fail=$((fail + 1))
+            printf '  FAIL --as=png exited %d\n' "$rc"
+            sed 's/^/    /' < "$tmp/png.err"
+        fi
+    elif [ ! -s "$png_out" ]; then
+        fail=$((fail + 1))
+        printf '  FAIL --as=png produced empty output\n'
+    elif ! head -c 8 "$png_out" | grep -q 'PNG'; then
+        fail=$((fail + 1))
+        printf '  FAIL --as=png output is not a PNG\n'
+    else
+        pass=$((pass + 1))
+        printf '  ok  --as=png produced a PNG\n'
+    fi
+
+    # Also confirm --as=png errors clearly when --out is missing.
+    "$SCRIPT" "$FIX/happy.json" --as=png >"$tmp/png-noout.out" 2>"$tmp/png-noout.err"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        fail=$((fail + 1))
+        printf '  FAIL --as=png without --out should fail, got 0\n'
+    elif ! grep -q 'requires --out' "$tmp/png-noout.err"; then
+        fail=$((fail + 1))
+        printf '  FAIL --as=png without --out: stderr missing guidance\n'
+    else
+        pass=$((pass + 1))
+        printf '  ok  --as=png without --out fails with guidance\n'
+    fi
+else
+    printf '  skip --as=png (node not on PATH)\n'
+fi
+
 echo "auto-fallback (dot not on PATH → --as=ascii)"
 py3="$(command -v python3)"
 PATH="" "$py3" "$SCRIPT" "$FIX/happy.json" > "$tmp/fallback.out" 2>"$tmp/fallback.err"

--- a/.claude/skills/plan-dag/scripts/svg-to-png.mjs
+++ b/.claude/skills/plan-dag/scripts/svg-to-png.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// svg-to-png — rasterise a graphviz SVG to PNG via headless Chromium.
+//
+// Usage:
+//   dot -Tsvg | node svg-to-png.mjs <out-path>
+//
+// Why not `dot -Tpng`? Going through the browser gives sharper text and
+// correct anti-aliasing at deviceScaleFactor=2, which matters when the
+// PNG is shown inline in chat surfaces.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const out = process.argv[2];
+if (!out) {
+  process.stderr.write('usage: svg-to-png.mjs <out-path>\n');
+  process.exit(2);
+}
+
+const svg = readFileSync(0, 'utf8');
+if (!svg.trim()) {
+  process.stderr.write('svg-to-png: no SVG on stdin\n');
+  process.exit(2);
+}
+
+let chromium;
+try {
+  ({ chromium } = await import('playwright'));
+} catch {
+  try {
+    const req = createRequire(import.meta.url);
+    ({ chromium } = req('/opt/node22/lib/node_modules/playwright/index.js'));
+  } catch (e) {
+    process.stderr.write(
+      'svg-to-png: cannot load Playwright. Install with `npm i -g playwright` '
+      + 'and `npx playwright install chromium`.\n'
+    );
+    process.exit(2);
+  }
+}
+
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+  html,body{margin:0;padding:0;background:#fff}
+  body{padding:24px;display:inline-block}
+  svg{display:block}
+</style></head><body>${svg}</body></html>`;
+
+const browser = await chromium.launch();
+try {
+  const ctx = await browser.newContext({ deviceScaleFactor: 2 });
+  const page = await ctx.newPage();
+  await page.setContent(html, { waitUntil: 'load' });
+  const box = await page.locator('body').boundingBox();
+  await page.setViewportSize({
+    width: Math.ceil(box.width),
+    height: Math.ceil(box.height),
+  });
+  await page.screenshot({ path: out, omitBackground: false, fullPage: true });
+} finally {
+  await browser.close();
+}
+
+process.stderr.write(`svg-to-png: wrote ${out}\n`);

--- a/.claude/skills/plan-dag/scripts/svg-to-png.mjs
+++ b/.claude/skills/plan-dag/scripts/svg-to-png.mjs
@@ -8,7 +8,8 @@
 // correct anti-aliasing at deviceScaleFactor=2, which matters when the
 // PNG is shown inline in chat surfaces.
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 
 const out = process.argv[2];
@@ -23,38 +24,70 @@ if (!svg.trim()) {
   process.exit(2);
 }
 
-let chromium;
-try {
-  ({ chromium } = await import('playwright'));
-} catch {
+async function loadPlaywright() {
   try {
-    const req = createRequire(import.meta.url);
-    ({ chromium } = req('/opt/node22/lib/node_modules/playwright/index.js'));
-  } catch (e) {
-    process.stderr.write(
-      'svg-to-png: cannot load Playwright. Install with `npm i -g playwright` '
-      + 'and `npx playwright install chromium`.\n'
-    );
-    process.exit(2);
+    return await import('playwright');
+  } catch (localErr) {
+    // Local resolution failed (e.g. script run from a directory that doesn't
+    // see the global node_modules). Try `npm root -g` to find the standard
+    // global install.
+    try {
+      const globalRoot = execSync('npm root -g', {
+        encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      const req = createRequire(import.meta.url);
+      return req(`${globalRoot}/playwright`);
+    } catch {
+      process.stderr.write(
+        'svg-to-png: cannot load Playwright. Install with '
+        + '`npm i -g playwright` and `npx playwright install chromium`.\n'
+        + `(local require error: ${localErr.message})\n`,
+      );
+      process.exit(2);
+    }
   }
 }
 
+const { chromium } = await loadPlaywright();
+
+const PAD = 24;
+const DPR = 2;
+
+// Parse the SVG's intrinsic width/height so we can size the viewport
+// to actually fit the content — `page.locator('body').boundingBox()` would
+// otherwise clip wide graphs to the default 1280×720 viewport.
+function toPx(value) {
+  if (!value) return null;
+  const num = parseFloat(value);
+  if (Number.isNaN(num)) return null;
+  if (/pt\s*$/i.test(value)) return num * 4 / 3;
+  if (/in\s*$/i.test(value)) return num * 96;
+  if (/cm\s*$/i.test(value)) return num * 96 / 2.54;
+  if (/mm\s*$/i.test(value)) return num * 96 / 25.4;
+  return num;
+}
+
+const widthAttr = svg.match(/<svg\b[^>]*?\swidth\s*=\s*"([^"]+)"/i);
+const heightAttr = svg.match(/<svg\b[^>]*?\sheight\s*=\s*"([^"]+)"/i);
+const svgW = toPx(widthAttr && widthAttr[1]) || 1280;
+const svgH = toPx(heightAttr && heightAttr[1]) || 720;
+const W = Math.max(1, Math.ceil(svgW + 2 * PAD));
+const H = Math.max(1, Math.ceil(svgH + 2 * PAD));
+
 const html = `<!doctype html><html><head><meta charset="utf-8"><style>
   html,body{margin:0;padding:0;background:#fff}
-  body{padding:24px;display:inline-block}
+  body{padding:${PAD}px;display:inline-block}
   svg{display:block}
 </style></head><body>${svg}</body></html>`;
 
 const browser = await chromium.launch();
 try {
-  const ctx = await browser.newContext({ deviceScaleFactor: 2 });
+  const ctx = await browser.newContext({
+    deviceScaleFactor: DPR,
+    viewport: { width: W, height: H },
+  });
   const page = await ctx.newPage();
   await page.setContent(html, { waitUntil: 'load' });
-  const box = await page.locator('body').boundingBox();
-  await page.setViewportSize({
-    width: Math.ceil(box.width),
-    height: Math.ceil(box.height),
-  });
   await page.screenshot({ path: out, omitBackground: false, fullPage: true });
 } finally {
   await browser.close();


### PR DESCRIPTION
## Summary

Mirrors onsager-ai/onsager-skills#8 into this repo's installed copy at `.claude/skills/plan-dag/`. The plan-dag skill picks up a new `--as=png --out <path>` target that rasterises the existing DOT through `dot -Tsvg` and a headless Chromium screenshot at `deviceScaleFactor=2`. This is the preferred output on image-capable chat surfaces (Claude Code on the web, claude.ai) — the AI then sends the PNG via `SendUserFile` instead of pasting glyph art that reflows under proportional fonts.

Terminal box-drawing default and the ASCII fallback are unchanged.

## Test plan

- [x] `.claude/skills/plan-dag/scripts/plan-dag-render.test.sh` — 24 passed, 0 failed locally (includes the new PNG smoke and missing-`--out` guard).
- [x] `--as=png` produces valid PNGs for both `happy.json` and `wide.json` fixtures.

https://claude.ai/code/session_01Sw8VtfK8epgHPyK7wgKfXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw8VtfK8epgHPyK7wgKfXQ)_