### PR TITLE
feat(observers): onsager-observers crate basics (OBS-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,6 @@ dependencies = [
  "tokio",
  "tracing",
  "ulid",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "onsager-observers"
+version = "0.2.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "onsager-artifact",
+ "onsager-spine",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ulid",
+ "uuid",
+]
+
+[[package]]
 name = "onsager-portal"
 version = "0.2.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/onsager-spine",
     "crates/onsager-substrate",
     "crates/onsager-nodes",
+    "crates/onsager-observers",
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",

--- a/crates/onsager-observers/Cargo.toml
+++ b/crates/onsager-observers/Cargo.toml
@@ -12,8 +12,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-uuid = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json", "chrono", "uuid"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json", "chrono"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/onsager-observers/Cargo.toml
+++ b/crates/onsager-observers/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "onsager-observers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "0.2 substrate observers — non-blocking S3* audit channel. Observers subscribe to spine events, run analysis off the hot path, and emit QualitySignal / Insight / Alert outputs to the observer_outputs table. ADR 0013, spec #361."
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+onsager-spine = { path = "../onsager-spine" }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json", "chrono", "uuid"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+ulid = { version = "1", features = ["serde"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/onsager-observers/src/lib.rs
+++ b/crates/onsager-observers/src/lib.rs
@@ -1,0 +1,68 @@
+//! # onsager-observers
+//!
+//! The 0.2 substrate's **second citizen**: non-blocking observers that
+//! audit the event stream and emit typed outputs without ever mutating
+//! it. Where a [`Workflow`](onsager_substrate::Workflow) is the
+//! managed-execution citizen (VSM S1/S2/S3), an [`Observer`] is the
+//! audit citizen (VSM S3*). The substrate runs both — workflow nodes
+//! and observers subscribe to the same spine, but observers run in
+//! their own tasks off the hot path and write only to the separate
+//! `observer_outputs` table.
+//!
+//! See [ADR 0013](../../../docs/adr/0013-observer-as-second-substrate-citizen.md).
+//!
+//! ## Surface
+//!
+//! - [`Observer`] — the trait. Implementors declare which spine event
+//!   types they care about ([`subscriptions`](Observer::subscriptions))
+//!   and produce typed outputs from each match ([`on_event`](Observer::on_event)).
+//! - [`SpineEvent`] — what `on_event` sees: the wire `event_type`, the
+//!   parsed [`FactoryEvent`](onsager_spine::FactoryEvent) payload, the
+//!   spine row id (so emitted outputs can reference the triggering
+//!   event), and the row's `created_at` timestamp.
+//! - [`EventPattern`] — simple glob (`"artifact.*"`, `"*"`, exact
+//!   match) used by [`subscriptions`](Observer::subscriptions). No
+//!   full regex; v1 is wildly inclusive.
+//! - [`ObserverOutput`] — the union of the three substrate-recognized
+//!   output kinds: [`QualitySignal`](onsager_artifact::QualitySignal),
+//!   [`Insight`], and [`Alert`].
+//! - [`ObserverRuntime`] — the runtime. Holds a set of registered
+//!   observers, subscribes to the spine, and fans events out: one
+//!   `tokio::spawn` per (observer, event) match so a slow observer
+//!   never blocks the substrate scheduler.
+//! - [`ObserverOutputStore`] — Postgres-backed persistence for
+//!   `ObserverOutput` rows. Schema lives at
+//!   `crates/onsager-spine/migrations/028_observer_outputs.sql`.
+//!
+//! ## Constitutive properties
+//!
+//! Per ADR 0013, these are not optional:
+//!
+//! 1. **Non-blocking** — observers run in separate tasks; their work
+//!    never delays workflow execution. The runtime fan-out spawns a
+//!    fresh task per dispatch.
+//! 2. **Cannot modify state** — the only writer surface this crate
+//!    exposes is [`ObserverOutputStore`], which targets a *separate*
+//!    table from spine business events. Observers do not have a
+//!    handle to the spine `EventStore`.
+//! 3. **Spine is the input** — the runtime is wired exclusively to
+//!    [`EventStore::subscribe`](onsager_spine::EventStore::subscribe);
+//!    there is no private coordination channel.
+//! 4. **Output is typed** — `ObserverOutput` is a closed enum; the
+//!    dashboard renders the three variants uniformly.
+
+pub mod observer;
+pub mod output;
+pub mod pattern;
+pub mod runtime;
+pub mod store;
+
+pub use observer::{Observer, SpineEvent};
+pub use output::{Alert, AlertSeverity, Insight, ObserverOutput, ObserverOutputKind};
+pub use pattern::EventPattern;
+pub use runtime::ObserverRuntime;
+pub use store::{ObserverOutputRecord, ObserverOutputStore, StoreError};
+
+// Convenience re-export so callers building outputs don't have to
+// reach across crates for the third variant.
+pub use onsager_artifact::QualitySignal;

--- a/crates/onsager-observers/src/observer.rs
+++ b/crates/onsager-observers/src/observer.rs
@@ -1,0 +1,68 @@
+//! [`Observer`] trait — the substrate's audit citizen.
+//!
+//! An observer is **stateful and serial per instance**: the runtime
+//! calls [`on_event`](Observer::on_event) with `&mut self`, so an
+//! observer can accumulate state across events (running counts,
+//! moving averages, simple memory of "what did the last 10 events
+//! look like"). The runtime serializes calls to one observer behind
+//! a mutex; observers from each other run fully in parallel.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use onsager_spine::FactoryEvent;
+
+use crate::output::ObserverOutput;
+use crate::pattern::EventPattern;
+
+/// The event shape an observer sees on each dispatch.
+///
+/// Carries the parsed [`FactoryEvent`] payload (so observers can
+/// match on typed variants instead of re-parsing JSON) plus the
+/// spine-row metadata observers reference when emitting outputs —
+/// `event_id` becomes the `triggered_by_event_id` link an emitted
+/// [`Insight`](crate::Insight) or [`Alert`](crate::Alert) carries
+/// back to the row that caused it.
+#[derive(Debug, Clone)]
+pub struct SpineEvent {
+    /// The `events.id` of the row on the spine.
+    pub event_id: i64,
+    /// Wire event type (`"artifact.state_changed"`, `"node.completed"`,
+    /// ...). Same value the
+    /// [`EventPattern`] matches against; passed through alongside the
+    /// parsed payload so a simple observer can branch on the string
+    /// without re-deriving it.
+    pub event_type: String,
+    /// Full parsed factory-event payload.
+    pub payload: FactoryEvent,
+    /// Timestamp the spine row was written.
+    pub created_at: DateTime<Utc>,
+}
+
+/// An observer of substrate events.
+///
+/// Implementors declare a set of [`EventPattern`]s in
+/// [`subscriptions`](Self::subscriptions) and produce
+/// [`ObserverOutput`]s from each matching event in
+/// [`on_event`](Self::on_event). The runtime guarantees:
+///
+/// - Each `on_event` call is delivered in its own `tokio::spawn`
+///   task — slow observers do not block other observers or the
+///   substrate scheduler.
+/// - Per-observer calls are serialized — two events that both match
+///   one observer are processed in `event_id` order, one at a time,
+///   even though different observers run in parallel.
+/// - The runtime persists every returned [`ObserverOutput`] before
+///   moving on; observers do not have direct DB access.
+#[async_trait]
+pub trait Observer: Send + Sync {
+    /// Event patterns this observer wants to receive. Returning an
+    /// empty list disables the observer (no events match).
+    fn subscriptions(&self) -> Vec<EventPattern>;
+
+    /// Process a matching spine event.
+    ///
+    /// Returns the outputs to persist — usually 0 or 1, but observers
+    /// may emit several (e.g. an `Alert` plus the `QualitySignal`
+    /// that triggered it).
+    async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput>;
+}

--- a/crates/onsager-observers/src/output.rs
+++ b/crates/onsager-observers/src/output.rs
@@ -95,8 +95,11 @@ pub struct Insight {
     /// Free-form observation text. Rendered as the headline in the
     /// dashboard.
     pub observation: String,
-    /// `0.0..=1.0` — observer's self-reported confidence. Consumers
-    /// may filter by threshold.
+    /// `0.0..=1.0` — observer's self-reported confidence. Construct
+    /// via [`Insight::new`] (or one of the typed-confidence ctors)
+    /// to get clamping; constructing the struct directly with a
+    /// stray value is allowed but the dashboard treats anything
+    /// outside `0..=1` (and NaN / ±∞) as `0.0`.
     pub confidence: f64,
     /// `events.id` rows that support this insight. Observers should
     /// include at least the triggering event id so the dashboard can
@@ -166,14 +169,28 @@ impl AlertSeverity {
 impl Insight {
     /// Convenience: bare-minimum insight from an observation and
     /// confidence. Evidence and tagging stay empty.
+    ///
+    /// `confidence` is clamped into `0.0..=1.0`. NaN / ±∞ collapse
+    /// to `0.0` so the dashboard's "filter by threshold" reads stay
+    /// well-defined. Producers that need to know the raw value was
+    /// rejected should validate at the call site.
     pub fn new(observation: impl Into<String>, confidence: f64) -> Self {
         Self {
             observation: observation.into(),
-            confidence,
+            confidence: clamp_confidence(confidence),
             evidence_event_ids: Vec::new(),
             about_artifact_id: None,
             tag: None,
         }
+    }
+}
+
+/// Clamp `c` into `0.0..=1.0`. NaN / ±∞ collapse to `0.0`.
+fn clamp_confidence(c: f64) -> f64 {
+    if !c.is_finite() {
+        0.0
+    } else {
+        c.clamp(0.0, 1.0)
     }
 }
 
@@ -270,6 +287,16 @@ mod tests {
         } else {
             panic!("expected QualitySignal variant");
         }
+    }
+
+    #[test]
+    fn insight_new_clamps_confidence() {
+        assert_eq!(Insight::new("ok", 0.5).confidence, 0.5);
+        assert_eq!(Insight::new("low", -0.4).confidence, 0.0);
+        assert_eq!(Insight::new("high", 1.7).confidence, 1.0);
+        assert_eq!(Insight::new("nan", f64::NAN).confidence, 0.0);
+        assert_eq!(Insight::new("inf", f64::INFINITY).confidence, 0.0);
+        assert_eq!(Insight::new("ninf", f64::NEG_INFINITY).confidence, 0.0);
     }
 
     #[test]

--- a/crates/onsager-observers/src/output.rs
+++ b/crates/onsager-observers/src/output.rs
@@ -1,0 +1,282 @@
+//! Typed observer outputs — the three substrate-recognized shapes.
+//!
+//! Per ADR 0013 ("Output is typed"), every observer emits a closed
+//! set of variants so the dashboard can render them with one
+//! component family. The three are:
+//!
+//! - [`QualitySignal`](onsager_artifact::QualitySignal) — append-only
+//!   record about artifact quality (already defined in
+//!   `onsager-artifact`; observers reuse it so signals raised by
+//!   substrate-side audits and ones raised by lifecycle hooks land
+//!   in the same shape).
+//! - [`Insight`] — a structured *observation* about the system: a
+//!   recurring pattern, a correlation, a hypothesis. Carries
+//!   confidence and pointers to the spine rows that support it.
+//! - [`Alert`] — an *action-worthy* signal: a deadline crossed, a
+//!   verdict pattern that needs human attention, an analyzer crash.
+//!   Severity-banded so triage can sort.
+//!
+//! The three exist on one [`ObserverOutput`] enum so [`Observer`]
+//! impls can return a heterogeneous batch from a single event.
+//!
+//! [`Observer`]: crate::Observer
+
+use onsager_artifact::QualitySignal;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// ObserverOutput
+// ---------------------------------------------------------------------------
+
+/// One typed output from an observer's `on_event` call.
+///
+/// `f64` confidence on [`Insight`] blocks `Eq`; only `PartialEq` is
+/// derived.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ObserverOutput {
+    /// A [`QualitySignal`] about an artifact — same shape as
+    /// `onsager-artifact::QualitySignal`.
+    QualitySignal(QualitySignal),
+    /// A structured observation. See [`Insight`].
+    Insight(Insight),
+    /// An action-worthy signal. See [`Alert`].
+    Alert(Alert),
+}
+
+impl ObserverOutput {
+    /// The output's kind tag, matching the serde `kind` discriminator
+    /// and the `kind` column of `observer_outputs`.
+    pub fn kind(&self) -> ObserverOutputKind {
+        match self {
+            Self::QualitySignal(_) => ObserverOutputKind::QualitySignal,
+            Self::Insight(_) => ObserverOutputKind::Insight,
+            Self::Alert(_) => ObserverOutputKind::Alert,
+        }
+    }
+}
+
+/// The three valid `kind` values for the `observer_outputs` table.
+///
+/// Kept as a closed enum so the SQL column and the in-Rust shape do
+/// not drift — new variants would need both a Rust change and a
+/// schema migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObserverOutputKind {
+    QualitySignal,
+    Insight,
+    Alert,
+}
+
+impl ObserverOutputKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::QualitySignal => "quality_signal",
+            Self::Insight => "insight",
+            Self::Alert => "alert",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Insight
+// ---------------------------------------------------------------------------
+
+/// A structured observation produced by an observer.
+///
+/// Distinct from the legacy `onsager-spine::protocol::Insight` (which
+/// is the Ising-to-Forge advisory shape from forge-v0.1) — this is
+/// the substrate-native shape ADR 0013 names. The two coexist while
+/// MIG-03 retires Ising; once the migration is complete the legacy
+/// one is removed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Insight {
+    /// Free-form observation text. Rendered as the headline in the
+    /// dashboard.
+    pub observation: String,
+    /// `0.0..=1.0` — observer's self-reported confidence. Consumers
+    /// may filter by threshold.
+    pub confidence: f64,
+    /// `events.id` rows that support this insight. Observers should
+    /// include at least the triggering event id so the dashboard can
+    /// link the insight back to its evidence.
+    #[serde(default)]
+    pub evidence_event_ids: Vec<i64>,
+    /// Optional artifact this insight is about (when the observer's
+    /// scope is narrow enough to name one).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub about_artifact_id: Option<String>,
+    /// Optional free-form tag (`"velocity"`, `"flaky_test"`, ...) so
+    /// the dashboard can group similar insights.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Alert
+// ---------------------------------------------------------------------------
+
+/// An action-worthy signal an observer raised.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Alert {
+    /// Short title — rendered as the dashboard inbox row.
+    pub title: String,
+    /// Free-form detail body (Markdown allowed; renderer is
+    /// dashboard-side).
+    pub detail: String,
+    pub severity: AlertSeverity,
+    /// `events.id` rows that support / triggered this alert.
+    #[serde(default)]
+    pub evidence_event_ids: Vec<i64>,
+    /// Optional artifact this alert is about.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub about_artifact_id: Option<String>,
+}
+
+/// Severity band on an [`Alert`].
+///
+/// Ordered as written — `Info < Warning < Error < Critical` — and
+/// `Ord` is derived so consumers can compare against a threshold
+/// (`alert.severity >= AlertSeverity::Error`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertSeverity {
+    Info,
+    Warning,
+    Error,
+    Critical,
+}
+
+impl AlertSeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+impl Insight {
+    /// Convenience: bare-minimum insight from an observation and
+    /// confidence. Evidence and tagging stay empty.
+    pub fn new(observation: impl Into<String>, confidence: f64) -> Self {
+        Self {
+            observation: observation.into(),
+            confidence,
+            evidence_event_ids: Vec::new(),
+            about_artifact_id: None,
+            tag: None,
+        }
+    }
+}
+
+impl Alert {
+    pub fn new(
+        title: impl Into<String>,
+        detail: impl Into<String>,
+        severity: AlertSeverity,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            detail: detail.into(),
+            severity,
+            evidence_event_ids: Vec::new(),
+            about_artifact_id: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Construction shortcuts on ObserverOutput
+// ---------------------------------------------------------------------------
+
+impl ObserverOutput {
+    pub fn insight(insight: Insight) -> Self {
+        Self::Insight(insight)
+    }
+
+    pub fn alert(alert: Alert) -> Self {
+        Self::Alert(alert)
+    }
+
+    pub fn quality_signal(signal: QualitySignal) -> Self {
+        Self::QualitySignal(signal)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_artifact::{QualitySource, QualityValue};
+
+    #[test]
+    fn output_kind_round_trips() {
+        let ev = ObserverOutput::Insight(Insight::new("recurring flake", 0.8));
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["kind"], "insight");
+        let back: ObserverOutput = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+        assert_eq!(back.kind(), ObserverOutputKind::Insight);
+        assert_eq!(back.kind().as_str(), "insight");
+    }
+
+    #[test]
+    fn alert_severity_is_ordered() {
+        assert!(AlertSeverity::Info < AlertSeverity::Warning);
+        assert!(AlertSeverity::Warning < AlertSeverity::Error);
+        assert!(AlertSeverity::Error < AlertSeverity::Critical);
+    }
+
+    #[test]
+    fn alert_round_trips() {
+        let ev = ObserverOutput::Alert(Alert::new(
+            "Stage SLA crossed",
+            "Stage `build` exceeded p95 by 4×.",
+            AlertSeverity::Warning,
+        ));
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["kind"], "alert");
+        assert_eq!(json["severity"], "warning");
+        let back: ObserverOutput = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn quality_signal_round_trips() {
+        let ev = ObserverOutput::QualitySignal(QualitySignal {
+            source: QualitySource::IsingInference,
+            dimension: "completeness".into(),
+            value: QualityValue::Score(0.42),
+            recorded_at: chrono::Utc::now(),
+            recorded_by: "obs:demo".into(),
+        });
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["kind"], "quality_signal");
+        let back: ObserverOutput = serde_json::from_value(json).unwrap();
+        assert_eq!(back.kind(), ObserverOutputKind::QualitySignal);
+        if let ObserverOutput::QualitySignal(s) = back {
+            assert_eq!(s.dimension, "completeness");
+        } else {
+            panic!("expected QualitySignal variant");
+        }
+    }
+
+    #[test]
+    fn insight_skips_none_optional_fields() {
+        let ev = ObserverOutput::Insight(Insight::new("seed", 0.5));
+        let json = serde_json::to_value(&ev).unwrap();
+        assert!(json.get("about_artifact_id").is_none());
+        assert!(json.get("tag").is_none());
+    }
+}

--- a/crates/onsager-observers/src/pattern.rs
+++ b/crates/onsager-observers/src/pattern.rs
@@ -6,15 +6,23 @@
 //!
 //! ## Supported shapes
 //!
-//! | Pattern             | Matches                                              |
-//! |---------------------|------------------------------------------------------|
-//! | `"*"`               | every event                                          |
-//! | `"artifact.*"`      | every `event_type` starting with `"artifact."`       |
-//! | `"node.completed"`  | exact match only                                     |
+//! | Pattern             | Matches                                                     |
+//! |---------------------|-------------------------------------------------------------|
+//! | `"*"`               | every event                                                 |
+//! | `"<prefix>.*"`      | every `event_type` starting with `"<prefix>."` (any depth)  |
+//! | `"node.completed"`  | exact match only                                            |
+//!
+//! `<prefix>.*` is a **prefix** match, not a single-segment match —
+//! `artifact.*` matches `artifact.state_changed`, `artifact.sealed`,
+//! AND `artifact.deeply.nested.foo`. The trailing dot in the
+//! comparison is solely to enforce the namespace boundary (`node.*`
+//! must not match `nodemap.touched`); it does not constrain depth
+//! beyond that. Observers that need single-segment semantics or
+//! more sophisticated matching should branch on the parsed
+//! [`FactoryEvent`](onsager_spine::FactoryEvent) inside `on_event`.
 //!
 //! No mid-string wildcards (`"a.*.b"`), no character classes, no
-//! escapes — observers that need that can match the parsed
-//! [`FactoryEvent`](onsager_spine::FactoryEvent) inside `on_event`.
+//! escapes.
 //!
 //! ## Why glob, not regex
 //!
@@ -52,9 +60,11 @@ impl EventPattern {
             // "*" — every event matches.
             "*" => true,
             // "<prefix>.*" — every event whose type starts with "<prefix>.".
-            // The trailing dot in the comparison prevents "node.*" from
-            // matching a hypothetical "nodemap" (which it shouldn't —
-            // they're different namespaces).
+            // Multi-segment by design: "artifact.*" matches both
+            // "artifact.state_changed" and "artifact.deeply.nested".
+            // The trailing dot in the comparison enforces the namespace
+            // boundary (so "node.*" does not match "nodemap.touched")
+            // but does not constrain depth past it.
             p if p.ends_with(".*") => {
                 let prefix = &p[..p.len() - 1]; // strip just the "*", keep the "."
                 event_type.starts_with(prefix)

--- a/crates/onsager-observers/src/pattern.rs
+++ b/crates/onsager-observers/src/pattern.rs
@@ -1,0 +1,139 @@
+//! [`EventPattern`] — simple glob matching against `event_type` strings.
+//!
+//! Per the spec #361 notes: "Pattern matching is simple glob:
+//! `artifact.*` matches `artifact.state_changed`, `artifact.sealed`,
+//! etc. Full regex is not needed in v1."
+//!
+//! ## Supported shapes
+//!
+//! | Pattern             | Matches                                              |
+//! |---------------------|------------------------------------------------------|
+//! | `"*"`               | every event                                          |
+//! | `"artifact.*"`      | every `event_type` starting with `"artifact."`       |
+//! | `"node.completed"`  | exact match only                                     |
+//!
+//! No mid-string wildcards (`"a.*.b"`), no character classes, no
+//! escapes — observers that need that can match the parsed
+//! [`FactoryEvent`](onsager_spine::FactoryEvent) inside `on_event`.
+//!
+//! ## Why glob, not regex
+//!
+//! Event types are short dotted identifiers — a five-line prefix
+//! matcher covers every real subscription pattern in 0.2. Reaching
+//! for regex would add a dependency, a compile step, and (most
+//! importantly) a way for an observer author to write a pattern that
+//! silently doesn't match.
+
+use serde::{Deserialize, Serialize};
+
+/// A glob pattern against the wire `event_type` string.
+///
+/// Built via [`EventPattern::new`] or the [`From<&str>`] impl; match
+/// with [`matches`](Self::matches).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EventPattern(String);
+
+impl EventPattern {
+    /// Construct a pattern from a string. The pattern is not
+    /// validated up front; an unknown shape (e.g. `"a.*.b"`) will
+    /// just never match anything.
+    pub fn new(pattern: impl Into<String>) -> Self {
+        Self(pattern.into())
+    }
+
+    /// The raw pattern string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns `true` if `event_type` matches this pattern.
+    pub fn matches(&self, event_type: &str) -> bool {
+        match self.0.as_str() {
+            // "*" — every event matches.
+            "*" => true,
+            // "<prefix>.*" — every event whose type starts with "<prefix>.".
+            // The trailing dot in the comparison prevents "node.*" from
+            // matching a hypothetical "nodemap" (which it shouldn't —
+            // they're different namespaces).
+            p if p.ends_with(".*") => {
+                let prefix = &p[..p.len() - 1]; // strip just the "*", keep the "."
+                event_type.starts_with(prefix)
+            }
+            // Exact match.
+            p => p == event_type,
+        }
+    }
+}
+
+impl From<&str> for EventPattern {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for EventPattern {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn star_matches_everything() {
+        let p = EventPattern::new("*");
+        assert!(p.matches("artifact.state_changed"));
+        assert!(p.matches("node.completed"));
+        assert!(p.matches(""));
+    }
+
+    #[test]
+    fn prefix_wildcard_matches_namespace() {
+        let p = EventPattern::new("artifact.*");
+        assert!(p.matches("artifact.state_changed"));
+        assert!(p.matches("artifact.archived"));
+        assert!(p.matches("artifact.registered"));
+        // Multi-segment events still match — prefix is the whole rule.
+        assert!(p.matches("artifact.some.nested"));
+    }
+
+    #[test]
+    fn prefix_wildcard_respects_dot_boundary() {
+        let p = EventPattern::new("node.*");
+        // Same prefix, different namespace — must not match. This is
+        // the key invariant: "node.*" must not eat "nodemap.foo".
+        assert!(!p.matches("nodemap.touched"));
+        // No dot at all — must not match.
+        assert!(!p.matches("node"));
+        // Real intent: matches any follow-on segment.
+        assert!(p.matches("node.started"));
+        assert!(p.matches("node.completed"));
+    }
+
+    #[test]
+    fn exact_match() {
+        let p = EventPattern::new("node.completed");
+        assert!(p.matches("node.completed"));
+        assert!(!p.matches("node.started"));
+        assert!(!p.matches("node.completed.extra"));
+    }
+
+    #[test]
+    fn empty_pattern_never_matches_real_events() {
+        let p = EventPattern::new("");
+        assert!(!p.matches("artifact.state_changed"));
+        // An empty event_type matches the empty pattern — degenerate
+        // but consistent with "exact match".
+        assert!(p.matches(""));
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let p = EventPattern::new("artifact.*");
+        let s = serde_json::to_string(&p).unwrap();
+        let back: EventPattern = serde_json::from_str(&s).unwrap();
+        assert_eq!(p, back);
+    }
+}

--- a/crates/onsager-observers/src/runtime.rs
+++ b/crates/onsager-observers/src/runtime.rs
@@ -12,19 +12,38 @@
 //!    one `tokio::spawn` per (observer, event), so a slow observer
 //!    never blocks another observer or the substrate scheduler.
 //!
-//! ## Single-task-per-observer ordering
+//! ## Per-observer concurrency
 //!
-//! Each observer instance lives behind a `tokio::sync::Mutex`. Two
-//! events matching the same observer therefore run *in order* —
-//! event A finishes before event B is processed by that observer —
-//! even though A and B may interleave with other observers'
-//! processing. Observers from each other are fully parallel.
+//! Each observer instance lives behind a `tokio::sync::Mutex`. At
+//! most one `on_event` call to a given observer runs at a time —
+//! observers can safely keep `&mut self` state without external
+//! locking. Across different observers, dispatches run fully in
+//! parallel.
+//!
+//! **Ordering note.** Per-observer calls are serialized but not
+//! guaranteed FIFO in `event_id` order: `tokio::sync::Mutex` does
+//! not promise FIFO wakeup, so two events arriving close in time
+//! may be processed by one observer in either order. Observers that
+//! genuinely need monotonic ordering must inspect `event_id` /
+//! `created_at` themselves; for the v1 audit use case the
+//! at-most-one-at-a-time guarantee is what callers depend on.
+//!
+//! ## Backpressure
+//!
+//! By default the runtime subscribes via [`EventStore::subscribe`],
+//! which is unbounded — fine for the audit workload most observers
+//! produce, but a slow observer behind dozens of registered
+//! observers can grow memory unboundedly. Use
+//! [`ObserverRuntime::with_capacity`] to switch to
+//! [`EventStore::subscribe_bounded`] with a fixed-capacity channel;
+//! the substrate writer will block once the buffer fills, applying
+//! backpressure upstream rather than buffering forever.
 
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use onsager_spine::{EventNotification, EventStore, FactoryEvent};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 
 use crate::observer::{Observer, SpineEvent};
 use crate::pattern::EventPattern;
@@ -52,6 +71,10 @@ pub struct ObserverRuntime {
     event_store: EventStore,
     output_store: ObserverOutputStore,
     observers: Vec<Registered>,
+    /// `Some(n)` switches the spine subscription to the
+    /// bounded variant with capacity `n`; `None` keeps the unbounded
+    /// default. See [`ObserverRuntime::with_capacity`].
+    capacity: Option<usize>,
 }
 
 impl ObserverRuntime {
@@ -61,7 +84,19 @@ impl ObserverRuntime {
             event_store,
             output_store,
             observers: Vec::new(),
+            capacity: None,
         }
+    }
+
+    /// Switch the spine subscription to the bounded variant with the
+    /// given channel capacity. The substrate writer blocks once the
+    /// buffer fills, applying backpressure upstream — appropriate
+    /// when observers are expected to lag (large fan-outs, slow DB
+    /// writes). Without this, the runtime uses
+    /// [`EventStore::subscribe`] (unbounded).
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
     }
 
     /// Register one observer under a stable id. Chainable.
@@ -102,17 +137,55 @@ impl ObserverRuntime {
     /// Run the subscription loop. Only returns when the underlying
     /// `pg_notify` channel closes or the spine fails.
     pub async fn run(self) -> Result<()> {
-        let mut rx = self
-            .event_store
-            .subscribe()
-            .await
-            .context("subscribe to spine pg_notify")?;
+        self.run_with_ready(None).await
+    }
+
+    /// Like [`run`](Self::run), but signals on `ready` once the spine
+    /// subscription is attached and the fan-out loop is about to
+    /// consume its first notification. Tests use this to wait for
+    /// readiness deterministically instead of sleeping a fixed
+    /// duration. Dropping the receiver is fine — the runtime simply
+    /// proceeds.
+    pub async fn run_with_ready(self, ready: Option<oneshot::Sender<()>>) -> Result<()> {
+        let mut rx_unbounded;
+        let mut rx_bounded;
+        let recv: &mut dyn AnyReceiver = match self.capacity {
+            None => {
+                rx_unbounded = self
+                    .event_store
+                    .subscribe()
+                    .await
+                    .context("subscribe to spine pg_notify")?;
+                &mut rx_unbounded
+            }
+            Some(cap) => {
+                rx_bounded = self
+                    .event_store
+                    .subscribe_bounded(cap)
+                    .await
+                    .context("subscribe_bounded to spine pg_notify")?;
+                &mut rx_bounded
+            }
+        };
+
+        // Subscription is attached — let any awaiter know.
+        if let Some(tx) = ready {
+            let _ = tx.send(());
+        }
 
         let registered: Arc<Vec<Registered>> = Arc::new(self.observers);
         let event_store = self.event_store;
         let output_store = self.output_store;
 
-        while let Some(notification) = rx.recv().await {
+        while let Some(notification) = recv.recv().await {
+            // Cheap pre-filter: observers see core spine events only
+            // (`events_ext` carries subsystem-private payloads that are
+            // not `FactoryEvent`-shaped). Doing this once here saves
+            // one `tokio::spawn` + one `SELECT FROM events WHERE id` per
+            // observer per ignored notification.
+            if notification.table != "events" {
+                continue;
+            }
             // Dispatch each matching observer in its own task so a
             // slow observer cannot back up the channel.
             for obs in registered.iter() {
@@ -179,8 +252,40 @@ fn any_pattern_matches(patterns: &[EventPattern], event_type: &str) -> bool {
     patterns.iter().any(|p| p.matches(event_type))
 }
 
+/// Trait abstracting over `mpsc::UnboundedReceiver` and `mpsc::Receiver`
+/// so [`ObserverRuntime::run_with_ready`] can drive either kind of
+/// channel through one loop.
+#[async_trait::async_trait]
+trait AnyReceiver: Send {
+    async fn recv(&mut self) -> Option<EventNotification>;
+}
+
+#[async_trait::async_trait]
+impl AnyReceiver for tokio::sync::mpsc::UnboundedReceiver<EventNotification> {
+    async fn recv(&mut self) -> Option<EventNotification> {
+        tokio::sync::mpsc::UnboundedReceiver::recv(self).await
+    }
+}
+
+#[async_trait::async_trait]
+impl AnyReceiver for tokio::sync::mpsc::Receiver<EventNotification> {
+    async fn recv(&mut self) -> Option<EventNotification> {
+        tokio::sync::mpsc::Receiver::recv(self).await
+    }
+}
+
 /// Per-task work: fetch the spine row, lock the observer, dispatch,
 /// persist outputs.
+///
+/// **Error visibility.** Failures here (`get_event_by_id` returning
+/// `None`, JSON parse failures, etc.) are surfaced only via
+/// `tracing::error!` today; the event drops out of the observer's
+/// view with no `observer_outputs` row. Promoting these to a typed
+/// dead-letter (synthetic `Alert` keyed to `triggered_by_event_id`
+/// or a `tokio_metrics`-style counter) is tracked as a follow-up to
+/// #361 — the right shape is a substrate-wide decision (it applies
+/// equally to scheduler-side parse failures) and is out of scope
+/// for OBS-01.
 async fn dispatch_one(
     observer_id: &str,
     observer: Arc<Mutex<Box<dyn Observer>>>,
@@ -188,11 +293,11 @@ async fn dispatch_one(
     event_store: EventStore,
     output_store: ObserverOutputStore,
 ) -> Result<()> {
-    // Observers see core spine events only — `events_ext` carries
-    // subsystem-private extension payloads, not factory events.
-    if notification.table != "events" {
-        return Ok(());
-    }
+    debug_assert_eq!(
+        notification.table, "events",
+        "dispatch_one should only see core spine events; \
+         run_with_ready filters events_ext before fan-out"
+    );
 
     let record = event_store
         .get_event_by_id(notification.id)

--- a/crates/onsager-observers/src/runtime.rs
+++ b/crates/onsager-observers/src/runtime.rs
@@ -1,0 +1,343 @@
+//! [`ObserverRuntime`] — drives the observer fan-out from the spine.
+//!
+//! Lifecycle:
+//!
+//! 1. Caller builds an `ObserverRuntime` with an `EventStore` and an
+//!    `ObserverOutputStore`.
+//! 2. Caller [`register`](ObserverRuntime::register)s zero or more
+//!    observers, each with a stable string id.
+//! 3. Caller spawns [`run`](ObserverRuntime::run) on a tokio task. The
+//!    loop subscribes to `pg_notify`, fetches each row's full
+//!    `FactoryEvent` payload, and fans out to matching observers —
+//!    one `tokio::spawn` per (observer, event), so a slow observer
+//!    never blocks another observer or the substrate scheduler.
+//!
+//! ## Single-task-per-observer ordering
+//!
+//! Each observer instance lives behind a `tokio::sync::Mutex`. Two
+//! events matching the same observer therefore run *in order* —
+//! event A finishes before event B is processed by that observer —
+//! even though A and B may interleave with other observers'
+//! processing. Observers from each other are fully parallel.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use onsager_spine::{EventNotification, EventStore, FactoryEvent};
+use tokio::sync::Mutex;
+
+use crate::observer::{Observer, SpineEvent};
+use crate::pattern::EventPattern;
+use crate::store::ObserverOutputStore;
+
+/// One observer registered with the runtime.
+///
+/// `id` is the stable identifier persisted on every emitted
+/// [`ObserverOutput`](crate::ObserverOutput)'s row. Callers should
+/// pick a short, dotted slug — `"ising.flaky_test"`,
+/// `"obs.workflow_latency"` — that survives across restarts.
+struct Registered {
+    id: String,
+    patterns: Vec<EventPattern>,
+    observer: Arc<Mutex<Box<dyn Observer>>>,
+}
+
+/// The observer runtime.
+///
+/// Built with [`new`](Self::new), populated with
+/// [`register`](Self::register), and driven by [`run`](Self::run).
+/// Cheap to construct; the cost is the live spine subscription
+/// `run` opens.
+pub struct ObserverRuntime {
+    event_store: EventStore,
+    output_store: ObserverOutputStore,
+    observers: Vec<Registered>,
+}
+
+impl ObserverRuntime {
+    /// Wire the runtime to an existing spine and output store.
+    pub fn new(event_store: EventStore, output_store: ObserverOutputStore) -> Self {
+        Self {
+            event_store,
+            output_store,
+            observers: Vec::new(),
+        }
+    }
+
+    /// Register one observer under a stable id. Chainable.
+    ///
+    /// `id` is what the runtime writes into `observer_outputs.observer_id`
+    /// — pick something stable across restarts. The observer's
+    /// declared [`subscriptions`](Observer::subscriptions) are read
+    /// once and cached; observers cannot change their patterns at
+    /// runtime.
+    pub fn register<O: Observer + 'static>(mut self, id: impl Into<String>, observer: O) -> Self {
+        let patterns = observer.subscriptions();
+        self.observers.push(Registered {
+            id: id.into(),
+            patterns,
+            observer: Arc::new(Mutex::new(Box::new(observer))),
+        });
+        self
+    }
+
+    /// Register an observer that is already boxed. Useful when the
+    /// caller stores observer instances by name in a registry of
+    /// their own.
+    pub fn register_boxed(mut self, id: impl Into<String>, observer: Box<dyn Observer>) -> Self {
+        let patterns = observer.subscriptions();
+        self.observers.push(Registered {
+            id: id.into(),
+            patterns,
+            observer: Arc::new(Mutex::new(observer)),
+        });
+        self
+    }
+
+    /// Number of registered observers. Mostly useful for tests.
+    pub fn observer_count(&self) -> usize {
+        self.observers.len()
+    }
+
+    /// Run the subscription loop. Only returns when the underlying
+    /// `pg_notify` channel closes or the spine fails.
+    pub async fn run(self) -> Result<()> {
+        let mut rx = self
+            .event_store
+            .subscribe()
+            .await
+            .context("subscribe to spine pg_notify")?;
+
+        let registered: Arc<Vec<Registered>> = Arc::new(self.observers);
+        let event_store = self.event_store;
+        let output_store = self.output_store;
+
+        while let Some(notification) = rx.recv().await {
+            // Dispatch each matching observer in its own task so a
+            // slow observer cannot back up the channel.
+            for obs in registered.iter() {
+                if !any_pattern_matches(&obs.patterns, &notification.event_type) {
+                    continue;
+                }
+                let observer = Arc::clone(&obs.observer);
+                let observer_id = obs.id.clone();
+                let event_store = event_store.clone();
+                let output_store = output_store.clone();
+                let notification = notification.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = dispatch_one(
+                        &observer_id,
+                        observer,
+                        notification,
+                        event_store,
+                        output_store,
+                    )
+                    .await
+                    {
+                        tracing::error!(observer = %observer_id, error = %e, "observer dispatch failed");
+                    }
+                });
+            }
+        }
+
+        tracing::warn!("observer runtime: pg_notify channel closed, shutting down");
+        Ok(())
+    }
+
+    /// Dispatch a single event directly, bypassing the spine
+    /// subscription. Exposed for tests and for use cases that
+    /// already have a parsed `SpineEvent` in hand (e.g. replaying
+    /// from history). Uses the same per-observer mutex as the live
+    /// loop.
+    pub async fn dispatch_for_test(&self, event: SpineEvent) -> Vec<i64> {
+        let mut output_ids = Vec::new();
+        for obs in &self.observers {
+            if !any_pattern_matches(&obs.patterns, &event.event_type) {
+                continue;
+            }
+            let mut guard = obs.observer.lock().await;
+            let outputs = guard.on_event(&event).await;
+            drop(guard);
+            for out in outputs {
+                match self
+                    .output_store
+                    .record(&obs.id, Some(event.event_id), &out)
+                    .await
+                {
+                    Ok(id) => output_ids.push(id),
+                    Err(e) => {
+                        tracing::error!(observer = %obs.id, error = %e, "persist observer output failed");
+                    }
+                }
+            }
+        }
+        output_ids
+    }
+}
+
+fn any_pattern_matches(patterns: &[EventPattern], event_type: &str) -> bool {
+    patterns.iter().any(|p| p.matches(event_type))
+}
+
+/// Per-task work: fetch the spine row, lock the observer, dispatch,
+/// persist outputs.
+async fn dispatch_one(
+    observer_id: &str,
+    observer: Arc<Mutex<Box<dyn Observer>>>,
+    notification: EventNotification,
+    event_store: EventStore,
+    output_store: ObserverOutputStore,
+) -> Result<()> {
+    // Observers see core spine events only — `events_ext` carries
+    // subsystem-private extension payloads, not factory events.
+    if notification.table != "events" {
+        return Ok(());
+    }
+
+    let record = event_store
+        .get_event_by_id(notification.id)
+        .await?
+        .context("spine row vanished between pg_notify and fetch")?;
+
+    let payload: FactoryEvent =
+        serde_json::from_value(record.data).context("parse FactoryEvent from spine row")?;
+
+    let spine_event = SpineEvent {
+        event_id: record.id,
+        event_type: record.event_type,
+        payload,
+        created_at: record.created_at,
+    };
+
+    let mut guard = observer.lock().await;
+    let outputs = guard.on_event(&spine_event).await;
+    drop(guard);
+
+    for out in outputs {
+        if let Err(e) = output_store
+            .record(observer_id, Some(spine_event.event_id), &out)
+            .await
+        {
+            tracing::error!(observer = %observer_id, error = %e, "persist observer output failed");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Insight, ObserverOutput};
+    use crate::pattern::EventPattern;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Counts events it sees and emits an insight for each one.
+    struct CountingObserver {
+        seen: Arc<AtomicUsize>,
+        patterns: Vec<EventPattern>,
+    }
+
+    #[async_trait]
+    impl Observer for CountingObserver {
+        fn subscriptions(&self) -> Vec<EventPattern> {
+            self.patterns.clone()
+        }
+        async fn on_event(&mut self, ev: &SpineEvent) -> Vec<ObserverOutput> {
+            let _ = ev; // referenced for shape; we don't branch on it here
+            let n = self.seen.fetch_add(1, Ordering::SeqCst) + 1;
+            vec![ObserverOutput::Insight(Insight::new(
+                format!("seen #{n}"),
+                0.5,
+            ))]
+        }
+    }
+
+    #[test]
+    fn any_pattern_matches_correctly() {
+        let patterns = vec![
+            EventPattern::new("artifact.*"),
+            EventPattern::new("node.completed"),
+        ];
+        assert!(any_pattern_matches(&patterns, "artifact.state_changed"));
+        assert!(any_pattern_matches(&patterns, "node.completed"));
+        assert!(!any_pattern_matches(&patterns, "node.started"));
+    }
+
+    /// In-process dispatch path: no spine, no DB. We invoke the
+    /// per-observer fan-out through `dispatch_for_test`-equivalent
+    /// glue: lock the mutex, call `on_event`, count.
+    #[tokio::test]
+    async fn observer_matches_pattern_and_receives_event_in_memory() {
+        let seen = Arc::new(AtomicUsize::new(0));
+        let observer: Box<dyn Observer> = Box::new(CountingObserver {
+            seen: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.*")],
+        });
+
+        // Simulate the runtime's per-observer logic without a real
+        // EventStore.
+        let observer = Arc::new(Mutex::new(observer));
+        let event_type = "artifact.state_changed".to_string();
+        let patterns = observer.lock().await.subscriptions();
+        assert!(any_pattern_matches(&patterns, &event_type));
+
+        let spine_event = SpineEvent {
+            event_id: 1,
+            event_type,
+            payload: dummy_factory_event(),
+            created_at: chrono::Utc::now(),
+        };
+
+        let outputs = {
+            let mut guard = observer.lock().await;
+            guard.on_event(&spine_event).await
+        };
+
+        assert_eq!(seen.load(Ordering::SeqCst), 1);
+        assert_eq!(outputs.len(), 1);
+        assert!(matches!(outputs[0], ObserverOutput::Insight(_)));
+    }
+
+    #[tokio::test]
+    async fn unmatched_event_does_not_invoke_observer() {
+        let seen = Arc::new(AtomicUsize::new(0));
+        let observer: Box<dyn Observer> = Box::new(CountingObserver {
+            seen: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.*")],
+        });
+        let observer = Arc::new(Mutex::new(observer));
+
+        let patterns = observer.lock().await.subscriptions();
+        let event_type = "node.started";
+        if any_pattern_matches(&patterns, event_type) {
+            let spine_event = SpineEvent {
+                event_id: 1,
+                event_type: event_type.into(),
+                payload: dummy_factory_event(),
+                created_at: chrono::Utc::now(),
+            };
+            observer.lock().await.on_event(&spine_event).await;
+        }
+
+        assert_eq!(seen.load(Ordering::SeqCst), 0);
+    }
+
+    fn dummy_factory_event() -> FactoryEvent {
+        use chrono::Utc;
+        use onsager_artifact::{ArtifactId, ArtifactState};
+        use onsager_spine::FactoryEventKind;
+        FactoryEvent {
+            event: FactoryEventKind::ArtifactStateChanged {
+                artifact_id: ArtifactId::new("art_test"),
+                from_state: ArtifactState::Draft,
+                to_state: ArtifactState::InProgress,
+            },
+            correlation_id: None,
+            causation_id: None,
+            actor: "test".into(),
+            timestamp: Utc::now(),
+        }
+    }
+}

--- a/crates/onsager-observers/src/store.rs
+++ b/crates/onsager-observers/src/store.rs
@@ -1,0 +1,237 @@
+//! Postgres-backed persistence for [`ObserverOutput`] rows.
+//!
+//! Schema lives at
+//! `crates/onsager-spine/migrations/028_observer_outputs.sql`. One
+//! row per emitted [`ObserverOutput`] — the runtime calls
+//! [`ObserverOutputStore::record`] from inside the per-event task it
+//! spawns, so persistence stays off the substrate scheduler's hot
+//! path.
+//!
+//! The store is deliberately separate from the spine `EventStore`:
+//! observers do not write to `events` / `events_ext` (ADR 0013
+//! "cannot modify state"). Persistence here is one-way — observers
+//! emit, the dashboard reads.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, postgres::PgRow};
+use thiserror::Error;
+
+use crate::output::{ObserverOutput, ObserverOutputKind};
+
+/// A persisted [`ObserverOutput`] row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObserverOutputRecord {
+    pub id: i64,
+    pub observer_id: String,
+    pub kind: ObserverOutputKind,
+    /// `events.id` of the row that triggered this output; `None` for
+    /// outputs not anchored to a specific event (rare — most
+    /// observers should carry the triggering event id).
+    pub triggered_by_event_id: Option<i64>,
+    /// JSON-encoded [`ObserverOutput`] payload.
+    pub payload: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ObserverOutputRecord {
+    /// Parse the JSON payload back into a typed [`ObserverOutput`].
+    pub fn into_output(self) -> Result<ObserverOutput, serde_json::Error> {
+        serde_json::from_value(self.payload)
+    }
+}
+
+impl<'r> sqlx::FromRow<'r, PgRow> for ObserverOutputRecord {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        let kind_str: String = row.try_get("kind")?;
+        let kind = match kind_str.as_str() {
+            "quality_signal" => ObserverOutputKind::QualitySignal,
+            "insight" => ObserverOutputKind::Insight,
+            "alert" => ObserverOutputKind::Alert,
+            other => {
+                return Err(sqlx::Error::ColumnDecode {
+                    index: "kind".into(),
+                    source: Box::new(StoreError::UnknownKind(other.to_string())),
+                });
+            }
+        };
+        Ok(Self {
+            id: row.try_get("id")?,
+            observer_id: row.try_get("observer_id")?,
+            kind,
+            triggered_by_event_id: row.try_get("triggered_by_event_id")?,
+            payload: row.try_get("payload")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
+}
+
+/// Errors returned by the observer-output persistence layer.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error("serializing ObserverOutput failed: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("unknown observer-output kind `{0}` in `observer_outputs.kind` column")]
+    UnknownKind(String),
+}
+
+/// Postgres-backed observer-output store. Cheap to clone.
+#[derive(Clone)]
+pub struct ObserverOutputStore {
+    pool: PgPool,
+}
+
+impl ObserverOutputStore {
+    /// Wrap an existing pool. The pool must point at a database with
+    /// the spine migrations applied (see
+    /// `crates/onsager-spine/migrations/028_observer_outputs.sql`).
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Borrow the underlying pool for advanced reads.
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Persist one [`ObserverOutput`] under `observer_id`, optionally
+    /// linking back to the spine event id that triggered it. Returns
+    /// the assigned row id.
+    pub async fn record(
+        &self,
+        observer_id: &str,
+        triggered_by_event_id: Option<i64>,
+        output: &ObserverOutput,
+    ) -> Result<i64, StoreError> {
+        let payload = serde_json::to_value(output)?;
+        let kind = output.kind().as_str();
+        let row: (i64,) = sqlx::query_as(
+            r#"
+            INSERT INTO observer_outputs (observer_id, kind, triggered_by_event_id, payload)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id
+            "#,
+        )
+        .bind(observer_id)
+        .bind(kind)
+        .bind(triggered_by_event_id)
+        .bind(payload)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    /// List rows for one observer, newest first, capped at `limit`.
+    pub async fn list_by_observer(
+        &self,
+        observer_id: &str,
+        limit: i64,
+    ) -> Result<Vec<ObserverOutputRecord>, StoreError> {
+        let rows = sqlx::query_as::<_, ObserverOutputRecord>(
+            r#"
+            SELECT id, observer_id, kind, triggered_by_event_id, payload, created_at
+            FROM observer_outputs
+            WHERE observer_id = $1
+            ORDER BY id DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(observer_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// List rows for one observer-output kind, newest first, capped
+    /// at `limit`. Useful for the dashboard's "all alerts" view.
+    pub async fn list_by_kind(
+        &self,
+        kind: ObserverOutputKind,
+        limit: i64,
+    ) -> Result<Vec<ObserverOutputRecord>, StoreError> {
+        let rows = sqlx::query_as::<_, ObserverOutputRecord>(
+            r#"
+            SELECT id, observer_id, kind, triggered_by_event_id, payload, created_at
+            FROM observer_outputs
+            WHERE kind = $1
+            ORDER BY id DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(kind.as_str())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Alert, AlertSeverity, Insight};
+    use onsager_artifact::{QualitySignal, QualitySource, QualityValue};
+
+    fn make_quality_signal() -> QualitySignal {
+        QualitySignal {
+            source: QualitySource::IsingInference,
+            dimension: "completeness".into(),
+            value: QualityValue::Score(0.42),
+            recorded_at: Utc::now(),
+            recorded_by: "obs:demo".into(),
+        }
+    }
+
+    /// Roundtrip: ObserverOutputRecord JSON payload <-> ObserverOutput.
+    #[test]
+    fn record_payload_roundtrip_for_each_variant() {
+        let cases = [
+            ObserverOutput::Insight(Insight::new("flaky test", 0.7)),
+            ObserverOutput::Alert(Alert::new("SLA crossed", "boom", AlertSeverity::Warning)),
+            ObserverOutput::QualitySignal(make_quality_signal()),
+        ];
+        for ev in cases {
+            let payload = serde_json::to_value(&ev).unwrap();
+            let back: ObserverOutput = serde_json::from_value(payload).unwrap();
+            assert_eq!(back.kind(), ev.kind());
+        }
+    }
+
+    /// Integration test against a real Postgres. Skipped unless
+    /// `DATABASE_URL` is set — matches the spine listener test.
+    #[tokio::test]
+    async fn record_and_read_back() {
+        let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let pool = sqlx::PgPool::connect(&db_url).await.unwrap();
+        let store = ObserverOutputStore::new(pool.clone());
+
+        let observer_id = format!("test_observer_{}", ulid::Ulid::new());
+        let insight = ObserverOutput::Insight(Insight::new("seed observation", 0.9));
+        // `triggered_by_event_id = None` keeps this unit test
+        // independent of the spine `events` table — the FK on the
+        // column allows NULL exactly for this case.
+        let id = store.record(&observer_id, None, &insight).await.unwrap();
+        assert!(id > 0);
+
+        let rows = store.list_by_observer(&observer_id, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind, ObserverOutputKind::Insight);
+        assert_eq!(rows[0].triggered_by_event_id, None);
+        let parsed = rows[0].clone().into_output().unwrap();
+        assert_eq!(parsed, insight);
+
+        // Cleanup.
+        sqlx::query("DELETE FROM observer_outputs WHERE observer_id = $1")
+            .bind(&observer_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/onsager-observers/tests/runtime_e2e.rs
+++ b/crates/onsager-observers/tests/runtime_e2e.rs
@@ -33,6 +33,7 @@ use onsager_observers::{
     ObserverRuntime, SpineEvent,
 };
 use onsager_spine::{EventMetadata, EventStore, FactoryEvent, FactoryEventKind};
+use tokio::sync::oneshot;
 
 /// Observer that counts events whose payload artifact_id starts with
 /// `tag`. Cross-test isolation is payload-side, not pattern-side,
@@ -165,10 +166,12 @@ async fn observer_receives_matching_event_and_persists_output() {
         },
     );
 
-    let handle = tokio::spawn(async move { runtime.run().await });
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
 
-    // Give the subscription a moment to attach.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Wait for the subscription to actually attach — replaces the
+    // flaky 200ms sleep.
+    ready_rx.await.unwrap();
 
     let event_id = write_artifact_state_changed(&event_store, &tag)
         .await
@@ -229,21 +232,30 @@ async fn observer_ignores_non_matching_event() {
             tag: tag.clone(),
         },
     );
-    let handle = tokio::spawn(async move { runtime.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
 
     let event_id = write_artifact_registered(&event_store, &tag).await.unwrap();
 
-    // Give the runtime time to *not* fire.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    let rows = output_store
-        .list_by_observer(&observer_id, 10)
-        .await
-        .unwrap();
+    // After the runtime is ready and the event has been written,
+    // poll briefly — if the runtime were going to fire wrongly it
+    // would have spawned a task in the same event-loop tick that
+    // pulled the notification off pg_notify, so a short bounded
+    // poll is enough.
+    for _ in 0..3 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let rows = output_store
+            .list_by_observer(&observer_id, 10)
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "non-matching event must not produce output, got: {:?}",
+            rows
+        );
+    }
     handle.abort();
-
-    assert_eq!(rows.len(), 0, "non-matching event must not produce output");
     assert_eq!(
         seen.load(Ordering::SeqCst),
         0,
@@ -275,8 +287,9 @@ async fn slow_observer_does_not_block_event_writer() {
             tag: tag.clone(),
         },
     );
-    let handle = tokio::spawn(async move { runtime.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
 
     // Time how long it takes to write the event onto the spine.
     let writer_start = Instant::now();

--- a/crates/onsager-observers/tests/runtime_e2e.rs
+++ b/crates/onsager-observers/tests/runtime_e2e.rs
@@ -1,0 +1,313 @@
+//! End-to-end runtime tests for `onsager-observers` (issue #361).
+//!
+//! Three scenarios, all of them DATABASE_URL-gated so they no-op in
+//! CI when no Postgres is available:
+//!
+//! 1. **Subscription matches and persists** — a `CountingObserver`
+//!    subscribed to `artifact.*` receives an `artifact.state_changed`
+//!    event end-to-end through the spine and writes one row to
+//!    `observer_outputs`.
+//! 2. **Non-matching events are filtered out** — the same observer
+//!    must NOT see a `node.started` event written to the same spine.
+//! 3. **Observer work does not block the substrate writer** — even
+//!    when the observer blocks for 500ms, the writer that emits the
+//!    event returns immediately (constitutive property 1 from
+//!    ADR 0013).
+//!
+//! Multiple tests run against the same DB; cross-test contamination
+//! is prevented by tagging each test's events with a unique
+//! `artifact_id` prefix and having every observer filter
+//! payload-side on that prefix. Each test's observer only counts /
+//! emits for its own events even when other tests' events stream
+//! past on the shared spine.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use onsager_artifact::{ArtifactId, ArtifactState, Kind};
+use onsager_observers::{
+    EventPattern, Insight, Observer, ObserverOutput, ObserverOutputKind, ObserverOutputStore,
+    ObserverRuntime, SpineEvent,
+};
+use onsager_spine::{EventMetadata, EventStore, FactoryEvent, FactoryEventKind};
+
+/// Observer that counts events whose payload artifact_id starts with
+/// `tag`. Cross-test isolation is payload-side, not pattern-side,
+/// because multiple tests subscribe to the same `artifact.*` channel.
+struct CountingObserver {
+    seen: Arc<AtomicUsize>,
+    sleep_ms: u64,
+    patterns: Vec<EventPattern>,
+    /// Only count / emit for events whose payload's `artifact_id`
+    /// starts with `art_<tag>` (`tag` is the test's per-run ULID).
+    tag: String,
+}
+
+impl CountingObserver {
+    fn payload_matches_tag(&self, ev: &SpineEvent) -> bool {
+        match &ev.payload.event {
+            FactoryEventKind::ArtifactStateChanged { artifact_id, .. }
+            | FactoryEventKind::ArtifactRegistered { artifact_id, .. }
+            | FactoryEventKind::ArtifactArchived { artifact_id, .. } => artifact_id
+                .as_str()
+                .starts_with(&format!("art_{}", self.tag)),
+            _ => false,
+        }
+    }
+}
+
+#[async_trait]
+impl Observer for CountingObserver {
+    fn subscriptions(&self) -> Vec<EventPattern> {
+        self.patterns.clone()
+    }
+
+    async fn on_event(&mut self, ev: &SpineEvent) -> Vec<ObserverOutput> {
+        if !self.payload_matches_tag(ev) {
+            return Vec::new();
+        }
+        if self.sleep_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.sleep_ms)).await;
+        }
+        let n = self.seen.fetch_add(1, Ordering::SeqCst) + 1;
+        vec![ObserverOutput::Insight(Insight::new(
+            format!("seen #{n} from {}", ev.event_type),
+            0.5,
+        ))]
+    }
+}
+
+async fn write_artifact_state_changed(store: &EventStore, tag: &str) -> Result<i64, sqlx::Error> {
+    let event = FactoryEvent {
+        event: FactoryEventKind::ArtifactStateChanged {
+            artifact_id: ArtifactId::new(format!("art_{tag}")),
+            from_state: ArtifactState::Draft,
+            to_state: ArtifactState::InProgress,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: "obs-test".into(),
+        timestamp: Utc::now(),
+    };
+    store
+        .append_factory_event(
+            &event,
+            &EventMetadata {
+                actor: "obs-test".into(),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn write_artifact_registered(store: &EventStore, tag: &str) -> Result<i64, sqlx::Error> {
+    let event = FactoryEvent {
+        event: FactoryEventKind::ArtifactRegistered {
+            artifact_id: ArtifactId::new(format!("art_{tag}")),
+            kind: Kind::Document,
+            name: "obs test".into(),
+            owner: "obs-test".into(),
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: "obs-test".into(),
+        timestamp: Utc::now(),
+    };
+    store
+        .append_factory_event(
+            &event,
+            &EventMetadata {
+                actor: "obs-test".into(),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn cleanup(store: &EventStore, observer_id: &str, event_ids: &[i64]) {
+    let _ = sqlx::query("DELETE FROM observer_outputs WHERE observer_id = $1")
+        .bind(observer_id)
+        .execute(store.pool())
+        .await;
+    if !event_ids.is_empty() {
+        let _ = sqlx::query("DELETE FROM events WHERE id = ANY($1)")
+            .bind(event_ids)
+            .execute(store.pool())
+            .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observer_receives_matching_event_and_persists_output() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let pool = event_store.pool().clone();
+    let output_store = ObserverOutputStore::new(pool.clone());
+
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_e2e_match_{}", tag);
+    let seen = Arc::new(AtomicUsize::new(0));
+
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone()).register(
+        &observer_id,
+        CountingObserver {
+            seen: Arc::clone(&seen),
+            sleep_ms: 0,
+            patterns: vec![EventPattern::new("artifact.*")],
+            tag: tag.clone(),
+        },
+    );
+
+    let handle = tokio::spawn(async move { runtime.run().await });
+
+    // Give the subscription a moment to attach.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let event_id = write_artifact_state_changed(&event_store, &tag)
+        .await
+        .unwrap();
+
+    // Poll for the observer output. Bounded so we fail fast on regression.
+    let mut found = Vec::new();
+    for _ in 0..30 {
+        found = output_store
+            .list_by_observer(&observer_id, 10)
+            .await
+            .unwrap();
+        if !found.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.abort();
+
+    assert_eq!(
+        found.len(),
+        1,
+        "expected exactly one persisted output for matched event"
+    );
+    assert_eq!(found[0].observer_id, observer_id);
+    assert_eq!(found[0].kind, ObserverOutputKind::Insight);
+    assert_eq!(found[0].triggered_by_event_id, Some(event_id));
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "observer saw exactly one event"
+    );
+
+    cleanup(&event_store, &observer_id, &[event_id]).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observer_ignores_non_matching_event() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+
+    // This observer only listens to "node.*"; we send an "artifact.*" event.
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_e2e_filter_{}", tag);
+    let seen = Arc::new(AtomicUsize::new(0));
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone()).register(
+        &observer_id,
+        CountingObserver {
+            seen: Arc::clone(&seen),
+            sleep_ms: 0,
+            patterns: vec![EventPattern::new("node.*")],
+            tag: tag.clone(),
+        },
+    );
+    let handle = tokio::spawn(async move { runtime.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let event_id = write_artifact_registered(&event_store, &tag).await.unwrap();
+
+    // Give the runtime time to *not* fire.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let rows = output_store
+        .list_by_observer(&observer_id, 10)
+        .await
+        .unwrap();
+    handle.abort();
+
+    assert_eq!(rows.len(), 0, "non-matching event must not produce output");
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        0,
+        "observer must not have been invoked"
+    );
+
+    cleanup(&event_store, &observer_id, &[event_id]).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slow_observer_does_not_block_event_writer() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_e2e_slow_{}", tag);
+    let seen = Arc::new(AtomicUsize::new(0));
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone()).register(
+        &observer_id,
+        CountingObserver {
+            seen: Arc::clone(&seen),
+            sleep_ms: 500, // Observer blocks for 500ms per event
+            patterns: vec![EventPattern::new("artifact.*")],
+            tag: tag.clone(),
+        },
+    );
+    let handle = tokio::spawn(async move { runtime.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Time how long it takes to write the event onto the spine.
+    let writer_start = Instant::now();
+    let event_id = write_artifact_state_changed(&event_store, &tag)
+        .await
+        .unwrap();
+    let writer_elapsed = writer_start.elapsed();
+
+    // The writer must return in well under 500ms — observers run in
+    // separate tasks, so the writer never waits on observer work.
+    assert!(
+        writer_elapsed < Duration::from_millis(200),
+        "spine writer was blocked by observer (took {:?})",
+        writer_elapsed
+    );
+
+    // Eventually the (slow) observer completes and persists its output.
+    let mut found = Vec::new();
+    for _ in 0..30 {
+        found = output_store
+            .list_by_observer(&observer_id, 10)
+            .await
+            .unwrap();
+        if !found.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.abort();
+
+    assert_eq!(found.len(), 1, "slow observer eventually completed");
+    cleanup(&event_store, &observer_id, &[event_id]).await;
+}

--- a/crates/onsager-spine/migrations/028_observer_outputs.sql
+++ b/crates/onsager-spine/migrations/028_observer_outputs.sql
@@ -1,0 +1,51 @@
+-- Onsager 0.2 substrate — issue #361 (OBS-01).
+--
+-- ADR 0013 makes Observers the second substrate citizen: they
+-- subscribe to spine events, run analysis off the hot path, and emit
+-- typed outputs (QualitySignal / Insight / Alert) into this table.
+-- Observers cannot write to `events` / `events_ext`; that's the
+-- constitutive "observers audit, not manage" property. This table
+-- is observer-only.
+--
+-- Schema (issue #361 § "Approach"):
+--   - one row per emitted `ObserverOutput`
+--   - `kind` is a closed enum (CHECK constraint) — `quality_signal`,
+--     `insight`, `alert`; matches the Rust `ObserverOutputKind`.
+--   - `triggered_by_event_id` carries the `events.id` of the row
+--     that caused this output, so the dashboard can render
+--     "Insight raised because of event #123". Nullable because some
+--     observers may emit outputs not anchored to a single event (a
+--     periodic summary, an aggregate at flush time). FK with
+--     ON DELETE SET NULL — losing the trigger row drops the link but
+--     keeps the audit trail.
+--   - `payload` is JSONB carrying the full `ObserverOutput` JSON
+--     (including the `kind` discriminator); the runtime's record
+--     path serializes via `serde_json::to_value`.
+--
+-- Pre-launch posture — brand-new table; no backfill obligations.
+
+CREATE TABLE IF NOT EXISTS observer_outputs (
+    id                    BIGSERIAL PRIMARY KEY,
+    observer_id           TEXT NOT NULL,
+    kind                  TEXT NOT NULL
+        CHECK (kind IN ('quality_signal', 'insight', 'alert')),
+    triggered_by_event_id BIGINT
+        REFERENCES events(id) ON DELETE SET NULL,
+    payload               JSONB NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Dashboard reads are dominated by "show me the latest outputs from
+-- observer X" and "show me the latest alerts (any observer)". Both
+-- want id-descending paging.
+CREATE INDEX IF NOT EXISTS observer_outputs_observer_id_id_idx
+    ON observer_outputs (observer_id, id DESC);
+CREATE INDEX IF NOT EXISTS observer_outputs_kind_id_idx
+    ON observer_outputs (kind, id DESC);
+
+-- Triggered-by lookup: "what did observers say about event #X" is
+-- the dashboard's drill-down from the event timeline into the
+-- observer audit trail.
+CREATE INDEX IF NOT EXISTS observer_outputs_triggered_by_event_id_idx
+    ON observer_outputs (triggered_by_event_id)
+    WHERE triggered_by_event_id IS NOT NULL;


### PR DESCRIPTION
## Summary

New `crates/onsager-observers` — the substrate's **second citizen** per [ADR 0013](https://github.com/onsager-ai/onsager/blob/main/docs/adr/0013-observer-as-second-substrate-citizen.md). Observers subscribe to spine events, run analysis off the hot path, and emit typed outputs to a separate `observer_outputs` table without ever mutating spine business state. This is OBS-01: the trait + runtime + persistence; analyzers port in OBS-02 (#362).

### Surface

- **`Observer` trait** — `subscriptions()` returns `Vec<EventPattern>`, `on_event(&mut self, &SpineEvent) -> Vec<ObserverOutput>`. Stateful per instance; runtime serializes calls to one observer behind a `tokio::sync::Mutex`, different observers run fully in parallel.
- **`SpineEvent`** — the event shape `on_event` sees: parsed `FactoryEvent` payload, the wire `event_type` string, the `events.id` of the triggering row (so emitted outputs link back), and the row's `created_at`.
- **`EventPattern`** — simple glob: `"*"`, `"<prefix>.*"`, or exact match. No regex (per the issue's v1 scope: "Full regex is not needed in v1"). The prefix variant respects the dot boundary — `node.*` does not match `nodemap.foo`.
- **`ObserverOutput`** — closed enum of the three substrate-recognized output shapes: `QualitySignal` (reused from `onsager-artifact` so audit-side signals share the lifecycle shape), `Insight` (observation + confidence + evidence event-ids), `Alert` (severity-banded).
- **`ObserverRuntime`** — subscribes via `EventStore::subscribe()`, fetches the full `FactoryEvent` from `events` for each notification, and fans out to matching observers via `tokio::spawn` per `(observer, event)` so a slow observer never blocks another observer or the substrate scheduler (constitutive property 1 of ADR 0013).
- **`ObserverOutputStore`** — Postgres-backed persistence keyed off migration `028_observer_outputs.sql`. FK on the trigger event id (`ON DELETE SET NULL` — losing the trigger row drops the link but keeps the audit trail). Two id-desc indexes for the dashboard's two read patterns: by-observer and by-kind.

### Constitutive properties (ADR 0013)

The crate enforces all four observer properties mechanically, not by convention:

1. **Non-blocking** — `ObserverRuntime::run` `tokio::spawn`s per `(observer, event)`; the writer that emits the event returns immediately (verified by `slow_observer_does_not_block_event_writer`).
2. **Cannot modify state** — observers do not have a handle to the spine `EventStore`. The only writer surface is `ObserverOutputStore`, which targets a *separate* table from spine business events.
3. **Spine is the input** — the runtime is wired exclusively to `EventStore::subscribe`; there is no private coordination channel.
4. **Output is typed** — `ObserverOutput` is a closed enum.

## Test plan

- [x] `cargo test -p onsager-observers --lib` — 16 unit tests (pattern matching, output round-trips, in-process dispatch).
- [x] `cargo test -p onsager-observers` with `DATABASE_URL` set — 3 runtime e2e tests pass in parallel:
  - `observer_receives_matching_event_and_persists_output` — `artifact.*` observer receives an `artifact.state_changed` event end-to-end through spine `pg_notify` and writes one row to `observer_outputs` with `triggered_by_event_id` set.
  - `observer_ignores_non_matching_event` — `node.*` observer sees an `artifact.registered` event arrive and does not invoke `on_event` or persist.
  - `slow_observer_does_not_block_event_writer` — observer sleeps 500ms per event; `append_factory_event` returns in <200ms, output eventually persists.
  - Cross-test contamination is prevented by payload-tagging on a per-test ULID; tests run safely in parallel against the shared DB.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo run -p xtask -- check-events` clean (54 events, 3 subsystems scanned).
- [x] `cargo run -p xtask -- lint-seams` clean.
- [x] `cargo run -p xtask -- check-api-contract` clean.
- [x] `cargo run -p xtask -- check-file-budget --mode=fail` clean (all new files well under 8000 tokens: runtime.rs 1721, output.rs 1547, e2e tests 2598).
- [x] `cargo run -p xtask -- gen-event-docs --check` in sync.
- [x] `cargo test --workspace --exclude onsager-spine --exclude stiglab` — all pass.
- [x] `cargo test -p onsager-spine -- --test-threads=1` with `DATABASE_URL` set — all 81 pass with migration 028 applied.

## Notes

- **Event manifest unchanged.** The substrate events that will become observer-consumed (`node.*`, `agent.session_*`, `synodic.verdict`) are still `diagnostic_only: true` in `onsager-registry::EVENTS` with the literal note "Observer consumer arrives with OBS-01 (#361)". Flipping each entry's `diagnostic_only` is per-analyzer work; that happens in OBS-02 (#362) when the actual `Observer` impls land and the lint can verify the listener call sites exist. Touching the manifest here without a real consumer would just trade one dangling wire for another.
- **No `Subsystem::Observer` added.** Same reason — the registry's `Subsystem` enum names entities that *produce or consume* spine events. Until an actual observer crate ships in OBS-02, there's nothing to register.
- **`triggered_by_event_id` is nullable** with `ON DELETE SET NULL`. Some observers may emit summary outputs not anchored to a single event (periodic aggregates); losing the trigger row drops the link but keeps the audit trail. The runtime's per-event dispatch always populates it.
- Branch name says `implement-issue-360` but this is in fact `#361` (OBS-01); #360 was already merged in PR #385.

Closes #361

---
_Generated by [Claude Code](https://claude.ai/code/session_01E79Vh61JarQSn9V6Upmbmq)_