### PR TITLE
fix(nodes): add missing entry_specs to verify acceptance test workflows

### DIFF
--- a/crates/onsager-nodes/src/verify.rs
+++ b/crates/onsager-nodes/src/verify.rs
@@ -487,6 +487,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out, verify_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         // Pass: invariant 1 holds because Verify emits Deterministic
@@ -544,6 +545,7 @@ mod tests {
                 },
             ],
             edges: vec![agent_out],
+            entry_specs: vec![],
             output_specs: vec![],
         };
         let err = validate_workflow(&w, &()).unwrap_err();


### PR DESCRIPTION
## Summary

Restores `cargo test --workspace` on main. #377 (SUB-05) added an `entry_specs` field to the `Workflow` struct; #376 (Verify) was rebased onto post-#377 main but its two acceptance-test `Workflow {...}` literals still used the pre-SUB-05 shape, breaking the test build on main after #376 merged.

Production code compiled fine — the executor implementation doesn't construct `Workflow` literally — so `cargo build --workspace` passed, but `cargo test --no-run` failed on the test compile.

## What changed

`crates/onsager-nodes/src/verify.rs` — adds `entry_specs: vec[],` to both `Workflow {...}` literals in the two acceptance tests:
- `workflow_with_verify_upgrades_uncertain_for_requires_deterministic_edge`
- `workflow_without_verify_fails_invariant_1_for_uncertain_upstream`

## Test plan

- [x] `cargo test -p onsager-nodes` — 55 pass (including the two acceptance tests above)
- [x] `cargo test --workspace --no-run` — compiles clean (was failing on main before this PR)
- [x] `cargo build --workspace` — green

## Why the rebase didn't catch this

The conflict during the #376 rebase was confined to `Cargo.lock`, `crates/onsager-nodes/Cargo.toml`, and `crates/onsager-nodes/src/lib.rs` (additive merge of new deps + module declarations). The `Workflow` struct shape change lived in `onsager-substrate` and wasn't a textual conflict — `verify.rs` happily compiled the stale literal in the lib build, and the only signal would have been a `cargo test --no-run` between rebase and force-push. Adding that to the merge protocol is the durable fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Dy6By2XQhAAKUgEoWHhV)_