### PR TITLE
feat(substrate): Plan Compiler algorithm (SUB-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3499,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ schemars = { version = "0.8", features = ["chrono"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.15"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 # Error handling
 thiserror = "2"

--- a/crates/onsager-substrate/src/compiler.rs
+++ b/crates/onsager-substrate/src/compiler.rs
@@ -22,8 +22,6 @@
 
 use std::collections::HashMap;
 
-use onsager_artifact::ArtifactId;
-
 use crate::ids::EdgeId;
 use crate::library::WorkflowLibrary;
 use crate::spec_plan::{SpecDep, SpecId, SpecPlan, SpecPlanError};
@@ -102,11 +100,29 @@ pub enum CompileError {
         to_kind: String,
     },
 
+    /// Two or more `SpecDep`s target the same downstream spec. ADR
+    /// 0015 fixes v1 at single-entry / single-exit per workflow, so
+    /// fan-in into the same entry slot is out of scope; widening the
+    /// IO model is a follow-up rather than a silent compile.
+    #[error(
+        "spec '{to}' has multiple incoming deps ({}) but v1 workflows \
+         declare a single entry slot — split the workflow or merge upstream \
+         specs", format_spec_ids(.from)
+    )]
+    MultipleIncomingDeps { to: SpecId, from: Vec<SpecId> },
+
     /// The merged Execution Plan failed one or more kernel invariants
     /// (ADR 0018). The wrapped vector is every violation found in
     /// one pass.
     #[error("Execution Plan failed kernel invariants: {} violation(s)", .0.len())]
     Invariant(Vec<InvariantViolation>),
+}
+
+fn format_spec_ids(ids: &[SpecId]) -> String {
+    ids.iter()
+        .map(SpecId::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Compile a Spec Plan against a Workflow Library.
@@ -137,13 +153,30 @@ pub fn compile(
 
     // Step 3 — connect. Build a per-spec entry rewrite map: for each
     // dep `from -> to`, point every reference to `to`'s entry
-    // edge_id at `from`'s exit edge_id. We support v1's
-    // single-entry / single-exit by wiring the first entry/exit pair
-    // declared on each side; multi-IO is left for a follow-up.
+    // edge_id at `from`'s exit edge_id. v1 fixes single-entry /
+    // single-exit per ADR 0015, so we reject the second incoming
+    // dep into any given spec rather than silently overwriting the
+    // first wiring.
     let mut rewrites: HashMap<EdgeId, EdgeId> = HashMap::new();
     let mut effective_entries: HashMap<SpecId, Vec<EdgeId>> = HashMap::new();
     for (spec_id, (_, inst)) in &instantiated {
         effective_entries.insert(spec_id.clone(), inst.entry_edges.clone());
+    }
+
+    // Detect fan-in (multiple `from` specs targeting the same `to`)
+    // up-front so the error names every offending upstream, not just
+    // the second one we happened to reach.
+    let mut incoming: HashMap<SpecId, Vec<SpecId>> = HashMap::new();
+    for SpecDep { from, to } in &spec_plan.deps {
+        incoming.entry(to.clone()).or_default().push(from.clone());
+    }
+    for (to, froms) in &incoming {
+        if froms.len() > 1 {
+            return Err(CompileError::MultipleIncomingDeps {
+                to: to.clone(),
+                from: froms.clone(),
+            });
+        }
     }
 
     for SpecDep { from, to } in &spec_plan.deps {
@@ -187,10 +220,13 @@ pub fn compile(
     }
 
     // Merge into the flat plan, applying entry-edge rewrites and
-    // dropping the now-redundant entry edge rows.
+    // dropping the now-redundant entry edge rows. Single-writer
+    // enforcement is delegated to invariant 5 in step 4, so this
+    // loop preserves every surviving edge verbatim — duplicate
+    // artifact ids surface as a kernel-invariant violation rather
+    // than a silent compile-time merge.
     let mut nodes: Vec<Node> = Vec::new();
     let mut edges: Vec<Edge> = Vec::new();
-    let mut seen_artifacts: HashMap<ArtifactId, usize> = HashMap::new();
     let mut spec_index: HashMap<SpecId, SpecSlot> = HashMap::new();
 
     // Iterate in spec_plan.specs declaration order so the resulting
@@ -218,15 +254,6 @@ pub fn compile(
                 // Dropped: this entry edge is now the upstream exit.
                 continue;
             }
-            // Drop duplicates produced when the same artifact id
-            // surfaces twice across spec subgraphs (it shouldn't,
-            // since artifact ids are spec-namespaced — but the
-            // single-writer rule is invariant 5's job, not ours).
-            if seen_artifacts.contains_key(&edge.artifact_id) {
-                edges.push(edge);
-                continue;
-            }
-            seen_artifacts.insert(edge.artifact_id.clone(), edges.len());
             edges.push(edge);
         }
 
@@ -265,7 +292,7 @@ mod tests {
     use crate::ids::{EdgeId, WorkflowId};
     use crate::spec_plan::SpecRef;
     use crate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
-    use onsager_artifact::{NodeId, Provenance};
+    use onsager_artifact::{ArtifactId, NodeId, Provenance};
     use std::collections::HashMap;
 
     /// Tiny in-memory library for tests — owns the workflows and
@@ -694,5 +721,65 @@ mod tests {
             matches!(err, CompileError::NoEntry { .. }),
             "expected NoEntry error, got: {err:?}",
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Multi-incoming dep into a single spec is rejected explicitly,
+    // not silently merged. v1 is single-entry per ADR 0015 — fan-in
+    // exceeds the contract, and silently overwriting the rewrite
+    // map (last-write-wins) would corrupt the wiring while leaving
+    // the spec_index back-pointer inconsistent with the merged
+    // node's actual inputs.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn multiple_incoming_deps_into_same_spec_are_rejected() {
+        let mut lib = TestLibrary::new();
+        lib.register("passthrough", passthrough_workflow());
+        lib.register("sink", sink_workflow());
+
+        // Diamond bottom: a→c and b→c — c receives two upstream deps.
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("a"),
+                    kind: "passthrough".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("b"),
+                    kind: "passthrough".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("c"),
+                    kind: "sink".to_string(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![
+                SpecDep {
+                    from: SpecId::new("a"),
+                    to: SpecId::new("c"),
+                },
+                SpecDep {
+                    from: SpecId::new("b"),
+                    to: SpecId::new("c"),
+                },
+            ],
+        };
+        let err = compile(&plan, &lib).unwrap_err();
+        match err {
+            CompileError::MultipleIncomingDeps { to, from } => {
+                assert_eq!(to, SpecId::new("c"));
+                let froms: std::collections::HashSet<_> = from.iter().cloned().collect();
+                assert_eq!(
+                    froms,
+                    std::collections::HashSet::from([SpecId::new("a"), SpecId::new("b")]),
+                    "error should name every offending upstream spec",
+                );
+            }
+            other => panic!("expected MultipleIncomingDeps, got {other:?}"),
+        }
     }
 }

--- a/crates/onsager-substrate/src/compiler.rs
+++ b/crates/onsager-substrate/src/compiler.rs
@@ -1,0 +1,698 @@
+//! Plan Compiler — turns a [`SpecPlan`] plus a [`WorkflowLibrary`]
+//! into a fully-resolved, validated [`ExecutionPlan`].
+//!
+//! See [ADR 0017](../../../docs/adr/0017-plan-compiler-three-step-algorithm.md)
+//! for the algorithm and [ADR 0009](../../../docs/adr/0009-three-layer-pipeline.md)
+//! for where this layer sits in the pipeline. The whole compiler is
+//! the four-step skeleton from ADR 0017:
+//!
+//! ```text
+//! 1. validate the Spec Plan as a DAG (cycles + dangling refs)
+//! 2. for each spec: lookup workflow → instantiate → graft into plan
+//! 3. for each dep: rewire to-spec entry to consume from-spec exit
+//! 4. run validate_workflow over the merged plan (ADR 0018)
+//! ```
+//!
+//! The compiler is **stateless**, **pure**, and **deterministic**:
+//! same `(SpecPlan, WorkflowLibrary)` snapshot always produces a
+//! byte-identical [`ExecutionPlan`] after canonical serialization.
+//! Determinism comes from [`crate::workflow::Workflow::instantiate`],
+//! which derives every UUID from a stable namespace seed plus
+//! `SpecId` (UUID v5) instead of generating fresh v4s.
+
+use std::collections::HashMap;
+
+use onsager_artifact::ArtifactId;
+
+use crate::ids::EdgeId;
+use crate::library::WorkflowLibrary;
+use crate::spec_plan::{SpecDep, SpecId, SpecPlan, SpecPlanError};
+use crate::validate::{InvariantViolation, validate_workflow};
+use crate::workflow::{Edge, EdgeRef, InstantiatedWorkflow, Node, OutputSpec, Workflow};
+
+/// A fully-resolved, immutable graph the substrate scheduler runs.
+///
+/// Nodes and edges are flat — there is no per-spec subgraph after
+/// compilation. The `spec_index` map keeps a back-pointer from the
+/// original [`SpecId`] to that spec's exit edges, useful for runtime
+/// observers and for diagnostics that want to attribute a node to
+/// the spec it came from.
+#[derive(Debug)]
+pub struct ExecutionPlan {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<Edge>,
+    /// `spec_id → ExecutionPlan-relative entry/exit edges`. Keys are
+    /// the original `SpecId`s from the input Spec Plan; entry edges
+    /// reflect rewiring from `connect`.
+    pub spec_index: HashMap<SpecId, SpecSlot>,
+}
+
+/// Where a single spec landed in the merged Execution Plan.
+///
+/// `entry_edges` are the workflow's declared entry edge IDs *after*
+/// any rewiring from spec deps — i.e. an entry that was wired to an
+/// upstream exit will appear here as the upstream's exit edge id, so
+/// downstream observers can trace the connection.
+#[derive(Debug, Clone)]
+pub struct SpecSlot {
+    pub entry_edges: Vec<EdgeId>,
+    pub exit_edges: Vec<OutputSpec>,
+}
+
+/// Why compilation failed. The compiler aborts at the first error
+/// because most failures invalidate every step that follows; the
+/// kernel-invariant errors from step 4 are the one batched case
+/// (every violation surfaces in a single `Vec`).
+#[derive(Debug, thiserror::Error)]
+pub enum CompileError {
+    /// Spec Plan failed structural validation before any workflow
+    /// lookup. The wrapped error names the offending spec ids.
+    #[error("Spec Plan structural error: {0}")]
+    SpecPlan(#[from] SpecPlanError),
+
+    /// `workflow_library.by_kind(kind)` returned `None`. ADR 0017
+    /// commits to hard-failing here — there is no fallback workflow.
+    #[error(
+        "no workflow registered for spec '{spec_id}' (kind '{kind}'); \
+         add it to the workflow library or fix the spec kind"
+    )]
+    MissingKind { spec_id: SpecId, kind: String },
+
+    /// A spec dependency wires `from → to` but `from` declares zero
+    /// exit edges, so there is nothing to connect.
+    #[error(
+        "cannot wire spec dependency '{from} -> {to}': upstream spec '{from}' \
+         (kind '{from_kind}') declares no exit edges in its workflow"
+    )]
+    NoExit {
+        from: SpecId,
+        to: SpecId,
+        from_kind: String,
+    },
+
+    /// A spec dependency wires `from → to` but `to` declares zero
+    /// entry edges, so there is nothing to wire into.
+    #[error(
+        "cannot wire spec dependency '{from} -> {to}': downstream spec '{to}' \
+         (kind '{to_kind}') declares no entry edges in its workflow"
+    )]
+    NoEntry {
+        from: SpecId,
+        to: SpecId,
+        to_kind: String,
+    },
+
+    /// The merged Execution Plan failed one or more kernel invariants
+    /// (ADR 0018). The wrapped vector is every violation found in
+    /// one pass.
+    #[error("Execution Plan failed kernel invariants: {} violation(s)", .0.len())]
+    Invariant(Vec<InvariantViolation>),
+}
+
+/// Compile a Spec Plan against a Workflow Library.
+///
+/// See the module docs for the algorithm. The function is pure: no
+/// I/O, no globals, no allocations beyond the returned plan.
+pub fn compile(
+    spec_plan: &SpecPlan,
+    library: &dyn WorkflowLibrary,
+) -> Result<ExecutionPlan, CompileError> {
+    // Step 0 — Spec Plan structural checks. Hoisted out of step 2's
+    // loop so authors see DAG errors before any library lookup runs.
+    spec_plan.validate()?;
+
+    let mut instantiated: HashMap<SpecId, (String, InstantiatedWorkflow)> = HashMap::new();
+
+    // Step 1+2 — lookup + instantiate, in declaration order.
+    for spec in &spec_plan.specs {
+        let workflow = library
+            .by_kind(&spec.kind)
+            .ok_or_else(|| CompileError::MissingKind {
+                spec_id: spec.id.clone(),
+                kind: spec.kind.clone(),
+            })?;
+        let inst = workflow.instantiate(&spec.id);
+        instantiated.insert(spec.id.clone(), (spec.kind.clone(), inst));
+    }
+
+    // Step 3 — connect. Build a per-spec entry rewrite map: for each
+    // dep `from -> to`, point every reference to `to`'s entry
+    // edge_id at `from`'s exit edge_id. We support v1's
+    // single-entry / single-exit by wiring the first entry/exit pair
+    // declared on each side; multi-IO is left for a follow-up.
+    let mut rewrites: HashMap<EdgeId, EdgeId> = HashMap::new();
+    let mut effective_entries: HashMap<SpecId, Vec<EdgeId>> = HashMap::new();
+    for (spec_id, (_, inst)) in &instantiated {
+        effective_entries.insert(spec_id.clone(), inst.entry_edges.clone());
+    }
+
+    for SpecDep { from, to } in &spec_plan.deps {
+        // Both ids resolve — already enforced by SpecPlan::validate.
+        let from_inst = &instantiated[from].1;
+        let from_kind = instantiated[from].0.clone();
+        let to_inst = &instantiated[to].1;
+        let to_kind = instantiated[to].0.clone();
+
+        let exit_edge_id = from_inst
+            .exit_edges
+            .first()
+            .map(|o| o.edge_id)
+            .ok_or_else(|| CompileError::NoExit {
+                from: from.clone(),
+                to: to.clone(),
+                from_kind,
+            })?;
+        let entry_edge_id =
+            to_inst
+                .entry_edges
+                .first()
+                .copied()
+                .ok_or_else(|| CompileError::NoEntry {
+                    from: from.clone(),
+                    to: to.clone(),
+                    to_kind,
+                })?;
+
+        rewrites.insert(entry_edge_id, exit_edge_id);
+
+        // Reflect the rewire in the to-spec's effective entry list so
+        // the spec_index back-pointer surfaces the wired edge id.
+        if let Some(entries) = effective_entries.get_mut(to) {
+            for e in entries.iter_mut() {
+                if *e == entry_edge_id {
+                    *e = exit_edge_id;
+                }
+            }
+        }
+    }
+
+    // Merge into the flat plan, applying entry-edge rewrites and
+    // dropping the now-redundant entry edge rows.
+    let mut nodes: Vec<Node> = Vec::new();
+    let mut edges: Vec<Edge> = Vec::new();
+    let mut seen_artifacts: HashMap<ArtifactId, usize> = HashMap::new();
+    let mut spec_index: HashMap<SpecId, SpecSlot> = HashMap::new();
+
+    // Iterate in spec_plan.specs declaration order so the resulting
+    // node/edge ordering is deterministic across runs (HashMap
+    // iteration is not).
+    for spec in &spec_plan.specs {
+        let (_, inst) = instantiated.remove(&spec.id).expect("inserted above");
+
+        for mut node in inst.nodes {
+            for input in node.inputs.iter_mut() {
+                if let Some(target) = rewrites.get(&input.edge_id) {
+                    *input = EdgeRef::new(*target);
+                }
+            }
+            for output in node.outputs.iter_mut() {
+                if let Some(target) = rewrites.get(&output.edge_id) {
+                    *output = EdgeRef::new(*target);
+                }
+            }
+            nodes.push(node);
+        }
+
+        for edge in inst.edges {
+            if rewrites.contains_key(&edge.id) {
+                // Dropped: this entry edge is now the upstream exit.
+                continue;
+            }
+            // Drop duplicates produced when the same artifact id
+            // surfaces twice across spec subgraphs (it shouldn't,
+            // since artifact ids are spec-namespaced — but the
+            // single-writer rule is invariant 5's job, not ours).
+            if seen_artifacts.contains_key(&edge.artifact_id) {
+                edges.push(edge);
+                continue;
+            }
+            seen_artifacts.insert(edge.artifact_id.clone(), edges.len());
+            edges.push(edge);
+        }
+
+        let entry_edges = effective_entries.remove(&spec.id).unwrap_or_default();
+        spec_index.insert(
+            spec.id.clone(),
+            SpecSlot {
+                entry_edges,
+                exit_edges: inst.exit_edges,
+            },
+        );
+    }
+
+    // Step 4 — kernel invariants over the merged graph.
+    let merged = Workflow {
+        nodes,
+        edges,
+        entry_specs: vec![],
+        output_specs: vec![],
+    };
+    if let Err(violations) = validate_workflow(&merged, library) {
+        return Err(CompileError::Invariant(violations));
+    }
+
+    Ok(ExecutionPlan {
+        nodes: merged.nodes,
+        edges: merged.edges,
+        spec_index,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::NoOpExecutor;
+    use crate::ids::{EdgeId, WorkflowId};
+    use crate::spec_plan::SpecRef;
+    use crate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
+    use onsager_artifact::{NodeId, Provenance};
+    use std::collections::HashMap;
+
+    /// Tiny in-memory library for tests — owns the workflows and
+    /// returns refs by either WorkflowId or kind.
+    struct TestLibrary {
+        by_id: HashMap<WorkflowId, Workflow>,
+        by_kind: HashMap<String, WorkflowId>,
+    }
+
+    impl TestLibrary {
+        fn new() -> Self {
+            Self {
+                by_id: HashMap::new(),
+                by_kind: HashMap::new(),
+            }
+        }
+
+        fn register(&mut self, kind: &str, workflow: Workflow) -> WorkflowId {
+            let id = WorkflowId::generate();
+            self.by_id.insert(id, workflow);
+            self.by_kind.insert(kind.to_string(), id);
+            id
+        }
+    }
+
+    impl WorkflowLibrary for TestLibrary {
+        fn get(&self, id: WorkflowId) -> Option<&Workflow> {
+            self.by_id.get(&id)
+        }
+        fn by_kind(&self, spec_kind: &str) -> Option<&Workflow> {
+            self.by_kind
+                .get(spec_kind)
+                .and_then(|id| self.by_id.get(id))
+        }
+    }
+
+    /// Build a trivial single-node workflow:
+    ///
+    /// ```text
+    /// (entry edge_in) → [NoOp node] → (exit edge_out)
+    /// ```
+    fn passthrough_workflow() -> Workflow {
+        let edge_in = EdgeId::generate();
+        let edge_out = EdgeId::generate();
+        Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(NoOpExecutor),
+                inputs: vec![EdgeRef::new(edge_in)],
+                outputs: vec![EdgeRef::new(edge_out)],
+            }],
+            edges: vec![
+                Edge {
+                    id: edge_in,
+                    artifact_id: ArtifactId::new("art_in"),
+                    requires_deterministic: false,
+                },
+                Edge {
+                    id: edge_out,
+                    artifact_id: ArtifactId::new("art_out"),
+                    requires_deterministic: false,
+                },
+            ],
+            entry_specs: vec![EntrySpec { edge_id: edge_in }],
+            output_specs: vec![OutputSpec {
+                edge_id: edge_out,
+                provenance: Provenance::external_deterministic(),
+            }],
+        }
+    }
+
+    /// A second workflow shape so we can prove cross-kind connect
+    /// works. Identical interface (entry/exit), distinct kind.
+    fn sink_workflow() -> Workflow {
+        let edge_in = EdgeId::generate();
+        Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(NoOpExecutor),
+                inputs: vec![EdgeRef::new(edge_in)],
+                outputs: vec![],
+            }],
+            edges: vec![Edge {
+                id: edge_in,
+                artifact_id: ArtifactId::new("art_in"),
+                requires_deterministic: false,
+            }],
+            entry_specs: vec![EntrySpec { edge_id: edge_in }],
+            output_specs: vec![],
+        }
+    }
+
+    fn spec_plan_two_specs() -> SpecPlan {
+        SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("s1"),
+                    kind: "passthrough".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("s2"),
+                    kind: "sink".to_string(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![SpecDep {
+                from: SpecId::new("s1"),
+                to: SpecId::new("s2"),
+            }],
+        }
+    }
+
+    fn make_library() -> TestLibrary {
+        let mut lib = TestLibrary::new();
+        lib.register("passthrough", passthrough_workflow());
+        lib.register("sink", sink_workflow());
+        lib
+    }
+
+    // ---------------------------------------------------------------
+    // Determinism: compile twice → byte-identical serialized output.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn compile_is_deterministic_across_runs() {
+        let lib = make_library();
+        let plan = spec_plan_two_specs();
+
+        let p1 = compile(&plan, &lib).unwrap();
+        let p2 = compile(&plan, &lib).unwrap();
+
+        // Compare node/edge identifiers — the part that v4 UUIDs
+        // would have randomized.
+        let ids1: Vec<_> = p1.nodes.iter().map(|n| n.id).collect();
+        let ids2: Vec<_> = p2.nodes.iter().map(|n| n.id).collect();
+        assert_eq!(ids1, ids2, "node ids must be deterministic across runs");
+
+        let edge_ids1: Vec<_> = p1.edges.iter().map(|e| e.id).collect();
+        let edge_ids2: Vec<_> = p2.edges.iter().map(|e| e.id).collect();
+        assert_eq!(
+            edge_ids1, edge_ids2,
+            "edge ids must be deterministic across runs",
+        );
+
+        let arts1: Vec<_> = p1.edges.iter().map(|e| e.artifact_id.clone()).collect();
+        let arts2: Vec<_> = p2.edges.iter().map(|e| e.artifact_id.clone()).collect();
+        assert_eq!(
+            arts1, arts2,
+            "artifact ids must be deterministic across runs"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Cross-kind dep wires upstream exit to downstream entry.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn cross_kind_dep_wires_exit_to_entry() {
+        let lib = make_library();
+        let plan = spec_plan_two_specs();
+        let compiled = compile(&plan, &lib).unwrap();
+
+        // Two specs → two nodes (passthrough + sink).
+        assert_eq!(compiled.nodes.len(), 2);
+
+        // s1's exit edge id (after instantiation) is the only edge
+        // any sink-side consumer should reference. Find it via the
+        // back-pointer in spec_index.
+        let s1_exit = compiled.spec_index[&SpecId::new("s1")].exit_edges[0].edge_id;
+        let s2_entry_after = &compiled.spec_index[&SpecId::new("s2")].entry_edges;
+        assert_eq!(
+            s2_entry_after,
+            &vec![s1_exit],
+            "s2's entry should now reference s1's exit edge id",
+        );
+
+        // The sink node consumes s1_exit (rewired from s2's original
+        // entry edge id).
+        let sink_node = compiled
+            .nodes
+            .iter()
+            .find(|n| n.outputs.is_empty())
+            .expect("sink workflow has one terminal node");
+        assert_eq!(sink_node.inputs.len(), 1);
+        assert_eq!(
+            sink_node.inputs[0].edge_id, s1_exit,
+            "sink node should consume the upstream exit edge directly",
+        );
+
+        // The dropped entry edge of s2 must not appear in the merged
+        // edge list.
+        let edge_ids: std::collections::HashSet<_> = compiled.edges.iter().map(|e| e.id).collect();
+        assert!(
+            edge_ids.contains(&s1_exit),
+            "merged plan must keep the upstream exit edge",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Invariant violation in the merged plan → CompileError.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn invariant_violation_surfaces_as_compile_error() {
+        // Build a single-spec workflow that violates invariant 5
+        // (single writer per artifact): two nodes both name the same
+        // artifact id on their output edges.
+        let edge_a = EdgeId::generate();
+        let edge_b = EdgeId::generate();
+        let bad = Workflow {
+            nodes: vec![
+                Node {
+                    id: NodeId::generate(),
+                    executor: Box::new(NoOpExecutor),
+                    inputs: vec![],
+                    outputs: vec![EdgeRef::new(edge_a)],
+                },
+                Node {
+                    id: NodeId::generate(),
+                    executor: Box::new(NoOpExecutor),
+                    inputs: vec![],
+                    outputs: vec![EdgeRef::new(edge_b)],
+                },
+            ],
+            edges: vec![
+                Edge {
+                    id: edge_a,
+                    artifact_id: ArtifactId::new("collide"),
+                    requires_deterministic: false,
+                },
+                Edge {
+                    id: edge_b,
+                    artifact_id: ArtifactId::new("collide"),
+                    requires_deterministic: false,
+                },
+            ],
+            entry_specs: vec![],
+            output_specs: vec![],
+        };
+
+        let mut lib = TestLibrary::new();
+        lib.register("bad", bad);
+
+        let plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new("only"),
+                kind: "bad".to_string(),
+                inputs: Default::default(),
+            }],
+            deps: vec![],
+        };
+
+        let err = compile(&plan, &lib).unwrap_err();
+        match err {
+            CompileError::Invariant(v) => {
+                assert!(
+                    v.iter().any(|iv| iv.invariant == 5),
+                    "expected invariant 5 violation, got {v:?}",
+                );
+                let msg = v.iter().find(|iv| iv.invariant == 5).unwrap().to_string();
+                assert!(
+                    msg.contains("only:collide"),
+                    "violation message should reference the namespaced artifact id, got: {msg}",
+                );
+            }
+            other => panic!("expected CompileError::Invariant, got {other:?}"),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Missing kind is a hard error.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn missing_kind_is_hard_error() {
+        let lib = TestLibrary::new(); // empty
+        let plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new("orphan"),
+                kind: "no-such-kind".to_string(),
+                inputs: Default::default(),
+            }],
+            deps: vec![],
+        };
+        let err = compile(&plan, &lib).unwrap_err();
+        match err {
+            CompileError::MissingKind { spec_id, kind } => {
+                assert_eq!(spec_id.as_str(), "orphan");
+                assert_eq!(kind, "no-such-kind");
+            }
+            other => panic!("expected MissingKind, got {other:?}"),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Spec Plan structural error short-circuits before any lookup.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn spec_plan_cycle_short_circuits_compile() {
+        let lib = TestLibrary::new(); // empty — would fail MissingKind
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("a"),
+                    kind: "any".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("b"),
+                    kind: "any".to_string(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![
+                SpecDep {
+                    from: SpecId::new("a"),
+                    to: SpecId::new("b"),
+                },
+                SpecDep {
+                    from: SpecId::new("b"),
+                    to: SpecId::new("a"),
+                },
+            ],
+        };
+        let err = compile(&plan, &lib).unwrap_err();
+        assert!(
+            matches!(err, CompileError::SpecPlan(SpecPlanError::CycleInDeps(_))),
+            "expected SpecPlan cycle error to short-circuit before MissingKind, got: {err:?}",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Two specs of the same kind don't collide on artifact ids.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn two_same_kind_specs_get_distinct_artifact_ids() {
+        let mut lib = TestLibrary::new();
+        lib.register("passthrough", passthrough_workflow());
+
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("alpha"),
+                    kind: "passthrough".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("beta"),
+                    kind: "passthrough".to_string(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![],
+        };
+        let compiled = compile(&plan, &lib).unwrap();
+
+        // Each spec contributes one node + one edge surviving (the
+        // entry edge is kept because nothing was wired into it).
+        assert_eq!(compiled.nodes.len(), 2);
+
+        // Artifact ids are namespaced by spec id — no collision.
+        let arts: std::collections::HashSet<_> = compiled
+            .edges
+            .iter()
+            .map(|e| e.artifact_id.clone())
+            .collect();
+        assert!(arts.contains(&ArtifactId::new("alpha:art_in")));
+        assert!(arts.contains(&ArtifactId::new("alpha:art_out")));
+        assert!(arts.contains(&ArtifactId::new("beta:art_in")));
+        assert!(arts.contains(&ArtifactId::new("beta:art_out")));
+    }
+
+    // ---------------------------------------------------------------
+    // NoExit / NoEntry surface usefully when wiring is impossible.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn dep_to_workflow_with_no_entry_is_rejected() {
+        let mut lib = TestLibrary::new();
+        // Workflow that produces something but declares no entry slot.
+        let edge_out = EdgeId::generate();
+        let no_entry = Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(NoOpExecutor),
+                inputs: vec![],
+                outputs: vec![EdgeRef::new(edge_out)],
+            }],
+            edges: vec![Edge {
+                id: edge_out,
+                artifact_id: ArtifactId::new("art_out"),
+                requires_deterministic: false,
+            }],
+            entry_specs: vec![],
+            output_specs: vec![OutputSpec {
+                edge_id: edge_out,
+                provenance: Provenance::external_deterministic(),
+            }],
+        };
+        lib.register("source", passthrough_workflow());
+        lib.register("noentry", no_entry);
+
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("s1"),
+                    kind: "source".to_string(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("s2"),
+                    kind: "noentry".to_string(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![SpecDep {
+                from: SpecId::new("s1"),
+                to: SpecId::new("s2"),
+            }],
+        };
+        let err = compile(&plan, &lib).unwrap_err();
+        assert!(
+            matches!(err, CompileError::NoEntry { .. }),
+            "expected NoEntry error, got: {err:?}",
+        );
+    }
+}

--- a/crates/onsager-substrate/src/lib.rs
+++ b/crates/onsager-substrate/src/lib.rs
@@ -26,19 +26,30 @@
 //! (#351) gives it a sqlx-backed implementation so the Plan Compiler
 //! (SUB-05, #352) can resolve `kind → Workflow` at runtime.
 
+pub mod compiler;
 pub mod executor;
 pub mod ids;
 pub mod library;
+pub mod spec_plan;
 pub mod validate;
 pub mod workflow;
 pub mod workflow_library;
 
+pub use compiler::*;
 pub use executor::*;
 pub use ids::*;
-pub use library::*;
+pub use spec_plan::*;
 pub use validate::*;
 pub use workflow::*;
 pub use workflow_library::*;
+
+// `library::WorkflowLibrary` (the lookup trait) is intentionally
+// not glob-re-exported — it shares its name with
+// `workflow_library::WorkflowLibrary` (the persisted struct).
+// Rust keeps both accessible via their qualified paths; the trait
+// is also available as `WorkflowLookup` for callers that want a
+// short name without ambiguity.
+pub use library::WorkflowLibrary as WorkflowLookup;
 
 // Re-exports for downstream convenience — anyone working with a
 // substrate `Workflow` will reach for provenance + artifact identity in

--- a/crates/onsager-substrate/src/library.rs
+++ b/crates/onsager-substrate/src/library.rs
@@ -11,15 +11,33 @@
 use crate::ids::WorkflowId;
 use crate::workflow::Workflow;
 
-/// Lookup surface the validator needs from the workflow library.
+/// Lookup surface the validator and Plan Compiler share for the
+/// workflow library.
 ///
 /// Implementors must return a stable reference for the lifetime of
 /// the lookup; the validator holds the borrow only as long as it
 /// needs to walk the workflow.
+///
+/// Two lookup paths are exposed:
+/// - [`WorkflowLibrary::get`] resolves an internal `WorkflowId` —
+///   the validator uses it for invariant 4 (SubWorkflow refs).
+/// - [`WorkflowLibrary::by_kind`] resolves a Spec Plan `kind` string
+///   — the Plan Compiler uses it to instantiate one workflow per
+///   `SpecRef` (ADR 0017 step 1). Defaults to `None` so existing
+///   validator-only impls (e.g. the unit type, fixture libraries)
+///   continue to compile; compile against such an impl will fail
+///   with `MissingKind` as soon as a real spec is offered, which is
+///   the correct behavior.
 pub trait WorkflowLibrary {
     /// Fetch a workflow by id, or `None` if no workflow is
     /// registered under that id.
     fn get(&self, id: WorkflowId) -> Option<&Workflow>;
+
+    /// Fetch the latest workflow registered under `spec_kind`. The
+    /// Plan Compiler treats `None` as a hard `CompileError::MissingKind`.
+    fn by_kind(&self, _spec_kind: &str) -> Option<&Workflow> {
+        None
+    }
 }
 
 /// Empty library — every lookup returns `None`.

--- a/crates/onsager-substrate/src/spec_plan.rs
+++ b/crates/onsager-substrate/src/spec_plan.rs
@@ -1,0 +1,353 @@
+//! Spec Plan — the external contract authored by humans / Refract / MCP
+//! clients and consumed by the Plan Compiler (SUB-05, #352).
+//!
+//! See [ADR 0015](../../../docs/adr/0015-spec-plan-as-dag-external-contract.md)
+//! for the design rationale. A Spec Plan is a DAG: a list of [`SpecRef`]
+//! nodes and a list of [`SpecDep`] edges between them. Each `SpecRef`
+//! names the workflow `kind` to compile against and carries any
+//! external entry-side artifact references.
+//!
+//! The compiler ([`crate::compiler::compile`]) walks `specs` to
+//! instantiate per-spec subgraphs, then walks `deps` to wire each
+//! upstream spec's exit to the downstream spec's entry. ADR 0015 fixes
+//! v1 at single-entry / single-exit per workflow.
+//!
+//! Validation of the Spec Plan as a DAG (cycles in `deps` are an
+//! error) lives in [`SpecPlan::validate`]; the compiler calls it
+//! before any lookup.
+
+use onsager_artifact::ArtifactId;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+/// Externally-assigned identity for a spec. GitHub issue number,
+/// Refract-allocated UUID, `mcp:<uuid>` — anything stable and
+/// stringable.
+///
+/// The compiler uses `SpecId` as the namespace key when instantiating
+/// a workflow (see [`crate::compiler::compile`]), so renumbering
+/// breaks identity per ADR 0015.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SpecId(String);
+
+impl SpecId {
+    /// Wrap an externally-assigned identifier. Empty strings are
+    /// permitted at the type level — callers that need to reject
+    /// them should validate at the boundary.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// The wrapped identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SpecId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SpecId {
+    fn from(id: String) -> Self {
+        Self(id)
+    }
+}
+
+impl From<&str> for SpecId {
+    fn from(id: &str) -> Self {
+        Self(id.to_string())
+    }
+}
+
+/// Entry-side artifact references for a spec.
+///
+/// Today this is a flat list of `ArtifactId`s the spec expects to
+/// have available at its workflow's entry edge. v1 does not type or
+/// position-tag these — single-entry / single-exit per ADR 0015 means
+/// at most one entry edge, and the compiler does not need to address
+/// individual inputs to wire deps.
+///
+/// The field is here so the Spec Plan shape matches ADR 0015's
+/// declared contract; downstream consumers (the scheduler, executor
+/// runtime) will pick it up later.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpecInputs {
+    #[serde(default)]
+    pub artifacts: Vec<ArtifactId>,
+}
+
+/// A single spec in a Spec Plan.
+///
+/// `kind` is matched against the Workflow Library at compile time;
+/// missing kinds are a hard error per ADR 0017 (no fallback).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecRef {
+    pub id: SpecId,
+    pub kind: String,
+    #[serde(default)]
+    pub inputs: SpecInputs,
+}
+
+/// A directed dependency between two specs.
+///
+/// `from` produces, `to` consumes. The compiler wires `from`'s
+/// workflow exit edge to `to`'s workflow entry edge; cycles among
+/// `SpecDep`s are a Spec Plan validation error (ADR 0015).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpecDep {
+    pub from: SpecId,
+    pub to: SpecId,
+}
+
+/// The whole Spec Plan: specs + dependency edges.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SpecPlan {
+    pub specs: Vec<SpecRef>,
+    #[serde(default)]
+    pub deps: Vec<SpecDep>,
+}
+
+/// Why a Spec Plan failed validation. The compiler surfaces these
+/// before any workflow lookup so authors see structural errors
+/// without having to populate the library first.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SpecPlanError {
+    /// Two `SpecRef`s share the same `SpecId`.
+    #[error("duplicate spec id '{0}' in Spec Plan")]
+    DuplicateSpecId(SpecId),
+    /// A `SpecDep` references an id that is not in `specs`.
+    #[error("dependency references unknown spec id '{0}'")]
+    UnknownSpecId(SpecId),
+    /// `deps` contains a cycle. The vector is one cycle on the
+    /// dependency graph in traversal order.
+    #[error("cycle in Spec Plan deps: {}", format_cycle(.0))]
+    CycleInDeps(Vec<SpecId>),
+}
+
+fn format_cycle(path: &[SpecId]) -> String {
+    path.iter()
+        .map(SpecId::to_string)
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+impl SpecPlan {
+    /// Run the structural checks the compiler depends on:
+    /// - every `SpecId` is unique
+    /// - every `SpecDep` references a known spec
+    /// - `deps` is acyclic (DAG)
+    pub fn validate(&self) -> Result<(), SpecPlanError> {
+        let mut seen: HashSet<&SpecId> = HashSet::new();
+        for spec in &self.specs {
+            if !seen.insert(&spec.id) {
+                return Err(SpecPlanError::DuplicateSpecId(spec.id.clone()));
+            }
+        }
+
+        for dep in &self.deps {
+            if !seen.contains(&dep.from) {
+                return Err(SpecPlanError::UnknownSpecId(dep.from.clone()));
+            }
+            if !seen.contains(&dep.to) {
+                return Err(SpecPlanError::UnknownSpecId(dep.to.clone()));
+            }
+        }
+
+        // Adjacency map. We walk in declaration order so the cycle
+        // path the user sees is reproducible run-to-run.
+        let mut adj: HashMap<&SpecId, Vec<&SpecId>> = HashMap::new();
+        for spec in &self.specs {
+            adj.entry(&spec.id).or_default();
+        }
+        for dep in &self.deps {
+            adj.entry(&dep.from).or_default().push(&dep.to);
+        }
+
+        let mut color: HashMap<&SpecId, Color> = HashMap::new();
+        for spec in &self.specs {
+            if !matches!(color.get(&spec.id), Some(Color::Black)) {
+                let mut stack: Vec<&SpecId> = Vec::new();
+                if dfs_cycle(&spec.id, &adj, &mut color, &mut stack) {
+                    return Err(SpecPlanError::CycleInDeps(
+                        stack.into_iter().cloned().collect(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Color {
+    Gray,
+    Black,
+}
+
+fn dfs_cycle<'p>(
+    node: &'p SpecId,
+    adj: &HashMap<&'p SpecId, Vec<&'p SpecId>>,
+    color: &mut HashMap<&'p SpecId, Color>,
+    stack: &mut Vec<&'p SpecId>,
+) -> bool {
+    color.insert(node, Color::Gray);
+    stack.push(node);
+    if let Some(succs) = adj.get(node) {
+        for next in succs {
+            match color.get(next) {
+                Some(Color::Gray) => {
+                    stack.push(next);
+                    return true;
+                }
+                Some(Color::Black) => {}
+                None => {
+                    if dfs_cycle(next, adj, color, stack) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    stack.pop();
+    color.insert(node, Color::Black);
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(id: &str, kind: &str) -> SpecRef {
+        SpecRef {
+            id: SpecId::new(id),
+            kind: kind.to_string(),
+            inputs: SpecInputs::default(),
+        }
+    }
+
+    fn dep(from: &str, to: &str) -> SpecDep {
+        SpecDep {
+            from: SpecId::new(from),
+            to: SpecId::new(to),
+        }
+    }
+
+    #[test]
+    fn empty_plan_is_valid() {
+        SpecPlan::default().validate().unwrap();
+    }
+
+    #[test]
+    fn linear_chain_is_valid() {
+        let plan = SpecPlan {
+            specs: vec![spec("a", "k"), spec("b", "k"), spec("c", "k")],
+            deps: vec![dep("a", "b"), dep("b", "c")],
+        };
+        plan.validate().unwrap();
+    }
+
+    #[test]
+    fn duplicate_spec_id_is_rejected() {
+        let plan = SpecPlan {
+            specs: vec![spec("a", "k"), spec("a", "k2")],
+            deps: vec![],
+        };
+        assert!(matches!(
+            plan.validate().unwrap_err(),
+            SpecPlanError::DuplicateSpecId(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_dep_target_is_rejected() {
+        let plan = SpecPlan {
+            specs: vec![spec("a", "k")],
+            deps: vec![dep("a", "missing")],
+        };
+        let err = plan.validate().unwrap_err();
+        match err {
+            SpecPlanError::UnknownSpecId(id) => assert_eq!(id.as_str(), "missing"),
+            other => panic!("expected UnknownSpecId, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cycle_is_rejected_with_path() {
+        let plan = SpecPlan {
+            specs: vec![spec("a", "k"), spec("b", "k"), spec("c", "k")],
+            deps: vec![dep("a", "b"), dep("b", "c"), dep("c", "a")],
+        };
+        let err = plan.validate().unwrap_err();
+        match err {
+            SpecPlanError::CycleInDeps(path) => {
+                let display = path
+                    .iter()
+                    .map(SpecId::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                assert!(
+                    display.contains("a") && display.contains("b") && display.contains("c"),
+                    "cycle path should include every node: {display}",
+                );
+            }
+            other => panic!("expected CycleInDeps, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_loop_is_rejected() {
+        let plan = SpecPlan {
+            specs: vec![spec("a", "k")],
+            deps: vec![dep("a", "a")],
+        };
+        assert!(matches!(
+            plan.validate().unwrap_err(),
+            SpecPlanError::CycleInDeps(_)
+        ));
+    }
+
+    #[test]
+    fn diamond_shape_is_acyclic_and_valid() {
+        // a -> b, a -> c, b -> d, c -> d
+        let plan = SpecPlan {
+            specs: vec![
+                spec("a", "k"),
+                spec("b", "k"),
+                spec("c", "k"),
+                spec("d", "k"),
+            ],
+            deps: vec![dep("a", "b"), dep("a", "c"), dep("b", "d"), dep("c", "d")],
+        };
+        plan.validate().unwrap();
+    }
+
+    #[test]
+    fn spec_plan_roundtrips_through_serde() {
+        let plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new("sp1"),
+                kind: "github-issue".to_string(),
+                inputs: SpecInputs {
+                    artifacts: vec![ArtifactId::new("art1")],
+                },
+            }],
+            deps: vec![],
+        };
+        let json = serde_json::to_value(&plan).unwrap();
+        let roundtrip: SpecPlan = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip.specs.len(), 1);
+        assert_eq!(roundtrip.specs[0].id, plan.specs[0].id);
+        assert_eq!(roundtrip.specs[0].kind, "github-issue");
+        assert_eq!(roundtrip.specs[0].inputs.artifacts.len(), 1);
+    }
+
+    #[test]
+    fn spec_id_displays_inner_string() {
+        assert_eq!(SpecId::new("github:42").to_string(), "github:42");
+    }
+}

--- a/crates/onsager-substrate/src/validate.rs
+++ b/crates/onsager-substrate/src/validate.rs
@@ -602,6 +602,7 @@ mod tests {
                 outputs: vec![EdgeRef::new(edge_out.id)],
             }],
             edges: vec![edge_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         validate_workflow(&w, &()).unwrap();
@@ -632,6 +633,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -673,6 +675,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out, verify_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         validate_workflow(&w, &()).unwrap();
@@ -702,6 +705,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out, script_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -741,6 +745,7 @@ mod tests {
                 outputs: vec![EdgeRef::new(out_edge.id)],
             }],
             edges: vec![out_edge],
+            entry_specs: vec![],
             output_specs: vec![spec],
         };
         validate_workflow(&w, &()).unwrap();
@@ -764,6 +769,7 @@ mod tests {
                 outputs: vec![EdgeRef::new(out_edge.id)],
             }],
             edges: vec![out_edge.clone()],
+            entry_specs: vec![],
             output_specs: vec![spec],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -798,6 +804,7 @@ mod tests {
                 outputs: vec![],
             }],
             edges: vec![],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         validate_workflow(&w, &lib).unwrap();
@@ -815,6 +822,7 @@ mod tests {
                 outputs: vec![],
             }],
             edges: vec![],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -847,6 +855,7 @@ mod tests {
                     outputs: vec![],
                 }],
                 edges: vec![],
+                entry_specs: vec![],
                 output_specs: vec![],
             },
         );
@@ -860,6 +869,7 @@ mod tests {
                     outputs: vec![],
                 }],
                 edges: vec![],
+                entry_specs: vec![],
                 output_specs: vec![],
             },
         );
@@ -874,6 +884,7 @@ mod tests {
                 outputs: vec![],
             }],
             edges: vec![],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&root, &lib).unwrap_err();
@@ -910,6 +921,7 @@ mod tests {
                 },
             ],
             edges: vec![edge_a, edge_b],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         validate_workflow(&w, &()).unwrap();
@@ -947,6 +959,7 @@ mod tests {
                 },
             ],
             edges: vec![edge_a, edge_b],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -1000,6 +1013,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out, script_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();
@@ -1054,6 +1068,7 @@ mod tests {
                 },
             ],
             edges: vec![edge_b, edge_a.clone()],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();

--- a/crates/onsager-substrate/src/workflow.rs
+++ b/crates/onsager-substrate/src/workflow.rs
@@ -12,9 +12,11 @@
 
 use onsager_artifact::{ArtifactId, NodeId, Provenance};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::executor::Executor;
 use crate::ids::EdgeId;
+use crate::spec_plan::SpecId;
 
 /// A reusable workflow template — graph of [`Node`]s connected by
 /// [`Edge`]s.
@@ -27,17 +29,18 @@ use crate::ids::EdgeId;
 pub struct Workflow {
     pub nodes: Vec<Node>,
     pub edges: Vec<Edge>,
+    /// Workflow-level entry slots — each entry names an inbound edge
+    /// the Plan Compiler may rewire when wiring spec-level deps
+    /// (ADR 0017 step 3). v1 fixes single-entry / single-exit per
+    /// ADR 0015; declaring zero entries is also valid (the workflow
+    /// stands alone, with no upstream wiring).
+    #[serde(default)]
+    pub entry_specs: Vec<EntrySpec>,
     /// Workflow-level output slots — each entry names an exit edge
     /// and the provenance the workflow promises to deliver on it.
     /// Invariant 3 (ADR 0018) checks the actual emitted provenance
     /// on each named edge equals the declaration; a workflow may
     /// declare zero outputs, in which case invariant 3 is a no-op.
-    ///
-    /// `EntrySpec` (the inbound counterpart from ADR 0015) is not
-    /// yet modeled — entry edges, identified as edges with no
-    /// producer node in this workflow, are treated by the validator
-    /// as `Deterministic { source: External }` per the default in
-    /// `Provenance::external_deterministic`.
     #[serde(default)]
     pub output_specs: Vec<OutputSpec>,
 }
@@ -53,6 +56,20 @@ pub struct Workflow {
 pub struct OutputSpec {
     pub edge_id: EdgeId,
     pub provenance: Provenance,
+}
+
+/// A declared workflow entry slot.
+///
+/// Names an inbound edge the Plan Compiler may rewire when an
+/// upstream spec dependency is connected to this spec. The compiler
+/// rewrites consumer references to this `edge_id` so they read from
+/// the upstream spec's exit edge instead.
+///
+/// Standalone workflows may omit entry specs entirely; the kernel
+/// validator already treats unproduced edges as External.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntrySpec {
+    pub edge_id: EdgeId,
 }
 
 /// A node in a workflow template.
@@ -108,6 +125,118 @@ impl From<EdgeId> for EdgeRef {
     }
 }
 
+/// Result of [`Workflow::instantiate`] — a copy of the workflow's
+/// node graph with deterministic, namespace-scoped identifiers.
+///
+/// The Plan Compiler ([`crate::compiler::compile`]) consumes one of
+/// these per spec, then merges them into the flat Execution Plan and
+/// rewires entry edges according to the Spec Plan deps.
+#[derive(Debug)]
+pub struct InstantiatedWorkflow {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<Edge>,
+    pub entry_edges: Vec<EdgeId>,
+    pub exit_edges: Vec<OutputSpec>,
+}
+
+/// Stable namespace seed for Plan-Compiler UUID derivation. Generated
+/// once (UUID v4) and frozen — changing it invalidates every cached
+/// compile output. The value itself is arbitrary; only its
+/// stability matters.
+const PLAN_COMPILER_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x4f, 0x4e, 0x53, 0x47, 0x52, 0x53, 0x55, 0x42, 0x53, 0x54, 0x52, 0x41, 0x54, 0x45, 0x05, 0x05,
+]);
+
+impl Workflow {
+    /// Produce a fresh copy of this workflow's nodes and edges with
+    /// every `NodeId` / `EdgeId` / `ArtifactId` rewritten under
+    /// `spec_id`'s namespace.
+    ///
+    /// Per ADR 0017, identifiers are deterministic — same `spec_id` +
+    /// same `Workflow` content → byte-identical output. Achieved with
+    /// UUID v5: the per-spec namespace is
+    /// `Uuid::new_v5(PLAN_COMPILER_NAMESPACE, spec_id)`, and each
+    /// original UUID is rewritten to
+    /// `Uuid::new_v5(spec_namespace, original_uuid)`.
+    ///
+    /// `ArtifactId` strings are namespaced by prefixing with
+    /// `"<spec_id>:"` so two specs of the same kind do not collide on
+    /// the spine's single-writer-per-artifact rule (invariant 5).
+    pub fn instantiate(&self, spec_id: &SpecId) -> InstantiatedWorkflow {
+        let spec_ns = Uuid::new_v5(&PLAN_COMPILER_NAMESPACE, spec_id.as_str().as_bytes());
+
+        let map_node_id = |old: NodeId| -> NodeId {
+            NodeId::new(Uuid::new_v5(&spec_ns, old.as_uuid().as_bytes()))
+        };
+        let map_edge_id = |old: EdgeId| -> EdgeId {
+            EdgeId::new(Uuid::new_v5(&spec_ns, old.as_uuid().as_bytes()))
+        };
+        let map_artifact_id = |old: &ArtifactId| -> ArtifactId {
+            ArtifactId::new(format!("{spec_id}:{}", old.as_str()))
+        };
+
+        // Edges first — node remap reads from this re-keyed table.
+        let edges: Vec<Edge> = self
+            .edges
+            .iter()
+            .map(|edge| Edge {
+                id: map_edge_id(edge.id),
+                artifact_id: map_artifact_id(&edge.artifact_id),
+                requires_deterministic: edge.requires_deterministic,
+            })
+            .collect();
+
+        // Nodes: rewrite ids and edge refs, then re-serialize the
+        // executor through serde so its trait-object form survives
+        // the copy. typetag round-trips the kind discriminator.
+        let nodes: Vec<Node> = self
+            .nodes
+            .iter()
+            .map(|node| {
+                let executor_json = serde_json::to_value(&node.executor)
+                    .expect("Executor serializes via typetag — see crate::executor");
+                let executor: Box<dyn Executor> = serde_json::from_value(executor_json)
+                    .expect("Executor round-trips via typetag — kind was just emitted above");
+                Node {
+                    id: map_node_id(node.id),
+                    executor,
+                    inputs: node
+                        .inputs
+                        .iter()
+                        .map(|r| EdgeRef::new(map_edge_id(r.edge_id)))
+                        .collect(),
+                    outputs: node
+                        .outputs
+                        .iter()
+                        .map(|r| EdgeRef::new(map_edge_id(r.edge_id)))
+                        .collect(),
+                }
+            })
+            .collect();
+
+        let entry_edges = self
+            .entry_specs
+            .iter()
+            .map(|e| map_edge_id(e.edge_id))
+            .collect();
+        let exit_edges = self
+            .output_specs
+            .iter()
+            .map(|o| OutputSpec {
+                edge_id: map_edge_id(o.edge_id),
+                provenance: o.provenance,
+            })
+            .collect();
+
+        InstantiatedWorkflow {
+            nodes,
+            edges,
+            entry_edges,
+            exit_edges,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,6 +264,7 @@ mod tests {
                     requires_deterministic: false,
                 },
             ],
+            entry_specs: vec![],
             output_specs: vec![],
         }
     }
@@ -222,6 +352,7 @@ mod tests {
         let w = Workflow {
             nodes: vec![],
             edges: vec![],
+            entry_specs: vec![],
             output_specs: vec![spec],
         };
         let json = serde_json::to_value(&w).unwrap();

--- a/crates/onsager-substrate/tests/workflow_library.rs
+++ b/crates/onsager-substrate/tests/workflow_library.rs
@@ -44,6 +44,8 @@ fn sample_workflow(label: &str) -> Workflow {
                 requires_deterministic: false,
             },
         ],
+        entry_specs: vec![],
+        output_specs: vec![],
     }
 }
 

--- a/docs/adr/0015-spec-plan-as-dag-external-contract.md
+++ b/docs/adr/0015-spec-plan-as-dag-external-contract.md
@@ -112,11 +112,20 @@ the dev-process compiler check.
 
 ## Adoption checklist
 
-- [ ] `SpecPlan`, `SpecRef`, `SpecDep` types in `onsager-substrate`
-      (SUB-02, #349).
-- [ ] DAG / cycle validation on Spec Plan load.
-- [ ] Unified `EntrySpec` / `OutputSpec` on `Workflow` (SUB-02).
-- [ ] Compile-time IO type matching (SUB-05, #352).
+- [x] `SpecPlan`, `SpecRef`, `SpecDep` types in `onsager-substrate`
+      (`crate::spec_plan`). Originally scoped to SUB-02 (#349); the
+      types landed alongside the Plan Compiler in SUB-05 (#352)
+      because the compiler is their first consumer.
+- [x] DAG / cycle validation on Spec Plan load —
+      `SpecPlan::validate` reports duplicate ids, dangling refs,
+      and cycles before any library lookup.
+- [x] Unified `EntrySpec` / `OutputSpec` on `Workflow` — `EntrySpec`
+      added in SUB-05 (#352) alongside the existing `OutputSpec`
+      from SUB-02 (#349).
+- [x] Structural IO check at compile time — `NoExit` / `NoEntry`
+      errors when a spec dep targets a workflow slot that doesn't
+      exist. Artifact-level type matching deferred until the kind
+      taxonomy stabilizes.
 - [ ] MCP tool `submit_spec_plan` derives schema from `SpecPlan` via
       schemars (per ADR 0007 SSOT principle).
 

--- a/docs/adr/0017-plan-compiler-three-step-algorithm.md
+++ b/docs/adr/0017-plan-compiler-three-step-algorithm.md
@@ -118,13 +118,23 @@ moving the kind taxonomy.
 
 ## Adoption checklist
 
-- [ ] `compile` function in `crates/onsager-substrate/src/compiler.rs`
+- [x] `compile` function in `crates/onsager-substrate/src/compiler.rs`
       (SUB-05, #352).
-- [ ] `Workflow::instantiate(spec)` — fresh UUIDs, spec-scoped
-      namespace.
-- [ ] `ExecutionPlan::connect` — exit/entry wiring with type-check.
-- [ ] Determinism property test (compile twice → identical output).
-- [ ] Compile errors carry offending IDs.
+- [x] `Workflow::instantiate(spec)` — fresh UUIDs, spec-scoped
+      namespace. Implemented as deterministic UUID v5 derivation
+      from a stable namespace seed plus `SpecId`, so "fresh" here
+      means *unique per spec* without the v4 randomness that would
+      break the determinism property test.
+- [x] `ExecutionPlan::connect` — exit/entry wiring with structural
+      check. Surfaces `NoExit` / `NoEntry` errors when a spec lacks
+      the IO slot the dep references; richer artifact-level type
+      matching is deferred until the kind taxonomy stabilizes.
+- [x] Determinism property test (compile twice → identical output) —
+      `compiler::tests::compile_is_deterministic_across_runs`.
+- [x] Compile errors carry offending IDs — `MissingKind` names the
+      `SpecId` + kind; `NoExit` / `NoEntry` name both endpoints;
+      kernel-invariant violations surface offending node/edge IDs
+      via `InvariantViolation` per ADR 0018.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Implements the Plan Compiler per [ADR 0017](docs/adr/0017-plan-compiler-three-step-algorithm.md): `compile(spec_plan, workflow_library) -> Result<ExecutionPlan, _>` running the four-step skeleton — validate-Spec-Plan → lookup → instantiate → connect → validate-kernel-invariants. Pure, sync, deterministic.

Closes #352.

## What landed

- **`crate::compiler`** — `compile(...)`, `ExecutionPlan { nodes, edges, spec_index }`, `CompileError { SpecPlan | MissingKind | NoExit | NoEntry | Invariant }`. The whole compiler is one screen of Rust.
- **`crate::spec_plan`** — `SpecPlan`, `SpecRef`, `SpecDep`, `SpecId`, `SpecInputs`. Originally scoped to SUB-02 (#349) but deferred; the compiler is their first consumer so they land here. `SpecPlan::validate` covers duplicate ids, dangling deps, and cycles.
- **`Workflow::instantiate(&SpecId)`** — produces a per-spec subgraph with deterministic UUIDs derived via UUID v5 from a stable namespace seed plus the `SpecId`. Artifact ids get a `<spec_id>:` prefix so two same-kind specs don't collide on single-writer (invariant 5).
- **`EntrySpec` on `Workflow`** — the inbound counterpart to `OutputSpec`. ADR 0015 named both; SUB-02 only landed the outbound side.
- **`WorkflowLibrary::by_kind(&str)`** — sync kind-based lookup the compiler needs, defaulting to `None` so existing trait impls (the unit type, fixture libraries) still compile.

## Determinism

Per ADR 0017's "compile twice → byte-identical output" property, every fresh id in `instantiate` is `Uuid::new_v5(spec_namespace, original_uuid_bytes)`, where `spec_namespace = Uuid::new_v5(PLAN_COMPILER_NAMESPACE, spec_id_bytes)`. Two compile runs of the same `(SpecPlan, WorkflowLibrary)` snapshot therefore produce equal `ExecutionPlan`s. Asserted in `compiler::tests::compile_is_deterministic_across_runs`.

## Drive-by fixes

`cargo test -p onsager-substrate` was broken on `main` for two pre-existing reasons that block this PR's tests too:

1. The SUB-04 integration test (`tests/workflow_library.rs`) constructs a `Workflow` literal that's missing the `output_specs` field added in SUB-03. Added `entry_specs: vec[]` and `output_specs: vec[]`.
2. `library::WorkflowLibrary` (the trait, SUB-03) and `workflow_library::WorkflowLibrary` (the struct, SUB-04) both glob-re-exported from `lib.rs`, producing ambiguous resolution at every call site that uses the unqualified name. Stopped glob-re-exporting the trait and added `pub use library::WorkflowLibrary as WorkflowLookup` so both surfaces stay available without ambiguity.

## ADR adoption checklists

Flipped the checkboxes on ADR 0017 and the SUB-05 + EntrySpec items on ADR 0015. The MCP `submit_spec_plan` schema-via-schemars item on ADR 0015 stays open — that's a portal-side follow-up.

## Test plan

- [x] `cargo test -p onsager-substrate` — 47 lib tests + 7 integration tests pass
- [x] `cargo build --workspace` — green
- [x] `cargo clippy -p onsager-substrate --all-targets -- -D warnings` — green
- [x] `cargo fmt --all -- --check` — green
- [x] `cargo run -p xtask -- check-file-budget` — green (no new files over budget)
- [x] `cargo run -p xtask -- lint-seams` — green
- [x] `cargo run -p xtask -- check-events` — green
- [x] Determinism property test (`compile_is_deterministic_across_runs`) — green
- [x] Cross-kind dep wires entry to exit (`cross_kind_dep_wires_exit_to_entry`) — green
- [x] Invariant violation in resulting plan surfaces as `CompileError` (`invariant_violation_surfaces_as_compile_error`) — green


---
_Generated by [Claude Code](https://claude.ai/code/session_019nX3G7hLBfUdnhkW7qwgjc)_