### PR TITLE
fix(nodes): add missing plan_id to subworkflow test ExecutorContext literals

### DIFF
--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -454,6 +454,7 @@ mod tests {
 
     fn ctx_for(node_id: NodeId, inputs: Vec<(ArtifactId, Artifact)>) -> ExecutorContext {
         ExecutorContext {
+            plan_id: PlanId::generate(),
             node_id,
             inputs,
             spine: Arc::new(MockSpine::default()),
@@ -467,6 +468,7 @@ mod tests {
         workflow_ref: WorkflowId,
     ) -> ExecutorContext {
         ExecutorContext {
+            plan_id: PlanId::generate(),
             node_id,
             inputs,
             spine: Arc::new(MockSpine::default()),


### PR DESCRIPTION
## Summary

Restores `cargo test --workspace` on main. Same shape as #379: a struct gained a field after a PR was opened, and the PR's test-only struct-literal usages couldn't be auto-merged.

#385 (RUN-02) added a `plan_id` field to `ExecutorContext`. #383 (EXE-05 SubWorkflow) was rebased onto post-#385 main, but its two test `ExecutorContext {...}` literals still used the pre-#385 shape — `cargo build` was clean because production code doesn't construct `ExecutorContext` literally, only tests do.

## What changed

`crates/onsager-nodes/src/subworkflow.rs` — adds `plan_id: PlanId::generate(),` to both `ExecutorContext {...}` literals in the test helpers (`ctx_for`, `ctx_for_with_ref`). `PlanId` was already imported via the existing `use crate::scheduler::{...}`.

## Test plan

- [x] `cargo test --workspace --no-run` clean (was failing on main before this PR)
- [x] `cargo test -p onsager-nodes` — all tests pass

## Recurrence

This is the second occurrence of the pattern (cf. #379). The durable fix is to add `cargo test --workspace --no-run` to the pre-merge gate so test-only struct shape drift can't ship onto main. Filing as a separate spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Dy6By2XQhAAKUgEoWHhV)_