### PR TITLE
feat(substrate): spine event emission contract (RUN-02)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,7 @@ name = "onsager-substrate"
 version = "0.2.0-alpha.1"
 dependencies = [
  "onsager-artifact",
+ "onsager-spine",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -246,20 +246,17 @@ impl Executor for AgentExecutor {
             user_prompt: render_user_prompt(&ctx),
         };
 
-        // RUN-02 (#360) lifecycle events. `plan_id` is unknown at the
-        // executor surface — the scheduler owns it; the executor
-        // contributes the session-level signals it alone knows about.
-        // Carry an empty `plan_id` until the executor context grows a
-        // `plan_id` field (follow-up); the dashboard run timeline keys
-        // by `(stream_id == plan:<plan>:<node>)`, which still works
-        // because `stream_id` is derived spine-side from the typed
-        // variant — node-level correlation by `node_id` is preserved.
+        // RUN-02 (#360) lifecycle events. `plan_id` comes off
+        // `ExecutorContext`, populated by the scheduler so the
+        // spine envelope's `stream_id` (`plan:<plan>:<node>`)
+        // correlates verdicts back to a specific run.
+        let plan_id = ctx.plan_id.as_str().to_string();
         let session_id = Uuid::new_v4().to_string();
         emit_event(
             &ctx,
             se::KIND_AGENT_SESSION_STARTED,
             &se::AgentSessionStarted {
-                plan_id: String::new(),
+                plan_id: plan_id.clone(),
                 node_id: ctx.node_id,
                 session_id: session_id.clone(),
                 model: self.model.clone(),
@@ -274,7 +271,7 @@ impl Executor for AgentExecutor {
                     &ctx,
                     se::KIND_AGENT_SESSION_FAILED,
                     &se::AgentSessionFailed {
-                        plan_id: String::new(),
+                        plan_id: plan_id.clone(),
                         node_id: ctx.node_id,
                         session_id: session_id.clone(),
                         error: e.to_string(),
@@ -289,7 +286,7 @@ impl Executor for AgentExecutor {
             &ctx,
             se::KIND_AGENT_SESSION_COMPLETED,
             &se::AgentSessionCompleted {
-                plan_id: String::new(),
+                plan_id,
                 node_id: ctx.node_id,
                 session_id,
                 // Token usage is not surfaced through `AgentResponse`
@@ -322,14 +319,22 @@ impl Executor for AgentExecutor {
     }
 }
 
-/// Best-effort spine emit for an executor lifecycle event. Failures
-/// are logged via the spine adapter (the scheduler's `warn!` path)
-/// rather than propagated — a missed lifecycle event must not stall
-/// the actual execution. `serde_json::to_value` on a substrate event
-/// struct cannot fail (only string keys, no NaN floats).
+/// Best-effort spine emit for an executor lifecycle event. A failed
+/// emit logs a warning and is not propagated — a missed lifecycle
+/// event must not stall the actual execution (the artifact still
+/// materializes; the dashboard timeline just loses one row).
+/// `serde_json::to_value` on a substrate event struct cannot fail
+/// (only string keys, no NaN floats).
 async fn emit_event<T: serde::Serialize>(ctx: &ExecutorContext, kind: &str, payload: &T) {
     let payload = serde_json::to_value(payload).expect("substrate event payload must serialize");
-    let _ = ctx.spine.emit(kind, payload).await;
+    if let Err(e) = ctx.spine.emit(kind, payload).await {
+        tracing::warn!(
+            plan = %ctx.plan_id,
+            node = %ctx.node_id,
+            kind,
+            "agent executor spine emit failed: {e}",
+        );
+    }
 }
 
 /// Render upstream artifacts into a single user-side prompt body. The
@@ -363,6 +368,7 @@ mod tests {
 
     fn empty_ctx() -> ExecutorContext {
         ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: Vec::new(),
             spine: Arc::new(MockSpine::default()),
@@ -423,6 +429,7 @@ mod tests {
         let exec = agent_with_stub("the agent said hello");
         let node_id = NodeId::generate();
         let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id,
             inputs: Vec::new(),
             spine: Arc::new(MockSpine::default()),
@@ -469,6 +476,7 @@ mod tests {
         let input_id = ArtifactId::new("art_input_1");
         let input_art = Artifact::new(Kind::Document, "upstream", "owner", "test", Vec::new());
         let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![(input_id.clone(), input_art)],
             spine: Arc::new(MockSpine::default()),
@@ -632,6 +640,7 @@ mod tests {
 
         let node_id = NodeId::generate();
         let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id,
             inputs: Vec::new(),
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -24,9 +24,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, Kind, Provenance, SourceTag};
+use onsager_substrate::events as se;
 use onsager_substrate::executor::Executor as SubstrateExecutor;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
 use crate::context::{ExecutorContext, ExecutorOutputs};
 use crate::error::ExecutorError;
@@ -244,11 +246,60 @@ impl Executor for AgentExecutor {
             user_prompt: render_user_prompt(&ctx),
         };
 
-        let response = self
-            .runner
-            .run(request)
-            .await
-            .map_err(|e| ExecutorError::failed(e.to_string()))?;
+        // RUN-02 (#360) lifecycle events. `plan_id` is unknown at the
+        // executor surface — the scheduler owns it; the executor
+        // contributes the session-level signals it alone knows about.
+        // Carry an empty `plan_id` until the executor context grows a
+        // `plan_id` field (follow-up); the dashboard run timeline keys
+        // by `(stream_id == plan:<plan>:<node>)`, which still works
+        // because `stream_id` is derived spine-side from the typed
+        // variant — node-level correlation by `node_id` is preserved.
+        let session_id = Uuid::new_v4().to_string();
+        emit_event(
+            &ctx,
+            se::KIND_AGENT_SESSION_STARTED,
+            &se::AgentSessionStarted {
+                plan_id: String::new(),
+                node_id: ctx.node_id,
+                session_id: session_id.clone(),
+                model: self.model.clone(),
+            },
+        )
+        .await;
+
+        let response = match self.runner.run(request).await {
+            Ok(r) => r,
+            Err(e) => {
+                emit_event(
+                    &ctx,
+                    se::KIND_AGENT_SESSION_FAILED,
+                    &se::AgentSessionFailed {
+                        plan_id: String::new(),
+                        node_id: ctx.node_id,
+                        session_id: session_id.clone(),
+                        error: e.to_string(),
+                    },
+                )
+                .await;
+                return Err(ExecutorError::failed(e.to_string()));
+            }
+        };
+
+        emit_event(
+            &ctx,
+            se::KIND_AGENT_SESSION_COMPLETED,
+            &se::AgentSessionCompleted {
+                plan_id: String::new(),
+                node_id: ctx.node_id,
+                session_id,
+                // Token usage is not surfaced through `AgentResponse`
+                // yet; the live runner will fill it in via a runner-
+                // side hook in a follow-up. Leaving `None` keeps the
+                // budget consumer honest — "not reported" ≠ "zero".
+                token_usage: None,
+            },
+        )
+        .await;
 
         let mut artifact = Artifact::new(
             Kind::Document,
@@ -269,6 +320,16 @@ impl Executor for AgentExecutor {
         let artifact_id = artifact.artifact_id.clone();
         Ok(ExecutorOutputs::single(artifact_id, artifact))
     }
+}
+
+/// Best-effort spine emit for an executor lifecycle event. Failures
+/// are logged via the spine adapter (the scheduler's `warn!` path)
+/// rather than propagated — a missed lifecycle event must not stall
+/// the actual execution. `serde_json::to_value` on a substrate event
+/// struct cannot fail (only string keys, no NaN floats).
+async fn emit_event<T: serde::Serialize>(ctx: &ExecutorContext, kind: &str, payload: &T) {
+    let payload = serde_json::to_value(payload).expect("substrate event payload must serialize");
+    let _ = ctx.spine.emit(kind, payload).await;
 }
 
 /// Render upstream artifacts into a single user-side prompt body. The

--- a/crates/onsager-nodes/src/context.rs
+++ b/crates/onsager-nodes/src/context.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use onsager_artifact::{Artifact, ArtifactId, NodeId};
 
 use crate::SpineClient;
+use crate::scheduler::PlanId;
 
 /// What an executor receives when the runtime invokes it.
 ///
@@ -21,6 +22,13 @@ use crate::SpineClient;
 /// `Executor::execute`.
 #[derive(Debug)]
 pub struct ExecutorContext {
+    /// Identifier for the Execution Plan run this dispatch belongs
+    /// to. Threaded onto every substrate lifecycle event the executor
+    /// emits (`agent.session_*`, `synodic.verdict`) so consumers can
+    /// correlate them back to a specific run — without it the spine
+    /// envelope's `stream_id` (`plan:<plan_id>:<node_id>`) collapses
+    /// across runs.
+    pub plan_id: PlanId,
     /// The node whose executor this is — identifies the producer for
     /// downstream `Artifact::produced_by_node` tagging.
     pub node_id: NodeId,
@@ -82,6 +90,7 @@ mod tests {
     #[test]
     fn context_is_constructible_with_mock_spine() {
         let ctx = ExecutorContext {
+            plan_id: PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/dispatch.rs
+++ b/crates/onsager-nodes/src/dispatch.rs
@@ -49,6 +49,7 @@ mod tests {
 
     fn empty_ctx() -> ExecutorContext {
         ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/executor.rs
+++ b/crates/onsager-nodes/src/executor.rs
@@ -100,6 +100,7 @@ mod tests {
 
     fn empty_ctx() -> ExecutorContext {
         ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/lib.rs
+++ b/crates/onsager-nodes/src/lib.rs
@@ -42,8 +42,8 @@ pub use error::ExecutorError;
 pub use executor::{Executor, NoOpExecutor};
 pub use registry::ExecutorRegistry;
 pub use scheduler::{
-    EVENT_NODE_COMPLETED, EVENT_NODE_FAILED, EVENT_NODE_READY, EVENT_NODE_RUNNING,
-    InMemoryPlanStore, NodeState, PlanId, PlanStore, PlanStoreError, Scheduler, SchedulerError,
+    EVENT_NODE_COMPLETED, EVENT_NODE_FAILED, EVENT_NODE_STARTED, InMemoryPlanStore, NodeState,
+    PlanId, PlanStore, PlanStoreError, Scheduler, SchedulerError,
 };
 pub use script::{INLINE_URI_PREFIX, ScriptExecutor, decode_inline_body};
 pub use spine::{SpineClient, SpineError};

--- a/crates/onsager-nodes/src/registry.rs
+++ b/crates/onsager-nodes/src/registry.rs
@@ -117,6 +117,7 @@ mod tests {
         let registry = ExecutorRegistry::with_noop();
         let exec = registry.get("noop").expect("registered");
         let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -415,10 +415,18 @@ impl Scheduler {
         node: &Node,
         state: &mut HashMap<NodeId, NodeState>,
     ) -> Result<(), SchedulerError> {
-        // Ready is purely internal — persisted so a restart can tell
-        // "queued but not yet running" apart from "never seen", but no
-        // spine event. `node.started` (below) is the first user-visible
-        // signal that a node has begun execution.
+        // Ready is purely internal — persisted as a marker that this
+        // dispatch reached the registry-lookup step, then immediately
+        // overwritten by Running before the executor is invoked. No
+        // spine event. `node.started` (below) is the first
+        // user-visible signal that a node has begun execution.
+        //
+        // Restart behavior: `run()` resets every non-terminal state
+        // (`Ready` / `Running`) to `Pending` on recovery — both are
+        // treated as "interrupted, re-dispatch" rather than
+        // distinguishable states. The persisted transitions are
+        // mainly an audit trail for diagnostics today; a future
+        // resume-mid-flight executor would key off them.
         state.insert(node.id, NodeState::Ready);
         self.store
             .set_node_state(plan_id, node.id, NodeState::Ready)
@@ -434,6 +442,7 @@ impl Scheduler {
 
         let inputs = self.gather_inputs(plan_id, node, plan).await?;
         let ctx = ExecutorContext {
+            plan_id: plan_id.clone(),
             node_id: node.id,
             inputs,
             spine: Arc::clone(&self.spine),

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -21,13 +21,19 @@
 //!
 //! 1. For each Pending node whose input edges are all Completed (or
 //!    External + materialized in the [`PlanStore`]), transition it to
-//!    `Ready` → `Running`, persist both transitions, then dispatch.
+//!    `Ready` → `Running`, persist both transitions, then emit
+//!    `node.started` and dispatch.
 //! 2. On `Ok` outputs: persist each output artifact under its edge's
 //!    `ArtifactId`, transition the node to `Completed`, emit
-//!    `node.completed` on the spine.
-//! 3. On `Err`: transition to `Failed`, emit `node.failed`, abort the
-//!    plan with [`SchedulerError::NodeFailed`].
+//!    `node.completed` (carrying `output_artifact_ids`) on the spine.
+//! 3. On `Err`: transition to `Failed`, emit `node.failed` (carrying
+//!    the executor's error message), abort the plan with
+//!    [`SchedulerError::NodeFailed`].
 //! 4. Repeat until no progress (every node is terminal).
+//!
+//! Wire vocabulary lives in `onsager-substrate::events` (typed
+//! authoring) and `onsager-spine::FactoryEventKind` (typed wire) —
+//! registered in `onsager-registry::EVENTS` per RUN-02 (#360).
 //!
 //! Restart safety: at `run()` entry the scheduler reads the persisted
 //! state map. `Completed` / `Failed` survive; `Running` / `Ready` are
@@ -42,6 +48,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, ArtifactId, NodeId};
 use onsager_substrate::compiler::ExecutionPlan;
+use onsager_substrate::events as se;
 use onsager_substrate::ids::EdgeId;
 use onsager_substrate::workflow::Node;
 use serde::{Deserialize, Serialize};
@@ -96,8 +103,10 @@ impl std::fmt::Display for PlanId {
 pub enum NodeState {
     /// Some input edges still have an unresolved producer.
     Pending,
-    /// All inputs are resolved — queued for dispatch. Emitted as
-    /// `plan.node_ready` on the spine.
+    /// All inputs are resolved — queued for dispatch. Internal-only;
+    /// no spine event (RUN-02, #360 collapsed `plan.node_ready` and
+    /// `plan.node_running` into the single `node.started` lifecycle
+    /// event emitted when the executor actually begins).
     Ready,
     /// `Executor::execute` is in flight.
     Running,
@@ -270,13 +279,15 @@ pub enum SchedulerError {
     Store(String),
 }
 
-/// Event names the scheduler emits on the spine. Free constants so the
-/// downstream `FactoryEventKind` migration (when these enter the typed
-/// registry) can match by string.
-pub const EVENT_NODE_READY: &str = "plan.node_ready";
-pub const EVENT_NODE_RUNNING: &str = "plan.node_running";
-pub const EVENT_NODE_COMPLETED: &str = "node.completed";
-pub const EVENT_NODE_FAILED: &str = "node.failed";
+/// Event names the scheduler emits on the spine, re-exported from
+/// `onsager-substrate::events` so external callers (the dashboard run
+/// timeline; future Observer subscriptions) can match by string
+/// without taking a second dep. The wire vocabulary itself lives in
+/// the registry manifest (`onsager-registry::EVENTS`) and the
+/// `FactoryEventKind` enum (`onsager-spine`) — per RUN-02 (#360).
+pub const EVENT_NODE_STARTED: &str = se::KIND_NODE_STARTED;
+pub const EVENT_NODE_COMPLETED: &str = se::KIND_NODE_COMPLETED;
+pub const EVENT_NODE_FAILED: &str = se::KIND_NODE_FAILED;
 
 /// The substrate scheduler.
 ///
@@ -404,12 +415,22 @@ impl Scheduler {
         node: &Node,
         state: &mut HashMap<NodeId, NodeState>,
     ) -> Result<(), SchedulerError> {
+        // Ready is purely internal — persisted so a restart can tell
+        // "queued but not yet running" apart from "never seen", but no
+        // spine event. `node.started` (below) is the first user-visible
+        // signal that a node has begun execution.
         state.insert(node.id, NodeState::Ready);
-        self.transition(plan_id, node.id, NodeState::Ready).await?;
+        self.store
+            .set_node_state(plan_id, node.id, NodeState::Ready)
+            .await
+            .map_err(|e| SchedulerError::Store(e.0))?;
 
         state.insert(node.id, NodeState::Running);
-        self.transition(plan_id, node.id, NodeState::Running)
-            .await?;
+        self.store
+            .set_node_state(plan_id, node.id, NodeState::Running)
+            .await
+            .map_err(|e| SchedulerError::Store(e.0))?;
+        self.emit_started(plan_id, node).await;
 
         let inputs = self.gather_inputs(plan_id, node, plan).await?;
         let ctx = ExecutorContext {
@@ -419,20 +440,84 @@ impl Scheduler {
         };
         match dispatch(&self.registry, node, ctx).await {
             Ok(outputs) => {
-                self.persist_outputs(plan_id, plan, node, outputs).await?;
+                let output_artifact_ids =
+                    self.persist_outputs(plan_id, plan, node, outputs).await?;
                 state.insert(node.id, NodeState::Completed);
-                self.transition(plan_id, node.id, NodeState::Completed)
-                    .await?;
+                self.store
+                    .set_node_state(plan_id, node.id, NodeState::Completed)
+                    .await
+                    .map_err(|e| SchedulerError::Store(e.0))?;
+                self.emit_completed(plan_id, node.id, output_artifact_ids)
+                    .await;
                 Ok(())
             }
             Err(err) => {
                 state.insert(node.id, NodeState::Failed);
-                self.transition(plan_id, node.id, NodeState::Failed).await?;
+                self.store
+                    .set_node_state(plan_id, node.id, NodeState::Failed)
+                    .await
+                    .map_err(|e| SchedulerError::Store(e.0))?;
+                self.emit_failed(plan_id, node.id, &err).await;
                 Err(SchedulerError::NodeFailed {
                     node_id: node.id,
                     source: err,
                 })
             }
+        }
+    }
+
+    async fn emit_started(&self, plan_id: &PlanId, node: &Node) {
+        let payload = se::NodeStarted {
+            plan_id: plan_id.as_str().to_string(),
+            node_id: node.id,
+            executor_kind: node.executor.executor_kind().to_string(),
+        };
+        self.emit(plan_id, node.id, EVENT_NODE_STARTED, &payload)
+            .await;
+    }
+
+    async fn emit_completed(
+        &self,
+        plan_id: &PlanId,
+        node_id: NodeId,
+        output_artifact_ids: Vec<ArtifactId>,
+    ) {
+        let payload = se::NodeCompleted {
+            plan_id: plan_id.as_str().to_string(),
+            node_id,
+            output_artifact_ids,
+        };
+        self.emit(plan_id, node_id, EVENT_NODE_COMPLETED, &payload)
+            .await;
+    }
+
+    async fn emit_failed(&self, plan_id: &PlanId, node_id: NodeId, err: &ExecutorError) {
+        let payload = se::NodeFailed {
+            plan_id: plan_id.as_str().to_string(),
+            node_id,
+            error: err.to_string(),
+        };
+        self.emit(plan_id, node_id, EVENT_NODE_FAILED, &payload)
+            .await;
+    }
+
+    async fn emit<T: serde::Serialize>(
+        &self,
+        plan_id: &PlanId,
+        node_id: NodeId,
+        kind: &str,
+        payload: &T,
+    ) {
+        // Serializing a typed payload struct from
+        // `onsager_substrate::events` cannot fail unless the type has
+        // non-string map keys or a NaN float — none of the substrate
+        // events carry either, so unwrapping is the right shape: a
+        // serialization failure here is a programmer error, not a
+        // runtime condition.
+        let payload =
+            serde_json::to_value(payload).expect("substrate event payload must serialize");
+        if let Err(e) = self.spine.emit(kind, payload).await {
+            warn!(plan = %plan_id, node = %node_id, "spine emit failed: {e}");
         }
     }
 
@@ -467,7 +552,7 @@ impl Scheduler {
         plan: &ExecutionPlan,
         node: &Node,
         outputs: crate::context::ExecutorOutputs,
-    ) -> Result<(), SchedulerError> {
+    ) -> Result<Vec<ArtifactId>, SchedulerError> {
         // Contract: an executor returns *at most* one artifact per
         // declared output edge, in declaration order. Side-effect-
         // only executors (NoOp) legitimately return zero; surface
@@ -486,6 +571,7 @@ impl Scheduler {
                 )),
             });
         }
+        let mut persisted = Vec::with_capacity(outputs.artifacts.len());
         for (i, (_, mut artifact)) in outputs.artifacts.into_iter().enumerate() {
             let output_ref = node.outputs[i];
             let edge = plan
@@ -504,35 +590,9 @@ impl Scheduler {
                 .put_artifact(plan_id, &edge.artifact_id, artifact)
                 .await
                 .map_err(|e| SchedulerError::Store(e.0))?;
+            persisted.push(edge.artifact_id.clone());
         }
-        Ok(())
-    }
-
-    async fn transition(
-        &self,
-        plan_id: &PlanId,
-        node_id: NodeId,
-        state: NodeState,
-    ) -> Result<(), SchedulerError> {
-        self.store
-            .set_node_state(plan_id, node_id, state)
-            .await
-            .map_err(|e| SchedulerError::Store(e.0))?;
-        let kind = match state {
-            NodeState::Ready => EVENT_NODE_READY,
-            NodeState::Running => EVENT_NODE_RUNNING,
-            NodeState::Completed => EVENT_NODE_COMPLETED,
-            NodeState::Failed => EVENT_NODE_FAILED,
-            NodeState::Pending => return Ok(()),
-        };
-        let payload = serde_json::json!({
-            "plan_id": plan_id.as_str(),
-            "node_id": node_id,
-        });
-        if let Err(e) = self.spine.emit(kind, payload).await {
-            warn!(plan = %plan_id, node = %node_id, "spine emit failed: {e}");
-        }
-        Ok(())
+        Ok(persisted)
     }
 }
 
@@ -606,7 +666,9 @@ mod tests {
         for (_, state) in states {
             assert_eq!(state, NodeState::Completed);
         }
-        // Each Completed node emitted at least one node.completed.
+        // Each Completed node emitted exactly one node.started and
+        // one node.completed (Ready is an internal-only transition
+        // post RUN-02 / #360 — no spine event).
         let kinds: Vec<_> = spine
             .emitted
             .lock()
@@ -618,9 +680,24 @@ mod tests {
             kinds.iter().filter(|k| *k == EVENT_NODE_COMPLETED).count(),
             2,
         );
-        // The Ready / Running transitions emitted too.
-        assert!(kinds.iter().any(|k| k == EVENT_NODE_READY));
-        assert!(kinds.iter().any(|k| k == EVENT_NODE_RUNNING));
+        assert_eq!(kinds.iter().filter(|k| *k == EVENT_NODE_STARTED).count(), 2,);
+        // No legacy `plan.node_ready` / `plan.node_running` emits.
+        assert!(!kinds.iter().any(|k| k == "plan.node_ready"));
+        assert!(!kinds.iter().any(|k| k == "plan.node_running"));
+
+        // node.completed payload is the typed `NodeCompleted` shape
+        // (plan_id, node_id, output_artifact_ids) — RUN-02 contract.
+        let completed_payload = spine
+            .emitted
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(k, _)| k == EVENT_NODE_COMPLETED)
+            .map(|(_, p)| p.clone())
+            .expect("at least one node.completed emit");
+        assert!(completed_payload.get("plan_id").is_some());
+        assert!(completed_payload.get("node_id").is_some());
+        assert!(completed_payload.get("output_artifact_ids").is_some());
     }
 
     #[tokio::test]
@@ -710,15 +787,20 @@ mod tests {
             .filter(|s| matches!(s, NodeState::Failed))
             .count();
         assert_eq!(failed, 1);
-        // node.failed event was emitted.
-        let kinds: Vec<_> = spine
-            .emitted
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(k, _)| k.clone())
-            .collect();
+        // node.failed event was emitted, with the typed NodeFailed
+        // payload (plan_id, node_id, error) per RUN-02 (#360).
+        let emitted = spine.emitted.lock().unwrap();
+        let kinds: Vec<_> = emitted.iter().map(|(k, _)| k.clone()).collect();
         assert!(kinds.iter().any(|k| k == EVENT_NODE_FAILED));
+        let (_, payload) = emitted
+            .iter()
+            .find(|(k, _)| k == EVENT_NODE_FAILED)
+            .expect("node.failed emit");
+        assert!(payload.get("error").is_some(), "payload = {payload}");
+        assert!(
+            payload["error"].as_str().unwrap().contains("boom"),
+            "expected executor error message to surface, got {payload}",
+        );
     }
 
     #[tokio::test]

--- a/crates/onsager-nodes/src/script.rs
+++ b/crates/onsager-nodes/src/script.rs
@@ -210,6 +210,7 @@ mod tests {
 
     fn ctx() -> ExecutorContext {
         ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/src/verify.rs
+++ b/crates/onsager-nodes/src/verify.rs
@@ -31,6 +31,7 @@
 
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, ArtifactId, Kind, NodeId, Provenance, SourceTag};
+use onsager_substrate::events as se;
 use onsager_substrate::executor::Executor as SubstrateExecutor;
 use serde::{Deserialize, Serialize};
 
@@ -184,6 +185,30 @@ impl RuntimeExecutor for VerifyExecutor {
     }
 
     async fn execute(&self, ctx: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+        let check_results: Vec<se::VerifyCheckResult> = self
+            .checks
+            .iter()
+            .map(|c| se::VerifyCheckResult {
+                name: c.name().to_string(),
+                passed: c.must_pass(),
+            })
+            .collect();
+        let passed = check_results.iter().all(|c| c.passed);
+
+        // RUN-02 (#360): emit `synodic.verdict` for every verify
+        // execution — pass or fail, escalate or deny. The dashboard
+        // run timeline keys off this event, not the wrapped
+        // `Err(ExecutorError)`. `plan_id` is empty until the executor
+        // context surfaces it (follow-up).
+        let verdict = se::SynodicVerdict {
+            plan_id: String::new(),
+            node_id: ctx.node_id,
+            passed,
+            check_results,
+        };
+        let payload = serde_json::to_value(&verdict).expect("verdict must serialize");
+        let _ = ctx.spine.emit(se::KIND_SYNODIC_VERDICT, payload).await;
+
         let failures: Vec<String> = self
             .checks
             .iter()

--- a/crates/onsager-nodes/src/verify.rs
+++ b/crates/onsager-nodes/src/verify.rs
@@ -198,16 +198,29 @@ impl RuntimeExecutor for VerifyExecutor {
         // RUN-02 (#360): emit `synodic.verdict` for every verify
         // execution — pass or fail, escalate or deny. The dashboard
         // run timeline keys off this event, not the wrapped
-        // `Err(ExecutorError)`. `plan_id` is empty until the executor
-        // context surfaces it (follow-up).
+        // `Err(ExecutorError)`. `plan_id` comes off the scheduler-
+        // populated `ExecutorContext` so the spine envelope's
+        // `stream_id` (`plan:<plan>:<node>`) correlates the verdict
+        // back to a specific run.
         let verdict = se::SynodicVerdict {
-            plan_id: String::new(),
+            plan_id: ctx.plan_id.as_str().to_string(),
             node_id: ctx.node_id,
             passed,
             check_results,
         };
         let payload = serde_json::to_value(&verdict).expect("verdict must serialize");
-        let _ = ctx.spine.emit(se::KIND_SYNODIC_VERDICT, payload).await;
+        if let Err(e) = ctx.spine.emit(se::KIND_SYNODIC_VERDICT, payload).await {
+            // Best-effort: a dropped verdict must not stall the run
+            // (the attestation artifact still materializes), but a
+            // silent drop hides why the dashboard timeline is missing
+            // a row. Log the failure with enough context to find it.
+            tracing::warn!(
+                plan = %ctx.plan_id,
+                node = %ctx.node_id,
+                kind = se::KIND_SYNODIC_VERDICT,
+                "verify executor spine emit failed: {e}",
+            );
+        }
 
         let failures: Vec<String> = self
             .checks
@@ -257,6 +270,7 @@ mod tests {
 
     fn ctx_with_inputs(inputs: Vec<(ArtifactId, Artifact)>) -> ExecutorContext {
         ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs,
             spine: Arc::new(MockSpine::default()),

--- a/crates/onsager-nodes/tests/scheduler_event_contract.rs
+++ b/crates/onsager-nodes/tests/scheduler_event_contract.rs
@@ -202,6 +202,29 @@ async fn script_agent_verify_emits_full_substrate_contract() {
         .map(|(_, p)| p)
         .collect();
     assert_eq!(verdicts.len(), 1, "expected one synodic.verdict emit");
+
+    // -- Executor-side emits MUST carry the real plan_id (not the
+    // empty-string regression the v1 implementation had before
+    // `ExecutorContext::plan_id` was wired in). Otherwise
+    // `FactoryEventKind::stream_id()` collapses across runs and
+    // consumers can't correlate verdicts / session events to a
+    // specific plan.
+    for kind in &[
+        se::KIND_AGENT_SESSION_STARTED,
+        se::KIND_AGENT_SESSION_COMPLETED,
+        se::KIND_SYNODIC_VERDICT,
+    ] {
+        let payload = emitted
+            .iter()
+            .find(|(k, _)| k == *kind)
+            .map(|(_, p)| p)
+            .unwrap_or_else(|| panic!("expected one emit for {kind}"));
+        assert_eq!(
+            payload["plan_id"],
+            plan_id.as_str(),
+            "executor-side emit for `{kind}` must carry the scheduler's plan_id, got: {payload}",
+        );
+    }
     assert_eq!(verdicts[0]["passed"], true);
     assert!(verdicts[0]["check_results"].is_array());
 

--- a/crates/onsager-nodes/tests/scheduler_event_contract.rs
+++ b/crates/onsager-nodes/tests/scheduler_event_contract.rs
@@ -1,0 +1,307 @@
+//! RUN-02 (#360) verification: an upstream → Agent → Verify run emits
+//! the complete substrate event contract on the spine.
+//!
+//! From the issue's verification list:
+//!
+//! > A Workflow run (Script → Agent → Verify) emits all expected event
+//! > types in spine.
+//!
+//! `ScriptExecutor` does not implement the substrate `Executor` trait
+//! today — that's a follow-up that needs serde + typetag wiring on
+//! `ScriptExecutor`. Until then the upstream slot in this test is
+//! `NoOpExecutor`, which exercises the same scheduler-side lifecycle
+//! emission contract (`node.started` → `node.completed`) every Script
+//! node would; the executor-specific events `script.*` are not part
+//! of the #360 contract anyway, so the substitution does not weaken
+//! the assertion.
+//!
+//! Expected events per node lifecycle:
+//!
+//! - Every node: one `node.started`, then one of
+//!   `node.completed` / `node.failed`.
+//! - Agent node only: one `agent.session_started`, then one of
+//!   `agent.session_completed` / `agent.session_failed`.
+//! - Verify node only: one `synodic.verdict` (pass or fail).
+//!
+//! `node.awaiting_human` / `node.human_approved` / `node.human_rejected`
+//! are the Human executor's contract (#357); not exercised here.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId, NodeId};
+use onsager_nodes::{
+    AgentExecutor, EVENT_NODE_COMPLETED, EVENT_NODE_FAILED, EVENT_NODE_STARTED, ExecutorRegistry,
+    InMemoryPlanStore, PlanId, PlanStore, Scheduler, SpineClient, SpineError, StubAgentRunner,
+    VerifyExecutor,
+    verify::{Check, FailPolicy},
+};
+use onsager_substrate::compiler::ExecutionPlan;
+use onsager_substrate::events as se;
+use onsager_substrate::executor::NoOpExecutor;
+use onsager_substrate::ids::EdgeId;
+use onsager_substrate::workflow::{Edge, EdgeRef, Node};
+use serde_json::Value;
+
+#[derive(Debug, Default)]
+struct CapturingSpine {
+    emitted: Mutex<Vec<(String, Value)>>,
+}
+
+#[async_trait]
+impl SpineClient for CapturingSpine {
+    async fn emit(&self, kind: &str, payload: Value) -> Result<(), SpineError> {
+        self.emitted
+            .lock()
+            .unwrap()
+            .push((kind.to_string(), payload));
+        Ok(())
+    }
+    async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+        Ok(None)
+    }
+}
+
+/// Linear plan: Script → Agent → Verify, threaded through three edges.
+/// Each node gets a runtime executor wired via the
+/// `ExecutorRegistry` so dispatch resolves by `executor_kind()`.
+fn script_agent_verify_plan() -> (ExecutionPlan, NodeId, NodeId, NodeId) {
+    let e_script_to_agent = EdgeId::generate();
+    let e_agent_to_verify = EdgeId::generate();
+    let e_verify_out = EdgeId::generate();
+
+    let script_node_id = NodeId::generate();
+    let agent_node_id = NodeId::generate();
+    let verify_node_id = NodeId::generate();
+
+    let script = Node {
+        id: script_node_id,
+        executor: Box::new(NoOpExecutor),
+        inputs: vec![],
+        outputs: vec![EdgeRef::new(e_script_to_agent)],
+    };
+    let agent = Node {
+        id: agent_node_id,
+        executor: Box::new(AgentExecutor::new("claude-sonnet-4-6", "you are helpful")),
+        inputs: vec![EdgeRef::new(e_script_to_agent)],
+        outputs: vec![EdgeRef::new(e_agent_to_verify)],
+    };
+    let verify = Node {
+        id: verify_node_id,
+        executor: Box::new(VerifyExecutor::with_checks(
+            vec![Check::TestRun {
+                name: "cargo_test".into(),
+                must_pass: true,
+            }],
+            FailPolicy::Escalate,
+        )),
+        inputs: vec![EdgeRef::new(e_agent_to_verify)],
+        outputs: vec![EdgeRef::new(e_verify_out)],
+    };
+
+    let plan = ExecutionPlan {
+        nodes: vec![script, agent, verify],
+        edges: vec![
+            Edge {
+                id: e_script_to_agent,
+                artifact_id: ArtifactId::new("script_out"),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: e_agent_to_verify,
+                artifact_id: ArtifactId::new("agent_out"),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: e_verify_out,
+                artifact_id: ArtifactId::new("verify_out"),
+                requires_deterministic: false,
+            },
+        ],
+        spec_index: Default::default(),
+    };
+    (plan, script_node_id, agent_node_id, verify_node_id)
+}
+
+fn registry_with_agent_stub() -> ExecutorRegistry {
+    // `with_noop` registers a runtime `NoOpExecutor` under "noop" so
+    // the upstream substitute dispatches. Verify is registered under
+    // "verify"; the agent under "agent" with a stub runner so the
+    // test never reaches the network.
+    let mut reg = ExecutorRegistry::with_noop();
+    reg.register(Arc::new(VerifyExecutor::default()));
+    reg.register(Arc::new(
+        AgentExecutor::new("claude-sonnet-4-6", "you are helpful")
+            .with_runner(Arc::new(StubAgentRunner::new("agent said hi"))),
+    ));
+    reg
+}
+
+#[tokio::test]
+async fn script_agent_verify_emits_full_substrate_contract() {
+    let (plan, script_id, agent_id, verify_id) = script_agent_verify_plan();
+    let registry = Arc::new(registry_with_agent_stub());
+    let store = Arc::new(InMemoryPlanStore::new());
+    let spine = Arc::new(CapturingSpine::default());
+    let scheduler = Scheduler::new(
+        registry,
+        Arc::clone(&store) as Arc<dyn PlanStore>,
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    );
+    let plan_id = PlanId::generate();
+
+    scheduler.run(&plan_id, &plan).await.unwrap();
+
+    let emitted = spine.emitted.lock().unwrap().clone();
+    let kinds: Vec<&str> = emitted.iter().map(|(k, _)| k.as_str()).collect();
+
+    // -- Scheduler-side lifecycle: 3 starts + 3 completions, 0 failures.
+    assert_eq!(
+        kinds.iter().filter(|k| **k == EVENT_NODE_STARTED).count(),
+        3,
+        "expected node.started per node, got: {kinds:?}",
+    );
+    assert_eq!(
+        kinds.iter().filter(|k| **k == EVENT_NODE_COMPLETED).count(),
+        3,
+        "expected node.completed per node, got: {kinds:?}",
+    );
+    assert_eq!(
+        kinds.iter().filter(|k| **k == EVENT_NODE_FAILED).count(),
+        0,
+        "no node should have failed in the happy-path run",
+    );
+
+    // -- Agent executor: session-started + session-completed.
+    assert_eq!(
+        kinds
+            .iter()
+            .filter(|k| **k == se::KIND_AGENT_SESSION_STARTED)
+            .count(),
+        1,
+    );
+    assert_eq!(
+        kinds
+            .iter()
+            .filter(|k| **k == se::KIND_AGENT_SESSION_COMPLETED)
+            .count(),
+        1,
+    );
+    assert_eq!(
+        kinds
+            .iter()
+            .filter(|k| **k == se::KIND_AGENT_SESSION_FAILED)
+            .count(),
+        0,
+    );
+
+    // -- Verify executor: one synodic.verdict, passed=true.
+    let verdicts: Vec<&Value> = emitted
+        .iter()
+        .filter(|(k, _)| k == se::KIND_SYNODIC_VERDICT)
+        .map(|(_, p)| p)
+        .collect();
+    assert_eq!(verdicts.len(), 1, "expected one synodic.verdict emit");
+    assert_eq!(verdicts[0]["passed"], true);
+    assert!(verdicts[0]["check_results"].is_array());
+
+    // -- Plan-level correlation: each scheduler-side event carries the
+    // plan_id and node_id RUN-02 names. node_id wiring is what lets the
+    // dashboard scope events to the right node.
+    let node_started: Vec<&Value> = emitted
+        .iter()
+        .filter(|(k, _)| k == EVENT_NODE_STARTED)
+        .map(|(_, p)| p)
+        .collect();
+    assert_eq!(node_started.len(), 3);
+    for payload in &node_started {
+        assert_eq!(payload["plan_id"], plan_id.as_str());
+        assert!(payload.get("node_id").is_some());
+        assert!(payload.get("executor_kind").is_some());
+    }
+
+    // Every started node id is one of the three real ones.
+    let started_ids: Vec<String> = node_started
+        .iter()
+        .map(|p| p["node_id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(started_ids.contains(&script_id.to_string()));
+    assert!(started_ids.contains(&agent_id.to_string()));
+    assert!(started_ids.contains(&verify_id.to_string()));
+}
+
+#[tokio::test]
+async fn verify_failure_still_emits_synodic_verdict() {
+    // A verify node with a failing check + Escalate policy emits a
+    // `synodic.verdict` (passed=false) AND a `node.failed`. The
+    // contract is "verdict emits regardless of pass/fail" — the
+    // dashboard renders the verdict row even on the failure path so a
+    // human can see why the run halted.
+    let e_in = EdgeId::generate();
+    let e_out = EdgeId::generate();
+    let node_id = NodeId::generate();
+    let plan = ExecutionPlan {
+        nodes: vec![Node {
+            id: node_id,
+            executor: Box::new(VerifyExecutor::with_checks(
+                vec![Check::Lint {
+                    name: "clippy".into(),
+                    must_pass: false,
+                }],
+                FailPolicy::Escalate,
+            )),
+            inputs: vec![EdgeRef::new(e_in)],
+            outputs: vec![EdgeRef::new(e_out)],
+        }],
+        edges: vec![
+            Edge {
+                id: e_in,
+                artifact_id: ArtifactId::new("upstream"),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: e_out,
+                artifact_id: ArtifactId::new("downstream"),
+                requires_deterministic: false,
+            },
+        ],
+        spec_index: Default::default(),
+    };
+
+    // Per-node executor configuration is not yet routed through the
+    // registry-backed dispatch (v1 holds one instance per kind; see
+    // RUN-01's `crate::dispatch` note). For the failure-path test
+    // the *registry* instance carries the failing check; the
+    // substrate-side `Node::executor` value is a serialization-only
+    // placeholder that hands off to the registered instance.
+    let mut reg = ExecutorRegistry::new();
+    reg.register(Arc::new(VerifyExecutor::with_checks(
+        vec![Check::Lint {
+            name: "clippy".into(),
+            must_pass: false,
+        }],
+        FailPolicy::Escalate,
+    )));
+    let store = Arc::new(InMemoryPlanStore::new());
+    let spine = Arc::new(CapturingSpine::default());
+    let scheduler = Scheduler::new(
+        Arc::new(reg),
+        Arc::clone(&store) as Arc<dyn PlanStore>,
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    );
+
+    let _ = scheduler.run(&PlanId::generate(), &plan).await;
+
+    let emitted = spine.emitted.lock().unwrap().clone();
+    let verdict = emitted
+        .iter()
+        .find(|(k, _)| k == se::KIND_SYNODIC_VERDICT)
+        .expect("synodic.verdict must emit on the failure path too");
+    assert_eq!(verdict.1["passed"], false);
+
+    let failed = emitted
+        .iter()
+        .find(|(k, _)| k == EVENT_NODE_FAILED)
+        .expect("Escalate policy must surface node.failed");
+    assert!(failed.1["error"].as_str().unwrap().contains("escalating"));
+}

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -30,36 +30,43 @@ use serde::Serialize;
 /// `Substrate` is the 0.2 production-line role (`onsager-substrate` +
 /// `onsager-nodes`) that replaces the deprecated 0.1 `Forge` crate
 /// (spec #363). The substrate scheduler dispatches executors and drives
-/// artifacts through their lifecycle. `Substrate` is intentionally not
-/// in [`SCANNED`] yet — the emit/listener call sites move in over RUN-02
-/// (spec #360); until then the manifest tracks the forward intent so
-/// downstream consumer-side checks remain wired.
+/// artifacts through their lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Subsystem {
-    Substrate,
     Stiglab,
     Synodic,
     Ising,
     Portal,
+    /// The 0.2 substrate — the scheduler (`onsager-nodes::scheduler`) and
+    /// executors (`onsager-nodes::{script,agent,verify,...}`) that emit
+    /// runtime lifecycle events (`node.*`, `agent.session_*`,
+    /// `synodic.verdict`) onto the spine. Replaces the Forge tick loop
+    /// per [ADR 0009](../../../docs/adr/0009-three-layer-pipeline.md).
+    /// Not in `SCANNED` because substrate source lives in
+    /// `onsager-substrate` / `onsager-nodes`, outside the
+    /// `crates/{stiglab,synodic,ising}/` scope the emit / listener
+    /// scan walks.
+    Substrate,
 }
 
 impl Subsystem {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Substrate => "substrate",
             Self::Stiglab => "stiglab",
             Self::Synodic => "synodic",
             Self::Ising => "ising",
             Self::Portal => "portal",
+            Self::Substrate => "substrate",
         }
     }
 
     /// Subsystems that own source under `crates/<name>/` and whose emit /
     /// listener call sites the CI check scans. `Portal` is excluded: its
     /// emitters live outside the workspace's lint surface. `Substrate`
-    /// is excluded until RUN-02 (spec #360) ports the emit/listener call
-    /// sites that used to live in `crates/forge/`.
+    /// is excluded for the same reason — its emitters live in
+    /// `onsager-substrate` / `onsager-nodes`, not the scanned source
+    /// trees.
     pub const SCANNED: &'static [Subsystem] = &[Self::Stiglab, Self::Synodic, Self::Ising];
 }
 
@@ -536,6 +543,125 @@ pub const EVENTS: EventManifest = EventManifest {
         // truth; mutations no longer publish a spine event. Add a row
         // back here when there is a real consumer.
 
+        // -- Substrate runtime (RUN-02, #360) -------------------------------
+        // Lifecycle events emitted by the substrate scheduler and the
+        // executor catalog. Producer is `Substrate` (the
+        // `onsager-nodes::scheduler` + executors under
+        // `onsager-nodes/src/{script,agent,verify,...}`); consumers will
+        // arrive with OBS-01 (#361) once the Observer runtime is wired
+        // up. Until then they're diagnostic-only so the dashboard run
+        // timeline can render them without falsely claiming a
+        // subsystem listener exists.
+        EventDefinition {
+            kind: "node.started",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
+            ),
+            description: "Substrate scheduler dispatched a node — execution began.",
+        },
+        EventDefinition {
+            kind: "node.completed",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
+            ),
+            description: "A node finished successfully; outputs persisted under the edge's ArtifactId.",
+        },
+        EventDefinition {
+            kind: "node.failed",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
+            ),
+            description: "A node's executor returned Err; the plan is aborted (v1 — no retries).",
+        },
+        EventDefinition {
+            kind: "node.awaiting_human",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard HITL inbox; Human executor approval round-trips via portal (#357)",
+            ),
+            description: "A Human executor is waiting on an out-of-band approval decision.",
+        },
+        EventDefinition {
+            kind: "node.human_approved",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard HITL audit; the substrate's own Human executor consumes the approval inline",
+            ),
+            description: "A pending Human executor node received an approval decision.",
+        },
+        EventDefinition {
+            kind: "node.human_rejected",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard HITL audit; the substrate's own Human executor consumes the rejection inline",
+            ),
+            description: "A pending Human executor node received a rejection decision.",
+        },
+        EventDefinition {
+            kind: "synodic.verdict",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard run timeline as gate outcome; Observer / dashboard read it directly — distinct from the legacy `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem (retired by MIG-03)",
+            ),
+            description: "Verify executor produced a verdict — pass / fail outcome with per-check details.",
+        },
+        EventDefinition {
+            kind: "agent.session_started",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard agent timeline; supersedes the 0.1 `stiglab.session_*` events once MIG-01 retires stiglab",
+            ),
+            description: "Agent executor opened an LLM session.",
+        },
+        EventDefinition {
+            kind: "agent.session_completed",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard agent timeline; carries optional token usage for budget consumers",
+            ),
+            description: "Agent executor's LLM session finished successfully.",
+        },
+        EventDefinition {
+            kind: "agent.session_failed",
+            schema_version: 1,
+            producers: &[Subsystem::Substrate],
+            consumers: &[],
+            diagnostic_only: true,
+            reason: Some(
+                "rendered in dashboard agent timeline; the executor wraps this into ExecutorError::Failed for the scheduler",
+            ),
+            description: "Agent executor's LLM session terminated with an error.",
+        },
         // -- Gate adapters (GitHub webhooks) --------------------------------
         EventDefinition {
             kind: "gate.check_updated",

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -7,7 +7,7 @@
 //! library provides a single typed vocabulary.
 
 use chrono::{DateTime, Utc};
-use onsager_artifact::{ArtifactId, ArtifactState, Kind};
+use onsager_artifact::{ArtifactId, ArtifactState, Kind, NodeId};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -529,6 +529,124 @@ pub enum FactoryEventKind {
         pr_number: u64,
         source: String,
     },
+
+    // -- Substrate runtime (RUN-02, #360) -----------------------------------
+    // Lifecycle events the 0.2 substrate scheduler and the executor
+    // catalog emit. The on-wire shapes mirror the typed payload structs
+    // in `onsager-substrate::events`; the structs there are the
+    // authoring surface for substrate-side code, this enum is the
+    // single wire vocabulary the spine read API hands to the dashboard
+    // and (post OBS-01 / #361) to Observers.
+    //
+    // `plan_id` is the externally-assigned identifier for one
+    // Execution Plan run (`onsager-nodes::scheduler::PlanId`) carried
+    // as a `String` here so the spine crate doesn't need to depend on
+    // the runtime; downstream consumers parse it back into `PlanId`
+    // via `PlanId::new(...)`.
+    /// Substrate scheduler dispatched a node — execution began.
+    NodeStarted {
+        plan_id: String,
+        node_id: NodeId,
+        /// Executor catalog key (`"script"`, `"agent"`, `"verify"`,
+        /// `"human"`, `"sub_workflow"`, `"noop"`).
+        executor_kind: String,
+    },
+
+    /// A node finished successfully; the scheduler persisted each output
+    /// artifact under its declared edge `ArtifactId`.
+    NodeCompleted {
+        plan_id: String,
+        node_id: NodeId,
+        /// `ArtifactId`s the executor materialized — order matches the
+        /// node's declared output edges.
+        output_artifact_ids: Vec<ArtifactId>,
+    },
+
+    /// A node's executor returned Err. The scheduler aborts the plan
+    /// (v1; no retries).
+    NodeFailed {
+        plan_id: String,
+        node_id: NodeId,
+        /// Free-text error message from the executor.
+        error: String,
+    },
+
+    /// A Human executor is parked waiting on an out-of-band approval
+    /// decision. The dashboard's HITL inbox renders this; the
+    /// substrate's own Human executor (#357) resolves it inline by
+    /// observing the matching `node.human_approved` /
+    /// `node.human_rejected`.
+    NodeAwaitingHuman {
+        plan_id: String,
+        node_id: NodeId,
+        /// Free-text prompt shown to the human reviewer.
+        prompt: String,
+    },
+
+    /// A pending Human executor node received an approval decision.
+    NodeHumanApproved {
+        plan_id: String,
+        node_id: NodeId,
+        /// Actor identifier — `"human:<id>"` for a dashboard user,
+        /// `"supervisor"` for a delegate agent.
+        approved_by: String,
+    },
+
+    /// A pending Human executor node received a rejection decision.
+    NodeHumanRejected {
+        plan_id: String,
+        node_id: NodeId,
+        /// Actor identifier — same shape as `approved_by` above.
+        rejected_by: String,
+        /// Free-text justification carried into the audit trail.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+
+    /// Verify executor produced a verdict — pass / fail outcome with
+    /// per-check details. Distinct from the legacy
+    /// `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem
+    /// (retired by MIG-03); per spec #360 this is the substrate-native
+    /// verdict event.
+    SynodicVerdict {
+        plan_id: String,
+        node_id: NodeId,
+        /// True when every check the executor ran passed.
+        passed: bool,
+        /// Per-check (name, passed) results so the dashboard can
+        /// render the failure surface without a follow-up read.
+        check_results: Vec<VerifyCheckResult>,
+    },
+
+    /// Agent executor opened an LLM session.
+    AgentSessionStarted {
+        plan_id: String,
+        node_id: NodeId,
+        /// Session identifier minted by the agent runner.
+        session_id: String,
+        /// Model name (`"claude-sonnet-4-6"`, etc.).
+        model: String,
+    },
+
+    /// Agent executor's LLM session finished successfully.
+    AgentSessionCompleted {
+        plan_id: String,
+        node_id: NodeId,
+        session_id: String,
+        /// Token usage for this session — `None` when the runner does
+        /// not report it (stub / mock runners).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        token_usage: Option<TokenUsage>,
+    },
+
+    /// Agent executor's LLM session terminated with an error.
+    AgentSessionFailed {
+        plan_id: String,
+        node_id: NodeId,
+        session_id: String,
+        /// Free-text error from the runner.
+        error: String,
+    },
 }
 
 impl FactoryEventKind {
@@ -579,6 +697,16 @@ impl FactoryEventKind {
             Self::StageAdvanced { .. } => "stage.advanced",
             Self::GateCheckUpdated { .. } => "gate.check_updated",
             Self::GateManualApprovalSignal { .. } => "gate.manual_approval_signal",
+            Self::NodeStarted { .. } => "node.started",
+            Self::NodeCompleted { .. } => "node.completed",
+            Self::NodeFailed { .. } => "node.failed",
+            Self::NodeAwaitingHuman { .. } => "node.awaiting_human",
+            Self::NodeHumanApproved { .. } => "node.human_approved",
+            Self::NodeHumanRejected { .. } => "node.human_rejected",
+            Self::SynodicVerdict { .. } => "synodic.verdict",
+            Self::AgentSessionStarted { .. } => "agent.session_started",
+            Self::AgentSessionCompleted { .. } => "agent.session_completed",
+            Self::AgentSessionFailed { .. } => "agent.session_failed",
         }
     }
 
@@ -631,6 +759,19 @@ impl FactoryEventKind {
             // mixing with first-class workflow runtime events.
             Self::WorkflowManualTriggered { .. } => "audit",
             Self::GateCheckUpdated { .. } | Self::GateManualApprovalSignal { .. } => "gate",
+            // Substrate runtime — node lifecycle, Verify verdicts, and
+            // agent-session signals share the `substrate` stream so the
+            // dashboard / Observer (#361) can subscribe with one prefix.
+            Self::NodeStarted { .. }
+            | Self::NodeCompleted { .. }
+            | Self::NodeFailed { .. }
+            | Self::NodeAwaitingHuman { .. }
+            | Self::NodeHumanApproved { .. }
+            | Self::NodeHumanRejected { .. }
+            | Self::SynodicVerdict { .. }
+            | Self::AgentSessionStarted { .. }
+            | Self::AgentSessionCompleted { .. }
+            | Self::AgentSessionFailed { .. } => "substrate",
         }
     }
 
@@ -701,6 +842,39 @@ impl FactoryEventKind {
                 pr_number,
                 ..
             } => format!("{repo_owner}/{repo_name}#{pr_number}"),
+            // Substrate runtime — `(plan_id, node_id)` is the natural
+            // composite key so the dashboard run timeline can scope
+            // by plan and node without parsing the payload.
+            Self::NodeStarted {
+                plan_id, node_id, ..
+            }
+            | Self::NodeCompleted {
+                plan_id, node_id, ..
+            }
+            | Self::NodeFailed {
+                plan_id, node_id, ..
+            }
+            | Self::NodeAwaitingHuman {
+                plan_id, node_id, ..
+            }
+            | Self::NodeHumanApproved {
+                plan_id, node_id, ..
+            }
+            | Self::NodeHumanRejected {
+                plan_id, node_id, ..
+            }
+            | Self::SynodicVerdict {
+                plan_id, node_id, ..
+            }
+            | Self::AgentSessionStarted {
+                plan_id, node_id, ..
+            }
+            | Self::AgentSessionCompleted {
+                plan_id, node_id, ..
+            }
+            | Self::AgentSessionFailed {
+                plan_id, node_id, ..
+            } => format!("plan:{plan_id}:{node_id}"),
         }
     }
 }
@@ -832,6 +1006,17 @@ pub enum RuleProposalAction {
         subject_ref: String,
         suggested_condition: Option<String>,
     },
+}
+
+/// One check's outcome carried on [`FactoryEventKind::SynodicVerdict`].
+/// The Verify executor's [`Check`](../../../crates/onsager-nodes/src/verify.rs)
+/// list maps 1:1 onto this struct list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifyCheckResult {
+    /// Check name (e.g. `"cargo_test"`, `"clippy"`, `"schema_lint"`).
+    pub name: String,
+    /// `true` when this check passed.
+    pub passed: bool,
 }
 
 /// How a rule proposal should be handled by Synodic.

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -57,7 +57,7 @@ pub use onsager_artifact::{
 pub use extension_event::ExtensionEventRecord;
 pub use factory_event::{
     EscalationResolution, EventRef, FactoryEvent, FactoryEventKind, ForgeProcessState, GatePoint,
-    InsightKind, InsightScope, ShapingOutcome, VerdictSummary,
+    InsightKind, InsightScope, ShapingOutcome, TokenUsage, VerdictSummary, VerifyCheckResult,
 };
 pub use listener::{EventHandler, Listener};
 pub use namespace::{Namespace, NamespaceError};

--- a/crates/onsager-substrate/Cargo.toml
+++ b/crates/onsager-substrate/Cargo.toml
@@ -15,4 +15,5 @@ sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"
 thiserror = { workspace = true }
 
 [dev-dependencies]
+onsager-spine = { path = "../onsager-spine" }
 tokio = { workspace = true }

--- a/crates/onsager-substrate/src/events.rs
+++ b/crates/onsager-substrate/src/events.rs
@@ -1,0 +1,440 @@
+//! Substrate event payload structs (RUN-02, [#360]).
+//!
+//! This module is the authoring surface for events the 0.2 substrate
+//! emits onto the spine — the scheduler ([`onsager-nodes`]) and the
+//! executor catalog ([`Script`], [`Agent`], [`Verify`], [`Human`],
+//! [`SubWorkflow`]). Each struct mirrors a [`FactoryEventKind`] variant
+//! over in `onsager-spine`; the two halves intentionally carry the same
+//! payload shape:
+//!
+//! - This module defines the typed authoring shape substrate-side code
+//!   reaches for ("emit a `NodeStarted { ... }`").
+//! - `onsager-spine::FactoryEventKind` carries the wire vocabulary the
+//!   spine read API hands to the dashboard and (post OBS-01, #361) to
+//!   Observers.
+//!
+//! Keeping the structs here — rather than embedding `FactoryEventKind`
+//! variants by reference — avoids forcing `onsager-spine` to depend on
+//! `onsager-substrate`. The two are tied together by an integration
+//! test that asserts byte-identical JSON for every event type (see
+//! `tests/spine_payload_compat.rs` in this crate).
+//!
+//! ## Schema stability
+//!
+//! Every struct here uses `#[serde(default,
+//! skip_serializing_if = "Option::is_none")]` on optional fields, so
+//! adding a new optional field is wire-compatible — old deserializers
+//! ignore the new field, new deserializers fill the field with
+//! `None` for old payloads. Renaming or removing fields is a
+//! schema-version bump in the registry manifest (see
+//! `crates/onsager-registry/src/events.rs`).
+//!
+//! ## Catalog
+//!
+//! | Wire kind                    | Struct                                  |
+//! |------------------------------|-----------------------------------------|
+//! | `artifact.state_changed`     | [`ArtifactStateChanged`]                |
+//! | `node.started`               | [`NodeStarted`]                         |
+//! | `node.completed`             | [`NodeCompleted`]                       |
+//! | `node.failed`                | [`NodeFailed`]                          |
+//! | `node.awaiting_human`        | [`NodeAwaitingHuman`]                   |
+//! | `node.human_approved`        | [`NodeHumanApproved`]                   |
+//! | `node.human_rejected`        | [`NodeHumanRejected`]                   |
+//! | `synodic.verdict`            | [`SynodicVerdict`]                      |
+//! | `agent.session_started`      | [`AgentSessionStarted`]                 |
+//! | `agent.session_completed`    | [`AgentSessionCompleted`]               |
+//! | `agent.session_failed`       | [`AgentSessionFailed`]                  |
+//!
+//! [#360]: https://github.com/onsager-ai/onsager/issues/360
+//! [`onsager-nodes`]: https://docs.rs/onsager-nodes
+//! [`Script`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/script/struct.ScriptExecutor.html
+//! [`Agent`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/agent/struct.AgentExecutor.html
+//! [`Verify`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/verify/struct.VerifyExecutor.html
+//! [`Human`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/human/struct.HumanExecutor.html
+//! [`SubWorkflow`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/subworkflow/struct.SubWorkflowExecutor.html
+//! [`FactoryEventKind`]: https://docs.rs/onsager-spine/latest/onsager_spine/enum.FactoryEventKind.html
+
+use onsager_artifact::{ArtifactId, ArtifactState, NodeId};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Wire-kind constants
+// ---------------------------------------------------------------------------
+//
+// One per struct, matching `FactoryEventKind::event_type()`. Constants
+// (not derived from struct names) so a typo on either side surfaces as a
+// compile-time mismatch in the compat tests rather than a silent
+// rename.
+
+pub const KIND_ARTIFACT_STATE_CHANGED: &str = "artifact.state_changed";
+pub const KIND_NODE_STARTED: &str = "node.started";
+pub const KIND_NODE_COMPLETED: &str = "node.completed";
+pub const KIND_NODE_FAILED: &str = "node.failed";
+pub const KIND_NODE_AWAITING_HUMAN: &str = "node.awaiting_human";
+pub const KIND_NODE_HUMAN_APPROVED: &str = "node.human_approved";
+pub const KIND_NODE_HUMAN_REJECTED: &str = "node.human_rejected";
+pub const KIND_SYNODIC_VERDICT: &str = "synodic.verdict";
+pub const KIND_AGENT_SESSION_STARTED: &str = "agent.session_started";
+pub const KIND_AGENT_SESSION_COMPLETED: &str = "agent.session_completed";
+pub const KIND_AGENT_SESSION_FAILED: &str = "agent.session_failed";
+
+// ---------------------------------------------------------------------------
+// Substrate event payloads
+// ---------------------------------------------------------------------------
+
+/// Artifact moved to a new lifecycle state.
+///
+/// Wire-equivalent to
+/// [`FactoryEventKind::ArtifactStateChanged`](https://docs.rs/onsager-spine/latest/onsager_spine/enum.FactoryEventKind.html#variant.ArtifactStateChanged).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactStateChanged {
+    pub artifact_id: ArtifactId,
+    pub from_state: ArtifactState,
+    pub to_state: ArtifactState,
+}
+
+impl ArtifactStateChanged {
+    pub fn kind(&self) -> &'static str {
+        KIND_ARTIFACT_STATE_CHANGED
+    }
+}
+
+/// Substrate scheduler dispatched a node — execution began.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeStarted {
+    /// `PlanId` for this Execution Plan run (carried as a `String` so
+    /// the substrate crate does not depend on the runtime; deserialize
+    /// via `PlanId::new(...)` on the consumer side).
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Executor catalog key (`"script"`, `"agent"`, `"verify"`,
+    /// `"human"`, `"sub_workflow"`, `"noop"`).
+    pub executor_kind: String,
+}
+
+impl NodeStarted {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_STARTED
+    }
+}
+
+/// A node finished successfully; the scheduler persisted each output
+/// artifact under its declared edge `ArtifactId`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeCompleted {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// `ArtifactId`s the executor materialized — order matches the
+    /// node's declared output edges.
+    pub output_artifact_ids: Vec<ArtifactId>,
+}
+
+impl NodeCompleted {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_COMPLETED
+    }
+}
+
+/// A node's executor returned Err. The scheduler aborts the plan
+/// (v1; no retries).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeFailed {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Free-text error message from the executor.
+    pub error: String,
+}
+
+impl NodeFailed {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_FAILED
+    }
+}
+
+/// A Human executor is parked waiting on an out-of-band approval
+/// decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeAwaitingHuman {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Free-text prompt shown to the human reviewer.
+    pub prompt: String,
+}
+
+impl NodeAwaitingHuman {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_AWAITING_HUMAN
+    }
+}
+
+/// A pending Human executor node received an approval decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeHumanApproved {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Actor identifier — `"human:<id>"` for a dashboard user,
+    /// `"supervisor"` for a delegate agent.
+    pub approved_by: String,
+}
+
+impl NodeHumanApproved {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_HUMAN_APPROVED
+    }
+}
+
+/// A pending Human executor node received a rejection decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeHumanRejected {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Actor identifier — same shape as `approved_by` above.
+    pub rejected_by: String,
+    /// Free-text justification carried into the audit trail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl NodeHumanRejected {
+    pub fn kind(&self) -> &'static str {
+        KIND_NODE_HUMAN_REJECTED
+    }
+}
+
+/// Verify executor produced a verdict — pass / fail outcome with
+/// per-check details.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SynodicVerdict {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// True when every check the executor ran passed.
+    pub passed: bool,
+    /// Per-check results — one entry per [`Check`] the executor ran.
+    ///
+    /// [`Check`]: https://docs.rs/onsager-nodes/latest/onsager_nodes/verify/enum.Check.html
+    pub check_results: Vec<VerifyCheckResult>,
+}
+
+impl SynodicVerdict {
+    pub fn kind(&self) -> &'static str {
+        KIND_SYNODIC_VERDICT
+    }
+}
+
+/// One check's outcome carried on [`SynodicVerdict`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifyCheckResult {
+    /// Check name (e.g. `"cargo_test"`, `"clippy"`, `"schema_lint"`).
+    pub name: String,
+    /// `true` when this check passed.
+    pub passed: bool,
+}
+
+/// Agent executor opened an LLM session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSessionStarted {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    /// Session identifier minted by the agent runner.
+    pub session_id: String,
+    /// Model name (`"claude-sonnet-4-6"`, etc.).
+    pub model: String,
+}
+
+impl AgentSessionStarted {
+    pub fn kind(&self) -> &'static str {
+        KIND_AGENT_SESSION_STARTED
+    }
+}
+
+/// Agent executor's LLM session finished successfully.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentSessionCompleted {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    pub session_id: String,
+    /// Token usage for this session — `None` when the runner does not
+    /// report it (stub / mock runners).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
+}
+
+impl AgentSessionCompleted {
+    pub fn kind(&self) -> &'static str {
+        KIND_AGENT_SESSION_COMPLETED
+    }
+}
+
+/// LLM token usage carried on [`AgentSessionCompleted`]. Mirrors the
+/// shape used by `onsager-spine::TokenUsage` so the dashboard and
+/// budget consumers see the same fields whether the row originated
+/// here or from the legacy `stiglab.session_completed` event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// Cache-read input tokens (Anthropic-style prompt caching). Zero
+    /// for providers without a cache concept.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    /// Cache-creation input tokens.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+    /// Model identifier (`"claude-sonnet-4-6"`, etc.) so the downstream
+    /// pricing table can resolve cost without guessing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Agent executor's LLM session terminated with an error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSessionFailed {
+    pub plan_id: String,
+    pub node_id: NodeId,
+    pub session_id: String,
+    /// Free-text error from the runner.
+    pub error: String,
+}
+
+impl AgentSessionFailed {
+    pub fn kind(&self) -> &'static str {
+        KIND_AGENT_SESSION_FAILED
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pid() -> String {
+        "plan_test_0001".to_string()
+    }
+    fn nid() -> NodeId {
+        NodeId::new(uuid::Uuid::nil())
+    }
+
+    #[test]
+    fn kinds_match_wire_names() {
+        assert_eq!(KIND_NODE_STARTED, "node.started");
+        assert_eq!(KIND_NODE_COMPLETED, "node.completed");
+        assert_eq!(KIND_NODE_FAILED, "node.failed");
+        assert_eq!(KIND_NODE_AWAITING_HUMAN, "node.awaiting_human");
+        assert_eq!(KIND_NODE_HUMAN_APPROVED, "node.human_approved");
+        assert_eq!(KIND_NODE_HUMAN_REJECTED, "node.human_rejected");
+        assert_eq!(KIND_SYNODIC_VERDICT, "synodic.verdict");
+        assert_eq!(KIND_AGENT_SESSION_STARTED, "agent.session_started");
+        assert_eq!(KIND_AGENT_SESSION_COMPLETED, "agent.session_completed");
+        assert_eq!(KIND_AGENT_SESSION_FAILED, "agent.session_failed");
+        assert_eq!(KIND_ARTIFACT_STATE_CHANGED, "artifact.state_changed");
+    }
+
+    #[test]
+    fn node_started_roundtrip() {
+        let ev = NodeStarted {
+            plan_id: pid(),
+            node_id: nid(),
+            executor_kind: "script".into(),
+        };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["plan_id"], pid());
+        assert_eq!(json["executor_kind"], "script");
+        let back: NodeStarted = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+        assert_eq!(ev.kind(), "node.started");
+    }
+
+    #[test]
+    fn node_completed_roundtrip() {
+        let ev = NodeCompleted {
+            plan_id: pid(),
+            node_id: nid(),
+            output_artifact_ids: vec![ArtifactId::new("art_1"), ArtifactId::new("art_2")],
+        };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["output_artifact_ids"][0], "art_1");
+        let back: NodeCompleted = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn node_failed_roundtrip() {
+        let ev = NodeFailed {
+            plan_id: pid(),
+            node_id: nid(),
+            error: "boom".into(),
+        };
+        let back: NodeFailed = serde_json::from_value(serde_json::to_value(&ev).unwrap()).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn synodic_verdict_roundtrip() {
+        let ev = SynodicVerdict {
+            plan_id: pid(),
+            node_id: nid(),
+            passed: false,
+            check_results: vec![
+                VerifyCheckResult {
+                    name: "cargo_test".into(),
+                    passed: true,
+                },
+                VerifyCheckResult {
+                    name: "clippy".into(),
+                    passed: false,
+                },
+            ],
+        };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["check_results"][1]["name"], "clippy");
+        assert_eq!(json["check_results"][1]["passed"], false);
+        let back: SynodicVerdict = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn agent_session_completed_omits_none_token_usage() {
+        let ev = AgentSessionCompleted {
+            plan_id: pid(),
+            node_id: nid(),
+            session_id: "sess_x".into(),
+            token_usage: None,
+        };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert!(
+            json.get("token_usage").is_none(),
+            "None token_usage must be omitted, got: {json}"
+        );
+    }
+
+    /// Schema-stability check from issue #360 verification: adding a new
+    /// optional field to a payload must not break consumers
+    /// deserializing the older shape. We exercise the rule by
+    /// deserializing a payload that lacks the future field — `None` is
+    /// the correct decoded value.
+    #[test]
+    fn schema_stable_optional_fields_default_to_none() {
+        // `NodeHumanRejected.reason` is the canonical optional field on
+        // a substrate event. Producing a payload without it (the way
+        // an older emitter would) must still deserialize cleanly.
+        let json = serde_json::json!({
+            "plan_id": pid(),
+            "node_id": nid(),
+            "rejected_by": "human:42",
+        });
+        let ev: NodeHumanRejected = serde_json::from_value(json).unwrap();
+        assert_eq!(ev.reason, None);
+
+        // Mirror for `AgentSessionCompleted.token_usage`.
+        let json = serde_json::json!({
+            "plan_id": pid(),
+            "node_id": nid(),
+            "session_id": "sess_42",
+        });
+        let ev: AgentSessionCompleted = serde_json::from_value(json).unwrap();
+        assert_eq!(ev.token_usage, None);
+    }
+}

--- a/crates/onsager-substrate/src/lib.rs
+++ b/crates/onsager-substrate/src/lib.rs
@@ -27,6 +27,7 @@
 //! (SUB-05, #352) can resolve `kind → Workflow` at runtime.
 
 pub mod compiler;
+pub mod events;
 pub mod executor;
 pub mod ids;
 pub mod library;
@@ -42,6 +43,12 @@ pub use spec_plan::*;
 pub use validate::*;
 pub use workflow::*;
 pub use workflow_library::*;
+
+// `events` is intentionally NOT glob-re-exported: many struct names
+// (`NodeStarted`, `NodeFailed`, `TokenUsage`, `VerifyCheckResult`)
+// would shadow the spine-side `FactoryEventKind` variants and the
+// `onsager-spine::TokenUsage` re-export when both crates are in scope.
+// Reach them via the qualified module path: `onsager_substrate::events`.
 
 // `library::WorkflowLibrary` (the lookup trait) is intentionally
 // not glob-re-exported — it shares its name with

--- a/crates/onsager-substrate/tests/spine_payload_compat.rs
+++ b/crates/onsager-substrate/tests/spine_payload_compat.rs
@@ -1,0 +1,401 @@
+//! Cross-crate compat: every substrate event payload struct in
+//! `onsager_substrate::events` serializes to the same JSON object the
+//! corresponding `FactoryEventKind` variant emits (modulo the
+//! enum's `"type"` discriminator).
+//!
+//! Two halves carry the same payload shape (RUN-02, #360):
+//!
+//! - `onsager-substrate::events` — typed authoring surface.
+//! - `onsager-spine::FactoryEventKind::*` — wire vocabulary.
+//!
+//! Field-name / field-type drift between the two would silently break
+//! the dashboard run timeline (which reads `FactoryEventKind`) and any
+//! future scheduler→spine adapter (which authors from the substrate
+//! side). The asserts below pin the shape so a typo or rename surfaces
+//! at `cargo test`, not in production.
+//!
+//! The check is structural: we serialize both halves, strip the
+//! `FactoryEventKind` `"type"` tag, and assert the resulting JSON
+//! objects are equal. Adding an optional field to the substrate struct
+//! without also adding it to the variant would diff here; same for the
+//! reverse.
+
+use onsager_artifact::{ArtifactId, NodeId};
+use onsager_spine::factory_event::{self as fe, FactoryEventKind};
+use onsager_substrate::events as se;
+use serde_json::Value;
+
+/// Drop the `"type"` discriminator the `FactoryEventKind` enum
+/// injects via `#[serde(tag = "type")]` so the remaining payload
+/// matches the substrate struct's serialization byte-for-byte.
+fn strip_type(mut v: Value) -> Value {
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("type");
+    }
+    v
+}
+
+fn pid() -> String {
+    "plan_test_42".into()
+}
+fn nid() -> NodeId {
+    NodeId::new(uuid::Uuid::nil())
+}
+
+#[test]
+fn node_started_payload_matches_variant() {
+    let s = se::NodeStarted {
+        plan_id: pid(),
+        node_id: nid(),
+        executor_kind: "script".into(),
+    };
+    let v = FactoryEventKind::NodeStarted {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        executor_kind: s.executor_kind.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn node_completed_payload_matches_variant() {
+    let s = se::NodeCompleted {
+        plan_id: pid(),
+        node_id: nid(),
+        output_artifact_ids: vec![ArtifactId::new("art_1"), ArtifactId::new("art_2")],
+    };
+    let v = FactoryEventKind::NodeCompleted {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        output_artifact_ids: s.output_artifact_ids.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn node_failed_payload_matches_variant() {
+    let s = se::NodeFailed {
+        plan_id: pid(),
+        node_id: nid(),
+        error: "boom".into(),
+    };
+    let v = FactoryEventKind::NodeFailed {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        error: s.error.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn node_awaiting_human_payload_matches_variant() {
+    let s = se::NodeAwaitingHuman {
+        plan_id: pid(),
+        node_id: nid(),
+        prompt: "approve?".into(),
+    };
+    let v = FactoryEventKind::NodeAwaitingHuman {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        prompt: s.prompt.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn node_human_approved_payload_matches_variant() {
+    let s = se::NodeHumanApproved {
+        plan_id: pid(),
+        node_id: nid(),
+        approved_by: "human:42".into(),
+    };
+    let v = FactoryEventKind::NodeHumanApproved {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        approved_by: s.approved_by.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn node_human_rejected_payload_matches_variant_with_and_without_reason() {
+    // With reason.
+    let s = se::NodeHumanRejected {
+        plan_id: pid(),
+        node_id: nid(),
+        rejected_by: "human:42".into(),
+        reason: Some("scope creep".into()),
+    };
+    let v = FactoryEventKind::NodeHumanRejected {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        rejected_by: s.rejected_by.clone(),
+        reason: s.reason.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+
+    // Without reason — the optional field must be omitted on both
+    // sides (same `skip_serializing_if = "Option::is_none"` behavior).
+    let s = se::NodeHumanRejected { reason: None, ..s };
+    let v = FactoryEventKind::NodeHumanRejected {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        rejected_by: s.rejected_by.clone(),
+        reason: None,
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn synodic_verdict_payload_matches_variant() {
+    let s = se::SynodicVerdict {
+        plan_id: pid(),
+        node_id: nid(),
+        passed: false,
+        check_results: vec![
+            se::VerifyCheckResult {
+                name: "cargo_test".into(),
+                passed: true,
+            },
+            se::VerifyCheckResult {
+                name: "clippy".into(),
+                passed: false,
+            },
+        ],
+    };
+    let v = FactoryEventKind::SynodicVerdict {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        passed: s.passed,
+        check_results: s
+            .check_results
+            .iter()
+            .map(|c| fe::VerifyCheckResult {
+                name: c.name.clone(),
+                passed: c.passed,
+            })
+            .collect(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn agent_session_started_payload_matches_variant() {
+    let s = se::AgentSessionStarted {
+        plan_id: pid(),
+        node_id: nid(),
+        session_id: "sess_42".into(),
+        model: "claude-sonnet-4-6".into(),
+    };
+    let v = FactoryEventKind::AgentSessionStarted {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        session_id: s.session_id.clone(),
+        model: s.model.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn agent_session_completed_payload_matches_variant() {
+    // With token_usage.
+    let s = se::AgentSessionCompleted {
+        plan_id: pid(),
+        node_id: nid(),
+        session_id: "sess_42".into(),
+        token_usage: Some(se::TokenUsage {
+            input_tokens: 1_200,
+            output_tokens: 340,
+            cache_read_tokens: 800,
+            cache_write_tokens: 0,
+            model: Some("claude-sonnet-4-6".into()),
+        }),
+    };
+    let v = FactoryEventKind::AgentSessionCompleted {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        session_id: s.session_id.clone(),
+        token_usage: s.token_usage.as_ref().map(|t| fe::TokenUsage {
+            input_tokens: t.input_tokens,
+            output_tokens: t.output_tokens,
+            cache_read_tokens: t.cache_read_tokens,
+            cache_write_tokens: t.cache_write_tokens,
+            model: t.model.clone(),
+        }),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+
+    // Without token_usage — both sides must omit the field.
+    let s = se::AgentSessionCompleted {
+        token_usage: None,
+        ..s
+    };
+    let v = FactoryEventKind::AgentSessionCompleted {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        session_id: s.session_id.clone(),
+        token_usage: None,
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+#[test]
+fn agent_session_failed_payload_matches_variant() {
+    let s = se::AgentSessionFailed {
+        plan_id: pid(),
+        node_id: nid(),
+        session_id: "sess_42".into(),
+        error: "api went down".into(),
+    };
+    let v = FactoryEventKind::AgentSessionFailed {
+        plan_id: s.plan_id.clone(),
+        node_id: s.node_id,
+        session_id: s.session_id.clone(),
+        error: s.error.clone(),
+    };
+    assert_eq!(
+        serde_json::to_value(&s).unwrap(),
+        strip_type(serde_json::to_value(&v).unwrap()),
+    );
+}
+
+/// Wire-kind constants in the substrate module match
+/// `FactoryEventKind::event_type()` for the corresponding variant —
+/// otherwise dashboards filtering by kind string would miss substrate
+/// emissions silently.
+#[test]
+fn wire_kind_constants_agree_with_factory_event_kind() {
+    use FactoryEventKind as F;
+    let pairs: &[(&str, F)] = &[
+        (
+            se::KIND_NODE_STARTED,
+            F::NodeStarted {
+                plan_id: pid(),
+                node_id: nid(),
+                executor_kind: "script".into(),
+            },
+        ),
+        (
+            se::KIND_NODE_COMPLETED,
+            F::NodeCompleted {
+                plan_id: pid(),
+                node_id: nid(),
+                output_artifact_ids: vec![],
+            },
+        ),
+        (
+            se::KIND_NODE_FAILED,
+            F::NodeFailed {
+                plan_id: pid(),
+                node_id: nid(),
+                error: "x".into(),
+            },
+        ),
+        (
+            se::KIND_NODE_AWAITING_HUMAN,
+            F::NodeAwaitingHuman {
+                plan_id: pid(),
+                node_id: nid(),
+                prompt: "x".into(),
+            },
+        ),
+        (
+            se::KIND_NODE_HUMAN_APPROVED,
+            F::NodeHumanApproved {
+                plan_id: pid(),
+                node_id: nid(),
+                approved_by: "x".into(),
+            },
+        ),
+        (
+            se::KIND_NODE_HUMAN_REJECTED,
+            F::NodeHumanRejected {
+                plan_id: pid(),
+                node_id: nid(),
+                rejected_by: "x".into(),
+                reason: None,
+            },
+        ),
+        (
+            se::KIND_SYNODIC_VERDICT,
+            F::SynodicVerdict {
+                plan_id: pid(),
+                node_id: nid(),
+                passed: true,
+                check_results: vec![],
+            },
+        ),
+        (
+            se::KIND_AGENT_SESSION_STARTED,
+            F::AgentSessionStarted {
+                plan_id: pid(),
+                node_id: nid(),
+                session_id: "x".into(),
+                model: "x".into(),
+            },
+        ),
+        (
+            se::KIND_AGENT_SESSION_COMPLETED,
+            F::AgentSessionCompleted {
+                plan_id: pid(),
+                node_id: nid(),
+                session_id: "x".into(),
+                token_usage: None,
+            },
+        ),
+        (
+            se::KIND_AGENT_SESSION_FAILED,
+            F::AgentSessionFailed {
+                plan_id: pid(),
+                node_id: nid(),
+                session_id: "x".into(),
+                error: "x".into(),
+            },
+        ),
+    ];
+    for (kind, variant) in pairs {
+        assert_eq!(*kind, variant.event_type(), "wire kind drift on `{kind}`");
+    }
+    // Plus artifact.state_changed (which already existed before #360,
+    // but the substrate module's KIND_ARTIFACT_STATE_CHANGED still has
+    // to match the canonical variant).
+    let v = F::ArtifactStateChanged {
+        artifact_id: ArtifactId::new("art_1"),
+        from_state: onsager_artifact::ArtifactState::Draft,
+        to_state: onsager_artifact::ArtifactState::InProgress,
+    };
+    assert_eq!(se::KIND_ARTIFACT_STATE_CHANGED, v.event_type());
+}

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -253,6 +253,20 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::GateManualApprovalSignal { .. }
         | FactoryEventKind::PortalSessionRequested { .. }
         | FactoryEventKind::PortalSessionCancelRequested { .. }
-        | FactoryEventKind::PortalPrOpenFailed { .. } => None,
+        | FactoryEventKind::PortalPrOpenFailed { .. }
+        // Substrate runtime events (RUN-02, #360) — node-scoped, not
+        // artifact-scoped at the spine envelope level. The output
+        // artifact ids on `NodeCompleted` are a payload concern, not
+        // a tenant-routing key.
+        | FactoryEventKind::NodeStarted { .. }
+        | FactoryEventKind::NodeCompleted { .. }
+        | FactoryEventKind::NodeFailed { .. }
+        | FactoryEventKind::NodeAwaitingHuman { .. }
+        | FactoryEventKind::NodeHumanApproved { .. }
+        | FactoryEventKind::NodeHumanRejected { .. }
+        | FactoryEventKind::SynodicVerdict { .. }
+        | FactoryEventKind::AgentSessionStarted { .. }
+        | FactoryEventKind::AgentSessionCompleted { .. }
+        | FactoryEventKind::AgentSessionFailed { .. } => None,
     }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,6 +63,7 @@ that requires a coordinated rollout.
 | `workflow` | stiglab (trigger) / substrate scheduler (stage) | 3 |
 | `audit` | (unknown — update `stream_producer` in xtask) | 1 |
 | `gate` | onsager-portal (GitHub) / substrate scheduler (manual) | 2 |
+| `substrate` | (unknown — update `stream_producer` in xtask) | 10 |
 
 Each section below covers one stream. Inside a section, every event lists its wire `event_type` string, the Rust variant name, the variant's doc comment, and a payload field table (where the field's own doc comment is the description).
 
@@ -689,6 +690,145 @@ A manual-approval gate received a signal (e.g. the PR was merged). Forge's manua
 | `repo_name` | `String` |  |
 | `pr_number` | `u64` |  |
 | `source` | `String` |  |
+
+## `substrate` events
+
+Producer subsystem: **(unknown — update `stream_producer` in xtask)**.
+
+### `node.started`
+
+- Variant: `FactoryEventKind::NodeStarted`
+- Stream: `substrate`
+
+Substrate scheduler dispatched a node — execution began.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `executor_kind` | `String` | Executor catalog key (`"script"`, `"agent"`, `"verify"`, `"human"`, `"sub_workflow"`, `"noop"`). |
+
+### `node.completed`
+
+- Variant: `FactoryEventKind::NodeCompleted`
+- Stream: `substrate`
+
+A node finished successfully; the scheduler persisted each output artifact under its declared edge `ArtifactId`.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `output_artifact_ids` | `Vec<ArtifactId>` | `ArtifactId`s the executor materialized — order matches the node's declared output edges. |
+
+### `node.failed`
+
+- Variant: `FactoryEventKind::NodeFailed`
+- Stream: `substrate`
+
+A node's executor returned Err. The scheduler aborts the plan (v1; no retries).
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `error` | `String` | Free-text error message from the executor. |
+
+### `node.awaiting_human`
+
+- Variant: `FactoryEventKind::NodeAwaitingHuman`
+- Stream: `substrate`
+
+A Human executor is parked waiting on an out-of-band approval decision. The dashboard's HITL inbox renders this; the substrate's own Human executor (#357) resolves it inline by observing the matching `node.human_approved` / `node.human_rejected`.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `prompt` | `String` | Free-text prompt shown to the human reviewer. |
+
+### `node.human_approved`
+
+- Variant: `FactoryEventKind::NodeHumanApproved`
+- Stream: `substrate`
+
+A pending Human executor node received an approval decision.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `approved_by` | `String` | Actor identifier — `"human:<id>"` for a dashboard user, `"supervisor"` for a delegate agent. |
+
+### `node.human_rejected`
+
+- Variant: `FactoryEventKind::NodeHumanRejected`
+- Stream: `substrate`
+
+A pending Human executor node received a rejection decision.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `rejected_by` | `String` | Actor identifier — same shape as `approved_by` above. |
+| `reason` | `Option<String>` | Free-text justification carried into the audit trail. _(optional)_ |
+
+### `synodic.verdict`
+
+- Variant: `FactoryEventKind::SynodicVerdict`
+- Stream: `substrate`
+
+Verify executor produced a verdict — pass / fail outcome with per-check details. Distinct from the legacy `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem (retired by MIG-03); per spec #360 this is the substrate-native verdict event.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `passed` | `bool` | True when every check the executor ran passed. |
+| `check_results` | `Vec<VerifyCheckResult>` | Per-check (name, passed) results so the dashboard can render the failure surface without a follow-up read. |
+
+### `agent.session_started`
+
+- Variant: `FactoryEventKind::AgentSessionStarted`
+- Stream: `substrate`
+
+Agent executor opened an LLM session.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `session_id` | `String` | Session identifier minted by the agent runner. |
+| `model` | `String` | Model name (`"claude-sonnet-4-6"`, etc.). |
+
+### `agent.session_completed`
+
+- Variant: `FactoryEventKind::AgentSessionCompleted`
+- Stream: `substrate`
+
+Agent executor's LLM session finished successfully.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `session_id` | `String` |  |
+| `token_usage` | `Option<TokenUsage>` | Token usage for this session — `None` when the runner does not report it (stub / mock runners). _(optional)_ |
+
+### `agent.session_failed`
+
+- Variant: `FactoryEventKind::AgentSessionFailed`
+- Stream: `substrate`
+
+Agent executor's LLM session terminated with an error.
+
+| Field | Type | Description |
+|---|---|---|
+| `plan_id` | `String` |  |
+| `node_id` | `NodeId` |  |
+| `session_id` | `String` |  |
+| `error` | `String` | Free-text error from the runner. |
 
 
 ---

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,7 +63,7 @@ that requires a coordinated rollout.
 | `workflow` | stiglab (trigger) / substrate scheduler (stage) | 3 |
 | `audit` | (unknown — update `stream_producer` in xtask) | 1 |
 | `gate` | onsager-portal (GitHub) / substrate scheduler (manual) | 2 |
-| `substrate` | (unknown — update `stream_producer` in xtask) | 10 |
+| `substrate` | substrate scheduler (onsager-nodes) + executor catalog (RUN-02, #360) | 10 |
 
 Each section below covers one stream. Inside a section, every event lists its wire `event_type` string, the Rust variant name, the variant's doc comment, and a payload field table (where the field's own doc comment is the description).
 
@@ -693,7 +693,7 @@ A manual-approval gate received a signal (e.g. the PR was merged). Forge's manua
 
 ## `substrate` events
 
-Producer subsystem: **(unknown — update `stream_producer` in xtask)**.
+Producer subsystem: **substrate scheduler (onsager-nodes) + executor catalog (RUN-02, #360)**.
 
 ### `node.started`
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -558,6 +558,7 @@ fn stream_producer(stream: &str) -> &'static str {
         "workflow" => "stiglab (trigger) / substrate scheduler (stage)",
         "registry" => "synodic (catalog crud)",
         "gate" => "onsager-portal (GitHub) / substrate scheduler (manual)",
+        "substrate" => "substrate scheduler (onsager-nodes) + executor catalog (RUN-02, #360)",
         _ => "(unknown — update `stream_producer` in xtask)",
     }
 }


### PR DESCRIPTION
## Summary

Defines the typed event contract for substrate runtime events — what the scheduler and executor catalog emit onto the spine so observers, the dashboard timeline, and audit trails can consume one stable vocabulary.

- New module `onsager-substrate::events` with payload structs for the ten substrate events: `node.started`, `node.completed`, `node.failed`, `node.awaiting_human`, `node.human_approved`, `node.human_rejected`, `synodic.verdict`, `agent.session_started`, `agent.session_completed`, `agent.session_failed`.
- Matching `FactoryEventKind` variants in `onsager-spine` as the wire vocabulary (single source of truth for the `events` table's `event_type` column).
- Manifest entries in `onsager-registry::EVENTS` with the new `Subsystem::Substrate` producer; existing `xtask check-events` passes.
- Scheduler emits `node.started` (collapsing the legacy `plan.node_ready` / `plan.node_running` pair) and richer `node.completed` / `node.failed` payloads carrying `output_artifact_ids` and the executor error.
- Agent and Verify executors emit their session / verdict lifecycle events through the existing `SpineClient` port.

### Schema stability

Optional fields use `#[serde(default, skip_serializing_if = "Option::is_none")]` so adding a new optional field is wire-compatible — old deserializers ignore it; new deserializers fill `None` for old payloads. A unit test pins this for `NodeHumanRejected.reason` and `AgentSessionCompleted.token_usage`.

### Wire-shape compat

The two halves (substrate authoring structs ↔ spine wire enum) carry the same payload shape. A structural compat test in `crates/onsager-substrate/tests/spine_payload_compat.rs` serializes both halves, strips the `FactoryEventKind` `"type"` discriminator, and asserts equality — drift surfaces at `cargo test`, not in production.

## Test plan

- [x] `cargo test --workspace` (all crates green)
- [x] `crates/onsager-substrate::events::tests` — 7 unit tests covering kind constants, round-trips, schema-stable optional fields
- [x] `crates/onsager-substrate/tests/spine_payload_compat.rs` — 11 tests pinning every event's wire shape between the two halves
- [x] `crates/onsager-nodes/tests/scheduler_event_contract.rs` — end-to-end NoOp → Agent → Verify run emits the full contract (3× `node.started`, 3× `node.completed`, 1× `agent.session_started` + `agent.session_completed`, 1× `synodic.verdict`); plus a failure-path test asserting `synodic.verdict` emits even when the verify executor escalates.
- [x] `cargo run -p xtask -- check-events` clean (54 events, 4 subsystems scanned)
- [x] `cargo run -p xtask -- gen-event-docs --check` — `docs/events.md` regenerated and pinned
- [x] `cargo run -p xtask -- lint-seams` / `check-api-contract` / `check-file-budget` all clean
- [x] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings`

## Notes

- `ScriptExecutor` doesn't yet implement the substrate `Executor` trait (needs serde + typetag wiring), so the end-to-end test uses `NoOpExecutor` in the upstream slot. The scheduler-side lifecycle contract (`node.started` → `node.completed`) is the same; executor-specific `script.*` events aren't part of the #360 contract. Wiring `ScriptExecutor` substrate-side is a small follow-up.
- `Subsystem::Substrate` is excluded from `SCANNED` because the emit / listener scan only walks `crates/{forge,stiglab,synodic,ising}/src/`. Substrate emits are trusted (same pattern as `Portal`).
- `synodic.verdict` is the substrate-native verdict event from the Verify executor, distinct from the legacy `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem (which is retired by MIG-03).

Closes #360

---
_Generated by [Claude Code](https://claude.ai/code/session_01QexKhrBNdf1W9ahQeTHgj6)_