### PR TITLE
feat(substrate): Workflow / Node / Edge types in new onsager-substrate crate (SUB-02)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1750,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "uuid",
+]
+
+[[package]]
+name = "onsager-substrate"
+version = "0.2.0-alpha.1"
+dependencies = [
+ "onsager-artifact",
+ "serde",
+ "serde_json",
+ "typetag",
  "uuid",
 ]
 
@@ -3305,10 +3336,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ulid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/onsager-artifact",
     "crates/onsager-registry",
     "crates/onsager-spine",
+    "crates/onsager-substrate",
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",

--- a/crates/onsager-substrate/Cargo.toml
+++ b/crates/onsager-substrate/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "onsager-substrate"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "0.2 substrate kernel — Workflow / Node / Edge data model and the Executor trait."
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+typetag = "0.2"

--- a/crates/onsager-substrate/src/executor.rs
+++ b/crates/onsager-substrate/src/executor.rs
@@ -1,0 +1,155 @@
+//! The `Executor` trait — how nodes describe their behavior.
+//!
+//! Per [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md),
+//! nodes do not carry a `NodeKind` enum. They carry an
+//! `executor: Box<dyn Executor>` and the trait's `executor_kind()`
+//! string is the discriminator.
+//!
+//! This issue (SUB-02, #349) lands the trait *stub* — only the methods
+//! the kernel needs to validate a workflow before running it:
+//!
+//! - [`Executor::executor_kind`] — the wire-format tag (also used by
+//!   the kernel to special-case Verify per ADR 0010 / invariant 2).
+//! - [`Executor::declared_provenance`] — what provenance this executor
+//!   *claims* to produce given its input provenances. Invariant 2
+//!   (ADR 0018) tightens this at validate time: for non-Verify
+//!   executors, the actual emitted provenance is the max-uncertainty
+//!   of `declared_provenance` and all inputs.
+//!
+//! The `async fn execute(..)` half of the trait lands in EXE-01
+//! (#353), in the separate `onsager-nodes` crate — see
+//! [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md)
+//! § "Adoption checklist".
+//!
+//! # Serialization
+//!
+//! `Box<dyn Executor>` is serialized via [`typetag`]. Every implementor
+//! attaches a `#[typetag::serde(name = "...")]` annotation that becomes
+//! the `kind` field on the wire:
+//!
+//! ```json
+//! {"kind": "noop"}
+//! {"kind": "script", "source_ref": "...", "checksum": "..."}
+//! ```
+//!
+//! The implementor crate must be linked into the binary at runtime; the
+//! substrate alone only registers [`NoOpExecutor`] (below). Production
+//! executors live in `onsager-nodes` (EXE-02..06) and register
+//! themselves the same way.
+
+use onsager_artifact::{Provenance, SourceTag};
+use serde::{Deserialize, Serialize};
+
+/// What a node does when the scheduler reaches it.
+///
+/// Object-safe by design: no generic methods, no `Self: Sized` clauses.
+/// `Box<dyn Executor>` is the storage form nodes hold and the wire
+/// form serializes through [`typetag`]'s `tag = "kind"` adjacency.
+#[typetag::serde(tag = "kind")]
+pub trait Executor: std::fmt::Debug + Send + Sync {
+    /// Stable wire-format tag for this executor. Must match the
+    /// `#[typetag::serde(name = "...")]` on the impl block so
+    /// `executor.executor_kind()` round-trips through serde.
+    ///
+    /// This string is also how the kernel identifies the Verify
+    /// executor at validate time (ADR 0010): a node whose
+    /// `executor_kind()` is `"verify"` is the only kind allowed to
+    /// upgrade `Uncertain` inputs to a `Deterministic` output.
+    fn executor_kind(&self) -> &'static str;
+
+    /// The provenance this executor claims to produce, given the
+    /// provenances flowing in on its input edges.
+    ///
+    /// Invariant 2 (ADR 0018) constrains the *actual* provenance: for
+    /// non-Verify executors it is the max-uncertainty of this
+    /// declared value and all `inputs`. Implementors that do not
+    /// upgrade provenance (i.e. everything except Verify) typically
+    /// return the max-uncertainty of `inputs` themselves; Verify
+    /// returns `Deterministic`.
+    fn declared_provenance(&self, inputs: &[Provenance]) -> Provenance;
+}
+
+/// A no-op executor — declares deterministic output, performs nothing.
+///
+/// Useful as:
+/// - the default executor on hand-written workflow fixtures (this
+///   crate's serde round-trip test uses it), and
+/// - a placeholder while authors stub out a workflow before the real
+///   executor lands.
+///
+/// On the wire: `{"kind": "noop"}`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoOpExecutor;
+
+#[typetag::serde(name = "noop")]
+impl Executor for NoOpExecutor {
+    fn executor_kind(&self) -> &'static str {
+        "noop"
+    }
+
+    /// A no-op preserves the worst input provenance — it neither
+    /// degrades nor upgrades. With no inputs, it declares the same
+    /// default that fresh externally-ingested artifacts carry
+    /// (`Deterministic { source: External }`).
+    fn declared_provenance(&self, inputs: &[Provenance]) -> Provenance {
+        inputs
+            .iter()
+            .copied()
+            .find(Provenance::is_uncertain)
+            .unwrap_or(Provenance::Deterministic {
+                source: SourceTag::External,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::SourceTag;
+
+    #[test]
+    fn noop_executor_kind() {
+        let exec = NoOpExecutor;
+        assert_eq!(exec.executor_kind(), "noop");
+    }
+
+    #[test]
+    fn noop_declared_provenance_with_no_inputs() {
+        let p = NoOpExecutor.declared_provenance(&[]);
+        assert_eq!(p, Provenance::external_deterministic());
+    }
+
+    #[test]
+    fn noop_declared_provenance_propagates_uncertain_input() {
+        let p = NoOpExecutor.declared_provenance(&[
+            Provenance::Deterministic {
+                source: SourceTag::Script,
+            },
+            Provenance::Uncertain {
+                source: SourceTag::Agent,
+            },
+        ]);
+        assert!(p.is_uncertain());
+        assert_eq!(p.source(), SourceTag::Agent);
+    }
+
+    #[test]
+    fn noop_executor_roundtrips_as_trait_object() {
+        let exec: Box<dyn Executor> = Box::new(NoOpExecutor);
+        let json = serde_json::to_value(&exec).unwrap();
+        assert_eq!(json, serde_json::json!({"kind": "noop"}));
+
+        let roundtrip: Box<dyn Executor> = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip.executor_kind(), "noop");
+    }
+
+    #[test]
+    fn unknown_executor_kind_fails_to_deserialize() {
+        let json = serde_json::json!({"kind": "no-such-executor"});
+        let result: Result<Box<dyn Executor>, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "deserializing an unregistered kind should fail"
+        );
+    }
+}

--- a/crates/onsager-substrate/src/ids.rs
+++ b/crates/onsager-substrate/src/ids.rs
@@ -1,0 +1,113 @@
+//! UUID newtype identifiers for substrate entities.
+//!
+//! `NodeId` lives in `onsager-artifact` (it landed alongside
+//! `Provenance` in SUB-01, #348, so `Artifact::produced_by_node` could
+//! be typed before this crate existed). It is re-exported from the
+//! crate root.
+//!
+//! `WorkflowId` and `EdgeId` are defined here — the `Workflow` and
+//! `Edge` types they identify also live in this crate.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+macro_rules! uuid_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(uuid::Uuid);
+
+        impl $name {
+            /// Wrap an existing UUID.
+            pub fn new(id: uuid::Uuid) -> Self {
+                Self(id)
+            }
+
+            /// Generate a fresh v4 UUID.
+            pub fn generate() -> Self {
+                Self(uuid::Uuid::new_v4())
+            }
+
+            /// The wrapped UUID.
+            pub fn as_uuid(&self) -> uuid::Uuid {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl From<uuid::Uuid> for $name {
+            fn from(id: uuid::Uuid) -> Self {
+                Self(id)
+            }
+        }
+
+        impl From<$name> for uuid::Uuid {
+            fn from(id: $name) -> uuid::Uuid {
+                id.0
+            }
+        }
+    };
+}
+
+uuid_newtype! {
+    /// Identifier of a `Workflow` template in the Workflow Library.
+    ///
+    /// Assigned by the library on registration (SUB-04, #351); stable
+    /// across all runs of that workflow version.
+    WorkflowId
+}
+
+uuid_newtype! {
+    /// Identifier of an `Edge` inside a `Workflow`.
+    ///
+    /// Edge identity is local to its workflow — two workflows may
+    /// reuse the same `EdgeId` value without conflict because no
+    /// kernel operation looks up edges across workflow boundaries.
+    EdgeId
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_id_serde_transparent_uuid() {
+        let raw = uuid::Uuid::new_v4();
+        let id = WorkflowId::new(raw);
+        let json = serde_json::to_value(id).unwrap();
+        assert_eq!(json, serde_json::json!(raw.to_string()));
+        let roundtrip: WorkflowId = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, id);
+        assert_eq!(id.as_uuid(), raw);
+    }
+
+    #[test]
+    fn edge_id_serde_transparent_uuid() {
+        let raw = uuid::Uuid::new_v4();
+        let id = EdgeId::new(raw);
+        let json = serde_json::to_value(id).unwrap();
+        assert_eq!(json, serde_json::json!(raw.to_string()));
+        let roundtrip: EdgeId = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, id);
+    }
+
+    #[test]
+    fn generate_yields_unique_ids() {
+        assert_ne!(WorkflowId::generate(), WorkflowId::generate());
+        assert_ne!(EdgeId::generate(), EdgeId::generate());
+    }
+
+    #[test]
+    fn uuid_conversions_round_trip() {
+        let raw = uuid::Uuid::new_v4();
+        let id: WorkflowId = raw.into();
+        let back: uuid::Uuid = id.into();
+        assert_eq!(back, raw);
+    }
+}

--- a/crates/onsager-substrate/src/lib.rs
+++ b/crates/onsager-substrate/src/lib.rs
@@ -1,0 +1,31 @@
+//! # onsager-substrate
+//!
+//! Kernel data model for the 0.2 substrate: the `Workflow` template
+//! (a node + edge graph), the `Executor` trait that every node carries,
+//! and the UUID newtypes that identify them.
+//!
+//! See:
+//! - [ADR 0009](../../../docs/adr/0009-three-layer-pipeline.md) — the
+//!   Spec Plan / Workflow / Execution Plan three-layer pipeline.
+//! - [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md)
+//!   — why nodes carry `Box<dyn Executor>` instead of a `NodeKind` enum.
+//! - [ADR 0018](../../../docs/adr/0018-five-kernel-invariants.md) — the
+//!   five static validators that operate on the types defined here
+//!   (lands in SUB-03, #350).
+//!
+//! This crate is intentionally pure data + a trait stub: no async, no
+//! database, no spine. Downstream crates (`onsager-nodes`, the Plan
+//! Compiler, the scheduler) layer behavior on top of these types.
+
+pub mod executor;
+pub mod ids;
+pub mod workflow;
+
+pub use executor::*;
+pub use ids::*;
+pub use workflow::*;
+
+// Re-exports for downstream convenience — anyone working with a
+// substrate `Workflow` will reach for provenance + artifact identity in
+// the same breath.
+pub use onsager_artifact::{ArtifactId, NodeId, Provenance, SourceTag};

--- a/crates/onsager-substrate/src/workflow.rs
+++ b/crates/onsager-substrate/src/workflow.rs
@@ -1,0 +1,181 @@
+//! `Workflow`, `Node`, `Edge`, `EdgeRef` — the substrate template shape.
+//!
+//! A `Workflow` is a *template*: a graph of nodes and edges that the
+//! Plan Compiler (SUB-05, #352) instantiates against a Spec Plan
+//! to produce an executable Execution Plan (SUB-04, #351).
+//!
+//! See [ADR 0009](../../../docs/adr/0009-three-layer-pipeline.md) for
+//! the three-layer pipeline this type lives at the middle of, and
+//! [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md)
+//! for why `Node` carries `Box<dyn Executor>` instead of a closed
+//! `NodeKind` enum.
+
+use onsager_artifact::{ArtifactId, NodeId};
+use serde::{Deserialize, Serialize};
+
+use crate::executor::Executor;
+use crate::ids::EdgeId;
+
+/// A reusable workflow template — graph of [`Node`]s connected by
+/// [`Edge`]s.
+///
+/// Workflows are referenced by `spec_kind` in the Workflow Library
+/// (SUB-04, #351). The library row carries the `WorkflowId` and
+/// version; the `Workflow` struct itself is the *content* — the shape
+/// the Plan Compiler instantiates.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Workflow {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<Edge>,
+}
+
+/// A node in a workflow template.
+///
+/// Behavior lives entirely in `executor`; the rest of the struct is
+/// just graph wiring. `inputs` and `outputs` reference edges by ID
+/// (see [`EdgeRef`]).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Node {
+    pub id: NodeId,
+    pub executor: Box<dyn Executor>,
+    pub inputs: Vec<EdgeRef>,
+    pub outputs: Vec<EdgeRef>,
+}
+
+/// An edge connecting two nodes in a workflow template.
+///
+/// `requires_deterministic` is the kernel's first invariant teeth
+/// (ADR 0018 invariant 1): if `true`, the upstream node's emitted
+/// provenance must be `Deterministic`, or the workflow refuses to
+/// compile. Verify executors (ADR 0010) are the only path to flipping
+/// `Uncertain` upstream into `Deterministic` downstream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Edge {
+    pub id: EdgeId,
+    pub artifact_id: ArtifactId,
+    #[serde(default)]
+    pub requires_deterministic: bool,
+}
+
+/// A reference to an [`Edge`] from a [`Node`]'s `inputs` / `outputs`
+/// list.
+///
+/// A separate type (rather than a bare `EdgeId`) so we can extend the
+/// reference shape later — e.g. a `role` tag if a node ever takes
+/// multiple inputs of the same artifact id — without rewriting every
+/// caller. The kernel today only reads `edge_id`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EdgeRef {
+    pub edge_id: EdgeId,
+}
+
+impl EdgeRef {
+    /// Build a reference to the given edge.
+    pub fn new(edge_id: EdgeId) -> Self {
+        Self { edge_id }
+    }
+}
+
+impl From<EdgeId> for EdgeRef {
+    fn from(edge_id: EdgeId) -> Self {
+        Self { edge_id }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::NoOpExecutor;
+
+    fn single_node_workflow() -> Workflow {
+        let edge_in = EdgeId::generate();
+        let edge_out = EdgeId::generate();
+        Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(NoOpExecutor),
+                inputs: vec![EdgeRef::new(edge_in)],
+                outputs: vec![EdgeRef::new(edge_out)],
+            }],
+            edges: vec![
+                Edge {
+                    id: edge_in,
+                    artifact_id: ArtifactId::new("art_in"),
+                    requires_deterministic: true,
+                },
+                Edge {
+                    id: edge_out,
+                    artifact_id: ArtifactId::new("art_out"),
+                    requires_deterministic: false,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn workflow_roundtrips_through_serde_json() {
+        let original = single_node_workflow();
+        let json = serde_json::to_value(&original).unwrap();
+        let roundtrip: Workflow = serde_json::from_value(json).unwrap();
+
+        // Graph shape preserved.
+        assert_eq!(roundtrip.nodes.len(), 1);
+        assert_eq!(roundtrip.edges.len(), 2);
+
+        // Node identity + edge refs preserved.
+        let node = &roundtrip.nodes[0];
+        assert_eq!(node.id, original.nodes[0].id);
+        assert_eq!(node.inputs, original.nodes[0].inputs);
+        assert_eq!(node.outputs, original.nodes[0].outputs);
+
+        // Executor round-tripped through the typetag tag — the
+        // deserialized trait object reports the same kind.
+        assert_eq!(node.executor.executor_kind(), "noop");
+
+        // Edge fields preserved.
+        assert_eq!(roundtrip.edges[0].id, original.edges[0].id);
+        assert_eq!(
+            roundtrip.edges[0].artifact_id,
+            original.edges[0].artifact_id
+        );
+        assert!(roundtrip.edges[0].requires_deterministic);
+        assert!(!roundtrip.edges[1].requires_deterministic);
+    }
+
+    #[test]
+    fn workflow_executor_serializes_with_kind_discriminator() {
+        let w = single_node_workflow();
+        let json = serde_json::to_value(&w).unwrap();
+        let exec_json = &json["nodes"][0]["executor"];
+        assert_eq!(exec_json, &serde_json::json!({"kind": "noop"}));
+    }
+
+    #[test]
+    fn edge_requires_deterministic_defaults_false_on_deserialize() {
+        let json = serde_json::json!({
+            "id": EdgeId::generate(),
+            "artifact_id": "art_legacy",
+        });
+        let edge: Edge = serde_json::from_value(json).unwrap();
+        assert!(!edge.requires_deterministic);
+    }
+
+    #[test]
+    fn edge_ref_constructors_agree() {
+        let edge_id = EdgeId::generate();
+        assert_eq!(EdgeRef::new(edge_id), EdgeRef::from(edge_id));
+        assert_eq!(EdgeRef::new(edge_id).edge_id, edge_id);
+    }
+
+    #[test]
+    fn empty_workflow_roundtrips() {
+        let w = Workflow {
+            nodes: vec![],
+            edges: vec![],
+        };
+        let json = serde_json::to_value(&w).unwrap();
+        let roundtrip: Workflow = serde_json::from_value(json).unwrap();
+        assert!(roundtrip.nodes.is_empty());
+        assert!(roundtrip.edges.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

New `crates/onsager-substrate` holds the 0.2 kernel data model — the shared vocabulary the Plan Compiler, scheduler, and executor crates will all import from. Pure data + a trait stub; no async, no database, no spine.

- `Workflow { nodes, edges }` — reusable template (not an instance)
- `Node { id, executor, inputs, outputs }` with `executor: Box<dyn Executor>` per ADR 0012 — no `NodeKind` enum
- `Edge { id, artifact_id, requires_deterministic }` — `requires_deterministic` is invariant 1's hook (ADR 0018, lands in SUB-03)
- `EdgeRef { edge_id }` — node-side reference, separated as its own type so it can grow a role tag later without rewriting callers
- `Executor` trait stub: `executor_kind()` + `declared_provenance()`. The async `execute()` half lands in EXE-01 (#353) in the separate `onsager-nodes` crate
- `NoOpExecutor` — concrete executor for the round-trip test + author stubs
- `WorkflowId`, `EdgeId` UUID newtypes. `NodeId` is re-exported from `onsager-artifact` where SUB-01 (#348) already landed it

`Box<dyn Executor>` round-trips through serde via `typetag` (workspace dep added) — `#[typetag::serde(tag = "kind")]` is exactly ADR 0012's "nodes still serialize with a kind discriminator; the kind is just a string now," without reintroducing the closed enum.

Closes #349. Unblocks SUB-03 (#350), SUB-04 (#351), SUB-05 (#352), and EXE-01 (#353).

## Test plan

- [x] `cargo build -p onsager-substrate` (issue's verification 1)
- [x] `cargo test -p onsager-substrate` — 14 tests, all pass (verification 3)
- [x] Hand-written single-node `Workflow` round-trips through `serde_json` — `workflow::tests::workflow_roundtrips_through_serde_json` (verification 2)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `xtask check-file-budget`, `lint-seams`, `check-events`, `check-api-contract` — all clean
- [x] `cargo doc -p onsager-substrate --no-deps` — intra-doc links resolve


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6P1KyxTyKrGwijy74gu1h)_