### PR TITLE
feat(scheduler): host the substrate scheduler in a deployed binary (RUN-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap",
  "onsager-artifact",
  "onsager-nodes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "onsager-scheduler"
+version = "0.2.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "onsager-artifact",
+ "onsager-nodes",
+ "onsager-spine",
+ "onsager-substrate",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "onsager-spine"
 version = "0.2.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",
+    "crates/onsager-scheduler",
     "crates/onsager-trigger",
     "crates/ising",
     "crates/stiglab",

--- a/crates/onsager-scheduler/Cargo.toml
+++ b/crates/onsager-scheduler/Cargo.toml
@@ -31,4 +31,5 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+chrono = { workspace = true }
 tokio = { workspace = true }

--- a/crates/onsager-scheduler/Cargo.toml
+++ b/crates/onsager-scheduler/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "onsager-scheduler"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Deployed substrate-scheduler host (RUN-03, #386) — bridges trigger.fired → Plan Compiler → Scheduler."
+
+[[bin]]
+name = "onsager-scheduler"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+onsager-artifact = { path = "../onsager-artifact" }
+onsager-nodes    = { path = "../onsager-nodes" }
+onsager-spine    = { path = "../onsager-spine" }
+onsager-substrate = { path = "../onsager-substrate" }
+
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/onsager-scheduler/src/bridge.rs
+++ b/crates/onsager-scheduler/src/bridge.rs
@@ -1,0 +1,443 @@
+//! [`TriggerBridge`] — turns a `trigger.fired` payload into one
+//! [`ExecutionPlan`] run.
+//!
+//! ## v1 contract
+//!
+//! The bridge resolves the workflow `spec_kind` from the trigger
+//! event in two steps:
+//!
+//! 1. The trigger payload may carry an explicit `"spec_kind": "..."`
+//!    field. When present, this wins. Manual fires
+//!    (`onsager trigger fire ... --payload '{"spec_kind": "..."}'`)
+//!    use this path today.
+//! 2. Otherwise, the bridge falls back to the workflow row's
+//!    `preset_id` (per `crates/onsager-spine/migrations/006_workflows.sql`).
+//!    Workflows created via a portal preset (`github-issue-to-pr`)
+//!    carry one; webhook-fired workflows that don't pin a preset
+//!    fall through to a structured warning and the event is dropped.
+//!
+//! The resolved `spec_kind` is looked up in the Workflow Library
+//! (SUB-04, #351). A missing kind is also a structured warning —
+//! the v1 contract is "best-effort dispatch": one drift between the
+//! trigger emitter and the library is logged loudly, not silently
+//! retried. Bringing the bridge to first-class status (workflow row
+//! gains a `spec_kind` column, manifest-driven dispatch) is a
+//! follow-up rather than part of RUN-03.
+//!
+//! ## Single-spec SpecPlan
+//!
+//! v1 builds a one-element [`SpecPlan`] per trigger: the resolved
+//! `spec_kind` is the spec's `kind`, and its id is derived from the
+//! workflow id. Multi-spec orchestration (Refract producing a
+//! many-spec plan) is a layer above this bridge — when it lands, it
+//! will hand the bridge a pre-built [`SpecPlan`] instead.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use onsager_nodes::{InMemoryPlanStore, PlanId, PlanStore, Scheduler, SchedulerError, SpineClient};
+use onsager_substrate::compiler::{CompileError, compile};
+use onsager_substrate::ids::WorkflowId;
+use onsager_substrate::library::WorkflowLibrary as WorkflowLookup;
+use onsager_substrate::spec_plan::{SpecId, SpecPlan, SpecRef};
+use onsager_substrate::workflow::Workflow;
+use serde_json::Value;
+use thiserror::Error;
+
+/// Outcome of running [`TriggerBridge::handle_payload`].
+#[derive(Debug, Error)]
+pub enum TriggerBridgeError {
+    /// The trigger payload did not name a `spec_kind` and no fallback
+    /// resolved one. The event is dropped with a structured log.
+    #[error(
+        "trigger payload missing spec_kind for workflow `{workflow_id}` (no payload field, no preset fallback)"
+    )]
+    UnresolvedSpecKind { workflow_id: String },
+
+    /// No workflow registered under the resolved kind.
+    #[error("no workflow registered for spec_kind `{kind}` (workflow `{workflow_id}`)")]
+    MissingKind { workflow_id: String, kind: String },
+
+    /// Compile-step failure — Spec Plan invalid, kernel invariant
+    /// violated, etc.
+    #[error("compile failed for workflow `{workflow_id}` (kind `{kind}`): {source}")]
+    Compile {
+        workflow_id: String,
+        kind: String,
+        #[source]
+        source: CompileError,
+    },
+
+    /// Scheduler-step failure — a node failed, the plan got stuck.
+    #[error("scheduler failed for workflow `{workflow_id}` (kind `{kind}`): {source}")]
+    Scheduler {
+        workflow_id: String,
+        kind: String,
+        #[source]
+        source: SchedulerError,
+    },
+}
+
+/// Source of a workflow's `spec_kind` for an incoming trigger. The
+/// service layer fetches one of these per `trigger.fired` workflow id;
+/// the bridge consumes it without touching the DB itself so tests
+/// drive the same control-flow as production.
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowMeta {
+    /// `preset_id` from the workflow row, when present. Used as the
+    /// fallback `spec_kind` when the trigger payload omits one.
+    pub preset_id: Option<String>,
+}
+
+/// Stateless bridge: trigger payload + workflow library → one
+/// executed plan.
+///
+/// Holds the scheduler-side wiring (registry, store, spine) once at
+/// construction time; each call to [`Self::handle_payload`] builds a
+/// fresh [`PlanId`] and runs the resolved plan through
+/// [`Scheduler::run`].
+#[derive(Clone)]
+pub struct TriggerBridge {
+    registry: Arc<onsager_nodes::ExecutorRegistry>,
+    spine: Arc<dyn SpineClient>,
+}
+
+impl std::fmt::Debug for TriggerBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TriggerBridge").finish_non_exhaustive()
+    }
+}
+
+impl TriggerBridge {
+    pub fn new(
+        registry: Arc<onsager_nodes::ExecutorRegistry>,
+        spine: Arc<dyn SpineClient>,
+    ) -> Self {
+        Self { registry, spine }
+    }
+
+    /// Run a single trigger.fired payload to completion.
+    ///
+    /// `workflow_id` is the spine workflow id from the
+    /// `FactoryEventKind::TriggerFired` envelope. `payload` is the
+    /// raw JSON the trigger emitter attached. `meta` carries
+    /// optional fallback data the service layer fetched from the
+    /// `workflows` row. `library` resolves the chosen `spec_kind`
+    /// to a [`Workflow`] template.
+    pub async fn handle_payload(
+        &self,
+        workflow_id: &str,
+        payload: &Value,
+        meta: &WorkflowMeta,
+        library: impl WorkflowLookupOwned,
+    ) -> Result<PlanId, TriggerBridgeError> {
+        let kind = resolve_spec_kind(payload, meta).ok_or_else(|| {
+            TriggerBridgeError::UnresolvedSpecKind {
+                workflow_id: workflow_id.to_string(),
+            }
+        })?;
+
+        let workflow =
+            library
+                .by_kind_owned(&kind)
+                .ok_or_else(|| TriggerBridgeError::MissingKind {
+                    workflow_id: workflow_id.to_string(),
+                    kind: kind.clone(),
+                })?;
+        let spec_plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new(format!("workflow:{workflow_id}")),
+                kind: kind.clone(),
+                inputs: Default::default(),
+            }],
+            deps: vec![],
+        };
+        let single = SingleWorkflowLookup::new(kind.clone(), workflow);
+        let exec_plan =
+            compile(&spec_plan, &single).map_err(|source| TriggerBridgeError::Compile {
+                workflow_id: workflow_id.to_string(),
+                kind: kind.clone(),
+                source,
+            })?;
+
+        let store: Arc<dyn PlanStore> = Arc::new(InMemoryPlanStore::new());
+        let scheduler = Scheduler::new(Arc::clone(&self.registry), store, Arc::clone(&self.spine));
+        let plan_id = PlanId::generate();
+        scheduler
+            .run(&plan_id, &exec_plan)
+            .await
+            .map_err(|source| TriggerBridgeError::Scheduler {
+                workflow_id: workflow_id.to_string(),
+                kind,
+                source,
+            })?;
+        Ok(plan_id)
+    }
+}
+
+/// Lookup surface the bridge needs: take a kind, give back an owned
+/// [`Workflow`] value (the persisted [`WorkflowLibrary`] returns by
+/// value because it deserializes per-call from JSONB).
+pub trait WorkflowLookupOwned {
+    fn by_kind_owned(&self, kind: &str) -> Option<Workflow>;
+}
+
+/// Adapter exposing a single owned [`Workflow`] under one `spec_kind`
+/// to the Plan Compiler's reference-borrowing [`WorkflowLookup`]
+/// trait. Built fresh per trigger so the borrow stays scoped.
+struct SingleWorkflowLookup {
+    kind: String,
+    workflow: Workflow,
+    subworkflows: HashMap<WorkflowId, Workflow>,
+}
+
+impl SingleWorkflowLookup {
+    fn new(kind: String, workflow: Workflow) -> Self {
+        Self {
+            kind,
+            workflow,
+            subworkflows: HashMap::new(),
+        }
+    }
+}
+
+impl WorkflowLookup for SingleWorkflowLookup {
+    fn get(&self, id: WorkflowId) -> Option<&Workflow> {
+        self.subworkflows.get(&id)
+    }
+    fn by_kind(&self, kind: &str) -> Option<&Workflow> {
+        if kind == self.kind {
+            Some(&self.workflow)
+        } else {
+            None
+        }
+    }
+}
+
+/// Service-layer helper: same resolution logic as the bridge uses
+/// internally, exposed so the listener can prefetch the workflow
+/// before calling [`TriggerBridge::handle_payload`]. Returning the
+/// chosen kind here (instead of re-running the logic inside the
+/// bridge) keeps the v1 resolution rule single-sourced.
+pub fn resolve_spec_kind_for_logging(payload: &Value, meta: &WorkflowMeta) -> Option<String> {
+    resolve_spec_kind(payload, meta)
+}
+
+/// Pick a `spec_kind` from the trigger payload, falling back to the
+/// workflow row's `preset_id`. Returns `None` when neither resolves —
+/// the caller surfaces that as [`TriggerBridgeError::UnresolvedSpecKind`].
+fn resolve_spec_kind(payload: &Value, meta: &WorkflowMeta) -> Option<String> {
+    if let Some(s) = payload.get("spec_kind").and_then(Value::as_str)
+        && !s.is_empty()
+    {
+        return Some(s.to_string());
+    }
+    meta.preset_id.clone().filter(|s| !s.is_empty())
+}
+
+// Convenience for tests / production: implement the lookup-by-value
+// trait directly on the persisted struct.
+impl WorkflowLookupOwned for onsager_substrate::workflow_library::WorkflowLibrary {
+    fn by_kind_owned(&self, _kind: &str) -> Option<Workflow> {
+        // The persisted library is async; the sync surface here is
+        // for the unit tests and the in-process bridge. The service
+        // layer fetches the workflow via the async `lookup` first
+        // and passes a [`PreloadedWorkflow`] adapter (below) to the
+        // bridge — never calling this method.
+        None
+    }
+}
+
+/// Adapter the service layer uses: it fetches the workflow once via
+/// the async [`onsager_substrate::workflow_library::WorkflowLibrary::lookup`]
+/// and hands the result to the bridge through this sync wrapper.
+pub struct PreloadedWorkflow {
+    pub kind: String,
+    pub workflow: Option<Workflow>,
+}
+
+impl WorkflowLookupOwned for PreloadedWorkflow {
+    fn by_kind_owned(&self, kind: &str) -> Option<Workflow> {
+        if kind == self.kind {
+            // The workflow is moved into the lookup once; subsequent
+            // calls would have to clone. The bridge calls once per
+            // trigger so a `take` shape would also work, but using
+            // serde round-trip here keeps the method `&self`.
+            self.workflow.as_ref().and_then(|w| {
+                serde_json::to_value(w)
+                    .ok()
+                    .and_then(|v| serde_json::from_value(v).ok())
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use onsager_artifact::{Artifact, ArtifactId, NodeId, Provenance};
+    use onsager_nodes::{Executor, ExecutorContext, ExecutorError, ExecutorOutputs, SpineError};
+    use onsager_substrate::ids::EdgeId;
+    use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec};
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct CapturingSpine {
+        emitted: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl SpineClient for CapturingSpine {
+        async fn emit(&self, kind: &str, _: serde_json::Value) -> Result<(), SpineError> {
+            self.emitted.lock().unwrap().push(kind.to_string());
+            Ok(())
+        }
+        async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+            Ok(None)
+        }
+    }
+
+    /// Echo executor — produces one declared artifact per call so the
+    /// scheduler reports a node.completed with output_artifact_ids.
+    #[derive(Debug)]
+    struct EchoExecutor;
+
+    #[async_trait]
+    impl Executor for EchoExecutor {
+        fn executor_kind(&self) -> &'static str {
+            "noop"
+        }
+        fn declared_provenance(&self, _: &[Provenance]) -> Provenance {
+            Provenance::external_deterministic()
+        }
+        async fn execute(&self, _: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+            let art = Artifact::new(
+                onsager_artifact::Kind::Document,
+                "trigger-output",
+                "marvin",
+                "scheduler",
+                vec![],
+            );
+            let id = art.artifact_id.clone();
+            Ok(ExecutorOutputs::single(id, art))
+        }
+    }
+
+    fn passthrough_workflow() -> Workflow {
+        let entry = EdgeId::generate();
+        let exit = EdgeId::generate();
+        Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+                inputs: vec![EdgeRef::new(entry)],
+                outputs: vec![EdgeRef::new(exit)],
+            }],
+            edges: vec![
+                Edge {
+                    id: entry,
+                    artifact_id: ArtifactId::new("trigger-in"),
+                    requires_deterministic: false,
+                },
+                Edge {
+                    id: exit,
+                    artifact_id: ArtifactId::new("trigger-out"),
+                    requires_deterministic: false,
+                },
+            ],
+            entry_specs: vec![EntrySpec { edge_id: entry }],
+            output_specs: vec![OutputSpec {
+                edge_id: exit,
+                provenance: Provenance::external_deterministic(),
+            }],
+        }
+    }
+
+    fn build_bridge() -> (TriggerBridge, Arc<CapturingSpine>) {
+        let mut registry = onsager_nodes::ExecutorRegistry::new();
+        registry.register(Arc::new(EchoExecutor));
+        let spine = Arc::new(CapturingSpine::default());
+        let bridge = TriggerBridge::new(
+            Arc::new(registry),
+            Arc::clone(&spine) as Arc<dyn SpineClient>,
+        );
+        (bridge, spine)
+    }
+
+    #[tokio::test]
+    async fn payload_spec_kind_drives_run() {
+        let (bridge, spine) = build_bridge();
+        let payload = serde_json::json!({ "spec_kind": "echo" });
+        let lookup = PreloadedWorkflow {
+            kind: "echo".to_string(),
+            workflow: Some(passthrough_workflow()),
+        };
+        bridge
+            .handle_payload("wf-1", &payload, &WorkflowMeta::default(), lookup)
+            .await
+            .expect("happy path runs the scheduler to completion");
+
+        let emitted = spine.emitted.lock().unwrap().clone();
+        assert!(
+            emitted.iter().any(|k| k == "node.started"),
+            "expected node.started emit, got {emitted:?}",
+        );
+        assert!(
+            emitted.iter().any(|k| k == "node.completed"),
+            "expected node.completed emit, got {emitted:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn preset_id_falls_back_when_payload_omits_kind() {
+        let (bridge, _) = build_bridge();
+        let payload = serde_json::json!({});
+        let meta = WorkflowMeta {
+            preset_id: Some("echo".to_string()),
+        };
+        let lookup = PreloadedWorkflow {
+            kind: "echo".to_string(),
+            workflow: Some(passthrough_workflow()),
+        };
+        bridge
+            .handle_payload("wf-2", &payload, &meta, lookup)
+            .await
+            .expect("preset fallback runs");
+    }
+
+    #[tokio::test]
+    async fn unresolved_spec_kind_surfaces_as_error() {
+        let (bridge, _) = build_bridge();
+        let payload = serde_json::json!({});
+        let lookup = PreloadedWorkflow {
+            kind: "never-asked".to_string(),
+            workflow: Some(passthrough_workflow()),
+        };
+        let err = bridge
+            .handle_payload("wf-3", &payload, &WorkflowMeta::default(), lookup)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TriggerBridgeError::UnresolvedSpecKind { .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_kind_surfaces_as_error() {
+        let (bridge, _) = build_bridge();
+        let payload = serde_json::json!({ "spec_kind": "echo" });
+        let lookup = PreloadedWorkflow {
+            kind: "different-kind".to_string(),
+            workflow: Some(passthrough_workflow()),
+        };
+        let err = bridge
+            .handle_payload("wf-4", &payload, &WorkflowMeta::default(), lookup)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, TriggerBridgeError::MissingKind { ref kind, .. } if kind == "echo"),
+            "expected MissingKind(echo), got {err:?}",
+        );
+    }
+}

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -1,0 +1,42 @@
+//! # onsager-scheduler
+//!
+//! Deployed host for the substrate scheduler (RUN-03, #386). Owns the
+//! process-level wiring the library-only [`onsager_nodes::Scheduler`]
+//! does not: a spine-backed [`SpineClient`], a long-running `Listener`
+//! that watches the spine for `trigger.fired` events, and the
+//! [`bridge`] adapter that turns each fire into a compiled
+//! [`onsager_substrate::compiler::ExecutionPlan`] handed to
+//! [`onsager_nodes::Scheduler::run`].
+//!
+//! ## Why this crate exists
+//!
+//! Per ADR 0009 the 0.2 substrate replaces the 0.1 Forge tick loop:
+//! coordination flows Spec Plan → Workflow → Execution Plan →
+//! substrate scheduler. RUN-01 (#359) landed the in-process scheduler
+//! library; MIG-01 (#363) deleted the forge subsystem that *used* to
+//! consume `trigger.fired`. The gap between "library exists" and
+//! "deployed binary consuming the spine" is what this crate closes.
+//!
+//! ## Host shape
+//!
+//! A dedicated binary, not a task colocated inside another subsystem:
+//!
+//! - The `onsager` dispatcher commits to **zero business deps** (see
+//!   `crates/onsager/Cargo.toml`); a substrate-scheduler task there
+//!   would force every dispatcher rebuild to recompile the executor
+//!   catalog. The dispatcher discovers `onsager-scheduler` on PATH
+//!   like every other subsystem binary.
+//! - `onsager-portal` is the **edge** subsystem (ADR 0006). The
+//!   scheduler has no external HTTP surface; hosting it inside
+//!   portal would conflate edge and runtime concerns.
+//!
+//! The binary obeys the seam rule: it depends on substrate / nodes /
+//! spine / artifact only — never on a sibling subsystem crate.
+
+pub mod bridge;
+pub mod service;
+pub mod spine_client;
+
+pub use bridge::{TriggerBridge, TriggerBridgeError};
+pub use service::{SchedulerService, ServiceConfig};
+pub use spine_client::SpineEventStoreClient;

--- a/crates/onsager-scheduler/src/main.rs
+++ b/crates/onsager-scheduler/src/main.rs
@@ -1,0 +1,66 @@
+//! `onsager-scheduler` — substrate scheduler host binary (RUN-03,
+//! #386). Listens on the spine for `trigger.fired`, compiles each
+//! fire's workflow into an [`ExecutionPlan`], and runs it through
+//! [`onsager_nodes::Scheduler`].
+//!
+//! Entrypoint shape mirrors the other subsystem binaries: a single
+//! `serve` subcommand under clap. The dispatcher (`crates/onsager/`)
+//! resolves this binary on PATH like every other subsystem.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use onsager_scheduler::{SchedulerService, ServiceConfig};
+
+#[derive(Parser)]
+#[command(
+    name = "onsager-scheduler",
+    about = "Substrate scheduler host (RUN-03, #386)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Run the scheduler service: subscribe to the spine, drive
+    /// trigger.fired through the bridge.
+    Serve(ServeArgs),
+}
+
+#[derive(clap::Args)]
+struct ServeArgs {
+    /// Postgres connection URL.
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+    /// Actor stamped on spine emits. Defaults to "substrate-scheduler".
+    #[arg(long, env = "SCHEDULER_ACTOR", default_value = "substrate-scheduler")]
+    actor: String,
+    /// Replay every historical `trigger.fired` on startup. Off by
+    /// default — surgical re-fires use `onsager trigger replay`.
+    #[arg(long, env = "SCHEDULER_REPLAY_HISTORY", default_value_t = false)]
+    replay_history: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("onsager_scheduler=info")),
+        )
+        .compact()
+        .init();
+
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::Serve(args) => {
+            let config = ServiceConfig {
+                database_url: args.database_url,
+                actor: args.actor,
+                replay_history: args.replay_history,
+            };
+            SchedulerService::new(config).run().await
+        }
+    }
+}

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -1,0 +1,244 @@
+//! [`SchedulerService`] — long-running task that subscribes to the
+//! spine and drives [`TriggerBridge`] on every `trigger.fired` event.
+//!
+//! The service is the binary's main loop. It:
+//!
+//! 1. Connects to the spine (sqlx via [`EventStore`]) and to the
+//!    persisted [`onsager_substrate::workflow_library::WorkflowLibrary`].
+//! 2. Subscribes a [`Listener`] to the `workflow` namespace (where
+//!    `trigger.fired` events stream) with a `with_since` cursor that
+//!    starts from the current tail — production replays prior fires
+//!    only when explicitly asked, not on every restart.
+//! 3. Dispatches each `trigger.fired` notification through
+//!    [`TriggerBridge::handle_payload`]. Failures log and continue
+//!    (one bad trigger does not stop the loop).
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use onsager_nodes::{ExecutorRegistry, NoOpExecutor, SpineClient};
+use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener, Namespace};
+use onsager_substrate::workflow_library::WorkflowLibrary as PersistedWorkflowLibrary;
+use sqlx::Row;
+
+use crate::bridge::{PreloadedWorkflow, TriggerBridge, WorkflowMeta};
+use crate::spine_client::SpineEventStoreClient;
+
+/// Configuration the service reads from env / CLI.
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    /// Postgres connection URL — `$DATABASE_URL` in env-driven
+    /// deployments.
+    pub database_url: String,
+    /// Actor stamped on every spine emit. Defaults to
+    /// `"substrate-scheduler"`.
+    pub actor: String,
+    /// When `true`, replay every historical `trigger.fired` event on
+    /// startup. Defaults to `false` — the typical container restart
+    /// resumes "live only", and replays use `onsager trigger replay`
+    /// for surgical re-fires.
+    pub replay_history: bool,
+}
+
+impl Default for ServiceConfig {
+    fn default() -> Self {
+        Self {
+            database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+            actor: "substrate-scheduler".to_string(),
+            replay_history: false,
+        }
+    }
+}
+
+/// The deployed scheduler service.
+pub struct SchedulerService {
+    config: ServiceConfig,
+    /// Optional executor registry override — production builds use
+    /// the default (NoOp + the catalog the binary registers); tests
+    /// inject a custom registry via `with_registry`.
+    registry: Option<Arc<ExecutorRegistry>>,
+}
+
+impl SchedulerService {
+    pub fn new(config: ServiceConfig) -> Self {
+        Self {
+            config,
+            registry: None,
+        }
+    }
+
+    /// Inject a custom [`ExecutorRegistry`]. Used by tests; binary
+    /// builds rely on the default registry that
+    /// [`default_executor_registry`] returns.
+    pub fn with_registry(mut self, registry: Arc<ExecutorRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Connect to the spine, build the bridge, and run the listener
+    /// loop. Returns only when the listener loop terminates (the
+    /// `pg_notify` channel closes).
+    pub async fn run(self) -> anyhow::Result<()> {
+        let store = EventStore::connect(&self.config.database_url)
+            .await
+            .with_context(|| format!("connecting to {}", self.config.database_url))?;
+        let library = PersistedWorkflowLibrary::new(store.pool().clone());
+        let spine: Arc<dyn SpineClient> = Arc::new(SpineEventStoreClient::new(
+            store.clone(),
+            &self.config.actor,
+        ));
+        let registry = self
+            .registry
+            .unwrap_or_else(|| Arc::new(default_executor_registry()));
+        let bridge = TriggerBridge::new(registry, spine);
+        let handler = TriggerHandler {
+            bridge,
+            library,
+            store: store.clone(),
+        };
+
+        // Default: live-only. `replay_history = true` rewinds to id=0
+        // so the listener replays every prior trigger.fired event.
+        let since = if self.config.replay_history {
+            Some(0)
+        } else {
+            store.max_event_id().await.context("reading spine cursor")?
+        };
+
+        let listener = Listener::new(store)
+            .subscribe(Namespace::workflow())
+            .with_since(since);
+        tracing::info!(
+            actor = %self.config.actor,
+            replay = self.config.replay_history,
+            "substrate scheduler listening for trigger.fired",
+        );
+        listener.run(handler).await?;
+        Ok(())
+    }
+}
+
+/// Build the default registry the deployed binary uses.
+///
+/// v1 registers only [`NoOpExecutor`]. Script / Verify / Agent /
+/// SubWorkflow are wired through the registry by `executor_kind`,
+/// but the dispatch path (`onsager_nodes::dispatch`) runs the
+/// *registered* instance — not the node's per-instance config (see
+/// dispatch.rs and the RUN-02 follow-up note in `crawlab_fixture.rs`).
+/// Until per-node config threading lands, registering a singleton
+/// ScriptExecutor with no command would dispatch every script node
+/// through that empty config — silently wrong. Registering only NoOp
+/// means non-NoOp nodes fail with [`ExecutorError::UnknownKind`],
+/// which is the correct loud failure; tests inject a richer registry
+/// via [`SchedulerService::with_registry`].
+pub fn default_executor_registry() -> ExecutorRegistry {
+    let mut r = ExecutorRegistry::new();
+    r.register(Arc::new(NoOpExecutor));
+    r
+}
+
+/// Spine [`EventHandler`] that dispatches `trigger.fired` events
+/// through the bridge.
+struct TriggerHandler {
+    bridge: TriggerBridge,
+    library: PersistedWorkflowLibrary,
+    store: EventStore,
+}
+
+#[async_trait]
+impl EventHandler for TriggerHandler {
+    async fn handle(&self, event: EventNotification) -> anyhow::Result<()> {
+        if event.event_type != "trigger.fired" {
+            return Ok(());
+        }
+        // Pull the row's data column so we can decode the typed
+        // payload. Notifications carry only stream_id + event_type;
+        // the body lives on `events_ext`.
+        let row = sqlx::query("SELECT data FROM events_ext WHERE id = $1")
+            .bind(event.id)
+            .fetch_optional(self.store.pool())
+            .await
+            .context("loading trigger.fired body")?;
+        let Some(row) = row else { return Ok(()) };
+        let data: serde_json::Value = row.try_get("data")?;
+        let kind = match decode_trigger_fired(&data) {
+            Some(k) => k,
+            None => {
+                tracing::warn!(
+                    event_id = event.id,
+                    "trigger.fired body did not decode as TriggerFired"
+                );
+                return Ok(());
+            }
+        };
+        let FactoryEventKind::TriggerFired {
+            workflow_id,
+            trigger_kind: _,
+            payload,
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        let meta = load_workflow_meta(&self.store, &workflow_id).await?;
+        let spec_kind = crate::bridge::resolve_spec_kind_for_logging(&payload, &meta);
+        let workflow = match spec_kind.as_deref() {
+            Some(kind) => self
+                .library
+                .lookup(kind)
+                .await
+                .with_context(|| format!("library lookup for kind `{kind}`"))?,
+            None => None,
+        };
+        let lookup = PreloadedWorkflow {
+            kind: spec_kind.clone().unwrap_or_default(),
+            workflow,
+        };
+        match self
+            .bridge
+            .handle_payload(&workflow_id, &payload, &meta, lookup)
+            .await
+        {
+            Ok(plan_id) => tracing::info!(
+                event_id = event.id,
+                %workflow_id,
+                plan_id = %plan_id,
+                "trigger.fired dispatched",
+            ),
+            Err(e) => tracing::warn!(
+                event_id = event.id,
+                %workflow_id,
+                "trigger.fired dispatch failed: {e}",
+            ),
+        }
+        Ok(())
+    }
+}
+
+/// Extract `FactoryEventKind::TriggerFired` from an `events_ext.data`
+/// column. The column may carry either the bare kind or the
+/// [`FactoryEvent`] envelope (per `onsager_trigger`'s precedent).
+fn decode_trigger_fired(data: &serde_json::Value) -> Option<FactoryEventKind> {
+    if let Ok(env) = serde_json::from_value::<FactoryEvent>(data.clone()) {
+        return Some(env.event);
+    }
+    serde_json::from_value::<FactoryEventKind>(data.clone()).ok()
+}
+
+/// Pull the workflow row's preset_id so the bridge can fall back to
+/// it. A missing workflow row produces an empty `WorkflowMeta`; the
+/// bridge then surfaces `UnresolvedSpecKind` to the caller.
+async fn load_workflow_meta(store: &EventStore, workflow_id: &str) -> anyhow::Result<WorkflowMeta> {
+    let row = sqlx::query("SELECT preset_id FROM workflows WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .fetch_optional(store.pool())
+        .await
+        .context("loading workflow meta")?;
+    let Some(row) = row else {
+        return Ok(WorkflowMeta::default());
+    };
+    let preset_id: Option<String> = row.try_get("preset_id").ok();
+    Ok(WorkflowMeta { preset_id })
+}

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -5,13 +5,18 @@
 //!
 //! 1. Connects to the spine (sqlx via [`EventStore`]) and to the
 //!    persisted [`onsager_substrate::workflow_library::WorkflowLibrary`].
-//! 2. Subscribes a [`Listener`] to the `workflow` namespace (where
-//!    `trigger.fired` events stream) with a `with_since` cursor that
-//!    starts from the current tail — production replays prior fires
-//!    only when explicitly asked, not on every restart.
-//! 3. Dispatches each `trigger.fired` notification through
-//!    [`TriggerBridge::handle_payload`]. Failures log and continue
-//!    (one bad trigger does not stop the loop).
+//! 2. Subscribes an unfiltered [`Listener`] with a `with_since`
+//!    cursor that starts from the current `events_ext` tail (live
+//!    only on a normal restart). The handler filters by `event_type
+//!    == "trigger.fired"` after the notification arrives — the
+//!    stream-id-prefix filter the listener offers can't be trusted
+//!    here because trigger.fired producers don't all share a
+//!    stream-id prefix (see `crates/onsager-portal/src/mcp/tools/
+//!    workflows.rs`).
+//! 3. Dispatches each `trigger.fired` notification through a per-
+//!    fire [`TriggerBridge`] scoped to the workflow's
+//!    `workspace_id`. Failures log and continue (one bad trigger
+//!    does not stop the loop).
 
 use std::sync::Arc;
 
@@ -19,7 +24,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use onsager_nodes::{ExecutorRegistry, NoOpExecutor, SpineClient};
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
-use onsager_spine::{EventHandler, EventNotification, EventStore, Listener, Namespace};
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 use onsager_substrate::workflow_library::WorkflowLibrary as PersistedWorkflowLibrary;
 use sqlx::Row;
 
@@ -85,31 +90,46 @@ impl SchedulerService {
             .await
             .with_context(|| format!("connecting to {}", self.config.database_url))?;
         let library = PersistedWorkflowLibrary::new(store.pool().clone());
-        let spine: Arc<dyn SpineClient> = Arc::new(SpineEventStoreClient::new(
-            store.clone(),
-            &self.config.actor,
-        ));
+        let base_spine = SpineEventStoreClient::new(store.clone(), &self.config.actor);
         let registry = self
             .registry
             .unwrap_or_else(|| Arc::new(default_executor_registry()));
-        let bridge = TriggerBridge::new(registry, spine);
         let handler = TriggerHandler {
-            bridge,
+            registry,
+            base_spine,
             library,
             store: store.clone(),
         };
 
         // Default: live-only. `replay_history = true` rewinds to id=0
         // so the listener replays every prior trigger.fired event.
+        //
+        // The listener seeds `max_events_id` and `max_ext_id` both
+        // from `since_id`. The global `EventStore::max_event_id()`
+        // returns the GREATEST of the two tables, so if the core
+        // `events` table is ahead of `events_ext`, the live loop
+        // would silently drop fresh `events_ext` rows with ids less
+        // than that global max. trigger.fired lives in `events_ext`,
+        // so we read its max directly. (Copilot review on PR #390.)
         let since = if self.config.replay_history {
             Some(0)
         } else {
-            store.max_event_id().await.context("reading spine cursor")?
+            events_ext_max_id(&store)
+                .await
+                .context("reading events_ext cursor")?
         };
 
-        let listener = Listener::new(store)
-            .subscribe(Namespace::workflow())
-            .with_since(since);
+        // Production trigger.fired emitters are inconsistent on the
+        // stream-id shape — `crates/onsager-portal/src/mcp/tools/
+        // workflows.rs` writes `stream_id = workflow_id` (no
+        // `workflow:` prefix) while other paths use `workflow:<id>`.
+        // The listener's namespace filter matches by `stream_id`
+        // prefix only, so a `.subscribe(Namespace::workflow())` call
+        // here would drop the MCP-fired ones. Take all notifications
+        // and filter by `event_type` inside the handler instead. The
+        // body-load + decode path is the existing cost, not a new
+        // one. (Copilot review on PR #390.)
+        let listener = Listener::new(store).with_since(since);
         tracing::info!(
             actor = %self.config.actor,
             replay = self.config.replay_history,
@@ -118,6 +138,18 @@ impl SchedulerService {
         listener.run(handler).await?;
         Ok(())
     }
+}
+
+/// Read `MAX(id) FROM events_ext`, returning `None` when the table is
+/// empty. Used as the warm-start cursor for the spine listener —
+/// `EventStore::max_event_id()` returns the GREATEST across `events`
+/// and `events_ext` and is wrong here (see the comment in
+/// [`SchedulerService::run`]).
+async fn events_ext_max_id(store: &EventStore) -> anyhow::Result<Option<i64>> {
+    let row: (Option<i64>,) = sqlx::query_as("SELECT MAX(id) FROM events_ext")
+        .fetch_one(store.pool())
+        .await?;
+    Ok(row.0)
 }
 
 /// Build the default registry the deployed binary uses.
@@ -142,7 +174,8 @@ pub fn default_executor_registry() -> ExecutorRegistry {
 /// Spine [`EventHandler`] that dispatches `trigger.fired` events
 /// through the bridge.
 struct TriggerHandler {
-    bridge: TriggerBridge,
+    registry: Arc<ExecutorRegistry>,
+    base_spine: SpineEventStoreClient,
     library: PersistedWorkflowLibrary,
     store: EventStore,
 }
@@ -153,16 +186,20 @@ impl EventHandler for TriggerHandler {
         if event.event_type != "trigger.fired" {
             return Ok(());
         }
-        // Pull the row's data column so we can decode the typed
-        // payload. Notifications carry only stream_id + event_type;
-        // the body lives on `events_ext`.
-        let row = sqlx::query("SELECT data FROM events_ext WHERE id = $1")
+        // Pull the row's data + workspace_id. Notifications carry
+        // only stream_id + event_type; the body lives on
+        // `events_ext`. workspace_id is the indexed tenant column —
+        // we thread it into the per-fire spine client so node
+        // lifecycle events emit under the same workspace as the
+        // triggering fire (Copilot review on PR #390).
+        let row = sqlx::query("SELECT data, workspace_id FROM events_ext WHERE id = $1")
             .bind(event.id)
             .fetch_optional(self.store.pool())
             .await
             .context("loading trigger.fired body")?;
         let Some(row) = row else { return Ok(()) };
         let data: serde_json::Value = row.try_get("data")?;
+        let row_workspace_id: String = row.try_get("workspace_id").unwrap_or_default();
         let kind = match decode_trigger_fired(&data) {
             Some(k) => k,
             None => {
@@ -196,14 +233,27 @@ impl EventHandler for TriggerHandler {
             kind: spec_kind.clone().unwrap_or_default(),
             workflow,
         };
-        match self
-            .bridge
+        // Workspace-scope this fire's emits: prefer the value the
+        // bridge resolves (workflows.workspace_id is the canonical
+        // truth) and fall back to the events_ext row's column. If
+        // both are empty we leave the default — the bridge / spine
+        // client still emits, just to "default".
+        let workspace_id = lookup_workspace(&self.store, &workflow_id)
+            .await
+            .unwrap_or(None)
+            .or_else(|| (!row_workspace_id.is_empty()).then(|| row_workspace_id.clone()))
+            .unwrap_or_else(|| "default".to_string());
+        let scoped_spine: Arc<dyn SpineClient> =
+            Arc::new(self.base_spine.with_workspace(&workspace_id));
+        let bridge = TriggerBridge::new(Arc::clone(&self.registry), scoped_spine);
+        match bridge
             .handle_payload(&workflow_id, &payload, &meta, lookup)
             .await
         {
             Ok(plan_id) => tracing::info!(
                 event_id = event.id,
                 %workflow_id,
+                %workspace_id,
                 plan_id = %plan_id,
                 "trigger.fired dispatched",
             ),
@@ -218,13 +268,58 @@ impl EventHandler for TriggerHandler {
 }
 
 /// Extract `FactoryEventKind::TriggerFired` from an `events_ext.data`
-/// column. The column may carry either the bare kind or the
-/// [`FactoryEvent`] envelope (per `onsager_trigger`'s precedent).
+/// column.
+///
+/// Three accepted shapes (in priority order — same precedent
+/// `onsager_trigger::main::load_trigger_fired` set, plus the raw-
+/// payload fallback Copilot flagged on PR #390):
+///
+/// 1. **`FactoryEvent` envelope** — `onsager-trigger` CLI and
+///    `onsager-portal/src/handlers/triggers.rs` write this shape.
+/// 2. **Bare `FactoryEventKind`** — historical shape some legacy
+///    producers wrote.
+/// 3. **Raw trigger payload** — `onsager-portal/src/mcp/tools/
+///    workflows.rs` writes the trigger payload object directly,
+///    with `workflow_id` (mandatory) and `trigger_kind` (optional,
+///    defaults to "unknown") inline. Synthesize a `TriggerFired`
+///    variant from that so the scheduler still dispatches.
 fn decode_trigger_fired(data: &serde_json::Value) -> Option<FactoryEventKind> {
     if let Ok(env) = serde_json::from_value::<FactoryEvent>(data.clone()) {
         return Some(env.event);
     }
-    serde_json::from_value::<FactoryEventKind>(data.clone()).ok()
+    if let Ok(kind) = serde_json::from_value::<FactoryEventKind>(data.clone()) {
+        return Some(kind);
+    }
+    // Raw payload fallback. The payload itself becomes
+    // `TriggerFired::payload` — every emitter convention seen so far
+    // (manual fire, MCP run_workflow, telegram webhook) embeds
+    // `workflow_id` and an optional `trigger_kind` directly in the
+    // payload object, so passing the whole thing back through keeps
+    // the bridge's spec_kind resolution working against the same
+    // fields.
+    let workflow_id = data.get("workflow_id").and_then(|v| v.as_str())?;
+    let trigger_kind = data
+        .get("trigger_kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    Some(FactoryEventKind::TriggerFired {
+        workflow_id: workflow_id.to_string(),
+        trigger_kind,
+        payload: data.clone(),
+    })
+}
+
+/// Pull the workflow row's workspace_id. Returns `Ok(None)` if no
+/// such row exists — the caller falls back to the events_ext row's
+/// workspace_id column (which is mandatory on append_ext).
+async fn lookup_workspace(store: &EventStore, workflow_id: &str) -> anyhow::Result<Option<String>> {
+    let row = sqlx::query("SELECT workspace_id FROM workflows WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .fetch_optional(store.pool())
+        .await
+        .context("loading workflow workspace_id")?;
+    Ok(row.and_then(|r| r.try_get::<String, _>("workspace_id").ok()))
 }
 
 /// Pull the workflow row's preset_id so the bridge can fall back to
@@ -241,4 +336,84 @@ async fn load_workflow_meta(store: &EventStore, workflow_id: &str) -> anyhow::Re
     };
     let preset_id: Option<String> = row.try_get("preset_id").ok();
     Ok(WorkflowMeta { preset_id })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_handles_factory_event_envelope() {
+        let env = FactoryEvent {
+            event: FactoryEventKind::TriggerFired {
+                workflow_id: "wf-1".into(),
+                trigger_kind: "manual".into(),
+                payload: serde_json::json!({"hello": "world"}),
+            },
+            correlation_id: None,
+            causation_id: None,
+            actor: "test".into(),
+            timestamp: chrono::Utc::now(),
+        };
+        let data = serde_json::to_value(&env).unwrap();
+        let kind = decode_trigger_fired(&data).expect("envelope decodes");
+        assert!(matches!(
+            kind,
+            FactoryEventKind::TriggerFired { ref workflow_id, .. } if workflow_id == "wf-1",
+        ));
+    }
+
+    #[test]
+    fn decode_handles_bare_kind() {
+        let kind = FactoryEventKind::TriggerFired {
+            workflow_id: "wf-2".into(),
+            trigger_kind: "github_issue_webhook".into(),
+            payload: serde_json::json!({}),
+        };
+        let data = serde_json::to_value(&kind).unwrap();
+        let decoded = decode_trigger_fired(&data).expect("bare kind decodes");
+        assert!(matches!(
+            decoded,
+            FactoryEventKind::TriggerFired { ref workflow_id, .. } if workflow_id == "wf-2",
+        ));
+    }
+
+    /// The MCP `run_workflow` producer
+    /// (`crates/onsager-portal/src/mcp/tools/workflows.rs`) writes a
+    /// raw payload object directly with `workflow_id` inline. Without
+    /// this fallback the scheduler logged "did not decode" and
+    /// dropped the fire (Copilot review on PR #390).
+    #[test]
+    fn decode_falls_back_to_raw_payload() {
+        let raw = serde_json::json!({
+            "workflow_id": "wf-mcp",
+            "trigger_kind": "manual",
+            "workspace_id": "ws-7",
+            "name": "run-it",
+            "actor": "mcp-client",
+        });
+        let decoded = decode_trigger_fired(&raw).expect("raw payload decodes");
+        let FactoryEventKind::TriggerFired {
+            workflow_id,
+            trigger_kind,
+            payload,
+        } = decoded
+        else {
+            panic!("expected TriggerFired");
+        };
+        assert_eq!(workflow_id, "wf-mcp");
+        assert_eq!(trigger_kind, "manual");
+        // The whole raw object survives as `payload` so the bridge's
+        // resolve_spec_kind / spec_kind lookup can read its fields.
+        assert_eq!(
+            payload.get("workspace_id").and_then(|v| v.as_str()),
+            Some("ws-7")
+        );
+    }
+
+    #[test]
+    fn decode_returns_none_for_payload_without_workflow_id() {
+        let data = serde_json::json!({ "not_a_workflow": "nope" });
+        assert!(decode_trigger_fired(&data).is_none());
+    }
 }

--- a/crates/onsager-scheduler/src/spine_client.rs
+++ b/crates/onsager-scheduler/src/spine_client.rs
@@ -1,0 +1,94 @@
+//! [`SpineEventStoreClient`] — a real [`SpineClient`] backed by
+//! [`onsager_spine::EventStore`].
+//!
+//! Bridges the executor-facing port (in `onsager-nodes`) to the
+//! sqlx-backed spine implementation. Every `emit` call writes one
+//! `events_ext` row in the `substrate` namespace.
+//!
+//! Lives here (in the scheduler binary) rather than in `onsager-nodes`
+//! to keep the executor-catalog crate database-free — the library
+//! stays test-friendly, only the deployed host pays the sqlx cost.
+//!
+//! ## `read_artifact` returns `None` in v1
+//!
+//! The spine `artifacts` schema (`crates/onsager-spine/migrations/
+//! 002_artifacts.sql`) splits an `Artifact` across several tables
+//! (`artifacts`, `artifact_versions`, `vertical_lineage`,
+//! `horizontal_lineage`, `quality_signals`); reconstructing a single
+//! `Artifact` value here would duplicate read logic that doesn't yet
+//! exist in `onsager-artifact`. The deployed scheduler's executors
+//! reach upstream artifacts through the [`PlanStore`], not through
+//! `read_artifact` — every executor in the catalog today gathers its
+//! inputs from `ExecutorContext::inputs`. Returning `Ok(None)` here
+//! is the same contract `StubSpine` ships with in the catalog's own
+//! tests. Wire a real reader when an executor needs it.
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId};
+use onsager_nodes::{SpineClient, SpineError};
+use onsager_spine::{EventMetadata, EventStore};
+
+/// Substrate-scheduler [`SpineClient`] backed by the real spine event
+/// store. Every emit writes one `events_ext` row in the `substrate`
+/// namespace.
+#[derive(Clone)]
+pub struct SpineEventStoreClient {
+    store: EventStore,
+    actor: String,
+}
+
+impl std::fmt::Debug for SpineEventStoreClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpineEventStoreClient")
+            .field("actor", &self.actor)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SpineEventStoreClient {
+    pub fn new(store: EventStore, actor: impl Into<String>) -> Self {
+        Self {
+            store,
+            actor: actor.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl SpineClient for SpineEventStoreClient {
+    async fn emit(&self, kind: &str, payload: serde_json::Value) -> Result<(), SpineError> {
+        let plan_id = payload
+            .get("plan_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let node_id = payload
+            .get("node_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let stream_id = format!("substrate:{plan_id}:{node_id}");
+        let metadata = EventMetadata {
+            correlation_id: None,
+            causation_id: None,
+            actor: self.actor.clone(),
+        };
+        self.store
+            .append_ext(
+                "default",
+                &stream_id,
+                "substrate",
+                kind,
+                payload,
+                &metadata,
+                None,
+            )
+            .await
+            .map_err(|e| SpineError::new(format!("append_ext failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn read_artifact(&self, _id: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+        // See module docs — v1 returns None; executors gather inputs
+        // through PlanStore, not through cross-plan spine reads.
+        Ok(None)
+    }
+}

--- a/crates/onsager-scheduler/src/spine_client.rs
+++ b/crates/onsager-scheduler/src/spine_client.rs
@@ -31,16 +31,25 @@ use onsager_spine::{EventMetadata, EventStore};
 /// Substrate-scheduler [`SpineClient`] backed by the real spine event
 /// store. Every emit writes one `events_ext` row in the `substrate`
 /// namespace.
+///
+/// `workspace_id` scopes the indexed `events_ext.workspace_id` column
+/// so dashboard queries can isolate runs per tenant. The bare
+/// constructor pins it to `"default"`; production wiring threads each
+/// fire's workflow-row workspace through [`Self::with_workspace`] so
+/// node lifecycle events stay queryable per workspace alongside the
+/// triggering fire (Copilot review feedback on PR #390).
 #[derive(Clone)]
 pub struct SpineEventStoreClient {
     store: EventStore,
     actor: String,
+    workspace_id: String,
 }
 
 impl std::fmt::Debug for SpineEventStoreClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SpineEventStoreClient")
             .field("actor", &self.actor)
+            .field("workspace_id", &self.workspace_id)
             .finish_non_exhaustive()
     }
 }
@@ -50,6 +59,17 @@ impl SpineEventStoreClient {
         Self {
             store,
             actor: actor.into(),
+            workspace_id: "default".to_string(),
+        }
+    }
+
+    /// Build a workspace-scoped clone. The new client emits every
+    /// event under `workspace_id`; the original is left untouched.
+    pub fn with_workspace(&self, workspace_id: impl Into<String>) -> Self {
+        Self {
+            store: self.store.clone(),
+            actor: self.actor.clone(),
+            workspace_id: workspace_id.into(),
         }
     }
 }
@@ -73,7 +93,7 @@ impl SpineClient for SpineEventStoreClient {
         };
         self.store
             .append_ext(
-                "default",
+                &self.workspace_id,
                 &stream_id,
                 "substrate",
                 kind,

--- a/crates/onsager-scheduler/tests/trigger_round_trip.rs
+++ b/crates/onsager-scheduler/tests/trigger_round_trip.rs
@@ -1,0 +1,143 @@
+//! Integration test: TriggerFired payload → bridge → scheduler →
+//! captured spine emits.
+//!
+//! Verifies the v1 contract — payload carries a `spec_kind`, the
+//! library returns a Workflow, the bridge compiles and runs it, the
+//! scheduler emits node lifecycle events to the spine.
+//!
+//! No Postgres dependency: the [`SpineClient`] is a capturing mock
+//! and the workflow is provided via the in-process
+//! `PreloadedWorkflow` adapter. The end-to-end with a real spine
+//! lives in `tests/spine_listener.rs` when the host's Postgres
+//! becomes addressable in CI; the bridge contract proven here is
+//! the same shape that path would execute.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId, Kind, NodeId, Provenance};
+use onsager_nodes::{
+    Executor, ExecutorContext, ExecutorError, ExecutorOutputs, ExecutorRegistry, SpineClient,
+    SpineError,
+};
+use onsager_scheduler::{TriggerBridge, bridge::PreloadedWorkflow, bridge::WorkflowMeta};
+use onsager_substrate::ids::EdgeId;
+use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
+
+#[derive(Debug, Default)]
+struct CapturingSpine {
+    emitted: Mutex<Vec<(String, serde_json::Value)>>,
+}
+
+#[async_trait]
+impl SpineClient for CapturingSpine {
+    async fn emit(&self, kind: &str, payload: serde_json::Value) -> Result<(), SpineError> {
+        self.emitted
+            .lock()
+            .unwrap()
+            .push((kind.to_string(), payload));
+        Ok(())
+    }
+    async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+struct EmitOne;
+
+#[async_trait]
+impl Executor for EmitOne {
+    fn executor_kind(&self) -> &'static str {
+        "noop"
+    }
+    fn declared_provenance(&self, _: &[Provenance]) -> Provenance {
+        Provenance::external_deterministic()
+    }
+    async fn execute(&self, _: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+        let art = Artifact::new(Kind::Document, "round-trip", "marvin", "test", vec![]);
+        let id = art.artifact_id.clone();
+        Ok(ExecutorOutputs::single(id, art))
+    }
+}
+
+fn build_workflow() -> Workflow {
+    let entry = EdgeId::generate();
+    let exit = EdgeId::generate();
+    Workflow {
+        nodes: vec![Node {
+            id: NodeId::generate(),
+            executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+            inputs: vec![EdgeRef::new(entry)],
+            outputs: vec![EdgeRef::new(exit)],
+        }],
+        edges: vec![
+            Edge {
+                id: entry,
+                artifact_id: ArtifactId::new("e2e-in"),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: exit,
+                artifact_id: ArtifactId::new("e2e-out"),
+                requires_deterministic: false,
+            },
+        ],
+        entry_specs: vec![EntrySpec { edge_id: entry }],
+        output_specs: vec![OutputSpec {
+            edge_id: exit,
+            provenance: Provenance::external_deterministic(),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn trigger_fired_drives_scheduler_and_emits_node_events() {
+    let mut registry = ExecutorRegistry::new();
+    registry.register(Arc::new(EmitOne));
+    let spine = Arc::new(CapturingSpine::default());
+    let bridge = TriggerBridge::new(
+        Arc::new(registry),
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    );
+
+    // Simulate a manual fire: `onsager trigger fire wf-e2e --manual run --payload '{"spec_kind":"e2e-kind"}'`
+    let payload = serde_json::json!({
+        "spec_kind": "e2e-kind",
+        "trigger_kind": "manual",
+        "actor": "test-runner",
+    });
+    let lookup = PreloadedWorkflow {
+        kind: "e2e-kind".to_string(),
+        workflow: Some(build_workflow()),
+    };
+    let plan_id = bridge
+        .handle_payload("wf-e2e", &payload, &WorkflowMeta::default(), lookup)
+        .await
+        .expect("bridge runs the plan to completion");
+
+    let emitted = spine.emitted.lock().unwrap().clone();
+    let kinds: Vec<&str> = emitted.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(
+        kinds.contains(&"node.started"),
+        "expected node.started, got {kinds:?}",
+    );
+    assert!(
+        kinds.contains(&"node.completed"),
+        "expected node.completed, got {kinds:?}",
+    );
+
+    // Every spine event was tagged with our PlanId — proves the
+    // trigger handle threaded the same plan_id through every emit.
+    for (kind, payload) in &emitted {
+        let got = payload
+            .get("plan_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert_eq!(
+            got,
+            plan_id.as_str(),
+            "{kind} payload plan_id should equal the bridge's PlanId",
+        );
+    }
+}

--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -26,12 +26,13 @@ or `<name>` (for known subsystems) is a valid subcommand.
 
 KNOWN SUBCOMMANDS:
     ising       Continuous improvement engine — observes and surfaces insights
+    scheduler   Substrate scheduler — hosts trigger.fired → Plan Compiler → executor dispatch
     stiglab     Distributed AI agent session orchestration
     synodic     AI agent governance
     trigger     Fire or replay workflow triggers (manual / replay)
 ";
 
-const KNOWN: &[&str] = &["ising", "stiglab", "synodic", "trigger"];
+const KNOWN: &[&str] = &["ising", "scheduler", "stiglab", "synodic", "trigger"];
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/crates/stiglab/deploy/Dockerfile
+++ b/crates/stiglab/deploy/Dockerfile
@@ -23,6 +23,7 @@ COPY crates/onsager-substrate/Cargo.toml  crates/onsager-substrate/Cargo.toml
 COPY crates/onsager-nodes/Cargo.toml      crates/onsager-nodes/Cargo.toml
 COPY crates/onsager-github/Cargo.toml     crates/onsager-github/Cargo.toml
 COPY crates/onsager-portal/Cargo.toml     crates/onsager-portal/Cargo.toml
+COPY crates/onsager-scheduler/Cargo.toml  crates/onsager-scheduler/Cargo.toml
 COPY crates/onsager-trigger/Cargo.toml    crates/onsager-trigger/Cargo.toml
 COPY crates/onsager/Cargo.toml            crates/onsager/Cargo.toml
 COPY crates/ising/Cargo.toml              crates/ising/Cargo.toml
@@ -39,6 +40,7 @@ RUN mkdir -p \
       crates/onsager-nodes/src \
       crates/onsager-github/src \
       crates/onsager-portal/src \
+      crates/onsager-scheduler/src \
       crates/onsager-trigger/src \
       crates/onsager/src \
       crates/ising/src \
@@ -53,6 +55,7 @@ RUN mkdir -p \
       crates/onsager-nodes/src/lib.rs \
       crates/onsager-github/src/lib.rs \
       crates/onsager-portal/src/lib.rs \
+      crates/onsager-scheduler/src/lib.rs \
       crates/ising/src/lib.rs \
       crates/stiglab/src/lib.rs \
       crates/synodic/src/lib.rs \
@@ -63,9 +66,10 @@ RUN mkdir -p \
       crates/stiglab/src/main.rs \
       crates/synodic/src/main.rs \
       crates/onsager-portal/src/main.rs \
+      crates/onsager-scheduler/src/main.rs \
       xtask/src/main.rs \
     && cargo build --release \
-         -p stiglab -p synodic -p onsager-portal \
+         -p stiglab -p synodic -p onsager-portal -p onsager-scheduler \
          --features synodic/postgres 2>/dev/null || true
 # Copy actual source and rebuild.
 # Touch all .rs files so their mtime is newer than the dummy-build artifacts —
@@ -74,7 +78,7 @@ RUN mkdir -p \
 COPY crates/ crates/
 RUN find crates -name "*.rs" | xargs touch \
     && cargo build --release \
-         -p stiglab -p synodic -p onsager-portal \
+         -p stiglab -p synodic -p onsager-portal -p onsager-scheduler \
          --features synodic/postgres
 
 # ---- Stage 3: Caddy binary ----
@@ -121,9 +125,10 @@ RUN printf '#!/bin/sh\necho "username=x-access-token\npassword=${GITHUB_TOKEN}"\
 RUN useradd -m -s /bin/bash onsager
 
 WORKDIR /app
-COPY --from=rust-builder /app/target/release/stiglab        /app/stiglab
-COPY --from=rust-builder /app/target/release/synodic        /app/synodic
-COPY --from=rust-builder /app/target/release/onsager-portal /app/onsager-portal
+COPY --from=rust-builder /app/target/release/stiglab           /app/stiglab
+COPY --from=rust-builder /app/target/release/synodic           /app/synodic
+COPY --from=rust-builder /app/target/release/onsager-portal    /app/onsager-portal
+COPY --from=rust-builder /app/target/release/onsager-scheduler /app/onsager-scheduler
 COPY --from=ui-builder /app/apps/dashboard/dist /app/static
 # Spine migrations — applied on startup when ONSAGER_DATABASE_URL is set
 COPY crates/onsager-spine/migrations/ /app/spine-migrations/

--- a/crates/stiglab/deploy/entrypoint.sh
+++ b/crates/stiglab/deploy/entrypoint.sh
@@ -48,6 +48,17 @@ if [ -n "$ONSAGER_DATABASE_URL" ]; then
     gosu onsager sh -c "while true; do PORTAL_BIND=\"$PORTAL_BIND\" DATABASE_URL=\"$ONSAGER_DATABASE_URL\" ONSAGER_CREDENTIAL_KEY=\"$PORTAL_CREDENTIAL_KEY\" SYNODIC_URL=\"$PORTAL_SYNODIC_URL\" /app/onsager-portal serve 2>&1; echo 'onsager-portal exited, restarting in 1s...'; sleep 1; done" &
 fi
 
+# Start the substrate scheduler (RUN-03, #386) — listens on the spine
+# for trigger.fired events, compiles each into an ExecutionPlan, and
+# runs it through onsager_nodes::Scheduler. Skipped when the spine DB
+# isn't configured; without DATABASE_URL there's nothing to listen on.
+if [ -n "$ONSAGER_DATABASE_URL" ]; then
+    SCHEDULER_ACTOR="${SCHEDULER_ACTOR:-substrate-scheduler}"
+    SCHEDULER_REPLAY_HISTORY="${SCHEDULER_REPLAY_HISTORY:-false}"
+    echo "Starting onsager-scheduler (actor=${SCHEDULER_ACTOR}, replay=${SCHEDULER_REPLAY_HISTORY})..."
+    gosu onsager sh -c "while true; do DATABASE_URL=\"$ONSAGER_DATABASE_URL\" SCHEDULER_ACTOR=\"$SCHEDULER_ACTOR\" SCHEDULER_REPLAY_HISTORY=\"$SCHEDULER_REPLAY_HISTORY\" /app/onsager-scheduler serve 2>&1; echo 'onsager-scheduler exited, restarting in 1s...'; sleep 1; done" &
+fi
+
 # Issue #156: legacy callers still expect STIGLAB_INTERNAL_DISPATCH_TOKEN
 # in the environment as a per-boot ephemeral secret. The 0.1 forge ↔
 # stiglab dispatch path is gone after spec #363, but synodic + stiglab
@@ -82,6 +93,6 @@ gosu onsager sh -c "while true; do STIGLAB_HOST=\"$STIGLAB_HOST\" STIGLAB_PORT=\
 : "${PORT:=8080}"
 export PORT
 echo "==> pre-exec: binaries present"
-ls -la /app/stiglab /app/synodic /app/onsager-portal /usr/local/bin/caddy
+ls -la /app/stiglab /app/synodic /app/onsager-portal /app/onsager-scheduler /usr/local/bin/caddy
 echo "==> exec-ing caddy on :${PORT}..."
 exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/deploy/dev/docker-compose.slot.yml
+++ b/deploy/dev/docker-compose.slot.yml
@@ -118,6 +118,27 @@ services:
       cargo watch -q -w crates/synodic -w crates/onsager-spine -w crates/onsager-artifact
       -x 'run -p synodic -- serve'
 
+  # Substrate scheduler (RUN-03, #386). Listens on the spine for
+  # `trigger.fired` events, compiles each into an `ExecutionPlan`,
+  # and runs it through `onsager_nodes::Scheduler`. No HTTP surface —
+  # coordination is via the event bus only. A manual fire
+  # (`onsager trigger fire ...`) drives the scheduler end-to-end.
+  scheduler:
+    <<: *rust-dev
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: postgres://onsager:onsager@db:5432/onsager
+      SCHEDULER_ACTOR: substrate-scheduler-slot
+      RUST_LOG: ${RUST_LOG:-info}
+    command: >
+      cargo watch -q -w crates/onsager-scheduler -w crates/onsager-nodes
+      -w crates/onsager-substrate -w crates/onsager-spine
+      -x 'run -p onsager-scheduler -- serve'
+
   # Edge subsystem (ADR 0006 / ADR 0008). Owns every external /api/*
   # route and is the route owner for /agent/ws — terminates the
   # WebSocket and proxies bytes to stiglab over the dev network.

--- a/justfile
+++ b/justfile
@@ -132,6 +132,10 @@ dev: dev-infra
     echo "==> Starting synodic on :3001..."
     PORT=3001 cargo run -p synodic -- serve &
 
+    echo "==> Starting onsager-scheduler (substrate scheduler)..."
+    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+        cargo run -p onsager-scheduler -- serve &
+
     echo "==> Starting dashboard on :5173..."
     pnpm --filter dashboard dev &
 
@@ -141,6 +145,7 @@ dev: dev-infra
     echo "  Stiglab:    http://localhost:3000"
     echo "  Synodic:    http://localhost:3001"
     echo "  Portal:     http://localhost:3002"
+    echo "  Scheduler:  spine listener (no HTTP port)"
     echo "  Postgres:   postgres://onsager:onsager@localhost:5432/onsager"
     echo ""
     echo "Press Ctrl+C to stop all services."
@@ -171,6 +176,10 @@ dev-portal port="3002":
     DATABASE_URL="${DATABASE_URL:-postgres://onsager:onsager@localhost:5432/onsager}" \
     PORTAL_BIND="0.0.0.0:{{port}}" \
         cargo run -p onsager-portal -- serve
+
+dev-scheduler:
+    DATABASE_URL="${DATABASE_URL:-postgres://onsager:onsager@localhost:5432/onsager}" \
+        cargo run -p onsager-scheduler -- serve
 
 dev-stiglab:
     cargo run -p stiglab -- server
@@ -249,6 +258,7 @@ deploy: deploy-build deploy-up
 install:
     cargo install --path crates/onsager
     cargo install --path crates/ising
+    cargo install --path crates/onsager-scheduler
     cargo install --path crates/stiglab
     cargo install --path crates/synodic
 

--- a/railway.toml
+++ b/railway.toml
@@ -2,12 +2,13 @@
 #
 # Unified single-container deployment. All subsystems run in one service:
 #
-#   Process         | Description                               | Port
-#   --------------- | ----------------------------------------- | ----
-#   stiglab         | Sessions, agents, dashboard, API          | 3000 (exposed)
-#   synodic         | Governance API (internal)                 | 3001 (proxied)
-#   onsager-portal  | GitHub webhook ingress (internal)         | 3002 (proxied)
-#   PostgreSQL      | Shared event spine (Railway plugin)       | 5432
+#   Process            | Description                                       | Port
+#   ------------------ | ------------------------------------------------- | -----------------
+#   stiglab            | Sessions, agents, dashboard, API                  | 3000 (exposed)
+#   synodic            | Governance API (internal)                         | 3001 (proxied)
+#   onsager-portal     | GitHub webhook ingress (internal)                 | 3002 (proxied)
+#   onsager-scheduler  | Substrate scheduler — trigger.fired → ExecPlan    | — (spine listener)
+#   PostgreSQL         | Shared event spine (Railway plugin)               | 5432
 #
 # Stiglab is the front door — it serves the dashboard, owns /api/health
 # and /agent/ws, and reverse-proxies all other /api/* traffic to portal


### PR DESCRIPTION
## Summary

- New `onsager-scheduler` binary crate hosts `onsager_nodes::Scheduler` in production. Owns the process-level wiring the library-only scheduler does not: spine-backed `SpineClient`, long-running `Listener` over the `workflow` namespace, and a stateless `TriggerBridge` that compiles each `trigger.fired` into an `ExecutionPlan` handed to `Scheduler::run`.
- Bridge resolves `spec_kind` from the trigger payload first (`{"spec_kind": "..."}`), falling back to `workflows.preset_id`. Missing kinds / library misses surface as structured warnings — the v1 contract is best-effort dispatch, documented in `bridge.rs`.
- Closes the gap MIG-01 (#384) left behind: `trigger.fired` events again have an in-tree consumer that advances workflows.

## Delivers

- `crates/onsager-scheduler/` — new binary + lib (`bridge.rs`, `service.rs`, `spine_client.rs`, `main.rs`) with 4 bridge unit tests + 1 integration test covering the trigger → compile → schedule → spine-emit round-trip.
- Deploy wiring:
  - `crates/stiglab/deploy/Dockerfile` — copies `Cargo.toml`, adds a dummy `src/main.rs` for the cache layer, builds `-p onsager-scheduler`, copies the binary to `/app/onsager-scheduler`.
  - `crates/stiglab/deploy/entrypoint.sh` — launches under `gosu` whenever `ONSAGER_DATABASE_URL` is set.
  - `deploy/dev/docker-compose.slot.yml` — new `scheduler` service running `cargo watch` against the source tree.
  - `justfile` — `dev` recipe starts it alongside the others; new `dev-scheduler` target for standalone runs; `install` target picks it up.
  - `railway.toml` — process-table comment lists `onsager-scheduler` with the "spine listener" port note.
  - `crates/onsager/src/main.rs` — dispatcher's `KNOWN` list adds `scheduler`.

## Host shape

A dedicated binary, not a task inside an existing process. The dispatcher (`crates/onsager/`) commits to **zero business deps**, so co-locating the scheduler there would defeat the rebuild isolation. Portal is the **edge** subsystem (ADR 0006) with no business in runtime dispatch. The new crate obeys the seam rule: depends only on `onsager-{spine,substrate,nodes,artifact}`, never on a sibling subsystem.

## Out of scope (deferred)

- **Spine-backed `PlanStore`.** RUN-01 (#359) ships only `InMemoryPlanStore`; the SQL-backed implementation is the MIG-* family's job (see `scheduler.rs` module docs). The deployed binary uses `InMemoryPlanStore` per plan — restart safety lives at the recovery-checklist level, not the persistence level.
- **Full executor catalog.** The default registry registers only `NoOpExecutor`. Script/Verify/Agent/SubWorkflow dispatch through a single registry instance today (the per-node config threading is a known RUN-02 follow-up referenced in `crawlab_fixture.rs`); registering a singleton ScriptExecutor with no command would dispatch every script node through that empty config — silently wrong. NoOp-only means non-NoOp nodes fail with `ExecutorError::UnknownKind`, which is the correct loud failure. Tests inject richer registries via `SchedulerService::with_registry`.
- **Workflow row `spec_kind` column.** The bridge's payload→preset_id fallback is the v1 contract; a first-class `workflows.spec_kind` column is named as a follow-up in `bridge.rs`.

## Test plan

- [x] `cargo test -p onsager-scheduler` — 4 bridge unit tests + 1 integration test pass.
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` — clean.
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --lib` — clean.
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `xtask lint-seams`, `check-api-contract`, `check-events`, `check-file-budget` — all clean.
- [ ] Production deploy: `trigger.fired` on the spine → scheduler dispatches → executor runs → artifact lifecycle advances. (Needs Railway deploy.)
- [ ] `just dev` local stack: same end-to-end flow against the local spine. (Needs running Postgres.)

Closes #386

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpJE8D63wusr3iJSUe31mK)_