### PR TITLE
chore(skills): sync plan-dag visual encoding from onsager-skills

### DIFF
--- a/.claude/skills/plan-dag/SKILL.md
+++ b/.claude/skills/plan-dag/SKILL.md
@@ -106,6 +106,20 @@ Emit a JSON IR matching the schema below, then invoke the renderer. **Do not han
 
 **Invocation.** Default emits top-to-bottom box-drawing via graphviz (requires `dot` on PATH — `apt install graphviz`, or `brew install graphviz`) and is the right choice for terminal-only surfaces. `--as=png --out <path>` rasterises the same DOT through `dot -Tsvg` and a headless Chromium screenshot at deviceScaleFactor=2 — sharper than `dot -Tpng` and the preferred output when the chat surface can show inline images (see Response handling below). Needs `dot`, `node`, and Playwright Chromium on PATH. `--as=ascii` produces a pure-ASCII indented tree with no external dependency — used explicitly for restricted terminals, and selected automatically (with a stderr note) when `dot` is missing. `--as=dot` emits raw DOT source for piping or debugging.
 
+**Visual encoding (PNG / DOT targets only).** Status is dual-encoded by fill and a leading emoji so the eye picks up state before reading the label:
+
+| State | Fill | Border | Emoji |
+|-------|------|--------|-------|
+| Done | muted green | green | ✅ |
+| In-progress | amber | thicker amber | 🟡 |
+| Open + all preds done ("available next") | cool blue | thick blue | 🎯 |
+| Open + blocked | near-white | grey, dashed | ⬜ |
+| Close sentinel | white | double | 🏁 |
+
+The "available next" highlight is computed from the graph (open + every predecessor is `done`) — no IR field for it. Critical-path edges are *not* bolded: which path is "the" critical path is a caller judgement, and elevating it visually would conflate the recommendation with the graph's topology. Keep the critical path in `ir.critical_path` and let the renderer print it as a footer / let prose carry the next-pick recommendation.
+
+The text box-drawing and ASCII targets stay glyph-only (`✓` / `…` markers) because their layout math counts characters, not visual columns, and emoji are East Asian Wide. The `--emoji` flag controls whether emoji are emitted in DOT/PNG labels: `auto` (default) is on for image targets, off for text targets; `on` / `off` force it. Turn `off` if a target system lacks a color emoji font and you see tofu boxes in the PNG.
+
 The renderer ships inside the skill. Use the path that matches how the skill was installed:
 
 - **Project-scope install** (default for `npx skills add onsager-ai/onsager-skills` from a repo root): `.claude/skills/plan-dag/scripts/plan-dag-render.py`
@@ -126,8 +140,9 @@ SCRIPT=.claude/skills/plan-dag/scripts/plan-dag-render.py   # project install
 # pure ASCII tree (no external deps; auto-selected when `dot` is missing)
 "$SCRIPT" /tmp/plan.json --as=ascii
 
-# raw DOT for piping / debugging
+# raw DOT for piping / debugging (styled by default; --emoji=off for portability)
 "$SCRIPT" /tmp/plan.json --as=dot
+"$SCRIPT" /tmp/plan.json --as=dot --emoji=off
 ```
 
 If the renderer aborts with `IR validation failed`, fix the IR — do not work around it by hand-drawing. The validation surface is the citation rule (`Conventions › No invented edges`) made executable.

--- a/.claude/skills/plan-dag/fixtures/expected/happy.dot
+++ b/.claude/skills/plan-dag/fixtures/expected/happy.dot
@@ -1,0 +1,23 @@
+digraph plan {
+  rankdir=TB;
+  bgcolor="white";
+  node [shape=box, style="filled,rounded", fontname="Helvetica", fontsize=12, penwidth=1.2, color="#495057", fillcolor="#ffffff"];
+  edge [color="#6c757d", penwidth=1.0, arrowsize=0.8];
+
+  "288" [label="✅  #288 MCP", fillcolor="#d4edda", color="#52a566"];
+  "301" [label="✅  #301 spine", fillcolor="#d4edda", color="#52a566"];
+  "302" [label="✅  #302 forge", fillcolor="#d4edda", color="#52a566"];
+  "304" [label="🎯  #304 chat", fillcolor="#cfe2ff", color="#0d6efd", penwidth="2.5"];
+  "305" [label="🟡  #305 router", fillcolor="#fff3cd", color="#d39e00", penwidth="2.0"];
+  "306" [label="⬜  #306 cleanup", fillcolor="#f8f9fa", color="#adb5bd", style="filled,rounded,dashed"];
+  "307" [label="⬜  #307 docs", fillcolor="#f8f9fa", color="#adb5bd", style="filled,rounded,dashed"];
+  "close" [label="🏁  close #300", peripheries="2", fillcolor="#ffffff", color="#495057"];
+
+  "288" -> "304";
+  "301" -> "305";
+  "302" -> "305";
+  "304" -> "306";
+  "305" -> "306";
+  "306" -> "307";
+  "307" -> "close";
+}

--- a/.claude/skills/plan-dag/fixtures/expected/happy.dot.noemoji
+++ b/.claude/skills/plan-dag/fixtures/expected/happy.dot.noemoji
@@ -1,0 +1,23 @@
+digraph plan {
+  rankdir=TB;
+  bgcolor="white";
+  node [shape=box, style="filled,rounded", fontname="Helvetica", fontsize=12, penwidth=1.2, color="#495057", fillcolor="#ffffff"];
+  edge [color="#6c757d", penwidth=1.0, arrowsize=0.8];
+
+  "288" [label="#288 MCP ✓", fillcolor="#d4edda", color="#52a566"];
+  "301" [label="#301 spine ✓", fillcolor="#d4edda", color="#52a566"];
+  "302" [label="#302 forge ✓", fillcolor="#d4edda", color="#52a566"];
+  "304" [label="#304 chat", fillcolor="#cfe2ff", color="#0d6efd", penwidth="2.5"];
+  "305" [label="#305 router …", fillcolor="#fff3cd", color="#d39e00", penwidth="2.0"];
+  "306" [label="#306 cleanup", fillcolor="#f8f9fa", color="#adb5bd", style="filled,rounded,dashed"];
+  "307" [label="#307 docs", fillcolor="#f8f9fa", color="#adb5bd", style="filled,rounded,dashed"];
+  "close" [label="close #300", peripheries="2", fillcolor="#ffffff", color="#495057"];
+
+  "288" -> "304";
+  "301" -> "305";
+  "302" -> "305";
+  "304" -> "306";
+  "305" -> "306";
+  "306" -> "307";
+  "307" -> "close";
+}

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.py
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.py
@@ -17,6 +17,29 @@ VALID_STATUS = set(STATUS_MARKER.keys())
 VALID_SOURCES = {"sub-issue", "depends-on", "pr-link", "closes", "part-of"}
 FORBIDDEN_LABEL_CHARS = ('"', "\\", "[", "]", "\n", "\r")
 
+# Styled-DOT visual vocabulary. Fills encode status; an additional "available
+# next" highlight is computed from the graph (open + all preds done). Used by
+# --as=dot and --as=png only — text/ascii paths stay glyph-only because the
+# layout math counts characters, not visual columns.
+_STYLE_DONE = {"fillcolor": "#d4edda", "color": "#52a566"}
+_STYLE_IN_PROGRESS = {"fillcolor": "#fff3cd", "color": "#d39e00", "penwidth": "2.0"}
+_STYLE_OPEN_BLOCKED = {
+    "fillcolor": "#f8f9fa", "color": "#adb5bd",
+    "style": "filled,rounded,dashed",
+}
+_STYLE_OPEN_AVAILABLE = {
+    "fillcolor": "#cfe2ff", "color": "#0d6efd", "penwidth": "2.5",
+}
+_STYLE_CLOSE = {"peripheries": "2", "fillcolor": "#ffffff", "color": "#495057"}
+
+_EMOJI = {
+    "done": "✅",
+    "in_progress": "🟡",
+    "open_blocked": "⬜",
+    "open_available": "🎯",
+    "close": "🏁",
+}
+
 
 def _dot_escape(s):
     return s.replace("\\", "\\\\").replace('"', '\\"')
@@ -144,19 +167,93 @@ def validate(ir):
     return errors
 
 
-def render_dot(ir, rankdir="TB", extra_graph_attrs=()):
+def _available_next(ir):
+    """Open nodes whose predecessors are all `done` — i.e. unblocked picks.
+
+    Used by the styled DOT path to highlight the next pickable node(s).
+    The close sentinel is excluded; it isn't a pickable task.
+    """
+    status_by_id = {str(n["id"]): n.get("status", "open") for n in ir["nodes"]}
+    preds = {nid: [] for nid in status_by_id}
+    for e in ir.get("edges", []):
+        v = str(e["to"])
+        if v in preds:
+            preds[v].append(str(e["from"]))
+    return {
+        nid for nid, st in status_by_id.items()
+        if st == "open" and all(status_by_id.get(p) == "done" for p in preds[nid])
+    }
+
+
+def _attrs_str(attrs):
+    return ", ".join(f'{k}="{v}"' for k, v in attrs.items())
+
+
+def render_dot(ir, rankdir="TB", extra_graph_attrs=(), styled=False, emoji=False):
+    """Emit DOT source.
+
+    styled=False: plain boxes with `✓`/`…` status markers — keeps the
+        `dot -Tplain` geometry that render_tb_boxart parses, and matches
+        the existing tb/ascii golden output.
+    styled=True: status fills, available-next highlight, double-bordered
+        close sentinel. Used by --as=dot and --as=png.
+    emoji=True (only meaningful with styled=True): prepend a status emoji
+        to each label and drop the `✓`/`…` marker. Requires a color emoji
+        font on the rendering system.
+    """
     lines = ["digraph plan {", f"  rankdir={rankdir};"]
     for attr in extra_graph_attrs:
         lines.append(f"  {attr};")
-    lines += ["  node [shape=box];", ""]
+    if styled:
+        lines += [
+            '  bgcolor="white";',
+            '  node [shape=box, style="filled,rounded", fontname="Helvetica", '
+            'fontsize=12, penwidth=1.2, color="#495057", fillcolor="#ffffff"];',
+            '  edge [color="#6c757d", penwidth=1.0, arrowsize=0.8];',
+            "",
+        ]
+    else:
+        lines += ["  node [shape=box];", ""]
+
+    available = _available_next(ir) if styled else set()
+
     for n in ir["nodes"]:
         nid = str(n["id"])
-        marker = STATUS_MARKER[n.get("status", "open")]
-        label = _dot_escape(f'#{nid} {n["label"]}{marker}')
-        lines.append(f'  "{_dot_escape(nid)}" [label="{label}"];')
+        status = n.get("status", "open")
+        if styled:
+            if status == "done":
+                attrs, em_key = _STYLE_DONE, "done"
+            elif status == "in_progress":
+                attrs, em_key = _STYLE_IN_PROGRESS, "in_progress"
+            elif nid in available:
+                attrs, em_key = _STYLE_OPEN_AVAILABLE, "open_available"
+            else:
+                attrs, em_key = _STYLE_OPEN_BLOCKED, "open_blocked"
+            if emoji:
+                label_text = f'{_EMOJI[em_key]}  #{nid} {n["label"]}'
+            else:
+                label_text = f'#{nid} {n["label"]}{STATUS_MARKER[status]}'
+            label = _dot_escape(label_text)
+            lines.append(
+                f'  "{_dot_escape(nid)}" [label="{label}", {_attrs_str(attrs)}];'
+            )
+        else:
+            label = _dot_escape(f'#{nid} {n["label"]}{STATUS_MARKER[status]}')
+            lines.append(f'  "{_dot_escape(nid)}" [label="{label}"];')
+
     if ir.get("close"):
-        close_label = _dot_escape(f'close #{ir["close"]}')
-        lines.append(f'  "close" [label="{close_label}"];')
+        if styled:
+            close_text = (
+                f'{_EMOJI["close"]}  close #{ir["close"]}'
+                if emoji else f'close #{ir["close"]}'
+            )
+            close_label = _dot_escape(close_text)
+            lines.append(
+                f'  "close" [label="{close_label}", {_attrs_str(_STYLE_CLOSE)}];'
+            )
+        else:
+            close_label = _dot_escape(f'close #{ir["close"]}')
+            lines.append(f'  "close" [label="{close_label}"];')
     lines.append("")
     for e in ir.get("edges", []):
         lines.append(f'  "{_dot_escape(str(e["from"]))}" -> "{_dot_escape(str(e["to"]))}";')
@@ -456,7 +553,7 @@ def render_ascii(ir):
     return out
 
 
-def render_png(ir, out_path):
+def render_png(ir, out_path, emoji=True):
     """Render the IR as a high-quality PNG.
 
     Pipeline: dot -Tsvg → headless Chromium (via Playwright) → PNG. Going
@@ -478,7 +575,7 @@ def render_png(ir, out_path):
     if not svg_to_png.exists():
         sys.exit(f"--as=png: missing helper {svg_to_png}")
 
-    dot_src = render_dot(ir)
+    dot_src = render_dot(ir, styled=True, emoji=emoji)
     try:
         svg_res = subprocess.run(
             ["dot", "-Tsvg"], input=dot_src,
@@ -521,6 +618,14 @@ def main():
         "--out", default=None,
         help="output file path. Required for --as=png; ignored otherwise.",
     )
+    ap.add_argument(
+        "--emoji", default="auto", choices=["auto", "on", "off"],
+        help="emoji status indicators in node labels. auto (default): on for "
+             "--as=dot and --as=png, off for text/ascii (whose layout math "
+             "assumes single-width characters). on/off forces it. Emoji "
+             "requires a color emoji font on the rendering system; turn off "
+             "if you see tofu boxes in the PNG.",
+    )
     args = ap.parse_args()
 
     text = sys.stdin.read() if args.ir == "-" else Path(args.ir).read_text()
@@ -545,14 +650,24 @@ def main():
             )
             target = "ascii"
 
+    # Emoji policy: on for image-producing targets (dot/png), off for
+    # text-producing targets (tb/ascii) whose layout math assumes
+    # single-width characters. `on` / `off` forces it either way.
+    if args.emoji == "on":
+        emoji_on = True
+    elif args.emoji == "off":
+        emoji_on = False
+    else:
+        emoji_on = target in ("dot", "png")
+
     if target == "dot":
-        print(render_dot(ir))
+        print(render_dot(ir, styled=True, emoji=emoji_on))
     elif target == "ascii":
         print(render_ascii(ir))
     elif target == "png":
         if not args.out:
             sys.exit("--as=png requires --out <path>")
-        render_png(ir, args.out)
+        render_png(ir, args.out, emoji=emoji_on)
     else:
         print(render_tb_boxart(ir))
         cp = ir.get("critical_path")

--- a/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
+++ b/.claude/skills/plan-dag/scripts/plan-dag-render.test.sh
@@ -56,10 +56,78 @@ trap 'rm -rf "$tmp"' EXIT
 echo "happy.json"
 run_and_compare "happy default (tb)"  "$FIX/happy.json" tb
 run_and_compare "happy --as=ascii"    "$FIX/happy.json" ascii --as=ascii
+run_and_compare "happy --as=dot (emoji on by default)" \
+                                       "$FIX/happy.json" dot --as=dot
+run_and_compare "happy --as=dot --emoji=off" \
+                                       "$FIX/happy.json" dot.noemoji \
+                                       --as=dot --emoji=off
 
 echo "wide.json"
 run_and_compare "wide default (tb)"   "$FIX/wide.json"  tb
 run_and_compare "wide --as=ascii"     "$FIX/wide.json"  ascii --as=ascii
+
+echo "styled DOT structural checks"
+# Available-next: #304 is open, only pred (#288) is done → highlighted in blue.
+"$SCRIPT" "$FIX/happy.json" --as=dot > "$tmp/happy.dot" 2>/dev/null
+if grep -q '"304"\s*\[.*fillcolor="#cfe2ff"' "$tmp/happy.dot"; then
+    pass=$((pass + 1))
+    printf '  ok  available-next (#304) gets blue highlight\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL #304 missing available-next highlight\n'
+fi
+# #306 is open but blocked (preds #304/#305 not done) → dashed muted style.
+if grep -q '"306"\s*\[.*style="filled,rounded,dashed"' "$tmp/happy.dot"; then
+    pass=$((pass + 1))
+    printf '  ok  blocked-open (#306) gets dashed style\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL #306 missing dashed blocked-open style\n'
+fi
+# Close sentinel gets a double border.
+if grep -q '"close"\s*\[.*peripheries="2"' "$tmp/happy.dot"; then
+    pass=$((pass + 1))
+    printf '  ok  close sentinel gets double border\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL close sentinel missing peripheries="2"\n'
+fi
+# Edges stay uniform — no penwidth bolding on the declared critical_path.
+# (We test by counting how many edge lines carry an explicit penwidth.)
+crit_edges=$(grep -E '"[^"]+"\s*->\s*"[^"]+"\s*\[' "$tmp/happy.dot" | grep -c 'penwidth' || true)
+if [ "$crit_edges" -eq 0 ]; then
+    pass=$((pass + 1))
+    printf '  ok  no critical-path edge bolding (subjective; footer-only)\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL %d edges carry explicit penwidth (expected 0)\n' "$crit_edges"
+fi
+# --emoji=off strips emoji from labels but keeps the ✓/… markers.
+"$SCRIPT" "$FIX/happy.json" --as=dot --emoji=off > "$tmp/happy.dot.off" 2>/dev/null
+if grep -q '✅\|🟡\|⬜\|🎯\|🏁' "$tmp/happy.dot.off"; then
+    fail=$((fail + 1))
+    printf '  FAIL --emoji=off leaked emoji into output\n'
+else
+    pass=$((pass + 1))
+    printf '  ok  --emoji=off strips emoji\n'
+fi
+if grep -q '#288 MCP ✓' "$tmp/happy.dot.off"; then
+    pass=$((pass + 1))
+    printf '  ok  --emoji=off retains text markers\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL --emoji=off missing text marker\n'
+fi
+# --emoji=on with default (tb) target must NOT affect tb output — the layout
+# math assumes single-width chars. The flag is silently inert for tb/ascii.
+"$SCRIPT" "$FIX/happy.json" --emoji=on > "$tmp/happy.tb.emoji-on" 2>/dev/null
+if diff -u "$EXP/happy.tb" "$tmp/happy.tb.emoji-on" >/dev/null; then
+    pass=$((pass + 1))
+    printf '  ok  --emoji=on does not affect default (tb) output\n'
+else
+    fail=$((fail + 1))
+    printf '  FAIL --emoji=on altered tb output\n'
+fi
 
 echo "bad.json (must fail validation)"
 "$SCRIPT" "$FIX/bad.json" > "$tmp/bad.out" 2>"$tmp/bad.err"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "onsager-ai/onsager-skills",
       "sourceType": "github",
       "skillPath": "skills/plan-dag/SKILL.md",
-      "computedHash": "de4868e3c23f0e5d128a9a8f1e52483674d05cf1f027132d16958d52859106a7"
+      "computedHash": "ce958abee3d5a9a183c7c1514847ee7dfcf0ebd726657fe073a77f12fcd6a4e9"
     },
     "web-design-guidelines": {
       "source": "vercel-labs/agent-skills",


### PR DESCRIPTION
## Summary

Mirrors [onsager-ai/onsager-skills#9](https://github.com/onsager-ai/onsager-skills/pull/9) into this repo's installed copy at `.claude/skills/plan-dag/`. The PNG/DOT renderer now dual-encodes status (fill color + leading emoji) and adds an **"available next"** highlight computed from the graph (open + every predecessor done) — no IR field, so callers don't have to label it.

- New `--emoji=on/off/auto` flag controls emoji emission in DOT/PNG labels (default `auto`: on for image targets, off for text targets).
- Text box-drawing and ASCII outputs are unchanged — they stay glyph-only (`✓` / `…`) so monospace column math doesn't break on East-Asian-wide emoji.
- New golden fixtures `happy.dot` / `happy.dot.noemoji` and matching test-script coverage.
- Critical-path edges are intentionally **not** bolded — `ir.critical_path` stays a footer line so the caller's recommendation doesn't get conflated with topology.

Also restores `.claude/skills/plan-dag/.upstream-source`, which the bumped `npx skills` tool dropped on re-sync — the `check-skill-edit` guardrail hook relies on it.

## Test plan

- [x] `diff -rq` against upstream `onsager-skills/skills/plan-dag/` clean post-sync.
- [x] `skills-lock.json` `computedHash` updated to match upstream HEAD (`ce958ab…`).
- [x] `.upstream-source` marker present and pointing at `onsager-ai/onsager-skills`.
- [ ] CI runs `plan-dag-render.test.sh` (requires `dot` + `node` + Chromium on the runner — not reproducible locally without graphviz).


---
_Generated by [Claude Code](https://claude.ai/code/session_015D3CqzY1zXphMCZGmhbqMP)_