### PR TITLE
feat(substrate): Workflow Library registry (SUB-04)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,9 @@ dependencies = [
  "onsager-artifact",
  "serde",
  "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
  "typetag",
  "uuid",
 ]

--- a/crates/onsager-spine/migrations/027_workflow_library.sql
+++ b/crates/onsager-spine/migrations/027_workflow_library.sql
@@ -21,11 +21,16 @@ CREATE TABLE IF NOT EXISTS workflow_library (
     version         INTEGER NOT NULL,
     workflow_json   JSONB NOT NULL,
     registered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE (spec_kind, version)
+    CONSTRAINT workflow_library_kind_version_unique UNIQUE (spec_kind, version)
 );
 
--- `latest()` picks `MAX(version)` per kind; an index ordered by
--- `(spec_kind, version DESC)` lets the planner answer that with a
--- straight index scan instead of a sort.
-CREATE INDEX IF NOT EXISTS idx_workflow_library_kind_version
-    ON workflow_library (spec_kind, version DESC);
+-- The named unique constraint above creates a btree index on
+-- `(spec_kind, version)`. Postgres can answer `WHERE spec_kind = $1
+-- ORDER BY version DESC LIMIT 1` by scanning that index backward, so
+-- a separate `version DESC` index would be redundant write/storage
+-- cost on every registration.
+--
+-- The substrate keys `DuplicateKind` off the constraint *name* (not
+-- the generic "unique violation" SQLSTATE) so unrelated future
+-- uniqueness constraints — e.g. the primary key on `id` — don't get
+-- misclassified.

--- a/crates/onsager-spine/migrations/027_workflow_library.sql
+++ b/crates/onsager-spine/migrations/027_workflow_library.sql
@@ -1,0 +1,31 @@
+-- Onsager 0.2 substrate — issue #351 (SUB-04).
+--
+-- ADR 0016 makes the Workflow Library the flat catalog that maps a
+-- spec kind to its reusable `Workflow` template. The substrate kernel
+-- (issue #349) defined the `Workflow` value object; this migration
+-- adds the persistence layer the Plan Compiler (SUB-05, #352) will
+-- read from when it instantiates a Spec Plan into an Execution Plan.
+--
+-- Per the issue's storage spec: one row per (spec_kind, version).
+-- Versions are monotonic per kind; the latest version wins (`latest()`
+-- uses `MAX(version)`). The unique constraint on (spec_kind, version)
+-- is what surfaces the substrate's `DuplicateKind` error — two
+-- workflows at the same (kind, version) are rejected at the database.
+--
+-- Pre-launch posture (CLAUDE.md § "Operating posture: pre-launch") —
+-- this table is brand-new and has no backfill obligations.
+
+CREATE TABLE IF NOT EXISTS workflow_library (
+    id              TEXT PRIMARY KEY,
+    spec_kind       TEXT NOT NULL,
+    version         INTEGER NOT NULL,
+    workflow_json   JSONB NOT NULL,
+    registered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (spec_kind, version)
+);
+
+-- `latest()` picks `MAX(version)` per kind; an index ordered by
+-- `(spec_kind, version DESC)` lets the planner answer that with a
+-- straight index scan instead of a sort.
+CREATE INDEX IF NOT EXISTS idx_workflow_library_kind_version
+    ON workflow_library (spec_kind, version DESC);

--- a/crates/onsager-substrate/Cargo.toml
+++ b/crates/onsager-substrate/Cargo.toml
@@ -3,7 +3,7 @@ name = "onsager-substrate"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "0.2 substrate kernel — Workflow / Node / Edge data model and the Executor trait."
+description = "0.2 substrate kernel — Workflow / Node / Edge data model, Executor trait, and the Workflow Library."
 
 [dependencies]
 onsager-artifact = { path = "../onsager-artifact" }
@@ -11,3 +11,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 typetag = "0.2"
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/onsager-substrate/src/lib.rs
+++ b/crates/onsager-substrate/src/lib.rs
@@ -2,28 +2,39 @@
 //!
 //! Kernel data model for the 0.2 substrate: the `Workflow` template
 //! (a node + edge graph), the `Executor` trait that every node carries,
-//! and the UUID newtypes that identify them.
+//! the UUID newtypes that identify them, and the
+//! [`WorkflowLibrary`](workflow_library::WorkflowLibrary) catalog
+//! resolving spec kind → workflow.
 //!
 //! See:
 //! - [ADR 0009](../../../docs/adr/0009-three-layer-pipeline.md) — the
 //!   Spec Plan / Workflow / Execution Plan three-layer pipeline.
 //! - [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md)
 //!   — why nodes carry `Box<dyn Executor>` instead of a `NodeKind` enum.
+//! - [ADR 0016](../../../docs/adr/0016-workflow-library-n-isomorphic-islands.md)
+//!   — the Workflow Library is a flat catalog: one active `Workflow`
+//!   per spec kind. The persistence layer lives in [`workflow_library`]
+//!   (SUB-04, #351).
 //! - [ADR 0018](../../../docs/adr/0018-five-kernel-invariants.md) — the
 //!   five static validators that operate on the types defined here
 //!   (lands in SUB-03, #350).
 //!
-//! This crate is intentionally pure data + a trait stub: no async, no
-//! database, no spine. Downstream crates (`onsager-nodes`, the Plan
-//! Compiler, the scheduler) layer behavior on top of these types.
+//! The kernel data types ([`Workflow`], [`Node`], [`Edge`], the
+//! [`Executor`] trait) stay pure data — no async, no database, no
+//! spine. The [`workflow_library`] module is the one exception: the
+//! library is `Workflow`-content's persistence layer, and SUB-04
+//! (#351) gives it a sqlx-backed implementation so the Plan Compiler
+//! (SUB-05, #352) can resolve `kind → Workflow` at runtime.
 
 pub mod executor;
 pub mod ids;
 pub mod workflow;
+pub mod workflow_library;
 
 pub use executor::*;
 pub use ids::*;
 pub use workflow::*;
+pub use workflow_library::*;
 
 // Re-exports for downstream convenience — anyone working with a
 // substrate `Workflow` will reach for provenance + artifact identity in

--- a/crates/onsager-substrate/src/workflow_library.rs
+++ b/crates/onsager-substrate/src/workflow_library.rs
@@ -38,6 +38,14 @@ use crate::workflow::Workflow;
 use sqlx::PgPool;
 use thiserror::Error;
 
+/// Name of the `(spec_kind, version)` unique constraint on
+/// `workflow_library`. Declared in
+/// `crates/onsager-spine/migrations/027_workflow_library.sql`; matched
+/// against `sqlx::error::DatabaseError::constraint()` so unrelated
+/// uniqueness violations (e.g. the primary key on `id`) don't get
+/// misclassified as [`WorkflowLibraryError::DuplicateKind`].
+const KIND_VERSION_UNIQUE_CONSTRAINT: &str = "workflow_library_kind_version_unique";
+
 /// Errors returned by [`WorkflowLibrary`] operations.
 #[derive(Debug, Error)]
 pub enum WorkflowLibraryError {
@@ -113,7 +121,9 @@ impl WorkflowLibrary {
 
         match result {
             Ok(version) => Ok(version),
-            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+            Err(sqlx::Error::Database(db_err))
+                if db_err.constraint() == Some(KIND_VERSION_UNIQUE_CONSTRAINT) =>
+            {
                 // The race-loser does not know which version it lost
                 // — re-read the latest to report a useful error.
                 let current = self.latest_version(kind).await.unwrap_or(0);

--- a/crates/onsager-substrate/src/workflow_library.rs
+++ b/crates/onsager-substrate/src/workflow_library.rs
@@ -1,0 +1,171 @@
+//! `WorkflowLibrary` — the flat catalog mapping spec kind → `Workflow`.
+//!
+//! Per [ADR 0016](../../../docs/adr/0016-workflow-library-n-isomorphic-islands.md)
+//! the Workflow Library is a flat catalog: one active `Workflow` per
+//! spec `kind`. The Plan Compiler (SUB-05, #352) resolves
+//! `kind → Workflow` via library lookup with no priority lists, no
+//! defaults, and no fallback chain. Same-kind specs share the same
+//! shape — the "N isomorphic islands" property.
+//!
+//! This issue (SUB-04, #351) adds the persistence layer the compiler
+//! reads from: a Postgres-backed registry keyed by `(spec_kind,
+//! version)`. Versions are monotonic per kind; the latest version is
+//! the active one (ADR 0016 "one active workflow per kind"). The
+//! kernel's data model — [`Workflow`], [`Node`], [`Edge`] — stays
+//! pure data and lives in [`crate::workflow`]; only this module
+//! reaches into the database.
+//!
+//! # Surface
+//!
+//! - [`WorkflowLibrary::register`] inserts a new version for a kind
+//!   and returns the assigned version number. Versions are monotonic
+//!   per kind (next = `MAX(version) + 1`).
+//! - [`WorkflowLibrary::lookup`] and [`WorkflowLibrary::latest`] both
+//!   return the latest registered workflow for a kind — they're the
+//!   compiler-facing read path. They return `Ok(None)` when the kind
+//!   has no entries.
+//!
+//! # Errors
+//!
+//! - [`WorkflowLibraryError::DuplicateKind`] surfaces the unique
+//!   constraint on `(spec_kind, version)` — two concurrent
+//!   registrations both computing the same next-version, or any
+//!   future caller that explicitly targets a version that already
+//!   exists. The compiler treats this as a non-fatal contention
+//!   signal: retry the register, or re-read the latest.
+
+use crate::workflow::Workflow;
+use sqlx::PgPool;
+use thiserror::Error;
+
+/// Errors returned by [`WorkflowLibrary`] operations.
+#[derive(Debug, Error)]
+pub enum WorkflowLibraryError {
+    /// A row already exists at the requested `(kind, version)` —
+    /// surfaced by the table's unique constraint. See ADR 0016's
+    /// "one active workflow per kind" rule.
+    #[error("duplicate registration for spec kind '{kind}' at version {version}")]
+    DuplicateKind { kind: String, version: i32 },
+
+    /// The stored `workflow_json` failed to deserialize back into a
+    /// `Workflow`. A row written by one substrate version and read
+    /// by another with an incompatible schema would land here.
+    #[error("workflow_json (de)serialization failed: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// Any other database failure — connection, timeout, schema
+    /// mismatch — bubbles up unchanged. The [`DuplicateKind`](Self::DuplicateKind)
+    /// constraint violation is intercepted earlier; everything else
+    /// reaches the caller here.
+    #[error("workflow_library database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Postgres-backed Workflow Library — the SUB-04 (#351) persistence
+/// layer described in ADR 0016.
+///
+/// Cheap to clone (wraps a `sqlx::PgPool`, which is itself
+/// reference-counted). The Plan Compiler holds one of these per
+/// process.
+#[derive(Clone)]
+pub struct WorkflowLibrary {
+    pool: PgPool,
+}
+
+impl WorkflowLibrary {
+    /// Wrap a pool. The pool must point at a database with the spine
+    /// migrations applied (see
+    /// `crates/onsager-spine/migrations/027_workflow_library.sql`).
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Register a new version of a workflow under `kind` and return
+    /// the assigned version. Versions are monotonic per kind starting
+    /// at 1.
+    ///
+    /// The next version is computed inline against the table:
+    /// `COALESCE(MAX(version), 0) + 1`. Two registrations racing on
+    /// the same kind can both compute the same next-version; the
+    /// unique constraint on `(spec_kind, version)` rejects the loser
+    /// with [`WorkflowLibraryError::DuplicateKind`]. Callers that
+    /// expect contention should retry.
+    pub async fn register(
+        &self,
+        kind: &str,
+        workflow: &Workflow,
+    ) -> Result<i32, WorkflowLibraryError> {
+        let json = serde_json::to_value(workflow)?;
+        let row_id = uuid::Uuid::new_v4().to_string();
+
+        let result = sqlx::query_scalar::<_, i32>(
+            "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
+             VALUES ($1, $2, \
+                     COALESCE((SELECT MAX(version) FROM workflow_library WHERE spec_kind = $2), 0) + 1, \
+                     $3) \
+             RETURNING version",
+        )
+        .bind(&row_id)
+        .bind(kind)
+        .bind(&json)
+        .fetch_one(&self.pool)
+        .await;
+
+        match result {
+            Ok(version) => Ok(version),
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                // The race-loser does not know which version it lost
+                // — re-read the latest to report a useful error.
+                let current = self.latest_version(kind).await.unwrap_or(0);
+                Err(WorkflowLibraryError::DuplicateKind {
+                    kind: kind.to_string(),
+                    version: current,
+                })
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Return the latest registered `Workflow` for `kind`, or
+    /// `Ok(None)` if the kind has never been registered.
+    ///
+    /// This is the ADR 0016 compiler-facing surface: "library[kind]"
+    /// resolves to a single active `Workflow`.
+    pub async fn lookup(&self, kind: &str) -> Result<Option<Workflow>, WorkflowLibraryError> {
+        self.latest(kind).await
+    }
+
+    /// Same as [`lookup`](Self::lookup) — return the workflow at the
+    /// highest registered version for `kind`. Spelled out as
+    /// `latest()` to make the "max version wins" semantics explicit
+    /// at call sites that care about the version-pick mechanic
+    /// rather than the catalog surface.
+    pub async fn latest(&self, kind: &str) -> Result<Option<Workflow>, WorkflowLibraryError> {
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(
+            "SELECT workflow_json FROM workflow_library \
+             WHERE spec_kind = $1 \
+             ORDER BY version DESC LIMIT 1",
+        )
+        .bind(kind)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some((json,)) => Ok(Some(serde_json::from_value(json)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Helper for the `DuplicateKind` error path — read the current
+    /// `MAX(version)` for a kind, returning `None` if no rows yet.
+    async fn latest_version(&self, kind: &str) -> Option<i32> {
+        sqlx::query_scalar::<_, Option<i32>>(
+            "SELECT MAX(version) FROM workflow_library WHERE spec_kind = $1",
+        )
+        .bind(kind)
+        .fetch_one(&self.pool)
+        .await
+        .ok()
+        .flatten()
+    }
+}

--- a/crates/onsager-substrate/tests/workflow_library.rs
+++ b/crates/onsager-substrate/tests/workflow_library.rs
@@ -147,44 +147,131 @@ async fn workflow_roundtrips_through_register_and_lookup() {
     cleanup(&pool, &kind).await;
 }
 
+/// Drive `register` through a deterministic collision on (kind, 1)
+/// so we observe its error-mapping path — not just the raw database
+/// constraint. The pattern: open a transaction that inserts at v=1
+/// but doesn't commit; in parallel, call `register` (which under
+/// READ COMMITTED can't see the uncommitted row, so its `MAX+1`
+/// also picks v=1 and its INSERT blocks on the unique constraint);
+/// then commit the blocker, which forces `register`'s INSERT to
+/// fail with the kind+version unique violation, which `register`
+/// must map to `WorkflowLibraryError::DuplicateKind`.
 #[tokio::test]
-async fn duplicate_kind_version_surfaces_as_error() {
+async fn register_maps_kind_version_collision_to_duplicate_kind() {
     let Some(url) = db_url() else {
         eprintln!("skipping: DATABASE_URL not set");
         return;
     };
     let pool = PgPool::connect(&url).await.unwrap();
-    let kind = unique_kind("sub04_dupe");
+    let kind = unique_kind("sub04_register_dupe");
     cleanup(&pool, &kind).await;
 
-    let lib = WorkflowLibrary::new(pool.clone());
-
-    // Land version 1 normally.
-    let w1 = sample_workflow("dupe_v1");
-    let v1 = lib.register(&kind, &w1).await.expect("register v1");
-    assert_eq!(v1, 1);
-
-    // Manufacture a colliding write at (kind, 1) directly — the
-    // unique constraint on (spec_kind, version) is what
-    // `DuplicateKind` maps in the public API. Doing this via raw SQL
-    // avoids depending on a race for determinism.
-    let json = serde_json::to_value(sample_workflow("dupe_v1_again")).unwrap();
-    let direct_err = sqlx::query(
+    // Blocker transaction: holds an uncommitted row at v=1.
+    let mut blocker = pool.begin().await.expect("begin blocker tx");
+    let blocker_json = serde_json::to_value(sample_workflow("blocker")).unwrap();
+    sqlx::query(
         "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
          VALUES ($1, $2, 1, $3)",
     )
     .bind(uuid::Uuid::new_v4().to_string())
     .bind(&kind)
+    .bind(&blocker_json)
+    .execute(&mut *blocker)
+    .await
+    .expect("blocker insert");
+
+    // Spawn `register` from outside the blocker's transaction. Its
+    // SELECT MAX runs under a separate connection that sees no
+    // committed rows for this kind, computes `next = 1`, and tries
+    // to INSERT at (kind, 1) — which blocks on the unique constraint
+    // until the blocker commits.
+    let lib = WorkflowLibrary::new(pool.clone());
+    let kind_for_task = kind.clone();
+    let racer_workflow = sample_workflow("racer");
+    let racer = tokio::spawn(async move { lib.register(&kind_for_task, &racer_workflow).await });
+
+    // Give the spawned task a moment to enqueue its INSERT and hit
+    // the row lock. 200ms is generous on local Postgres; the test
+    // remains correct if it's longer.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Releasing the blocker commits its row at v=1; the racer's
+    // INSERT is now refused by the unique constraint.
+    blocker.commit().await.expect("commit blocker");
+
+    match racer.await.expect("join racer") {
+        Err(WorkflowLibraryError::DuplicateKind { kind: k, version }) => {
+            assert_eq!(k, kind);
+            // The error reports whatever version is now live — i.e.
+            // the blocker's v=1.
+            assert_eq!(version, 1);
+        }
+        other => panic!("expected DuplicateKind through register, got: {other:?}"),
+    }
+
+    cleanup(&pool, &kind).await;
+}
+
+/// An unrelated unique-constraint violation (the primary key on
+/// `id`) must NOT be reported as `DuplicateKind`. This pins
+/// `register`'s constraint-name check so future schema additions
+/// (more unique constraints on the table) don't get silently
+/// misclassified.
+#[tokio::test]
+async fn unrelated_unique_violation_does_not_surface_as_duplicate_kind() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_pk_dupe");
+    cleanup(&pool, &kind).await;
+
+    // Take a row id and pre-insert at v=99 to force a PK collision
+    // by re-inserting the same id from a separate path. We don't
+    // have a public hook to control `register`'s generated id, so we
+    // instead exercise the constraint directly and verify the error
+    // shape — confirming that `is_unique_violation()` alone would
+    // misclassify it.
+    let fixed_id = uuid::Uuid::new_v4().to_string();
+    let json = serde_json::to_value(sample_workflow("pk_dupe")).unwrap();
+
+    sqlx::query(
+        "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
+         VALUES ($1, $2, 1, $3)",
+    )
+    .bind(&fixed_id)
+    .bind(&kind)
     .bind(&json)
     .execute(&pool)
     .await
-    .expect_err("second insert at (kind, 1) must violate UNIQUE");
+    .expect("seed row");
 
-    match direct_err {
-        sqlx::Error::Database(db_err) => assert!(
-            db_err.is_unique_violation(),
-            "expected unique violation, got: {db_err}"
-        ),
+    let err = sqlx::query(
+        "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
+         VALUES ($1, $2, 2, $3)",
+    )
+    .bind(&fixed_id)
+    .bind(&kind)
+    .bind(&json)
+    .execute(&pool)
+    .await
+    .expect_err("duplicate id must violate PK");
+
+    match err {
+        sqlx::Error::Database(db_err) => {
+            assert!(
+                db_err.is_unique_violation(),
+                "expected unique violation, got: {db_err}"
+            );
+            // The constraint name on the PK is *not* the kind+version
+            // one — so register's match-guard would correctly skip it.
+            assert_ne!(
+                db_err.constraint(),
+                Some("workflow_library_kind_version_unique"),
+                "PK violation must not look like kind+version collision"
+            );
+        }
         other => panic!("expected Database error, got: {other:?}"),
     }
 

--- a/crates/onsager-substrate/tests/workflow_library.rs
+++ b/crates/onsager-substrate/tests/workflow_library.rs
@@ -1,0 +1,262 @@
+//! Integration tests for `WorkflowLibrary` (SUB-04, #351).
+//!
+//! These tests need a Postgres instance with the spine migrations
+//! applied — they skip themselves when `DATABASE_URL` is unset, the
+//! same pattern as `forge/tests/persistence_restart.rs`.
+//!
+//! Each test scopes its writes to a unique `spec_kind` so concurrent
+//! runs of the suite don't trip each other on the `(spec_kind,
+//! version)` unique constraint.
+
+use onsager_artifact::{ArtifactId, NodeId};
+use onsager_substrate::{
+    EdgeId, EdgeRef, NoOpExecutor, Workflow, WorkflowLibrary, WorkflowLibraryError,
+};
+use sqlx::PgPool;
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL").ok()
+}
+
+fn unique_kind(prefix: &str) -> String {
+    format!("{}_{}", prefix, uuid::Uuid::new_v4().simple())
+}
+
+fn sample_workflow(label: &str) -> Workflow {
+    let edge_in = EdgeId::generate();
+    let edge_out = EdgeId::generate();
+    Workflow {
+        nodes: vec![onsager_substrate::Node {
+            id: NodeId::generate(),
+            executor: Box::new(NoOpExecutor),
+            inputs: vec![EdgeRef::new(edge_in)],
+            outputs: vec![EdgeRef::new(edge_out)],
+        }],
+        edges: vec![
+            onsager_substrate::Edge {
+                id: edge_in,
+                artifact_id: ArtifactId::new(format!("art_in_{label}")),
+                requires_deterministic: true,
+            },
+            onsager_substrate::Edge {
+                id: edge_out,
+                artifact_id: ArtifactId::new(format!("art_out_{label}")),
+                requires_deterministic: false,
+            },
+        ],
+    }
+}
+
+async fn cleanup(pool: &PgPool, kind: &str) {
+    sqlx::query("DELETE FROM workflow_library WHERE spec_kind = $1")
+        .bind(kind)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn register_then_lookup_returns_latest_version() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_register_lookup");
+    cleanup(&pool, &kind).await;
+
+    let lib = WorkflowLibrary::new(pool.clone());
+
+    // Register v1 — lookup returns it.
+    let w1 = sample_workflow("v1");
+    let v1 = lib.register(&kind, &w1).await.expect("register v1");
+    assert_eq!(v1, 1);
+
+    let after_v1 = lib
+        .lookup(&kind)
+        .await
+        .expect("lookup after v1")
+        .expect("workflow exists");
+    assert_eq!(after_v1.nodes.len(), 1);
+    assert_eq!(after_v1.edges.len(), 2);
+    assert_eq!(after_v1.edges[0].artifact_id, w1.edges[0].artifact_id);
+
+    // Register v2 — latest now wins.
+    let w2 = sample_workflow("v2");
+    let v2 = lib.register(&kind, &w2).await.expect("register v2");
+    assert_eq!(v2, 2);
+
+    let after_v2 = lib
+        .latest(&kind)
+        .await
+        .expect("latest after v2")
+        .expect("workflow exists");
+    assert_eq!(after_v2.edges[0].artifact_id, w2.edges[0].artifact_id);
+
+    // lookup() and latest() agree.
+    let by_lookup = lib.lookup(&kind).await.unwrap().unwrap();
+    assert_eq!(by_lookup.edges[0].artifact_id, w2.edges[0].artifact_id);
+
+    cleanup(&pool, &kind).await;
+}
+
+#[tokio::test]
+async fn lookup_returns_none_for_unknown_kind() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_unknown");
+
+    let lib = WorkflowLibrary::new(pool);
+    assert!(lib.lookup(&kind).await.unwrap().is_none());
+    assert!(lib.latest(&kind).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn workflow_roundtrips_through_register_and_lookup() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_roundtrip");
+    cleanup(&pool, &kind).await;
+
+    let lib = WorkflowLibrary::new(pool.clone());
+
+    let original = sample_workflow("roundtrip");
+    let original_json = serde_json::to_value(&original).unwrap();
+
+    lib.register(&kind, &original).await.expect("register");
+
+    let fetched = lib
+        .lookup(&kind)
+        .await
+        .expect("lookup")
+        .expect("workflow exists");
+    let fetched_json = serde_json::to_value(&fetched).unwrap();
+
+    // Identical JSON ⇒ identical struct — the substrate's serde
+    // round-trip property (pinned by `workflow.rs::tests::
+    // workflow_roundtrips_through_serde_json`) carries through the
+    // database layer.
+    assert_eq!(original_json, fetched_json);
+
+    cleanup(&pool, &kind).await;
+}
+
+#[tokio::test]
+async fn duplicate_kind_version_surfaces_as_error() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_dupe");
+    cleanup(&pool, &kind).await;
+
+    let lib = WorkflowLibrary::new(pool.clone());
+
+    // Land version 1 normally.
+    let w1 = sample_workflow("dupe_v1");
+    let v1 = lib.register(&kind, &w1).await.expect("register v1");
+    assert_eq!(v1, 1);
+
+    // Manufacture a colliding write at (kind, 1) directly — the
+    // unique constraint on (spec_kind, version) is what
+    // `DuplicateKind` maps in the public API. Doing this via raw SQL
+    // avoids depending on a race for determinism.
+    let json = serde_json::to_value(sample_workflow("dupe_v1_again")).unwrap();
+    let direct_err = sqlx::query(
+        "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
+         VALUES ($1, $2, 1, $3)",
+    )
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(&kind)
+    .bind(&json)
+    .execute(&pool)
+    .await
+    .expect_err("second insert at (kind, 1) must violate UNIQUE");
+
+    match direct_err {
+        sqlx::Error::Database(db_err) => assert!(
+            db_err.is_unique_violation(),
+            "expected unique violation, got: {db_err}"
+        ),
+        other => panic!("expected Database error, got: {other:?}"),
+    }
+
+    cleanup(&pool, &kind).await;
+}
+
+/// Two `register` calls racing on the same fresh kind should produce
+/// either one success per call (Postgres serialized them) OR one
+/// success and one [`WorkflowLibraryError::DuplicateKind`] (the
+/// next-version computation collided). Either outcome proves the
+/// "one active per (kind, version)" invariant holds — the table
+/// never ends up with two rows at the same version.
+#[tokio::test]
+async fn concurrent_register_preserves_uniqueness() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let pool = PgPool::connect(&url).await.unwrap();
+    let kind = unique_kind("sub04_concurrent");
+    cleanup(&pool, &kind).await;
+
+    let lib_a = WorkflowLibrary::new(pool.clone());
+    let lib_b = WorkflowLibrary::new(pool.clone());
+    let kind_a = kind.clone();
+    let kind_b = kind.clone();
+    let w_a = sample_workflow("race_a");
+    let w_b = sample_workflow("race_b");
+
+    let (r_a, r_b) = tokio::join!(
+        async move { lib_a.register(&kind_a, &w_a).await },
+        async move { lib_b.register(&kind_b, &w_b).await },
+    );
+
+    match (&r_a, &r_b) {
+        (Ok(va), Ok(vb)) => {
+            assert_ne!(
+                va, vb,
+                "two successful registers must hand out distinct versions"
+            );
+        }
+        (Err(WorkflowLibraryError::DuplicateKind { kind: k, .. }), Ok(_))
+        | (Ok(_), Err(WorkflowLibraryError::DuplicateKind { kind: k, .. })) => {
+            assert_eq!(k, &kind);
+        }
+        other => panic!("unexpected concurrent register result: {other:?}"),
+    }
+
+    // Final state: at most two rows at distinct versions, both for `kind`.
+    let rows: Vec<(i32,)> =
+        sqlx::query_as("SELECT version FROM workflow_library WHERE spec_kind = $1")
+            .bind(&kind)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let mut versions: Vec<i32> = rows.into_iter().map(|(v,)| v).collect();
+    versions.sort();
+    assert!(
+        versions == vec![1] || versions == vec![1, 2],
+        "got: {versions:?}"
+    );
+
+    cleanup(&pool, &kind).await;
+}
+
+#[test]
+fn duplicate_kind_error_displays_kind_and_version() {
+    let err = WorkflowLibraryError::DuplicateKind {
+        kind: "design".into(),
+        version: 7,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("design"), "got: {msg}");
+    assert!(msg.contains('7'), "got: {msg}");
+}


### PR DESCRIPTION
## Summary

Adds the Postgres-backed `WorkflowLibrary` registry that maps spec `kind` → active `Workflow`, per ADR 0016 ("Workflow Library: N isomorphic islands"). The Plan Compiler (SUB-05, #352) will read through this registry when it instantiates a Spec Plan into an Execution Plan.

- **Migration 027** — `workflow_library` table with `(id, spec_kind, version, workflow_json, registered_at)` and a `UNIQUE(spec_kind, version)` constraint. Index on `(spec_kind, version DESC)` for `latest()`.
- **`onsager-substrate::workflow_library`** — `WorkflowLibrary { pool }` with:
  - `register(kind, &Workflow) -> Result<i32>` — auto-increments per kind (`COALESCE(MAX(version), 0) + 1`), returns the assigned version.
  - `lookup(kind) -> Result<Option<Workflow>>` — ADR 0016's compiler-facing surface; resolves to the latest active workflow.
  - `latest(kind) -> Result<Option<Workflow>>` — same shape, explicit naming for "max-version wins".
- **`WorkflowLibraryError::DuplicateKind`** — surfaces the unique-constraint violation when two concurrent registrations both compute the same next-version. Re-reads `MAX(version)` to attach a useful version to the error.
- **Integration tests** — `crates/onsager-substrate/tests/workflow_library.rs`. Skip themselves when `DATABASE_URL` is unset, matching `forge/tests/persistence_restart.rs`. Cover the verification matrix from the issue:
  - register → lookup → newer version → latest wins
  - unknown kind returns `Ok(None)`
  - workflow round-trips through register + lookup (struct equality via JSON)
  - duplicate `(kind, version)` surfaces a unique violation
  - concurrent register preserves the uniqueness invariant

The substrate's "pure data + trait stub" rule is amended: this module is the one DB-touching corner, and `lib.rs` calls that out. The kernel data types (`Workflow`, `Node`, `Edge`, `Executor`) stay pure.

## Test plan

- [x] `cargo build -p onsager-substrate`
- [x] `cargo test -p onsager-substrate` (DB-requiring tests skip without `DATABASE_URL`; unit test for `DuplicateKind` display runs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `xtask lint-seams`, `xtask check-file-budget`
- [ ] Run integration tests against a live Postgres with migrations applied (`DATABASE_URL=... cargo test -p onsager-substrate`)

Closes #351

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4zMc61uuDoDmG4pBhr4wV)_