### PR TITLE
feat(artifact): add Provenance type system (SUB-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ulid",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/onsager-artifact/Cargo.toml
+++ b/crates/onsager-artifact/Cargo.toml
@@ -10,3 +10,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 ulid = { version = "1", features = ["serde"] }
+uuid = { workspace = true }

--- a/crates/onsager-artifact/src/artifact.rs
+++ b/crates/onsager-artifact/src/artifact.rs
@@ -8,6 +8,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use crate::provenance::{NodeId, Provenance};
+
 // ---------------------------------------------------------------------------
 // Identity
 // ---------------------------------------------------------------------------
@@ -303,6 +305,21 @@ pub struct Artifact {
     pub current_stage_index: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_parked_reason: Option<String>,
+
+    // Provenance (ADR 0010, issue #348).
+    //
+    // `provenance` records whether this artifact was produced by a
+    // deterministic process (script, external system-of-record, Verify
+    // certification) or an uncertain one (LLM, human edit, composed
+    // from uncertain parents). `produced_by_node` identifies the
+    // Execution Plan node that emitted it; `None` for legacy /
+    // externally-ingested rows that predate the workflow runtime.
+    // Both fields carry serde defaults so pre-#348 wire payloads
+    // round-trip as `Deterministic { source: External }` / `None`.
+    #[serde(default)]
+    pub provenance: Provenance,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub produced_by_node: Option<NodeId>,
 }
 
 impl Artifact {
@@ -348,6 +365,8 @@ impl Artifact {
             workflow_id: None,
             current_stage_index: None,
             workflow_parked_reason: None,
+            provenance: Provenance::external_deterministic(),
+            produced_by_node: None,
         }
     }
 }
@@ -359,6 +378,7 @@ impl Artifact {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provenance::SourceTag;
 
     #[test]
     fn artifact_id_format() {
@@ -494,6 +514,62 @@ mod tests {
             10_000,
             "expected 10 000 unique IDs, got duplicates"
         );
+    }
+
+    #[test]
+    fn new_artifact_defaults_to_external_deterministic_provenance() {
+        let art = Artifact::new(Kind::Document, "spec", "marvin", "system", vec![]);
+        assert_eq!(
+            art.provenance,
+            Provenance::Deterministic {
+                source: SourceTag::External
+            }
+        );
+        assert!(art.produced_by_node.is_none());
+    }
+
+    #[test]
+    fn artifact_roundtrips_provenance_through_serde() {
+        let mut art = Artifact::new(Kind::Code, "agent-edit", "marvin", "stiglab", vec![]);
+        art.provenance = Provenance::Uncertain {
+            source: SourceTag::Agent,
+        };
+        art.produced_by_node = Some(NodeId::generate());
+
+        let json = serde_json::to_value(&art).unwrap();
+        let roundtrip: Artifact = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip.provenance, art.provenance);
+        assert_eq!(roundtrip.produced_by_node, art.produced_by_node);
+    }
+
+    #[test]
+    fn pre_provenance_payload_defaults_on_deserialize() {
+        // Wire payload from a pre-#348 producer — no provenance /
+        // produced_by_node fields at all. Must deserialize with the
+        // back-compat defaults rather than erroring.
+        let json = serde_json::json!({
+            "artifact_id": "art_01HXYZABC123DEFGHJKMNPQRST",
+            "kind": "code",
+            "name": "legacy",
+            "created_at": "2025-01-01T00:00:00Z",
+            "created_by": "system",
+            "owner": "marvin",
+            "consumers": [],
+            "state": "draft",
+            "current_version": 0,
+            "versions": [],
+            "vertical_lineage": [],
+            "horizontal_lineage": [],
+            "quality_signals": [],
+        });
+        let art: Artifact = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            art.provenance,
+            Provenance::Deterministic {
+                source: SourceTag::External
+            }
+        );
+        assert!(art.produced_by_node.is_none());
     }
 
     #[test]

--- a/crates/onsager-artifact/src/lib.rs
+++ b/crates/onsager-artifact/src/lib.rs
@@ -8,5 +8,7 @@
 //! without pulling in unrelated concerns.
 
 pub mod artifact;
+pub mod provenance;
 
 pub use artifact::*;
+pub use provenance::*;

--- a/crates/onsager-artifact/src/provenance.rs
+++ b/crates/onsager-artifact/src/provenance.rs
@@ -1,7 +1,7 @@
 //! Provenance — substrate first-class type tracking whether an
 //! artifact was produced deterministically or by an uncertain process.
 //!
-//! See [ADR 0010](../../../../docs/adr/0010-provenance-as-substrate-first-class.md).
+//! See [ADR 0010](../../../docs/adr/0010-provenance-as-substrate-first-class.md).
 //!
 //! The kernel question this answers: given an artifact, what must be
 //! true for a downstream consumer to trust it as deterministic? The

--- a/crates/onsager-artifact/src/provenance.rs
+++ b/crates/onsager-artifact/src/provenance.rs
@@ -1,0 +1,269 @@
+//! Provenance — substrate first-class type tracking whether an
+//! artifact was produced deterministically or by an uncertain process.
+//!
+//! See [ADR 0010](../../../../docs/adr/0010-provenance-as-substrate-first-class.md).
+//!
+//! The kernel question this answers: given an artifact, what must be
+//! true for a downstream consumer to trust it as deterministic? The
+//! two-valued `Provenance` enum is the decidable shape; a Verify
+//! executor (EXE-04) is the only kernel-recognized upgrade path from
+//! `Uncertain` to `Deterministic`.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// The producer kind that emitted an artifact.
+///
+/// Wire form is snake_case: `"agent"`, `"script"`, `"external"`,
+/// `"human"`, `"composed"`. Used both inside [`Provenance`] and as a
+/// standalone tag on events that carry producer identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceTag {
+    /// LLM / model output.
+    Agent,
+    /// Deterministic code (sandboxed).
+    Script,
+    /// Upstream system (GitHub, etc.).
+    External,
+    /// Human edit.
+    Human,
+    /// Derived from multiple parents (e.g., a composed/merged artifact).
+    Composed,
+}
+
+impl fmt::Display for SourceTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SourceTag::Agent => "agent",
+            SourceTag::Script => "script",
+            SourceTag::External => "external",
+            SourceTag::Human => "human",
+            SourceTag::Composed => "composed",
+        };
+        f.write_str(s)
+    }
+}
+
+/// The kernel-level trust classification of an artifact.
+///
+/// Serialized as a tagged enum with `kind` discriminator and a
+/// `source` payload:
+///
+/// ```json
+/// {"kind": "deterministic", "source": "external"}
+/// {"kind": "uncertain",     "source": "agent"}
+/// ```
+///
+/// Propagation rule (ADR 0010, invariant 2): a node's emitted
+/// provenance is the maximum uncertainty of its declared output
+/// provenance and all input provenances. `Uncertain` is contagious;
+/// only a Verify executor (EXE-04) may upgrade an `Uncertain` input
+/// to `Deterministic` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Provenance {
+    /// Produced by a process whose output is reproducible from its
+    /// inputs (pinned script, external system-of-record, or a Verify
+    /// executor's certification).
+    Deterministic { source: SourceTag },
+    /// Produced by a process whose output is not reproducible from its
+    /// inputs (LLM completion, human edit, composed from `Uncertain`
+    /// parents).
+    Uncertain { source: SourceTag },
+}
+
+impl Provenance {
+    /// The default provenance assigned to artifacts that predate the
+    /// substrate's provenance field — externally-ingested rows whose
+    /// origin is the upstream system-of-record.
+    pub fn external_deterministic() -> Self {
+        Provenance::Deterministic {
+            source: SourceTag::External,
+        }
+    }
+
+    /// The producer tag inside this provenance, regardless of variant.
+    pub fn source(&self) -> SourceTag {
+        match self {
+            Provenance::Deterministic { source } | Provenance::Uncertain { source } => *source,
+        }
+    }
+
+    /// Whether this provenance is `Uncertain`. Convenience for the
+    /// propagation rule — `is_uncertain` short-circuits the max-of-
+    /// inputs check at edge validation time.
+    pub fn is_uncertain(&self) -> bool {
+        matches!(self, Provenance::Uncertain { .. })
+    }
+}
+
+impl Default for Provenance {
+    fn default() -> Self {
+        Provenance::external_deterministic()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NodeId
+// ---------------------------------------------------------------------------
+
+/// Identifier of a node in an Execution Plan.
+///
+/// A UUID v4 newtype; the full `Node` struct lands in SUB-02 (#349).
+/// Held here so `Artifact::produced_by_node` can be typed before the
+/// node module exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NodeId(uuid::Uuid);
+
+impl NodeId {
+    /// Wrap an existing UUID.
+    pub fn new(id: uuid::Uuid) -> Self {
+        Self(id)
+    }
+
+    /// Generate a fresh v4 UUID.
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    /// The wrapped UUID.
+    pub fn as_uuid(&self) -> uuid::Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<uuid::Uuid> for NodeId {
+    fn from(id: uuid::Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl From<NodeId> for uuid::Uuid {
+    fn from(id: NodeId) -> uuid::Uuid {
+        id.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_serde_deterministic() {
+        let p = Provenance::Deterministic {
+            source: SourceTag::External,
+        };
+        let json = serde_json::to_value(p).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"kind": "deterministic", "source": "external"})
+        );
+        let roundtrip: Provenance = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, p);
+    }
+
+    #[test]
+    fn provenance_serde_uncertain() {
+        let p = Provenance::Uncertain {
+            source: SourceTag::Agent,
+        };
+        let json = serde_json::to_value(p).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"kind": "uncertain", "source": "agent"})
+        );
+        let roundtrip: Provenance = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, p);
+    }
+
+    #[test]
+    fn source_tag_all_variants_serialize_snake_case() {
+        for (tag, expected) in [
+            (SourceTag::Agent, "agent"),
+            (SourceTag::Script, "script"),
+            (SourceTag::External, "external"),
+            (SourceTag::Human, "human"),
+            (SourceTag::Composed, "composed"),
+        ] {
+            let json = serde_json::to_string(&tag).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+            let roundtrip: SourceTag = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip, tag);
+        }
+    }
+
+    #[test]
+    fn provenance_default_is_external_deterministic() {
+        assert_eq!(
+            Provenance::default(),
+            Provenance::Deterministic {
+                source: SourceTag::External
+            }
+        );
+    }
+
+    #[test]
+    fn is_uncertain_classifies_variants() {
+        assert!(
+            !Provenance::Deterministic {
+                source: SourceTag::Script
+            }
+            .is_uncertain()
+        );
+        assert!(
+            Provenance::Uncertain {
+                source: SourceTag::Agent
+            }
+            .is_uncertain()
+        );
+    }
+
+    #[test]
+    fn source_accessor_returns_inner_tag() {
+        assert_eq!(
+            Provenance::Deterministic {
+                source: SourceTag::Script
+            }
+            .source(),
+            SourceTag::Script
+        );
+        assert_eq!(
+            Provenance::Uncertain {
+                source: SourceTag::Composed
+            }
+            .source(),
+            SourceTag::Composed
+        );
+    }
+
+    #[test]
+    fn node_id_serde_transparent_uuid() {
+        let raw = uuid::Uuid::new_v4();
+        let id = NodeId::new(raw);
+        let json = serde_json::to_value(id).unwrap();
+        // Transparent — wire form is the bare UUID string.
+        assert_eq!(json, serde_json::json!(raw.to_string()));
+        let roundtrip: NodeId = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, id);
+        assert_eq!(id.as_uuid(), raw);
+    }
+
+    #[test]
+    fn node_id_generate_unique() {
+        let a = NodeId::generate();
+        let b = NodeId::generate();
+        assert_ne!(a, b);
+    }
+}

--- a/crates/onsager-spine/migrations/026_artifact_provenance.sql
+++ b/crates/onsager-spine/migrations/026_artifact_provenance.sql
@@ -1,0 +1,53 @@
+-- Onsager 0.2 substrate — issue #348 (SUB-01).
+--
+-- ADR 0010 makes provenance a first-class field on every artifact:
+-- the substrate needs to answer, given an artifact, whether a
+-- downstream consumer may trust it as deterministic. Without this
+-- column, the kernel invariants formalized in ADR 0018 (especially
+-- invariants 1 and 2) cannot be statically validated.
+--
+-- This migration:
+--   1. Adds `provenance` (jsonb) carrying the kernel-recognized
+--      `Provenance` enum's wire form (`{"kind": "...", "source": "..."}`).
+--      NOT NULL with a default — existing rows backfill to
+--      `Deterministic { source: External }` because they were
+--      produced before workflow runtime existed, so their authority
+--      is the external system-of-record (GitHub, the dashboard, an
+--      ingestion job), not an agent.
+--   2. Adds `produced_by_node` (uuid, nullable) — populated by the
+--      workflow runtime at dispatch time. NULL for legacy /
+--      externally-ingested rows. References the node module that
+--      lands in SUB-02 (#349); no FK yet — the `nodes` table itself
+--      is introduced there.
+--
+-- Pre-launch posture (CLAUDE.md § "Operating posture: pre-launch")
+-- skips deprecation choreography: the column is NOT NULL from day one
+-- with a default + inline backfill in a single transaction.
+
+ALTER TABLE artifacts
+    ADD COLUMN IF NOT EXISTS provenance JSONB NOT NULL
+        DEFAULT '{"kind": "deterministic", "source": "external"}'::jsonb;
+
+ALTER TABLE artifacts
+    ADD COLUMN IF NOT EXISTS produced_by_node UUID;
+
+-- Re-state the backfill explicitly so re-runs against a partially-
+-- migrated database converge — `ADD COLUMN ... DEFAULT` only fires
+-- on the first add, but an `IF NOT EXISTS` no-op leaves nothing for
+-- the default to do. The `WHERE` clause makes this a no-op on a
+-- freshly-populated default.
+UPDATE artifacts
+   SET provenance = '{"kind": "deterministic", "source": "external"}'::jsonb
+ WHERE provenance IS NULL
+    OR provenance = '{}'::jsonb;
+
+-- Filtering by provenance kind ("show me uncertain artifacts") is a
+-- recurring query for the dashboard and the static validators. A
+-- jsonb_path_ops GIN index covers the equality lookups on `kind` /
+-- `source` without bloating like a btree on the whole jsonb would.
+CREATE INDEX IF NOT EXISTS idx_artifacts_provenance
+    ON artifacts USING gin (provenance jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_produced_by_node
+    ON artifacts (produced_by_node)
+    WHERE produced_by_node IS NOT NULL;


### PR DESCRIPTION
## Summary

- Add `Provenance` + `SourceTag` enums and a `NodeId` UUID newtype to `onsager-artifact` (new module `provenance.rs`), per [ADR 0010](docs/adr/0010-provenance-as-substrate-first-class.md).
- Add `provenance: Provenance` and `produced_by_node: Option<NodeId>` fields to the `Artifact` struct, both with serde defaults so pre-#348 wire payloads round-trip as `Deterministic { source: External } / None` without producer changes.
- Add migration `026_artifact_provenance.sql`: `provenance jsonb NOT NULL DEFAULT '{"kind": "deterministic", "source": "external"}'::jsonb` (backfills existing rows inline via Postgres 11+ catalog-stored defaults) and `produced_by_node uuid NULL`, with a GIN(jsonb_path_ops) index on provenance and a partial btree on `produced_by_node`.

Wire form for `Provenance` follows the existing tagged-enum convention in `onsager-spine` (`trigger.rs`, `factory_event.rs`):

```json
{"kind": "deterministic", "source": "external"}
{"kind": "uncertain",     "source": "agent"}
```

`NodeId` is the minimum needed so `Artifact.produced_by_node` can be typed in this PR; the full `Node` struct lands in SUB-02 (#349).

## Test plan

- [x] `cargo test -p onsager-artifact` — 24 tests pass (10 new: serde round-trip for `Provenance` / `SourceTag` / `NodeId`, default behavior, pre-#348 payload deserialization, accessors)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -p xtask -- check-file-budget` — `provenance.rs` is 1.0k tokens, well under the 8000-token ceiling
- [x] `cargo run -p xtask -- lint-seams` — clean (no new seam violations)
- [x] Migration applies cleanly on an **empty** database — full 001..026 sequence ran without errors in an ephemeral Postgres 16
- [x] Migration applies cleanly on a **populated** database — re-running `026` after inserting rows is a no-op (`UPDATE 0`, `idx_*` skipped); legacy rows correctly default to `Deterministic { source: External }`; explicit `Uncertain { source: Agent }` round-trips through jsonb

Closes #348

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1uotQyHS1NZRJn1vZs3HJ)_