### PR TITLE
feat(nodes): runtime Executor trait + dispatch in onsager-nodes (EXE-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "onsager-nodes"
+version = "0.2.0-alpha.1"
+dependencies = [
+ "async-trait",
+ "onsager-artifact",
+ "onsager-substrate",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "onsager-portal"
 version = "0.2.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/onsager-registry",
     "crates/onsager-spine",
     "crates/onsager-substrate",
+    "crates/onsager-nodes",
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",

--- a/crates/onsager-nodes/Cargo.toml
+++ b/crates/onsager-nodes/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "onsager-nodes"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Runtime Executor catalog — the async half of the Executor trait plus the dispatch registry."
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+onsager-substrate = { path = "../onsager-substrate" }
+
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/onsager-nodes/src/context.rs
+++ b/crates/onsager-nodes/src/context.rs
@@ -1,0 +1,91 @@
+//! [`ExecutorContext`] / [`ExecutorOutputs`] — the input and output
+//! shapes the runtime hands to / takes back from an executor.
+//!
+//! The scheduler (RUN-01, #359) builds a context from the upstream
+//! edges' resolved artifacts, calls `Executor::execute`, and routes
+//! the returned [`ExecutorOutputs`] onto the downstream edges. This
+//! crate doesn't host the scheduler — only the data shapes the
+//! executor sees.
+
+use std::sync::Arc;
+
+use onsager_artifact::{Artifact, ArtifactId, NodeId};
+
+use crate::SpineClient;
+
+/// What an executor receives when the runtime invokes it.
+///
+/// The fields are exactly the runtime context the kernel commits to;
+/// future capabilities (cancellation, structured logging, secrets)
+/// extend this struct rather than adding new arguments to
+/// `Executor::execute`.
+#[derive(Debug)]
+pub struct ExecutorContext {
+    /// The node whose executor this is — identifies the producer for
+    /// downstream `Artifact::produced_by_node` tagging.
+    pub node_id: NodeId,
+    /// Resolved upstream artifacts on this node's input edges, in
+    /// declaration order. The runtime is responsible for matching
+    /// these up to the executor's expected input shape.
+    pub inputs: Vec<(ArtifactId, Artifact)>,
+    /// Port for emitting events and reading other artifacts. Shared
+    /// across executors in a run.
+    pub spine: Arc<dyn SpineClient>,
+}
+
+/// What an executor returns to the runtime.
+///
+/// Each `(ArtifactId, Artifact)` pair lines up with one of the node's
+/// declared output edges, again in declaration order. An empty vec is
+/// legal — a side-effecting executor that emits events but produces no
+/// artifact returns `ExecutorOutputs::empty()`.
+#[derive(Debug, Default)]
+pub struct ExecutorOutputs {
+    pub artifacts: Vec<(ArtifactId, Artifact)>,
+}
+
+impl ExecutorOutputs {
+    /// An empty outputs value. Used by side-effect-only executors
+    /// (including [`crate::NoOpExecutor`]).
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Build an outputs value from a single `(id, artifact)` pair.
+    pub fn single(id: ArtifactId, artifact: Artifact) -> Self {
+        Self {
+            artifacts: vec![(id, artifact)],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spine::test_support::{MockSpine, dummy_artifact};
+
+    #[test]
+    fn outputs_empty_has_no_artifacts() {
+        assert!(ExecutorOutputs::empty().artifacts.is_empty());
+        assert!(ExecutorOutputs::default().artifacts.is_empty());
+    }
+
+    #[test]
+    fn outputs_single_carries_one_pair() {
+        let art = dummy_artifact();
+        let id = art.artifact_id.clone();
+        let out = ExecutorOutputs::single(id.clone(), art);
+        assert_eq!(out.artifacts.len(), 1);
+        assert_eq!(out.artifacts[0].0, id);
+    }
+
+    #[test]
+    fn context_is_constructible_with_mock_spine() {
+        let ctx = ExecutorContext {
+            node_id: NodeId::generate(),
+            inputs: vec![],
+            spine: Arc::new(MockSpine::default()),
+        };
+        assert!(ctx.inputs.is_empty());
+    }
+}

--- a/crates/onsager-nodes/src/dispatch.rs
+++ b/crates/onsager-nodes/src/dispatch.rs
@@ -1,0 +1,79 @@
+//! End-to-end dispatch helper — given a substrate [`Node`] and an
+//! [`ExecutorRegistry`], find the runtime executor for the node's
+//! kind and run it.
+//!
+//! Future scheduler work (RUN-01, #359) will wrap this with edge
+//! resolution, output routing, and provenance propagation. The bare
+//! helper exists today so dispatch is testable in isolation and so
+//! `cargo build -p onsager-nodes` exercises both the substrate
+//! dependency and the runtime registry as a single pipeline.
+
+use onsager_substrate::workflow::Node;
+
+use crate::context::{ExecutorContext, ExecutorOutputs};
+use crate::error::ExecutorError;
+use crate::registry::ExecutorRegistry;
+
+/// Resolve `node.executor.executor_kind()` through `registry` and run
+/// it. Returns [`ExecutorError::UnknownKind`] if no runtime executor
+/// is registered for the node's kind string.
+pub async fn dispatch(
+    registry: &ExecutorRegistry,
+    node: &Node,
+    ctx: ExecutorContext,
+) -> Result<ExecutorOutputs, ExecutorError> {
+    let kind = node.executor.executor_kind();
+    let runtime = registry
+        .get(kind)
+        .ok_or_else(|| ExecutorError::UnknownKind(kind.to_string()))?;
+    runtime.execute(ctx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spine::test_support::MockSpine;
+    use onsager_artifact::NodeId;
+    use onsager_substrate::executor::NoOpExecutor as SubstrateNoOp;
+    use onsager_substrate::workflow::Node;
+    use std::sync::Arc;
+
+    fn noop_node() -> Node {
+        Node {
+            id: NodeId::generate(),
+            executor: Box::new(SubstrateNoOp),
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+
+    fn empty_ctx() -> ExecutorContext {
+        ExecutorContext {
+            node_id: NodeId::generate(),
+            inputs: vec![],
+            spine: Arc::new(MockSpine::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_resolves_substrate_node_to_runtime_executor() {
+        // The substrate NoOp and the runtime NoOp share the kind
+        // string "noop" — that's the entire dispatch contract.
+        let registry = ExecutorRegistry::with_noop();
+        let node = noop_node();
+        let outputs = dispatch(&registry, &node, empty_ctx()).await.unwrap();
+        assert!(outputs.artifacts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_kind_returns_unknown_kind_error() {
+        // Empty registry — the node's "noop" kind has no runtime.
+        let registry = ExecutorRegistry::new();
+        let node = noop_node();
+        let err = dispatch(&registry, &node, empty_ctx()).await.unwrap_err();
+        match err {
+            ExecutorError::UnknownKind(kind) => assert_eq!(kind, "noop"),
+            other => panic!("expected UnknownKind, got {other:?}"),
+        }
+    }
+}

--- a/crates/onsager-nodes/src/error.rs
+++ b/crates/onsager-nodes/src/error.rs
@@ -1,0 +1,69 @@
+//! [`ExecutorError`] — the error type runtime executors return.
+//!
+//! Executors fail in three shapes:
+//!
+//! - **`UnknownKind`** — the registry was asked to dispatch a kind it
+//!   doesn't know. Surfaces from [`crate::dispatch`]; an individual
+//!   `Executor::execute` impl will never construct this itself.
+//! - **`Spine`** — a [`crate::SpineClient`] call failed. Most
+//!   executors propagate this with `?`; the `#[from]` impl keeps the
+//!   call sites quiet.
+//! - **`Failed`** — anything else the executor wants to report. Free-
+//!   text on purpose: forcing every executor's domain errors into a
+//!   closed enum would re-introduce the catalog problem ADR 0012
+//!   removes.
+
+use thiserror::Error;
+
+use crate::SpineError;
+
+/// Error returned by a runtime executor's `execute()` method (or by
+/// [`crate::dispatch`] when the kind isn't registered).
+#[derive(Debug, Error)]
+pub enum ExecutorError {
+    /// The registry had no entry for the executor kind requested.
+    #[error("no executor registered for kind `{0}`")]
+    UnknownKind(String),
+
+    /// A call into the spine port failed.
+    #[error(transparent)]
+    Spine(#[from] SpineError),
+
+    /// Executor-specific failure — free-text reason.
+    #[error("executor failed: {0}")]
+    Failed(String),
+}
+
+impl ExecutorError {
+    /// Build a `Failed` error from any displayable value.
+    pub fn failed(msg: impl Into<String>) -> Self {
+        Self::Failed(msg.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_kind_message_includes_kind() {
+        let err = ExecutorError::UnknownKind("script".into());
+        assert_eq!(err.to_string(), "no executor registered for kind `script`");
+    }
+
+    #[test]
+    fn spine_error_converts_via_from() {
+        let spine = SpineError::new("boom");
+        let err: ExecutorError = spine.into();
+        assert!(matches!(err, ExecutorError::Spine(_)));
+        // Transparent forwarding — the spine error's display shows
+        // through, no extra "executor:" prefix.
+        assert_eq!(err.to_string(), "spine error: boom");
+    }
+
+    #[test]
+    fn failed_helper_wraps_string() {
+        let err = ExecutorError::failed("nope");
+        assert_eq!(err.to_string(), "executor failed: nope");
+    }
+}

--- a/crates/onsager-nodes/src/executor.rs
+++ b/crates/onsager-nodes/src/executor.rs
@@ -1,0 +1,149 @@
+//! The runtime [`Executor`] trait and the [`NoOpExecutor`] reference
+//! implementation.
+//!
+//! See [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md).
+//! The static / serializable half of "what a node carries" lives in
+//! [`onsager_substrate::Executor`] — this trait is the runtime sibling.
+//! Both halves share an `executor_kind()` string: the substrate side
+//! uses it as a typetag discriminator, the runtime side uses it as the
+//! [`crate::ExecutorRegistry`] lookup key. A workflow's static
+//! `executor.executor_kind()` and the registered runtime executor's
+//! `executor_kind()` must agree — that's the only contract the
+//! kernel relies on to route a node to its behavior.
+//!
+//! Trait-object safety is load-bearing: the registry stores
+//! `Arc<dyn Executor>` and the scheduler dispatches through it. No
+//! generic methods, no `where Self: Sized`.
+
+use async_trait::async_trait;
+use onsager_artifact::Provenance;
+
+use crate::context::{ExecutorContext, ExecutorOutputs};
+use crate::error::ExecutorError;
+
+/// What a node *does* at runtime.
+///
+/// Implementations live as flat sibling modules in this crate
+/// (`script.rs`, `agent.rs`, `verify.rs`, `human.rs`, `subworkflow.rs`)
+/// — see ADR 0012 § Decision. Each implementation registers itself
+/// with the [`crate::ExecutorRegistry`] at startup so the scheduler
+/// can resolve a node's kind to the running instance.
+///
+/// `declared_provenance` mirrors the substrate trait's contract: a
+/// non-Verify executor must return at least the worst input provenance
+/// (the kernel's invariant 2 from ADR 0018 enforces this at validate
+/// time). Verify (EXE-04) is the only executor allowed to upgrade
+/// `Uncertain` inputs to `Deterministic`.
+#[async_trait]
+pub trait Executor: Send + Sync + std::fmt::Debug {
+    /// The wire-format tag for this executor. Must match the
+    /// `executor_kind()` of the corresponding
+    /// [`onsager_substrate::Executor`] implementation — the registry
+    /// uses this string as its lookup key.
+    fn executor_kind(&self) -> &'static str;
+
+    /// Provenance this executor claims to produce, given its inputs.
+    /// See [`onsager_substrate::Executor::declared_provenance`] for
+    /// the contract; the runtime side restates it so an executor that
+    /// only implements the runtime trait still answers the question.
+    fn declared_provenance(&self, input_provenances: &[Provenance]) -> Provenance;
+
+    /// Run the node. The runtime supplies upstream artifacts and a
+    /// spine port; the executor returns the artifacts it produced (or
+    /// `ExecutorOutputs::empty()` for side-effect-only kinds).
+    async fn execute(&self, ctx: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError>;
+}
+
+/// A no-op runtime executor — produces no artifacts, emits no events.
+///
+/// The runtime counterpart of [`onsager_substrate::NoOpExecutor`].
+/// Both register under the kind string `"noop"`, so a workflow whose
+/// nodes use the substrate `NoOpExecutor` dispatches correctly the
+/// moment the runtime side is registered.
+///
+/// Use cases:
+/// - the registry's default-registered executor, so dispatch compiles
+///   and works end-to-end before any real executor (EXE-02..06) lands;
+/// - placeholder while a workflow author stubs a node before the real
+///   executor exists.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoOpExecutor;
+
+#[async_trait]
+impl Executor for NoOpExecutor {
+    fn executor_kind(&self) -> &'static str {
+        "noop"
+    }
+
+    fn declared_provenance(&self, inputs: &[Provenance]) -> Provenance {
+        // Mirror the substrate NoOpExecutor: propagate the worst input
+        // (any `Uncertain` wins), default to external-deterministic
+        // when there are no inputs at all.
+        inputs
+            .iter()
+            .copied()
+            .find(Provenance::is_uncertain)
+            .unwrap_or_default()
+    }
+
+    async fn execute(&self, _ctx: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+        Ok(ExecutorOutputs::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spine::test_support::MockSpine;
+    use onsager_artifact::{NodeId, SourceTag};
+    use std::sync::Arc;
+
+    fn empty_ctx() -> ExecutorContext {
+        ExecutorContext {
+            node_id: NodeId::generate(),
+            inputs: vec![],
+            spine: Arc::new(MockSpine::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_execute_returns_empty_outputs() {
+        let out = NoOpExecutor.execute(empty_ctx()).await.unwrap();
+        assert!(out.artifacts.is_empty());
+    }
+
+    #[test]
+    fn noop_executor_kind_is_noop() {
+        assert_eq!(NoOpExecutor.executor_kind(), "noop");
+    }
+
+    #[test]
+    fn noop_declared_provenance_with_no_inputs_is_external_deterministic() {
+        assert_eq!(
+            NoOpExecutor.declared_provenance(&[]),
+            Provenance::external_deterministic()
+        );
+    }
+
+    #[test]
+    fn noop_declared_provenance_propagates_uncertain_input() {
+        let p = NoOpExecutor.declared_provenance(&[
+            Provenance::Deterministic {
+                source: SourceTag::Script,
+            },
+            Provenance::Uncertain {
+                source: SourceTag::Agent,
+            },
+        ]);
+        assert!(p.is_uncertain());
+        assert_eq!(p.source(), SourceTag::Agent);
+    }
+
+    /// Compile-time check: the trait is object-safe and `Box<dyn>` /
+    /// `Arc<dyn>` storage works without `where Self: Sized` hacks.
+    #[test]
+    fn executor_trait_is_object_safe() {
+        let _boxed: Box<dyn Executor> = Box::new(NoOpExecutor);
+        let _arced: Arc<dyn Executor> = Arc::new(NoOpExecutor);
+    }
+}

--- a/crates/onsager-nodes/src/lib.rs
+++ b/crates/onsager-nodes/src/lib.rs
@@ -1,0 +1,36 @@
+//! # onsager-nodes
+//!
+//! The runtime half of the executor catalog — the `async` side of the
+//! `Executor` trait, the [`ExecutorRegistry`] that holds one instance
+//! per executor kind, and a `dispatch(...)` helper that takes a
+//! substrate `Node` and runs its executor.
+//!
+//! See:
+//! - [ADR 0012](../../../docs/adr/0012-executor-catalog-replaces-nodekind.md)
+//!   — why nodes carry `Box<dyn Executor>` instead of a closed
+//!   `NodeKind` enum, and the flat-crate convention for executor
+//!   implementations.
+//! - The static / serializable half of the trait lives in
+//!   [`onsager_substrate::Executor`] — `executor_kind()` /
+//!   `declared_provenance()` for workflow validation and serde
+//!   round-trips. This crate's [`Executor`] is the runtime sibling: it
+//!   shares the same `executor_kind()` string (that's how dispatch
+//!   resolves a node to its runtime), and adds `async fn execute(..)`.
+//!
+//! Subsequent issues (EXE-02 through EXE-06) land concrete executors
+//! — Script, Agent, Verify, Human, SubWorkflow — as flat sibling
+//! modules here.
+
+pub mod context;
+pub mod dispatch;
+pub mod error;
+pub mod executor;
+pub mod registry;
+pub mod spine;
+
+pub use context::{ExecutorContext, ExecutorOutputs};
+pub use dispatch::dispatch;
+pub use error::ExecutorError;
+pub use executor::{Executor, NoOpExecutor};
+pub use registry::ExecutorRegistry;
+pub use spine::{SpineClient, SpineError};

--- a/crates/onsager-nodes/src/registry.rs
+++ b/crates/onsager-nodes/src/registry.rs
@@ -1,0 +1,127 @@
+//! [`ExecutorRegistry`] — the runtime catalog mapping
+//! `executor_kind` → `Arc<dyn Executor>`.
+//!
+//! Populated at startup, looked up at dispatch time. The registry is
+//! the single point of failure for "did you remember to register your
+//! executor" (ADR 0012 § Negative consequences); workflows referencing
+//! an unregistered kind fail at [`crate::dispatch`] with
+//! [`crate::ExecutorError::UnknownKind`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::executor::{Executor, NoOpExecutor};
+
+/// Lookup table for runtime executors, keyed by `executor_kind()`.
+///
+/// Build one per process at startup, register each concrete executor
+/// once, then hand `&self` to the scheduler. Mutable construction is
+/// intentional — the registry is finalized before dispatch starts;
+/// hot-reload is explicitly out of scope (ADR 0012 § Out of scope).
+#[derive(Debug, Default)]
+pub struct ExecutorRegistry {
+    by_kind: HashMap<&'static str, Arc<dyn Executor>>,
+}
+
+impl ExecutorRegistry {
+    /// An empty registry. Combine with [`Self::register`] to populate.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A registry pre-populated with the no-op executor.
+    ///
+    /// Useful for early-bringup runtimes and tests that exercise the
+    /// dispatch machinery before any real executor (EXE-02..06) has
+    /// landed.
+    pub fn with_noop() -> Self {
+        let mut r = Self::new();
+        r.register(Arc::new(NoOpExecutor));
+        r
+    }
+
+    /// Register an executor. Subsequent calls to [`Self::get`] with
+    /// the same `executor_kind()` resolve to this instance. A second
+    /// registration under the same kind silently replaces the first —
+    /// startup wiring controls the order, so "last writer wins"
+    /// matches the way registries are built in practice.
+    pub fn register(&mut self, executor: Arc<dyn Executor>) {
+        let kind = executor.executor_kind();
+        self.by_kind.insert(kind, executor);
+    }
+
+    /// Look up the runtime executor for a kind, if registered.
+    pub fn get(&self, kind: &str) -> Option<Arc<dyn Executor>> {
+        self.by_kind.get(kind).cloned()
+    }
+
+    /// Iterate over the registered kinds. Order is unspecified.
+    pub fn kinds(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.by_kind.keys().copied()
+    }
+
+    /// Number of registered executors.
+    pub fn len(&self) -> usize {
+        self.by_kind.len()
+    }
+
+    /// Whether the registry has no executors.
+    pub fn is_empty(&self) -> bool {
+        self.by_kind.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ExecutorContext;
+    use crate::spine::test_support::MockSpine;
+    use onsager_artifact::NodeId;
+
+    #[test]
+    fn new_registry_is_empty() {
+        let r = ExecutorRegistry::new();
+        assert!(r.is_empty());
+        assert_eq!(r.len(), 0);
+        assert!(r.get("noop").is_none());
+    }
+
+    #[test]
+    fn with_noop_registers_the_noop_executor() {
+        let r = ExecutorRegistry::with_noop();
+        assert_eq!(r.len(), 1);
+        let exec = r.get("noop").expect("noop should be registered");
+        assert_eq!(exec.executor_kind(), "noop");
+    }
+
+    #[test]
+    fn register_overwrites_same_kind() {
+        let mut r = ExecutorRegistry::new();
+        r.register(Arc::new(NoOpExecutor));
+        r.register(Arc::new(NoOpExecutor));
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn kinds_lists_registered_executors() {
+        let r = ExecutorRegistry::with_noop();
+        let kinds: Vec<&'static str> = r.kinds().collect();
+        assert_eq!(kinds, vec!["noop"]);
+    }
+
+    #[tokio::test]
+    async fn noop_dispatched_through_registry_returns_empty_outputs() {
+        // Acceptance test from issue #353 verification list:
+        // "NoOpExecutor dispatched through the registry returns
+        // ExecutorOutputs { artifacts: vec![] }".
+        let registry = ExecutorRegistry::with_noop();
+        let exec = registry.get("noop").expect("registered");
+        let ctx = ExecutorContext {
+            node_id: NodeId::generate(),
+            inputs: vec![],
+            spine: Arc::new(MockSpine::default()),
+        };
+        let outputs = exec.execute(ctx).await.unwrap();
+        assert!(outputs.artifacts.is_empty());
+    }
+}

--- a/crates/onsager-nodes/src/spine.rs
+++ b/crates/onsager-nodes/src/spine.rs
@@ -1,0 +1,130 @@
+//! [`SpineClient`] — the thin async port over the spine event store
+//! that executors use at runtime.
+//!
+//! Executors are pure logic; they don't open database connections or
+//! mount HTTP routes. They take a `&dyn SpineClient` and call into it
+//! when they need to emit a runtime event or read the current state of
+//! an artifact. The real implementation (a sqlx-backed adapter over the
+//! `events` / `events_ext` tables) lives in `onsager-spine`; tests
+//! pass a mock.
+//!
+//! This trait is intentionally minimal — only the surface
+//! the first wave of executors (EXE-02..06) actually needs. New
+//! capabilities (transactional reads across multiple artifacts, batched
+//! emits, listening for replies) extend this trait rather than
+//! introducing parallel ports.
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId};
+use thiserror::Error;
+
+/// Error returned by a [`SpineClient`] call.
+///
+/// Carries a free-text message rather than a closed enum: adapter
+/// crates (`onsager-spine`, mocks) report their own underlying errors
+/// without forcing every executor crate to depend on sqlx / reqwest /
+/// etc. Executors typically convert this into [`crate::ExecutorError`]
+/// via the `?` operator.
+#[derive(Debug, Error)]
+#[error("spine error: {0}")]
+pub struct SpineError(pub String);
+
+impl SpineError {
+    /// Build a spine error from any displayable value.
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
+/// Async port over the spine event store, scoped to the surface an
+/// executor needs while it runs.
+///
+/// Object-safe by design: no generic methods, no associated types.
+/// Held inside [`crate::ExecutorContext`] as `Arc<dyn SpineClient>`.
+#[async_trait]
+pub trait SpineClient: Send + Sync + std::fmt::Debug {
+    /// Append a runtime event to the spine, tagged with a kind string
+    /// (the wire-format event name) and a JSON payload. The adapter
+    /// owns timestamping and durability.
+    async fn emit(&self, kind: &str, payload: serde_json::Value) -> Result<(), SpineError>;
+
+    /// Read the current state of an artifact by id, if it exists.
+    /// `Ok(None)` for a missing id is not an error — executors decide
+    /// whether absence is a failure condition.
+    async fn read_artifact(&self, id: &ArtifactId) -> Result<Option<Artifact>, SpineError>;
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use onsager_artifact::Kind;
+    use std::sync::Mutex;
+
+    /// In-memory mock used by this crate's tests. Captures every
+    /// `emit` call and looks up artifacts in a fixed table.
+    #[derive(Debug, Default)]
+    pub struct MockSpine {
+        pub emitted: Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    #[async_trait]
+    impl SpineClient for MockSpine {
+        async fn emit(&self, kind: &str, payload: serde_json::Value) -> Result<(), SpineError> {
+            self.emitted
+                .lock()
+                .unwrap()
+                .push((kind.to_string(), payload));
+            Ok(())
+        }
+
+        async fn read_artifact(&self, _id: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+            Ok(None)
+        }
+    }
+
+    /// A fresh, empty `Artifact` for cases where a test only needs the
+    /// shape — never reads any specific field.
+    pub fn dummy_artifact() -> Artifact {
+        Artifact::new(Kind::Document, "fixture", "marvin", "test", vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn mock_spine_captures_emits() {
+        let mock = Arc::new(MockSpine::default());
+        // Exercise the trait surface — that's what executors see.
+        let spine: Arc<dyn SpineClient> = Arc::clone(&mock) as _;
+        spine
+            .emit("test.kind", serde_json::json!({"hello": "world"}))
+            .await
+            .unwrap();
+        spine
+            .emit("test.other", serde_json::json!({"n": 7}))
+            .await
+            .unwrap();
+
+        let emitted = mock.emitted.lock().unwrap();
+        assert_eq!(emitted.len(), 2);
+        assert_eq!(emitted[0].0, "test.kind");
+        assert_eq!(emitted[1].0, "test.other");
+    }
+
+    #[tokio::test]
+    async fn mock_spine_read_artifact_returns_none_by_default() {
+        let spine: Arc<dyn SpineClient> = Arc::new(MockSpine::default());
+        let id = dummy_artifact().artifact_id.clone();
+        assert!(spine.read_artifact(&id).await.unwrap().is_none());
+    }
+
+    #[test]
+    fn spine_error_displays_message() {
+        let err = SpineError::new("connection refused");
+        assert_eq!(err.to_string(), "spine error: connection refused");
+    }
+}


### PR DESCRIPTION
## Summary

New `crates/onsager-nodes` crate hosting the **async / runtime half** of the executor catalog (ADR 0012, EXE-01).

`onsager-substrate` already carries the static stub `Executor` trait — `executor_kind()` + `declared_provenance()` — used for typetag serde and workflow validation. This PR adds the runtime sibling:

- **`Executor` trait** — object-safe, three methods (`executor_kind`, `declared_provenance`, `async fn execute`). No `where Self: Sized` hacks.
- **`ExecutorContext` / `ExecutorOutputs`** — the input/output shapes the scheduler hands to / takes back from an executor.
- **`ExecutorError`** — closed enum with `UnknownKind` (raised by `dispatch`), `Spine` (transparent `From<SpineError>`), and `Failed(String)` (executor-domain).
- **`SpineClient`** — thin async port over the spine event store: `emit(kind, payload)` + `read_artifact(id)`. Real adapter lives downstream in `onsager-spine`; this crate ships only the trait + an in-tree mock for tests.
- **`ExecutorRegistry`** — `executor_kind` string → `Arc<dyn Executor>`. `with_noop()` pre-populates the runtime `NoOpExecutor` so dispatch compiles and works end-to-end before EXE-02..06 land.
- **`dispatch(registry, node, ctx)`** — reads `node.executor.executor_kind()` from a substrate `Node` and routes to the runtime executor; returns `UnknownKind` if the registry has no entry. Exercises both the `onsager-substrate` and runtime-registry sides as a single pipeline.

`NoOpExecutor` registers under `"noop"` — the same kind string as substrate's serde stub — so a workflow whose nodes carry the substrate noop dispatches end-to-end the moment the runtime registry is populated.

### Verification (from #353)

- `cargo build -p onsager-nodes` — clean.
- `NoOpExecutor` dispatched through the registry returns `ExecutorOutputs { artifacts: vec[] }` — covered by `registry::tests::noop_dispatched_through_registry_returns_empty_outputs` and `dispatch::tests::dispatch_resolves_substrate_node_to_runtime_executor`.
- Trait-object safety: `executor::tests::executor_trait_is_object_safe` constructs `Box<dyn Executor>` and `Arc<dyn Executor>` without any `Self: Sized` clauses.

Unblocks #354 (EXE-02), #355 (EXE-03), #356 (EXE-04), #357 (EXE-05), #358 (EXE-06), #359 (RUN-01).

Closes #353

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` — all suites pass, including 21 new tests in `onsager-nodes`.
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run -p xtask -- lint-seams` clean.
- [x] `cargo run -p xtask -- check-events` clean.
- [x] `cargo run -p xtask -- check-api-contract` clean.
- [x] `cargo run -p xtask -- check-file-budget --mode=fail` clean.

https://claude.ai/code/session_01DmgYDRmxHD2rmNGcvA6Bi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmgYDRmxHD2rmNGcvA6Bi2)_