### PR TITLE
feat(observers): startup hydration / event-history replay (OBS-03)

### DIFF
--- a/crates/onsager-observers/src/gate_deny_rate.rs
+++ b/crates/onsager-observers/src/gate_deny_rate.rs
@@ -94,6 +94,12 @@ impl Observer for GateDenyRateObserver {
         ]
     }
 
+    fn hydration_window(&self) -> Option<Duration> {
+        // Match the analyzer's sliding window — see the sibling
+        // [`GateOverrideObserver::hydration_window`] for rationale.
+        Some(self.config.window)
+    }
+
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput> {
         match &event.payload.event {
             FactoryEventKind::ArtifactRegistered {

--- a/crates/onsager-observers/src/gate_override.rs
+++ b/crates/onsager-observers/src/gate_override.rs
@@ -105,6 +105,15 @@ impl Observer for GateOverrideObserver {
         ]
     }
 
+    fn hydration_window(&self) -> Option<Duration> {
+        // Match the analyzer's own sliding window so the runtime
+        // replays exactly what `prune_old` keeps live. The
+        // artifact-id → kind index is rebuilt from registrations in
+        // the same window — verdicts whose registration is older
+        // than `window` would drop out of grouping anyway.
+        Some(self.config.window)
+    }
+
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput> {
         match &event.payload.event {
             FactoryEventKind::ArtifactRegistered {

--- a/crates/onsager-observers/src/observer.rs
+++ b/crates/onsager-observers/src/observer.rs
@@ -8,7 +8,7 @@
 //! a mutex; observers from each other run fully in parallel.
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use onsager_spine::FactoryEvent;
 
 use crate::output::ObserverOutput;
@@ -65,4 +65,31 @@ pub trait Observer: Send + Sync {
     /// may emit several (e.g. an `Alert` plus the `QualitySignal`
     /// that triggered it).
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput>;
+
+    /// Lookback window the runtime should replay through this
+    /// observer on startup, before attaching the live `pg_notify`
+    /// subscription. Returning `Some(d)` opts in: the runtime fetches
+    /// events written in the last `d` and dispatches them through
+    /// `on_event` to rebuild observer state (artifact-id → kind
+    /// indices, sliding-window buffers, …) that would otherwise be
+    /// empty after a process restart.
+    ///
+    /// Outputs produced during hydration are **suppressed** — the
+    /// runtime drops everything `on_event` returns while replaying
+    /// history, so an observer does not need to know whether it is
+    /// being hydrated. Observers whose `on_event` mutates external
+    /// state directly should still avoid doing so (the trait already
+    /// asks observers not to — outputs are the only sanctioned write
+    /// surface).
+    ///
+    /// Default: `None` — no hydration. Appropriate for stateless
+    /// observers and for ones whose state is bounded by a window
+    /// shorter than a typical restart gap (where the cold-start
+    /// correctness gap is acceptable).
+    ///
+    /// See spec #392 for the runtime-side mechanics and the
+    /// correctness rationale.
+    fn hydration_window(&self) -> Option<Duration> {
+        None
+    }
 }

--- a/crates/onsager-observers/src/observer.rs
+++ b/crates/onsager-observers/src/observer.rs
@@ -67,12 +67,17 @@ pub trait Observer: Send + Sync {
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput>;
 
     /// Lookback window the runtime should replay through this
-    /// observer on startup, before attaching the live `pg_notify`
-    /// subscription. Returning `Some(d)` opts in: the runtime fetches
-    /// events written in the last `d` and dispatches them through
-    /// `on_event` to rebuild observer state (artifact-id → kind
-    /// indices, sliding-window buffers, …) that would otherwise be
-    /// empty after a process restart.
+    /// observer on startup, before the runtime signals ready and
+    /// begins consuming live `pg_notify` notifications. (The
+    /// subscription itself is attached *first* so notifications are
+    /// buffered while hydration runs; the runtime then skips the
+    /// buffered notifications that hydration already covered. See
+    /// [`ObserverRuntime::run_with_ready`](crate::ObserverRuntime::run_with_ready)
+    /// for the full sequence.) Returning `Some(d)` opts in: the
+    /// runtime fetches events written in the last `d` and dispatches
+    /// them through `on_event` to rebuild observer state (artifact-id
+    /// → kind indices, sliding-window buffers, …) that would otherwise
+    /// be empty after a process restart.
     ///
     /// Outputs produced during hydration are **suppressed** — the
     /// runtime drops everything `on_event` returns while replaying

--- a/crates/onsager-observers/src/pattern.rs
+++ b/crates/onsager-observers/src/pattern.rs
@@ -73,6 +73,14 @@ impl EventPattern {
             p => p == event_type,
         }
     }
+
+    /// Returns `true` if this pattern is a wildcard form (`"*"` or
+    /// `"<prefix>.*"`). Used by the hydration path to decide whether
+    /// the spine replay query can use a server-side `event_type`
+    /// filter or must scan the full window.
+    pub fn is_wildcard(&self) -> bool {
+        self.0 == "*" || self.0.ends_with(".*")
+    }
 }
 
 impl From<&str> for EventPattern {

--- a/crates/onsager-observers/src/pr_churn.rs
+++ b/crates/onsager-observers/src/pr_churn.rs
@@ -95,6 +95,10 @@ impl Observer for PrChurnObserver {
         ]
     }
 
+    fn hydration_window(&self) -> Option<Duration> {
+        Some(self.config.window)
+    }
+
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput> {
         match &event.payload.event {
             FactoryEventKind::GitPrOpened {

--- a/crates/onsager-observers/src/runtime.rs
+++ b/crates/onsager-observers/src/runtime.rs
@@ -225,11 +225,17 @@ impl ObserverRuntime {
         // (subscribe started first, channel is buffering). Events
         // with id <= cutoff are hydrated below and skipped when the
         // live loop sees them.
+        //
+        // We read `max_core_event_id` (core `events` only) — *not*
+        // `max_event_id`, which mixes in `events_ext.id`. A higher
+        // `events_ext.id` could otherwise mask a newer-but-lower
+        // `events.id` and cause the live loop to skip live core
+        // rows below the inflated cutoff.
         let cutoff_id = self
             .event_store
-            .max_event_id()
+            .max_core_event_id()
             .await
-            .context("read max_event_id for hydration cutoff")?
+            .context("read max_core_event_id for hydration cutoff")?
             .unwrap_or(0);
 
         // Replay history through hydrating observers. Outputs are
@@ -339,9 +345,15 @@ impl ObserverRuntime {
     /// Events should be supplied in `event_id` ASC order; the runtime
     /// dispatches them as-is and observers that depend on monotonic
     /// ordering rely on the caller's ordering.
+    ///
+    /// A single hydration reference timestamp is captured up front
+    /// (`Utc::now()`) and used to evaluate every per-observer window
+    /// — so the in/out decision for an event near the window
+    /// boundary does not depend on how long replay takes.
     pub async fn hydrate_from_events(&self, history: Vec<SpineEvent>) {
+        let hydration_now = chrono::Utc::now();
         for event in history {
-            dispatch_hydration(&self.observers, &event).await;
+            dispatch_hydration(&self.observers, &event, hydration_now).await;
         }
     }
 }
@@ -383,8 +395,18 @@ fn hydration_event_type_filter(observers: &[&Registered]) -> Option<Vec<String>>
 /// where that rule is enforced — observers don't need to know
 /// whether they're being hydrated, and the same `on_event`
 /// implementation handles both modes.
-async fn dispatch_hydration(observers: &[Registered], event: &SpineEvent) {
-    let now = chrono::Utc::now();
+///
+/// `hydration_now` is the single reference timestamp captured at
+/// the start of the hydration phase. Threading it through (rather
+/// than reading `Utc::now()` per event) keeps the in/out boundary
+/// of each observer's window stable regardless of how long replay
+/// takes, and identical to the lower bound used for the spine
+/// query.
+async fn dispatch_hydration(
+    observers: &[Registered],
+    event: &SpineEvent,
+    hydration_now: chrono::DateTime<chrono::Utc>,
+) {
     for obs in observers {
         let Some(window) = obs.hydration_window else {
             // Observer didn't opt into hydration. Live-only — its
@@ -396,7 +418,7 @@ async fn dispatch_hydration(observers: &[Registered], event: &SpineEvent) {
         // window does not get re-fed events older than it cares
         // about even if a sibling observer requested a longer
         // window.
-        if event.created_at < now - window {
+        if event.created_at < hydration_now - window {
             continue;
         }
         if !any_pattern_matches(&obs.patterns, &event.event_type) {
@@ -436,12 +458,20 @@ async fn hydrate_observers(
     // the union of declared windows". Per-observer windows are still
     // honored at dispatch time (`dispatch_hydration` re-checks each
     // event's age against each observer's own window).
+    //
+    // `hydration_now` is captured ONCE up front and reused for both
+    // the query lower bound AND each per-observer in-window check
+    // in `dispatch_hydration`. Without this, a long-running replay
+    // could pull rows close to the query boundary that then get
+    // skipped at dispatch (or vice versa) — the in/out decision
+    // would depend on wall-clock drift during hydration.
     let max_window = hydrating
         .iter()
         .filter_map(|o| o.hydration_window)
         .max()
         .expect("at least one hydrating observer");
-    let since = chrono::Utc::now() - max_window;
+    let hydration_now = chrono::Utc::now();
+    let since = hydration_now - max_window;
     let event_types = hydration_event_type_filter(&hydrating);
 
     let rows = event_store
@@ -470,7 +500,7 @@ async fn hydrate_observers(
             payload,
             created_at: record.created_at,
         };
-        dispatch_hydration(observers, &spine_event).await;
+        dispatch_hydration(observers, &spine_event, hydration_now).await;
         dispatched += 1;
     }
     tracing::info!(
@@ -800,7 +830,7 @@ mod tests {
             ev(12, "artifact.archived", Duration::seconds(5)),
         ];
         for e in history {
-            dispatch_hydration(&observers, &e).await;
+            dispatch_hydration(&observers, &e, chrono::Utc::now()).await;
         }
 
         let ids = seen.lock().unwrap().clone();
@@ -828,6 +858,7 @@ mod tests {
         dispatch_hydration(
             &observers,
             &ev(10, "artifact.registered", Duration::minutes(5)),
+            chrono::Utc::now(),
         )
         .await;
         assert!(seen.lock().unwrap().is_empty());
@@ -851,9 +882,11 @@ mod tests {
             obs,
         )];
 
+        let hydration_now = chrono::Utc::now();
         dispatch_hydration(
             &observers,
             &ev(10, "artifact.registered", Duration::hours(2)),
+            hydration_now,
         )
         .await;
         assert!(seen.lock().unwrap().is_empty());
@@ -862,6 +895,7 @@ mod tests {
         dispatch_hydration(
             &observers,
             &ev(11, "artifact.registered", Duration::minutes(10)),
+            hydration_now,
         )
         .await;
         assert_eq!(seen.lock().unwrap().clone(), vec![11]);
@@ -886,6 +920,7 @@ mod tests {
         dispatch_hydration(
             &observers,
             &ev(10, "artifact.registered", Duration::minutes(5)),
+            chrono::Utc::now(),
         )
         .await;
         assert!(seen.lock().unwrap().is_empty());
@@ -913,10 +948,12 @@ mod tests {
             obs,
         )];
 
+        let hydration_now = chrono::Utc::now();
         for i in 0..5 {
             dispatch_hydration(
                 &observers,
                 &ev(20 + i, "artifact.registered", Duration::minutes(1)),
+                hydration_now,
             )
             .await;
         }

--- a/crates/onsager-observers/src/runtime.rs
+++ b/crates/onsager-observers/src/runtime.rs
@@ -39,9 +39,11 @@
 //! the substrate writer will block once the buffer fills, applying
 //! backpressure upstream rather than buffering forever.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use chrono::Duration;
 use onsager_spine::{EventNotification, EventStore, FactoryEvent};
 use tokio::sync::{Mutex, oneshot};
 
@@ -58,6 +60,11 @@ use crate::store::ObserverOutputStore;
 struct Registered {
     id: String,
     patterns: Vec<EventPattern>,
+    /// Cached at registration so the hydration phase doesn't have to
+    /// lock the observer mutex (and so each observer's window is read
+    /// exactly once — the spec is "declare alongside subscriptions",
+    /// not "ask repeatedly").
+    hydration_window: Option<Duration>,
     observer: Arc<Mutex<Box<dyn Observer>>>,
 }
 
@@ -103,14 +110,16 @@ impl ObserverRuntime {
     ///
     /// `id` is what the runtime writes into `observer_outputs.observer_id`
     /// — pick something stable across restarts. The observer's
-    /// declared [`subscriptions`](Observer::subscriptions) are read
-    /// once and cached; observers cannot change their patterns at
-    /// runtime.
+    /// declared [`subscriptions`](Observer::subscriptions) and
+    /// [`hydration_window`](Observer::hydration_window) are read
+    /// once and cached; observers cannot change either at runtime.
     pub fn register<O: Observer + 'static>(mut self, id: impl Into<String>, observer: O) -> Self {
         let patterns = observer.subscriptions();
+        let hydration_window = observer.hydration_window();
         self.observers.push(Registered {
             id: id.into(),
             patterns,
+            hydration_window,
             observer: Arc::new(Mutex::new(Box::new(observer))),
         });
         self
@@ -121,9 +130,11 @@ impl ObserverRuntime {
     /// their own.
     pub fn register_boxed(mut self, id: impl Into<String>, observer: Box<dyn Observer>) -> Self {
         let patterns = observer.subscriptions();
+        let hydration_window = observer.hydration_window();
         self.observers.push(Registered {
             id: id.into(),
             patterns,
+            hydration_window,
             observer: Arc::new(Mutex::new(observer)),
         });
         self
@@ -163,11 +174,30 @@ impl ObserverRuntime {
     }
 
     /// Like [`run`](Self::run), but signals on `ready` once the spine
-    /// subscription is attached and the fan-out loop is about to
-    /// consume its first notification. Tests use this to wait for
-    /// readiness deterministically instead of sleeping a fixed
-    /// duration. Dropping the receiver is fine — the runtime simply
-    /// proceeds.
+    /// subscription is attached, history has been replayed, and the
+    /// fan-out loop is about to consume its first live notification.
+    /// Tests use this to wait for readiness deterministically instead
+    /// of sleeping a fixed duration. Dropping the receiver is fine —
+    /// the runtime simply proceeds.
+    ///
+    /// Startup sequence (spec #392):
+    ///
+    /// 1. Subscribe to `pg_notify`. The live channel starts
+    ///    buffering immediately so events written during hydration
+    ///    are not lost.
+    /// 2. Capture
+    ///    [`max_event_id`](onsager_spine::EventStore::max_event_id)
+    ///    as a cutoff.
+    /// 3. For every registered observer that opted into hydration
+    ///    via [`hydration_window`](Observer::hydration_window),
+    ///    replay events in `[now - window, cutoff]` through
+    ///    `on_event` — but suppress the outputs. Observer state
+    ///    (artifact-id → kind indices, sliding-window buffers, …) is
+    ///    rebuilt to the shape it would have had if the observer had
+    ///    been online over the window.
+    /// 4. Signal `ready`.
+    /// 5. Drive the live loop, skipping events with `id <= cutoff`
+    ///    (those were already hydrated).
     pub async fn run_with_ready(self, ready: Option<oneshot::Sender<()>>) -> Result<()> {
         let mut rx_unbounded;
         let mut rx_bounded;
@@ -190,7 +220,25 @@ impl ObserverRuntime {
             }
         };
 
-        // Subscription is attached — let any awaiter know.
+        // Cutoff captured AFTER subscribe so any event with id >
+        // cutoff is guaranteed to also arrive via the live channel
+        // (subscribe started first, channel is buffering). Events
+        // with id <= cutoff are hydrated below and skipped when the
+        // live loop sees them.
+        let cutoff_id = self
+            .event_store
+            .max_event_id()
+            .await
+            .context("read max_event_id for hydration cutoff")?
+            .unwrap_or(0);
+
+        // Replay history through hydrating observers. Outputs are
+        // suppressed — see `hydrate_observers`.
+        hydrate_observers(&self.observers, &self.event_store, cutoff_id).await?;
+
+        // Subscription attached AND hydration complete — only now
+        // is the runtime really "ready". Test waiters rely on this
+        // ordering.
         if let Some(tx) = ready {
             let _ = tx.send(());
         }
@@ -206,6 +254,17 @@ impl ObserverRuntime {
             // one `tokio::spawn` + one `SELECT FROM events WHERE id` per
             // observer per ignored notification.
             if notification.table != "events" {
+                continue;
+            }
+            // Skip events already replayed during hydration. A
+            // notification with `id <= cutoff_id` is one of:
+            //  - a row written before subscribe attached, then
+            //    captured by the cutoff and replayed by
+            //    `hydrate_observers`;
+            //  - a row written between subscribe and the cutoff read
+            //    (also replayed — the cutoff is post-subscribe).
+            // Either way the observer state already accounts for it.
+            if notification.id <= cutoff_id {
                 continue;
             }
             // Dispatch each matching observer in its own task so a
@@ -268,10 +327,161 @@ impl ObserverRuntime {
         }
         output_ids
     }
+
+    /// Replay a pre-built list of historical [`SpineEvent`]s through
+    /// the runtime's observers, with **outputs suppressed**.
+    ///
+    /// Exposed primarily for tests that want to drive the hydration
+    /// path without standing up a live spine subscription. The
+    /// `run_with_ready` startup path uses the same dispatch shape
+    /// after fetching events via the spine.
+    ///
+    /// Events should be supplied in `event_id` ASC order; the runtime
+    /// dispatches them as-is and observers that depend on monotonic
+    /// ordering rely on the caller's ordering.
+    pub async fn hydrate_from_events(&self, history: Vec<SpineEvent>) {
+        for event in history {
+            dispatch_hydration(&self.observers, &event).await;
+        }
+    }
 }
 
 fn any_pattern_matches(patterns: &[EventPattern], event_type: &str) -> bool {
     patterns.iter().any(|p| p.matches(event_type))
+}
+
+/// Compute the spine-side `event_type = ANY(...)` filter for the
+/// hydration query.
+///
+/// Returns `None` (no server-side filter; scan the window) when any
+/// hydrating observer subscribes via a wildcard pattern. Otherwise
+/// returns the sorted, deduplicated union of exact event types — the
+/// query only fetches rows whose `event_type` is in this set, which
+/// keeps the replay cost proportional to what the observers actually
+/// care about.
+fn hydration_event_type_filter(observers: &[&Registered]) -> Option<Vec<String>> {
+    let mut exacts: BTreeSet<String> = BTreeSet::new();
+    for obs in observers {
+        for pat in &obs.patterns {
+            if pat.is_wildcard() {
+                return None;
+            }
+            exacts.insert(pat.as_str().to_owned());
+        }
+    }
+    Some(exacts.into_iter().collect())
+}
+
+/// Dispatch one historical event through every matching observer
+/// with the observer's hydration window respected and outputs
+/// suppressed.
+///
+/// "Output suppression" is the spec's key correctness rule
+/// (#392): hydration must not write to `observer_outputs`,
+/// otherwise restarts would re-emit insights for last week's
+/// patterns. Discarding the returned `Vec<ObserverOutput>` here is
+/// where that rule is enforced — observers don't need to know
+/// whether they're being hydrated, and the same `on_event`
+/// implementation handles both modes.
+async fn dispatch_hydration(observers: &[Registered], event: &SpineEvent) {
+    let now = chrono::Utc::now();
+    for obs in observers {
+        let Some(window) = obs.hydration_window else {
+            // Observer didn't opt into hydration. Live-only — its
+            // state will warm up from incoming events after ready.
+            continue;
+        };
+        // Per-observer window: the spec is explicit that hydration
+        // bounds are per-observer, so an observer with a tight
+        // window does not get re-fed events older than it cares
+        // about even if a sibling observer requested a longer
+        // window.
+        if event.created_at < now - window {
+            continue;
+        }
+        if !any_pattern_matches(&obs.patterns, &event.event_type) {
+            continue;
+        }
+        let mut guard = obs.observer.lock().await;
+        // Outputs are intentionally discarded — see function
+        // doc-comment. The observer's state mutations
+        // (artifact-id → kind index updates, sliding-window
+        // pushes, …) persist; the returned insights/alerts do not.
+        let _ = guard.on_event(event).await;
+    }
+}
+
+/// Replay historical events through the runtime's observers before
+/// the live loop starts.
+///
+/// One bulk query against `events` — the union of declared hydration
+/// windows — and one dispatch pass per event. Observers without a
+/// declared hydration window are skipped. Failures to parse a row's
+/// payload are logged and skipped (matching the live loop's
+/// best-effort behavior); they do not abort hydration.
+async fn hydrate_observers(
+    observers: &[Registered],
+    event_store: &EventStore,
+    cutoff_id: i64,
+) -> Result<()> {
+    let hydrating: Vec<&Registered> = observers
+        .iter()
+        .filter(|o| o.hydration_window.is_some())
+        .collect();
+    if hydrating.is_empty() {
+        return Ok(());
+    }
+
+    // Union of declared windows: the spec says "the runtime fetches
+    // the union of declared windows". Per-observer windows are still
+    // honored at dispatch time (`dispatch_hydration` re-checks each
+    // event's age against each observer's own window).
+    let max_window = hydrating
+        .iter()
+        .filter_map(|o| o.hydration_window)
+        .max()
+        .expect("at least one hydrating observer");
+    let since = chrono::Utc::now() - max_window;
+    let event_types = hydration_event_type_filter(&hydrating);
+
+    let rows = event_store
+        .query_events_for_replay(since, cutoff_id, event_types.as_deref())
+        .await
+        .context("query events for observer hydration")?;
+
+    let total = rows.len();
+    let mut dispatched = 0usize;
+    for record in rows {
+        let payload: FactoryEvent = match serde_json::from_value(record.data) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    event_id = record.id,
+                    event_type = %record.event_type,
+                    error = %e,
+                    "skip hydration row: parse FactoryEvent failed"
+                );
+                continue;
+            }
+        };
+        let spine_event = SpineEvent {
+            event_id: record.id,
+            event_type: record.event_type,
+            payload,
+            created_at: record.created_at,
+        };
+        dispatch_hydration(observers, &spine_event).await;
+        dispatched += 1;
+    }
+    tracing::info!(
+        observers = hydrating.len(),
+        rows = total,
+        dispatched,
+        cutoff_id,
+        window_seconds = max_window.num_seconds(),
+        "observer runtime: hydration complete"
+    );
+    Ok(())
 }
 
 /// Trait abstracting over `mpsc::UnboundedReceiver` and `mpsc::Receiver`
@@ -508,5 +718,363 @@ mod tests {
             actor: "test".into(),
             timestamp: Utc::now(),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Hydration (#392) — unit-level coverage
+    //
+    // Exercises the runtime-side replay logic without standing up a
+    // spine. The end-to-end DB-backed scenario (subscribe → cutoff
+    // → hydrate → live) is covered in tests/runtime_hydration_e2e.rs
+    // behind the DATABASE_URL gate.
+    // -----------------------------------------------------------------
+
+    /// Test observer that records every event it sees and would
+    /// gladly emit on each one — useful for asserting that hydration
+    /// *does* drive `on_event` while *not* persisting outputs.
+    struct RecordingObserver {
+        seen_ids: Arc<std::sync::Mutex<Vec<i64>>>,
+        patterns: Vec<EventPattern>,
+        hydration: Option<Duration>,
+    }
+
+    #[async_trait]
+    impl Observer for RecordingObserver {
+        fn subscriptions(&self) -> Vec<EventPattern> {
+            self.patterns.clone()
+        }
+        fn hydration_window(&self) -> Option<Duration> {
+            self.hydration
+        }
+        async fn on_event(&mut self, ev: &SpineEvent) -> Vec<ObserverOutput> {
+            self.seen_ids.lock().unwrap().push(ev.event_id);
+            vec![ObserverOutput::Insight(Insight::new(
+                format!("would-emit for {}", ev.event_id),
+                0.5,
+            ))]
+        }
+    }
+
+    fn registered(
+        id: &str,
+        patterns: Vec<EventPattern>,
+        hydration: Option<Duration>,
+        obs: Box<dyn Observer>,
+    ) -> Registered {
+        Registered {
+            id: id.into(),
+            patterns,
+            hydration_window: hydration,
+            observer: Arc::new(Mutex::new(obs)),
+        }
+    }
+
+    fn ev(event_id: i64, event_type: &str, age: Duration) -> SpineEvent {
+        SpineEvent {
+            event_id,
+            event_type: event_type.into(),
+            payload: dummy_factory_event(),
+            created_at: chrono::Utc::now() - age,
+        }
+    }
+
+    #[tokio::test]
+    async fn hydration_dispatches_to_observers_that_opted_in() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<i64>::new()));
+        let obs = Box::new(RecordingObserver {
+            seen_ids: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.*")],
+            hydration: Some(Duration::days(7)),
+        });
+        let observers = vec![registered(
+            "obs.recording",
+            vec![EventPattern::new("artifact.*")],
+            Some(Duration::days(7)),
+            obs,
+        )];
+
+        // Three events inside the window — all should be dispatched.
+        let history = vec![
+            ev(10, "artifact.registered", Duration::hours(1)),
+            ev(11, "artifact.state_changed", Duration::minutes(30)),
+            ev(12, "artifact.archived", Duration::seconds(5)),
+        ];
+        for e in history {
+            dispatch_hydration(&observers, &e).await;
+        }
+
+        let ids = seen.lock().unwrap().clone();
+        assert_eq!(ids, vec![10, 11, 12]);
+    }
+
+    #[tokio::test]
+    async fn hydration_skips_observers_without_window() {
+        // Same patterns, but no opt-in — observer must not be invoked
+        // during hydration. Live mode would still drive it; hydration
+        // is opt-in only.
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<i64>::new()));
+        let obs = Box::new(RecordingObserver {
+            seen_ids: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.*")],
+            hydration: None,
+        });
+        let observers = vec![registered(
+            "obs.no_hydrate",
+            vec![EventPattern::new("artifact.*")],
+            None,
+            obs,
+        )];
+
+        dispatch_hydration(
+            &observers,
+            &ev(10, "artifact.registered", Duration::minutes(5)),
+        )
+        .await;
+        assert!(seen.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn hydration_skips_events_outside_observer_window() {
+        // Observer wants 1 hour of history; the event is 2 hours
+        // old. Bounded window — older events do not get replayed
+        // even if they would have matched.
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<i64>::new()));
+        let obs = Box::new(RecordingObserver {
+            seen_ids: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.registered")],
+            hydration: Some(Duration::hours(1)),
+        });
+        let observers = vec![registered(
+            "obs.bounded",
+            vec![EventPattern::new("artifact.registered")],
+            Some(Duration::hours(1)),
+            obs,
+        )];
+
+        dispatch_hydration(
+            &observers,
+            &ev(10, "artifact.registered", Duration::hours(2)),
+        )
+        .await;
+        assert!(seen.lock().unwrap().is_empty());
+
+        // An in-window event still drives the observer.
+        dispatch_hydration(
+            &observers,
+            &ev(11, "artifact.registered", Duration::minutes(10)),
+        )
+        .await;
+        assert_eq!(seen.lock().unwrap().clone(), vec![11]);
+    }
+
+    #[tokio::test]
+    async fn hydration_skips_events_that_do_not_match_pattern() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<i64>::new()));
+        let obs = Box::new(RecordingObserver {
+            seen_ids: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("forge.gate_verdict")],
+            hydration: Some(Duration::days(1)),
+        });
+        let observers = vec![registered(
+            "obs.specific",
+            vec![EventPattern::new("forge.gate_verdict")],
+            Some(Duration::days(1)),
+            obs,
+        )];
+
+        // Pattern mismatch — even though in window.
+        dispatch_hydration(
+            &observers,
+            &ev(10, "artifact.registered", Duration::minutes(5)),
+        )
+        .await;
+        assert!(seen.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn hydration_outputs_are_suppressed() {
+        // The recording observer would happily emit one Insight per
+        // event; the contract is that hydration discards them. We
+        // verify by reaching directly into the observer state — the
+        // events were seen (state mutated) but no path here would
+        // have persisted to `observer_outputs` (there is no
+        // `output_store.record(...)` call inside `dispatch_hydration`,
+        // so the suppression is structural, not behavioral).
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<i64>::new()));
+        let obs = Box::new(RecordingObserver {
+            seen_ids: Arc::clone(&seen),
+            patterns: vec![EventPattern::new("artifact.*")],
+            hydration: Some(Duration::days(7)),
+        });
+        let observers = vec![registered(
+            "obs.suppress",
+            vec![EventPattern::new("artifact.*")],
+            Some(Duration::days(7)),
+            obs,
+        )];
+
+        for i in 0..5 {
+            dispatch_hydration(
+                &observers,
+                &ev(20 + i, "artifact.registered", Duration::minutes(1)),
+            )
+            .await;
+        }
+        // Events drove `on_event`...
+        assert_eq!(seen.lock().unwrap().len(), 5);
+        // ...but we have no path through `dispatch_hydration` that
+        // would have written to `observer_outputs`. The E2E DB
+        // test confirms the storage is empty after a restart.
+    }
+
+    #[tokio::test]
+    async fn restart_rebuilds_gate_override_kind_index_via_hydration() {
+        // The motivating scenario from spec #392: a code artifact
+        // registered before restart, with no `artifact.registered`
+        // replay, would mean post-restart verdicts can't be grouped
+        // by kind. With hydration, the registration is replayed and
+        // the verdicts trip the override-rate insight as before.
+        use crate::gate_override::{GateOverrideObserver, TAG};
+        use chrono::Utc;
+        use onsager_artifact::{ArtifactId, Kind};
+        use onsager_spine::factory_event::{FactoryEventKind, GatePoint, VerdictSummary};
+
+        let id = ArtifactId::new("art_restart");
+        let mut obs = GateOverrideObserver::default();
+        // Sanity: the observer opts into hydration.
+        assert_eq!(obs.hydration_window(), Some(Duration::days(7)));
+
+        // History: the registration is the only event before "restart".
+        let history = vec![SpineEvent {
+            event_id: 1,
+            event_type: "artifact.registered".into(),
+            payload: FactoryEvent {
+                event: FactoryEventKind::ArtifactRegistered {
+                    artifact_id: id.clone(),
+                    kind: Kind::Code,
+                    name: "t".into(),
+                    owner: "marvin".into(),
+                },
+                correlation_id: None,
+                causation_id: None,
+                actor: "test".into(),
+                timestamp: Utc::now(),
+            },
+            created_at: Utc::now() - Duration::hours(1),
+        }];
+
+        // Replay the registration into the observer's state. Drive
+        // the observer directly (not through `dispatch_hydration`,
+        // since we want to inspect emitted outputs from the post-
+        // restart verdicts below — those go through live `on_event`).
+        for ev in &history {
+            // Hydration call: outputs discarded.
+            let _ = obs.on_event(ev).await;
+        }
+
+        // Post-restart: a burst of denies arrives over the live
+        // stream. Without hydration, the observer's
+        // `artifacts: HashMap<String, Kind>` is empty and the
+        // verdicts drop out of grouping (`evaluate`'s
+        // `self.artifacts.get(...)` returns `None`). With
+        // hydration it returns `Some(Kind::Code)` and the rate trips.
+        let mut emitted = Vec::new();
+        for i in 0..5 {
+            let ev = SpineEvent {
+                event_id: 10 + i,
+                event_type: "forge.gate_verdict".into(),
+                payload: FactoryEvent {
+                    event: FactoryEventKind::ForgeGateVerdict {
+                        artifact_id: id.clone(),
+                        gate_point: GatePoint::PreDispatch,
+                        verdict: VerdictSummary::Deny,
+                    },
+                    correlation_id: None,
+                    causation_id: None,
+                    actor: "test".into(),
+                    timestamp: Utc::now(),
+                },
+                created_at: Utc::now(),
+            };
+            emitted.extend(obs.on_event(&ev).await);
+        }
+        assert_eq!(
+            emitted.len(),
+            1,
+            "post-restart verdicts must group by kind via hydrated index, got {emitted:?}"
+        );
+        match &emitted[0] {
+            ObserverOutput::Insight(i) => {
+                assert_eq!(i.tag.as_deref(), Some(TAG));
+            }
+            _ => panic!("expected Insight"),
+        }
+    }
+
+    #[test]
+    fn hydration_event_type_filter_unions_exact_patterns() {
+        let o1 = registered(
+            "o1",
+            vec![
+                EventPattern::new("artifact.registered"),
+                EventPattern::new("forge.gate_verdict"),
+            ],
+            Some(Duration::days(1)),
+            Box::new(RecordingObserver {
+                seen_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
+                patterns: vec![],
+                hydration: None,
+            }),
+        );
+        let o2 = registered(
+            "o2",
+            vec![EventPattern::new("forge.shaping_returned")],
+            Some(Duration::days(1)),
+            Box::new(RecordingObserver {
+                seen_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
+                patterns: vec![],
+                hydration: None,
+            }),
+        );
+        let filter = hydration_event_type_filter(&[&o1, &o2]).expect("all exact -> Some(...)");
+        // BTreeSet ordering keeps this stable.
+        assert_eq!(
+            filter,
+            vec![
+                "artifact.registered".to_string(),
+                "forge.gate_verdict".to_string(),
+                "forge.shaping_returned".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn hydration_event_type_filter_returns_none_for_wildcard() {
+        // Any wildcard in any hydrating observer disables the
+        // server-side filter — we can't enumerate the matching
+        // event types up front.
+        let o1 = registered(
+            "o1",
+            vec![EventPattern::new("artifact.*")],
+            Some(Duration::days(1)),
+            Box::new(RecordingObserver {
+                seen_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
+                patterns: vec![],
+                hydration: None,
+            }),
+        );
+        assert!(hydration_event_type_filter(&[&o1]).is_none());
+
+        let o2 = registered(
+            "o2",
+            vec![EventPattern::new("*")],
+            Some(Duration::days(1)),
+            Box::new(RecordingObserver {
+                seen_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
+                patterns: vec![],
+                hydration: None,
+            }),
+        );
+        assert!(hydration_event_type_filter(&[&o2]).is_none());
     }
 }

--- a/crates/onsager-observers/src/shape_retry.rs
+++ b/crates/onsager-observers/src/shape_retry.rs
@@ -94,6 +94,10 @@ impl Observer for ShapeRetryObserver {
         ]
     }
 
+    fn hydration_window(&self) -> Option<Duration> {
+        Some(self.config.window)
+    }
+
     async fn on_event(&mut self, event: &SpineEvent) -> Vec<ObserverOutput> {
         match &event.payload.event {
             FactoryEventKind::ArtifactRegistered {

--- a/crates/onsager-observers/tests/runtime_hydration_e2e.rs
+++ b/crates/onsager-observers/tests/runtime_hydration_e2e.rs
@@ -1,0 +1,440 @@
+//! End-to-end hydration tests for `onsager-observers` (spec #392).
+//!
+//! Three scenarios, all DATABASE_URL-gated so they no-op in CI when
+//! no Postgres is available:
+//!
+//! 1. **Restart correctness** — write an `artifact.registered` event,
+//!    start a fresh runtime so it has to hydrate, then write a burst
+//!    of `forge.gate_verdict` rows post-"restart". The
+//!    [`GateOverrideObserver`] must group the live verdicts by the
+//!    kind learned from the hydrated registration, exactly as if it
+//!    had been online the whole time.
+//! 2. **Hydration is silent** — historical events written before the
+//!    runtime starts must NOT cause `observer_outputs` rows to be
+//!    written. Output suppression is the key correctness rule from
+//!    the spec.
+//! 3. **Window is bounded** — events older than the observer's
+//!    declared `hydration_window` are not replayed even if they
+//!    matched.
+//!
+//! All three reuse the cross-test isolation trick from
+//! `runtime_e2e.rs`: every test tags its events with a unique
+//! per-run ULID and filters payload-side, so multiple tests can
+//! share the same spine without contaminating each other.
+
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use chrono::{Duration, Utc};
+use onsager_artifact::{ArtifactId, Kind};
+use onsager_observers::{
+    GateOverrideObserver, ObserverOutputStore, ObserverRuntime, gate_override::TAG as OVERRIDE_TAG,
+};
+use onsager_spine::factory_event::{FactoryEventKind, GatePoint, VerdictSummary};
+use onsager_spine::{EventMetadata, EventStore, FactoryEvent};
+use tokio::sync::oneshot;
+
+async fn write_registered(
+    store: &EventStore,
+    id: &ArtifactId,
+    kind: Kind,
+) -> Result<i64, sqlx::Error> {
+    let event = FactoryEvent {
+        event: FactoryEventKind::ArtifactRegistered {
+            artifact_id: id.clone(),
+            kind,
+            name: "hyd test".into(),
+            owner: "obs-hyd".into(),
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: "obs-hyd".into(),
+        timestamp: Utc::now(),
+    };
+    store
+        .append_factory_event(
+            &event,
+            &EventMetadata {
+                actor: "obs-hyd".into(),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn write_verdict(
+    store: &EventStore,
+    id: &ArtifactId,
+    v: VerdictSummary,
+) -> Result<i64, sqlx::Error> {
+    let event = FactoryEvent {
+        event: FactoryEventKind::ForgeGateVerdict {
+            artifact_id: id.clone(),
+            gate_point: GatePoint::PreDispatch,
+            verdict: v,
+        },
+        correlation_id: None,
+        causation_id: None,
+        actor: "obs-hyd".into(),
+        timestamp: Utc::now(),
+    };
+    store
+        .append_factory_event(
+            &event,
+            &EventMetadata {
+                actor: "obs-hyd".into(),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn cleanup(store: &EventStore, observer_id: &str, event_ids: &[i64]) {
+    let _ = sqlx::query("DELETE FROM observer_outputs WHERE observer_id = $1")
+        .bind(observer_id)
+        .execute(store.pool())
+        .await;
+    if !event_ids.is_empty() {
+        let _ = sqlx::query("DELETE FROM events WHERE id = ANY($1)")
+            .bind(event_ids)
+            .execute(store.pool())
+            .await;
+    }
+}
+
+/// Restart correctness: an artifact registered *before* the runtime
+/// starts must still drive grouping for verdicts that arrive *after*
+/// the runtime is up. Without hydration the observer's
+/// artifact-id → kind index would be empty after restart and the
+/// override-rate insight would never fire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hydration_replays_artifact_registered_so_post_restart_verdicts_group() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_hyd_restart_{}", tag);
+    let art = ArtifactId::new(format!("art_{}", tag));
+
+    // Pre-"restart" history: just the registration.
+    let registered_id = write_registered(&event_store, &art, Kind::Code)
+        .await
+        .unwrap();
+
+    // Bring up the runtime. `run_with_ready` only signals once
+    // hydration is complete, so the post-ready writes below are
+    // guaranteed to land on a hydrated observer.
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone())
+        .register(&observer_id, GateOverrideObserver::default());
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
+
+    // Post-"restart" live verdicts: 4 deny + 1 allow against the
+    // hydrated kind. The default config wants 5 samples at >50%
+    // override — 4/5 = 80% trips it.
+    let mut verdict_ids = Vec::new();
+    for v in [
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Allow,
+    ] {
+        verdict_ids.push(write_verdict(&event_store, &art, v).await.unwrap());
+    }
+
+    // Poll for the override-rate insight. Bounded so a regression
+    // fails fast.
+    let mut found = Vec::new();
+    for _ in 0..30 {
+        found = output_store
+            .list_by_observer(&observer_id, 10)
+            .await
+            .unwrap();
+        if !found.is_empty() {
+            break;
+        }
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+    }
+    handle.abort();
+
+    let insights: Vec<_> = found
+        .iter()
+        .filter_map(|r| match r.clone().into_output().ok()? {
+            onsager_observers::ObserverOutput::Insight(i)
+                if i.tag.as_deref() == Some(OVERRIDE_TAG) =>
+            {
+                Some(i)
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !insights.is_empty(),
+        "hydration should have rebuilt the kind index so live verdicts trip the rate; got {found:?}"
+    );
+
+    let mut all_ids = verdict_ids;
+    all_ids.push(registered_id);
+    cleanup(&event_store, &observer_id, &all_ids).await;
+}
+
+/// Hydration is silent: replaying historical events that *would*
+/// have produced insights must not write to `observer_outputs`.
+/// We pre-stage enough history to trip the override-rate threshold,
+/// start a fresh runtime, wait for ready, and assert no rows landed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hydration_does_not_emit_outputs_for_replayed_events() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_hyd_silent_{}", tag);
+    let art = ArtifactId::new(format!("art_{}", tag));
+
+    // Pre-stage: registration + 5 denies. Same shape that the
+    // live-only test trips on.
+    let mut event_ids = Vec::new();
+    event_ids.push(
+        write_registered(&event_store, &art, Kind::Code)
+            .await
+            .unwrap(),
+    );
+    for v in [
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+    ] {
+        event_ids.push(write_verdict(&event_store, &art, v).await.unwrap());
+    }
+
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone())
+        .register(&observer_id, GateOverrideObserver::default());
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
+
+    // After ready, the runtime has hydrated. Give it a beat to
+    // settle any in-flight writes — there shouldn't be any from
+    // hydration, but if there were a regression we want to see it.
+    tokio::time::sleep(StdDuration::from_millis(200)).await;
+
+    let rows = output_store
+        .list_by_observer(&observer_id, 50)
+        .await
+        .unwrap();
+    handle.abort();
+
+    assert!(
+        rows.is_empty(),
+        "hydration must not write observer_outputs rows; got {rows:?}"
+    );
+
+    cleanup(&event_store, &observer_id, &event_ids).await;
+}
+
+/// Hydration window is bounded: an artifact registered LONG before
+/// the runtime starts (older than the observer's window) must NOT
+/// be replayed, so live verdicts referencing it drop out of
+/// grouping. We force the bound by registering with a configured
+/// 1-minute window and writing the registration "now" — the test
+/// instead uses a *custom-configured* observer whose hydration
+/// window is shorter than the live verdict timing, then asserts
+/// the observer's kind index stays empty.
+///
+/// We can't easily backdate `created_at` (the spine sets it), so
+/// the strategy here is the inverse: configure the observer with a
+/// 0-second hydration window (effectively no hydration), then
+/// write a registration before the runtime starts and assert that
+/// post-runtime verdicts do NOT trip the rate (because the kind
+/// index never got the registration). This is the "without
+/// hydration, restart drops verdicts" failure mode the spec calls
+/// out — it's the negative-control for the first test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hydration_window_zero_means_no_replay_and_verdicts_drop() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_hyd_zero_{}", tag);
+    let art = ArtifactId::new(format!("art_{}", tag));
+
+    // Pre-"restart" history: just the registration.
+    let registered_id = write_registered(&event_store, &art, Kind::Code)
+        .await
+        .unwrap();
+
+    // Build an observer with a `window` of 1 nanosecond so any
+    // historical event falls outside the hydration window. We do
+    // NOT change the analyzer's live window (the analyzer's
+    // sliding-window prune uses `config.window`, so a 1ns window
+    // would also break live grouping). Instead we use a custom
+    // wrapper observer for this scenario.
+    use async_trait::async_trait;
+    use onsager_observers::{EventPattern, Observer, ObserverOutput, SpineEvent};
+
+    /// Wraps a real observer but advertises a zero hydration
+    /// window — so the runtime skips replaying through it even
+    /// though the inner observer would have benefited.
+    struct NoHydrate(GateOverrideObserver);
+
+    #[async_trait]
+    impl Observer for NoHydrate {
+        fn subscriptions(&self) -> Vec<EventPattern> {
+            self.0.subscriptions()
+        }
+        async fn on_event(&mut self, ev: &SpineEvent) -> Vec<ObserverOutput> {
+            self.0.on_event(ev).await
+        }
+        fn hydration_window(&self) -> Option<Duration> {
+            None
+        }
+    }
+
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone())
+        .register(&observer_id, NoHydrate(GateOverrideObserver::default()));
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
+
+    // Live: same 5-verdict burst.
+    let mut verdict_ids = Vec::new();
+    for v in [
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Deny,
+        VerdictSummary::Allow,
+    ] {
+        verdict_ids.push(write_verdict(&event_store, &art, v).await.unwrap());
+    }
+
+    // Give the live loop time to drain — bounded so regressions
+    // surface quickly.
+    tokio::time::sleep(StdDuration::from_millis(500)).await;
+    let rows = output_store
+        .list_by_observer(&observer_id, 10)
+        .await
+        .unwrap();
+    handle.abort();
+
+    assert!(
+        rows.is_empty(),
+        "without hydration, post-restart verdicts must drop out of grouping (no kind index); got {rows:?}"
+    );
+
+    let mut all_ids = verdict_ids;
+    all_ids.push(registered_id);
+    cleanup(&event_store, &observer_id, &all_ids).await;
+}
+
+/// Live notifications with `id <= cutoff_id` must be skipped: they
+/// were already hydrated and re-dispatching them would double-count
+/// in the observer's sliding-window buffer. We can't easily race the
+/// cutoff capture from a test, but we can pre-stage an
+/// `artifact.registered` event before the runtime starts, then
+/// assert that after ready the observer's kind index has ONE entry
+/// for this artifact, not two.
+///
+/// This is a weak proxy for "no double-dispatch" — the strong
+/// version is structural (the live loop's `if notification.id <=
+/// cutoff_id { continue; }` is a hard skip, no dispatch). The unit
+/// test in `runtime.rs::tests` exercises the dispatch surface; this
+/// E2E asserts the wired-up runtime behaves consistently.
+///
+/// Arc<AtomicUsize> counts every `on_event` call across both
+/// hydration and live paths.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cutoff_skip_avoids_double_dispatch_of_pre_subscribe_events() {
+    let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let event_store = EventStore::connect(&db_url).await.unwrap();
+    let output_store = ObserverOutputStore::new(event_store.pool().clone());
+    let tag = ulid::Ulid::new().to_string();
+    let observer_id = format!("obs_hyd_cutoff_{}", tag);
+    let art = ArtifactId::new(format!("art_{}", tag));
+
+    use async_trait::async_trait;
+    use onsager_observers::{EventPattern, Observer, ObserverOutput, SpineEvent};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Counts every `on_event` invocation for OUR tagged event ids
+    /// (cross-test isolation: other tests' events may also
+    /// stream past).
+    struct DispatchCounter {
+        count: Arc<AtomicUsize>,
+        tag: String,
+    }
+
+    #[async_trait]
+    impl Observer for DispatchCounter {
+        fn subscriptions(&self) -> Vec<EventPattern> {
+            vec![EventPattern::new("artifact.registered")]
+        }
+        fn hydration_window(&self) -> Option<Duration> {
+            Some(Duration::days(7))
+        }
+        async fn on_event(&mut self, ev: &SpineEvent) -> Vec<ObserverOutput> {
+            // Filter to events that name our tagged artifact.
+            if let FactoryEventKind::ArtifactRegistered { artifact_id, .. } = &ev.payload.event
+                && artifact_id
+                    .as_str()
+                    .starts_with(&format!("art_{}", self.tag))
+            {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+            Vec::new()
+        }
+    }
+
+    // Pre-stage: one registration before the runtime starts.
+    let registered_id = write_registered(&event_store, &art, Kind::Code)
+        .await
+        .unwrap();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let runtime = ObserverRuntime::new(event_store.clone(), output_store.clone()).register(
+        &observer_id,
+        DispatchCounter {
+            count: Arc::clone(&count),
+            tag: tag.clone(),
+        },
+    );
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move { runtime.run_with_ready(Some(ready_tx)).await });
+    ready_rx.await.unwrap();
+
+    // Hydration must have dispatched the pre-staged registration.
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        1,
+        "hydration should have dispatched the pre-staged registration once"
+    );
+
+    // Give the live loop time to drain the buffered notification
+    // (if it WAS going to be re-dispatched, it would happen here).
+    tokio::time::sleep(StdDuration::from_millis(300)).await;
+    handle.abort();
+
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        1,
+        "live notification for pre-cutoff event id must be skipped, not re-dispatched"
+    );
+
+    cleanup(&event_store, &observer_id, &[registered_id]).await;
+}

--- a/crates/onsager-observers/tests/runtime_hydration_e2e.rs
+++ b/crates/onsager-observers/tests/runtime_hydration_e2e.rs
@@ -1,6 +1,6 @@
 //! End-to-end hydration tests for `onsager-observers` (spec #392).
 //!
-//! Three scenarios, all DATABASE_URL-gated so they no-op in CI when
+//! Four scenarios, all DATABASE_URL-gated so they no-op in CI when
 //! no Postgres is available:
 //!
 //! 1. **Restart correctness** — write an `artifact.registered` event,
@@ -13,11 +13,16 @@
 //!    runtime starts must NOT cause `observer_outputs` rows to be
 //!    written. Output suppression is the key correctness rule from
 //!    the spec.
-//! 3. **Window is bounded** — events older than the observer's
-//!    declared `hydration_window` are not replayed even if they
-//!    matched.
+//! 3. **Negative control: no hydration → verdicts drop** — an
+//!    observer wrapped to advertise `hydration_window() -> None`
+//!    returns to the cold-start failure mode the spec calls out —
+//!    post-restart verdicts no longer group by kind.
+//! 4. **Cutoff-skip / no double-dispatch** — events with `id <=
+//!    cutoff_id` that arrived before subscribe must be replayed
+//!    exactly once (via hydration), never re-dispatched off the
+//!    live channel.
 //!
-//! All three reuse the cross-test isolation trick from
+//! All four reuse the cross-test isolation trick from
 //! `runtime_e2e.rs`: every test tags its events with a unique
 //! per-run ULID and filters payload-side, so multiple tests can
 //! share the same spine without contaminating each other.
@@ -242,23 +247,22 @@ async fn hydration_does_not_emit_outputs_for_replayed_events() {
     cleanup(&event_store, &observer_id, &event_ids).await;
 }
 
-/// Hydration window is bounded: an artifact registered LONG before
-/// the runtime starts (older than the observer's window) must NOT
-/// be replayed, so live verdicts referencing it drop out of
-/// grouping. We force the bound by registering with a configured
-/// 1-minute window and writing the registration "now" — the test
-/// instead uses a *custom-configured* observer whose hydration
-/// window is shorter than the live verdict timing, then asserts
-/// the observer's kind index stays empty.
+/// Negative control: an observer that opts OUT of hydration falls
+/// back to the cold-start failure mode the spec calls out — an
+/// artifact registered before the runtime starts is invisible to
+/// post-restart verdicts, so the override-rate insight never fires
+/// even when the same verdict sequence would trip it on a hydrated
+/// observer (test #1 above).
 ///
-/// We can't easily backdate `created_at` (the spine sets it), so
-/// the strategy here is the inverse: configure the observer with a
-/// 0-second hydration window (effectively no hydration), then
-/// write a registration before the runtime starts and assert that
-/// post-runtime verdicts do NOT trip the rate (because the kind
-/// index never got the registration). This is the "without
-/// hydration, restart drops verdicts" failure mode the spec calls
-/// out — it's the negative-control for the first test.
+/// We can't easily backdate `created_at` to prove the *bounded
+/// window* directly (the spine sets `created_at`, and registering
+/// "now" is always inside any reasonable hydration window). Instead
+/// we pin the bound's complement: a wrapper observer that returns
+/// `hydration_window() -> None` makes the runtime skip replay
+/// through it entirely — equivalent to the case where the
+/// registration was older than the declared window. Post-runtime
+/// verdicts then drop out of grouping because the kind index never
+/// got the registration.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hydration_window_zero_means_no_replay_and_verdicts_drop() {
     let Some(db_url) = std::env::var("DATABASE_URL").ok() else {
@@ -276,18 +280,19 @@ async fn hydration_window_zero_means_no_replay_and_verdicts_drop() {
         .await
         .unwrap();
 
-    // Build an observer with a `window` of 1 nanosecond so any
-    // historical event falls outside the hydration window. We do
-    // NOT change the analyzer's live window (the analyzer's
-    // sliding-window prune uses `config.window`, so a 1ns window
-    // would also break live grouping). Instead we use a custom
-    // wrapper observer for this scenario.
+    // The wrapper below advertises `hydration_window() -> None` so
+    // the runtime skips replaying history through it even though
+    // the wrapped `GateOverrideObserver` would have benefited.
+    // Direct opt-out is the cleanest negative control — using a 1ns
+    // window would also break the analyzer's live `prune_old`
+    // (which keys off the SAME `config.window`), conflating two
+    // failure modes.
     use async_trait::async_trait;
     use onsager_observers::{EventPattern, Observer, ObserverOutput, SpineEvent};
 
-    /// Wraps a real observer but advertises a zero hydration
-    /// window — so the runtime skips replaying through it even
-    /// though the inner observer would have benefited.
+    /// Wraps a real observer but advertises no hydration window —
+    /// so the runtime skips replaying through it even though the
+    /// inner observer would have benefited.
     struct NoHydrate(GateOverrideObserver);
 
     #[async_trait]

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -251,6 +251,70 @@ impl EventStore {
         .await
     }
 
+    /// Range-scan core events for replay / hydration. Returns rows
+    /// where `created_at >= since` and `id <= max_id`, ordered by `id
+    /// ASC` so callers can fold them through stateful consumers in
+    /// the same order they were originally written.
+    ///
+    /// When `event_types` is `Some`, only rows whose `event_type` is
+    /// in the list are returned (`event_type = ANY($types)`). When
+    /// `None`, no event-type filter is applied — every row in the
+    /// `[since, max_id]` window is returned.
+    ///
+    /// Designed for the `onsager-observers` hydration path
+    /// (spec #392): on startup an observer needs the historical
+    /// events it would have seen had it been online over its
+    /// lookback window, *before* the live `pg_notify` stream takes
+    /// over. The `max_id` cutoff lets the caller capture a stable
+    /// upper bound (via [`max_event_id`](Self::max_event_id)) and
+    /// then skip live notifications with `id <= max_id` to avoid
+    /// double-dispatching events that arrived between subscribe and
+    /// hydration.
+    ///
+    /// This is read-only and unbounded in result-set size; callers
+    /// scope it via the window and the event-type filter.
+    pub async fn query_events_for_replay(
+        &self,
+        since: DateTime<Utc>,
+        max_id: i64,
+        event_types: Option<&[String]>,
+    ) -> Result<Vec<EventRecord>, sqlx::Error> {
+        match event_types {
+            Some(types) => {
+                sqlx::query_as::<_, EventRecord>(
+                    r#"
+                    SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at, correlation_id
+                    FROM events
+                    WHERE created_at >= $1
+                      AND id <= $2
+                      AND event_type = ANY($3)
+                    ORDER BY id ASC
+                    "#,
+                )
+                .bind(since)
+                .bind(max_id)
+                .bind(types)
+                .fetch_all(&self.pool)
+                .await
+            }
+            None => {
+                sqlx::query_as::<_, EventRecord>(
+                    r#"
+                    SELECT id, stream_id, stream_type, event_type, data, metadata, sequence, created_at, correlation_id
+                    FROM events
+                    WHERE created_at >= $1
+                      AND id <= $2
+                    ORDER BY id ASC
+                    "#,
+                )
+                .bind(since)
+                .bind(max_id)
+                .fetch_all(&self.pool)
+                .await
+            }
+        }
+    }
+
     /// Return the highest id present in either `events` or `events_ext`,
     /// or `None` if both tables are empty. Callers use this as a
     /// warm-start cursor so a [`Listener`] with `with_since` skips

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -266,10 +266,12 @@ impl EventStore {
     /// events it would have seen had it been online over its
     /// lookback window, *before* the live `pg_notify` stream takes
     /// over. The `max_id` cutoff lets the caller capture a stable
-    /// upper bound (via [`max_event_id`](Self::max_event_id)) and
-    /// then skip live notifications with `id <= max_id` to avoid
-    /// double-dispatching events that arrived between subscribe and
-    /// hydration.
+    /// upper bound (via [`max_core_event_id`](Self::max_core_event_id)
+    /// — *not* [`max_event_id`](Self::max_event_id), which mixes in
+    /// `events_ext.id` and would let a newer extension event mask a
+    /// newer core event) and then skip live notifications with `id
+    /// <= max_id` to avoid double-dispatching events that arrived
+    /// between subscribe and hydration.
     ///
     /// This is read-only and unbounded in result-set size; callers
     /// scope it via the window and the event-type filter.
@@ -319,6 +321,13 @@ impl EventStore {
     /// or `None` if both tables are empty. Callers use this as a
     /// warm-start cursor so a [`Listener`] with `with_since` skips
     /// backfill over history it doesn't need to replay.
+    ///
+    /// **Not appropriate as a `query_events_for_replay` cutoff.**
+    /// Because the result mixes in `events_ext.id`, a higher extension
+    /// id can mask a newer-but-lower core-table id — consumers that
+    /// de-dup against the result would skip live `events` rows that
+    /// arrived after the cutoff. Use
+    /// [`max_core_event_id`](Self::max_core_event_id) for that path.
     pub async fn max_event_id(&self) -> Result<Option<i64>, sqlx::Error> {
         let row: (Option<i64>,) = sqlx::query_as(
             "SELECT GREATEST( \
@@ -328,6 +337,22 @@ impl EventStore {
         )
         .fetch_one(&self.pool)
         .await?;
+        Ok(row.0)
+    }
+
+    /// Return the highest id present in the core `events` table only,
+    /// or `None` if the table is empty.
+    ///
+    /// Paired with [`query_events_for_replay`](Self::query_events_for_replay):
+    /// the cutoff has to come from the same table the replay query
+    /// reads, otherwise a higher `events_ext.id` could trick a
+    /// consumer that uses the combined max
+    /// ([`max_event_id`](Self::max_event_id)) into skipping live core
+    /// rows that arrived after subscribe.
+    pub async fn max_core_event_id(&self) -> Result<Option<i64>, sqlx::Error> {
+        let row: (Option<i64>,) = sqlx::query_as("SELECT MAX(id) FROM events")
+            .fetch_one(&self.pool)
+            .await?;
         Ok(row.0)
     }
 


### PR DESCRIPTION
## Summary

`ObserverRuntime` now replays each observer's declared lookback window
through `on_event` **before** attaching the live `pg_notify`
subscription. Outputs produced during hydration are suppressed — the
runtime drops everything `on_event` returns while replaying history,
so observer state (artifact-id → kind indices, sliding-window buffers,
…) is rebuilt but no `observer_outputs` rows are written.

Without this, a process restart left observers blind to live verdicts
whose artifact registered *before* the restart — the artifact-id →
kind index was empty after restart, verdicts dropped out of grouping,
and rate-based insights silently never fired. The four ported analyzers
(#391, OBS-02) all hit this; per the spec the fix belongs at the
runtime layer so every future observer inherits it.

## Delivers (#392 Plan items)

- [x] **Trait shape — per-observer declared window.** New default
  `Observer::hydration_window() -> Option<Duration>`. Returning
  `Some(d)` opts in; `None` (default) keeps a stateless observer
  hydration-free. Hydration reuses the existing `on_event` — no
  parallel dispatch surface, no observer-side awareness of mode.
- [x] **Window source — per-observer.** The four shipped analyzers
  (`GateOverrideObserver`, `GateDenyRateObserver`,
  `ShapeRetryObserver`, `PrChurnObserver`) opt in with their own
  `config.window` so hydration replays exactly what `prune_old`
  keeps live.
- [x] **Output suppression.** `dispatch_hydration` discards the
  `Vec<ObserverOutput>` returned by `on_event` — there is no path
  through hydration that reaches `ObserverOutputStore::record`. The
  no-emit rule is structural.
- [x] **Bounded window.** A 30-day-old `artifact.registered` whose
  associated verdicts are inside the window is not required to be
  replayed; each observer's window is rechecked per event at
  dispatch time.
- [x] **No double-dispatch race.** Subscribe → capture
  `max_event_id` cutoff → hydrate → ready → live loop skips
  notifications with `id <= cutoff` (those were already replayed).

## How it works

```
ObserverRuntime::run_with_ready (spec #392 startup sequence)

  ├─ subscribe to pg_notify          (live channel starts buffering)
  ├─ cutoff_id = max_event_id()      (post-subscribe cutoff)
  ├─ hydrate_observers(cutoff_id)    (replay history, outputs suppressed)
  │     ├─ union of declared windows determines query window
  │     ├─ union of exact event-types → ANY($types) server-side filter
  │     │   (wildcard pattern in any hydrating observer → no filter)
  │     └─ each event re-dispatched per-observer with its own window
  ├─ signal ready                    (only NOW is the runtime "ready")
  └─ live loop                       (skip notifications with id <= cutoff_id)
```

A new `EventStore::query_events_for_replay(since, max_id, event_types)`
is the spine-side primitive — id-ASC range scan, optional `event_type
= ANY($types)` filter.

## Test plan

- [x] `cargo test -p onsager-observers --lib` — 45 passing, includes:
  - hydration dispatches to observers that opted in
  - hydration skips observers without a window
  - hydration skips events outside the per-observer window
  - hydration skips events that do not match pattern
  - hydration outputs are suppressed (structural)
  - **restart scenario:** `GateOverrideObserver`'s kind index is
    rebuilt via hydration; post-restart verdicts trip the rate
  - `hydration_event_type_filter` unions exact patterns and
    returns `None` for wildcards
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `xtask lint-seams`, `check-api-contract`, `check-file-budget`,
  `gen-event-docs --check` all clean
- [x] New `tests/runtime_hydration_e2e.rs` (DATABASE_URL-gated, no-op
  in CI without DB):
  - end-to-end restart correctness through a real spine
  - hydration writes no `observer_outputs` rows
  - cutoff-skip avoids double-dispatch of pre-subscribe events
  - negative control: observer without `hydration_window` returns to
    the cold-start failure mode

Closes #392

---
_Generated by [Claude Code](https://claude.ai/code/session_018RQ4i7VcgbHNstAe3WtGM5)_