### PR TITLE
feat(ftue): template library v0 + factory metaphor copy

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -51,6 +51,9 @@ const PersonalAccessTokensPage = lazy(() =>
 const ChatPage = lazy(() =>
   import("@/pages/ChatPage").then((m) => ({ default: m.ChatPage })),
 )
+const LandingPage = lazy(() =>
+  import("@/pages/LandingPage").then((m) => ({ default: m.LandingPage })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -167,6 +170,14 @@ function AppRoutes() {
       <Route
         path="/login"
         element={user ? <Navigate to="/" replace /> : <LoginPage />}
+      />
+      <Route
+        path="/landing"
+        element={
+          <LazyRoute>
+            <LandingPage />
+          </LazyRoute>
+        }
       />
       <Route
         path="/*"

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -161,23 +161,35 @@ function SessionIdRedirect() {
 function AppRoutes() {
   const { user, loading } = useAuth()
 
+  // Public landing surface (#408 location 4) — must render before the
+  // auth probe resolves so a first-contact visit isn't gated on
+  // `/api/auth/me`. Matched before the auth-loading branch.
+  const landingRoute = (
+    <Route
+      path="/landing"
+      element={
+        <LazyRoute>
+          <LandingPage />
+        </LazyRoute>
+      }
+    />
+  )
+
   if (loading) {
-    return <AppShellSkeleton />
+    return (
+      <Routes>
+        {landingRoute}
+        <Route path="*" element={<AppShellSkeleton />} />
+      </Routes>
+    )
   }
 
   return (
     <Routes>
+      {landingRoute}
       <Route
         path="/login"
         element={user ? <Navigate to="/" replace /> : <LoginPage />}
-      />
-      <Route
-        path="/landing"
-        element={
-          <LazyRoute>
-            <LandingPage />
-          </LazyRoute>
-        }
       />
       <Route
         path="/*"

--- a/apps/dashboard/src/components/chat/TemplateGallery.tsx
+++ b/apps/dashboard/src/components/chat/TemplateGallery.tsx
@@ -1,99 +1,97 @@
-import type { ComponentType } from "react"
-import { GitBranch, GitMerge, Rocket, Shield, Sparkles } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import {
-  WORKFLOW_PRESETS,
-  type WorkflowDocument,
-  type WorkflowPreset,
-} from "@/components/factory/workflows/workflow-draft"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { TEMPLATES, type FtueTemplate } from "@/lib/templates"
 
-// Six FTUE templates per spec #400's empty-state gallery. The preset
-// catalog (workflow-draft.ts) supplies the underlying DAGs; this list
-// maps each to evaluator-friendly framing (factory-metaphor short copy,
-// icon, primary artifact). Until axis 9 ships the full template-library
-// API (umbrella Open Question 9), the gallery reads from the dashboard's
-// static preset catalog — one source of truth for both "create from
-// scratch" (PresetPicker) and "FTUE workspace-less browse".
-const FACE_BY_PRESET: Record<
-  string,
-  { headline: string; intent: string; icon: ComponentType<{ className?: string }> }
-> = {
-  "github-issue-to-pr": {
-    headline: "Issue → PR",
-    intent: "Agent picks up labeled issues and ships a reviewed PR.",
-    icon: GitBranch,
-  },
-  "agent-only": {
-    headline: "Agent only",
-    intent: "Run one agent session on every triggered issue.",
-    icon: Sparkles,
-  },
-  "ci-then-merge": {
-    headline: "CI → Merge",
-    intent: "Wait for CI to go green, then prompt a human to merge.",
-    icon: GitMerge,
-  },
-  "governed-pipeline": {
-    headline: "Governed pipeline",
-    intent: "Spec → PR with Synodic governance and human sign-off.",
-    icon: Shield,
-  },
-  "merge-to-deploy": {
-    headline: "Merge → Deploy",
-    intent: "Roll merged PRs to staging on every merge.",
-    icon: Rocket,
-  },
+interface TemplateGalleryProps {
+  onPick: (template: FtueTemplate) => void
+  selectedId?: string
 }
 
-export interface TemplateGalleryProps {
-  onPick: (
-    preset: WorkflowPreset,
-    workflow: WorkflowDocument,
-  ) => void
-}
-
-export function TemplateGallery({ onPick }: TemplateGalleryProps) {
+// Horizontal scroll-strip of v0 templates (spec #406). Card click
+// populates the right-panel DAG preview. The factory-framing string
+// lives here as the card subtitle — the only place the metaphor
+// surfaces in the chat empty state (#408 location 3).
+export function TemplateGallery({ onPick, selectedId }: TemplateGalleryProps) {
   return (
-    <div className="flex w-full flex-col gap-2">
-      <p className="px-1 text-xs font-medium text-muted-foreground">
-        Start from a template or describe your own.
-      </p>
-      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
-        {WORKFLOW_PRESETS.map((preset) => {
-          const face = FACE_BY_PRESET[preset.id] ?? {
-            headline: preset.label,
-            intent: preset.description,
-            icon: Sparkles,
-          }
-          const Icon = face.icon
-          // Use the preset builder with an empty trigger — FTUE users
-          // don't yet have an install/repo to bind to. The binding flow
-          // (axis 5) fills the trigger in at promote-to-real time.
-          const workflow = preset.build({
-            install_id: "",
-            repo_owner: "",
-            repo_name: "",
-            label: "",
-          })
-          return (
-            <Button
-              key={preset.id}
-              type="button"
-              variant="outline"
-              className="h-auto min-w-[200px] flex-col items-start gap-1.5 whitespace-normal p-3 text-left"
-              onClick={() => onPick(preset, workflow)}
-            >
-              <div className="flex items-center gap-1.5 text-sm font-medium">
-                <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-                {face.headline}
-              </div>
-              <span className="text-xs font-normal text-muted-foreground">
-                {face.intent}
-              </span>
-            </Button>
-          )
-        })}
+    <div className="w-full">
+      <div className="mb-2 flex items-baseline justify-between px-1">
+        <h3 className="text-sm font-medium">Start from a template</h3>
+        <span className="text-xs text-muted-foreground">
+          {TEMPLATES.length} templates
+        </span>
+      </div>
+      <div
+        className="flex w-full snap-x snap-mandatory gap-3 overflow-x-auto pb-2 pl-1 pr-4"
+        role="list"
+        aria-label="Workflow templates"
+      >
+        {TEMPLATES.map((template) => (
+          <TemplateCard
+            key={template.id}
+            template={template}
+            selected={selectedId === template.id}
+            onClick={() => onPick(template)}
+          />
+        ))}
       </div>
     </div>
   )
+}
+
+function TemplateCard({
+  template,
+  selected,
+  onClick,
+}: {
+  template: FtueTemplate
+  selected: boolean
+  onClick: () => void
+}) {
+  return (
+    <Card
+      role="listitem"
+      size="sm"
+      data-selected={selected || undefined}
+      className="w-64 shrink-0 cursor-pointer snap-start text-left transition-colors hover:bg-muted/40 data-[selected]:ring-2 data-[selected]:ring-primary"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      tabIndex={0}
+      aria-pressed={selected}
+    >
+      <CardContent className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <h4 className="truncate text-sm font-semibold">{template.name}</h4>
+          <Badge variant="outline" className="ml-auto shrink-0 text-[10px]">
+            class {template.scenario_class}
+          </Badge>
+        </div>
+        <p className="line-clamp-2 text-xs italic text-muted-foreground">
+          {template.factory_framing}
+        </p>
+        <div className="text-[11px] text-muted-foreground/80">
+          {template.stages.length} stage{template.stages.length !== 1 ? "s" : ""}
+          {" · "}
+          {triggerLabel(template.trigger_kind)}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function triggerLabel(triggerKind: string): string {
+  switch (triggerKind) {
+    case "github_issue_webhook":
+      return "GitHub label"
+    case "cron":
+      return "Schedule"
+    case "manual":
+      return "Manual"
+    default:
+      return triggerKind
+  }
 }

--- a/apps/dashboard/src/components/chat/TemplateGallery.tsx
+++ b/apps/dashboard/src/components/chat/TemplateGallery.tsx
@@ -8,9 +8,11 @@ interface TemplateGalleryProps {
 }
 
 // Horizontal scroll-strip of v0 templates (spec #406). Card click
-// populates the right-panel DAG preview. The factory-framing string
-// lives here as the card subtitle — the only place the metaphor
-// surfaces in the chat empty state (#408 location 3).
+// populates the right-panel DAG preview. Each card's subtitle is the
+// `factory_framing` string — that's the surface #408 location 3
+// commits to. (The chat empty state also carries the location-1
+// inspection-report callout in `ChatPage.tsx`; this component owns
+// the card surface, not the full empty-state vocabulary audit.)
 export function TemplateGallery({ onPick, selectedId }: TemplateGalleryProps) {
   return (
     <div className="w-full">
@@ -20,20 +22,20 @@ export function TemplateGallery({ onPick, selectedId }: TemplateGalleryProps) {
           {TEMPLATES.length} templates
         </span>
       </div>
-      <div
-        className="flex w-full snap-x snap-mandatory gap-3 overflow-x-auto pb-2 pl-1 pr-4"
-        role="list"
+      <ul
+        className="flex w-full snap-x snap-mandatory list-none gap-3 overflow-x-auto pb-2 pl-1 pr-4"
         aria-label="Workflow templates"
       >
         {TEMPLATES.map((template) => (
-          <TemplateCard
-            key={template.id}
-            template={template}
-            selected={selectedId === template.id}
-            onClick={() => onPick(template)}
-          />
+          <li key={template.id} className="shrink-0 snap-start">
+            <TemplateCard
+              template={template}
+              selected={selectedId === template.id}
+              onClick={() => onPick(template)}
+            />
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   )
 }
@@ -49,10 +51,10 @@ function TemplateCard({
 }) {
   return (
     <Card
-      role="listitem"
+      role="button"
       size="sm"
       data-selected={selected || undefined}
-      className="w-64 shrink-0 cursor-pointer snap-start text-left transition-colors hover:bg-muted/40 data-[selected]:ring-2 data-[selected]:ring-primary"
+      className="w-64 cursor-pointer text-left transition-colors hover:bg-muted/40 data-[selected]:ring-2 data-[selected]:ring-primary"
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -62,6 +64,7 @@ function TemplateCard({
       }}
       tabIndex={0}
       aria-pressed={selected}
+      aria-label={`${template.name}. ${template.factory_framing}`}
     >
       <CardContent className="flex flex-col gap-2">
         <div className="flex items-center gap-2">

--- a/apps/dashboard/src/components/factory/workflows/MetaphorBanner.tsx
+++ b/apps/dashboard/src/components/factory/workflows/MetaphorBanner.tsx
@@ -9,16 +9,27 @@ import { Button } from "@/components/ui/button"
 const STORAGE_KEY = "onsager.metaphor_seen.workflow_detail"
 
 function readDismissed(): boolean {
-  if (typeof window === "undefined") return true
-  return window.localStorage.getItem(STORAGE_KEY) === "1"
+  // Private/restricted-mode storage throws on access; treat as
+  // not-yet-dismissed and let the in-memory dismiss handle the
+  // session so the banner doesn't crash the page.
+  try {
+    if (typeof window === "undefined") return true
+    return window.localStorage.getItem(STORAGE_KEY) === "1"
+  } catch {
+    return false
+  }
 }
 
 export function MetaphorBanner() {
   const [dismissed, setDismissed] = useState<boolean>(readDismissed)
 
   const dismiss = () => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEY, "1")
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, "1")
+      }
+    } catch {
+      // Quota or private mode — keep in-memory dismissal and move on.
     }
     setDismissed(true)
   }
@@ -40,7 +51,7 @@ export function MetaphorBanner() {
         variant="ghost"
         size="sm"
         onClick={dismiss}
-        aria-label="Dismiss"
+        aria-label="Got it, dismiss"
       >
         Got it
         <X className="h-3.5 w-3.5" />

--- a/apps/dashboard/src/components/factory/workflows/MetaphorBanner.tsx
+++ b/apps/dashboard/src/components/factory/workflows/MetaphorBanner.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react"
+import { X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+// Location 5 of spec #408. First time a user lands on a bound workflow's
+// detail page, show the factory-metaphor helper once. Dismissed state is
+// global (not workspace-scoped, per spec #408 OQ): the metaphor is
+// concept-level, learned once.
+const STORAGE_KEY = "onsager.metaphor_seen.workflow_detail"
+
+function readDismissed(): boolean {
+  if (typeof window === "undefined") return true
+  return window.localStorage.getItem(STORAGE_KEY) === "1"
+}
+
+export function MetaphorBanner() {
+  const [dismissed, setDismissed] = useState<boolean>(readDismissed)
+
+  const dismiss = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, "1")
+    }
+    setDismissed(true)
+  }
+
+  if (dismissed) return null
+
+  return (
+    <div
+      role="note"
+      className="flex items-start gap-3 rounded-md border bg-muted/30 px-3 py-2.5 text-sm"
+    >
+      <p className="flex-1 text-muted-foreground">
+        This is your first production line. Each stage is a work station;
+        each gate is a QC checkpoint. Once a run completes, you&apos;ll see
+        the inspection reports here.
+      </p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={dismiss}
+        aria-label="Dismiss"
+      >
+        Got it
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/chat/llm-client.ts
+++ b/apps/dashboard/src/lib/chat/llm-client.ts
@@ -60,6 +60,13 @@ const SYSTEM_PROMPT = [
   "  Stage. Use those nouns in copy; never `bundle`, `sealed`, or `spec`.",
   "- If a tool call needs a workspace_id and one was not provided in the",
   "  conversation, ask before guessing.",
+  "",
+  "First-touch framing (#408):",
+  "- Be concrete: end your first reply with a workflow draft proposal.",
+  "  Frame the proposal as a production-line blueprint — trigger as \"order",
+  "  intake\", stages as \"work stations\", gates as \"QC checkpoints\". Use",
+  "  these framings once in the first reply, then drop back to standard",
+  "  vocabulary.",
 ].join("\n")
 
 // FTUE preamble prepended to the system prompt when the user is in

--- a/apps/dashboard/src/lib/drafts.ts
+++ b/apps/dashboard/src/lib/drafts.ts
@@ -46,6 +46,7 @@ export function makeDraft(
   source: WorkflowDraftSource = "blank",
   workflow: WorkflowDocument = emptyDocument(),
   name = "Untitled draft",
+  templateId?: string,
 ): WorkflowDraft {
   const now = new Date().toISOString()
   return {
@@ -53,6 +54,7 @@ export function makeDraft(
     user_id: userId ?? ANON_USER_KEY,
     name,
     source,
+    template_id: templateId,
     workflow,
     created_at: now,
     updated_at: now,
@@ -169,6 +171,7 @@ export interface UseWorkflowDraftResult {
     source?: WorkflowDraftSource,
     workflow?: WorkflowDocument,
     name?: string,
+    templateId?: string,
   ) => WorkflowDraft
   /** Delete a draft. If it was the active one, switches to the next newest. */
   deleteById: (id: string) => void
@@ -216,8 +219,9 @@ export function useWorkflowDraft(
       source: WorkflowDraftSource = "blank",
       workflow: WorkflowDocument = emptyDocument(),
       name = "Untitled draft",
+      templateId?: string,
     ): WorkflowDraft => {
-      const fresh = makeDraft(userId, source, workflow, name)
+      const fresh = makeDraft(userId, source, workflow, name, templateId)
       saveDraft(userId, fresh)
       bumpAndSelect(fresh.id)
       return fresh

--- a/apps/dashboard/src/lib/templates/index.ts
+++ b/apps/dashboard/src/lib/templates/index.ts
@@ -40,8 +40,14 @@ export function getTemplate(id: string): FtueTemplate | undefined {
 
 // Project a template into a fresh editable WorkflowDocument. The outer
 // WorkflowDraft record (source: "template", template_id, timestamps) is
-// composed by the caller via useWorkflowDraft.newDraft. Trigger fields
-// stay blank — binding (#402) fills them in.
+// composed by the caller via useWorkflowDraft.newDraft. The repo-scoped
+// fields (`install_id`, `repo_owner`, `repo_name`) stay blank because
+// binding (#402) is what picks the workspace, install, and project.
+// The `label` field carries whatever the template's trigger shape
+// contributes (GitHub label name, cron expression, etc.) so the data
+// round-trips into binding rather than being silently dropped — once
+// the WorkflowTriggerDraft type grows non-GitHub trigger fields (#402),
+// the cron expression moves into its proper slot.
 export function templateToDocument(template: FtueTemplate): WorkflowDocument {
   return {
     name: template.name,
@@ -49,7 +55,7 @@ export function templateToDocument(template: FtueTemplate): WorkflowDocument {
       install_id: "",
       repo_owner: "",
       repo_name: "",
-      label: template.trigger_kind === "cron" ? "" : template.trigger_label,
+      label: template.trigger_label,
     },
     stages: template.stages.map((s) =>
       makeStage(s.gate_kind, s.artifact_kind, s.name),

--- a/apps/dashboard/src/lib/templates/index.ts
+++ b/apps/dashboard/src/lib/templates/index.ts
@@ -1,0 +1,58 @@
+import type {
+  WorkflowArtifactKind,
+  WorkflowGateKind,
+} from "@/lib/api/types"
+import type { WorkflowDocument } from "@/components/factory/workflows/workflow-draft"
+import { makeStage } from "@/components/factory/workflows/workflow-draft"
+import templatesData from "./v0.json"
+
+export interface FtueTemplateStage {
+  name: string
+  gate_kind: WorkflowGateKind
+  artifact_kind: WorkflowArtifactKind
+}
+
+export interface FtueTemplate {
+  id: string
+  name: string
+  scenario_class: "A" | "B" | "C" | "D"
+  intent: string
+  trigger_kind: string
+  trigger_label: string
+  stages: FtueTemplateStage[]
+  primary_artifact_kind: WorkflowArtifactKind
+  factory_framing: string
+  cloud_only_note?: string
+}
+
+interface TemplateManifest {
+  version: number
+  templates: FtueTemplate[]
+}
+
+const manifest = templatesData as TemplateManifest
+
+export const TEMPLATES: FtueTemplate[] = manifest.templates
+
+export function getTemplate(id: string): FtueTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id)
+}
+
+// Project a template into a fresh editable WorkflowDocument. The outer
+// WorkflowDraft record (source: "template", template_id, timestamps) is
+// composed by the caller via useWorkflowDraft.newDraft. Trigger fields
+// stay blank — binding (#402) fills them in.
+export function templateToDocument(template: FtueTemplate): WorkflowDocument {
+  return {
+    name: template.name,
+    trigger: {
+      install_id: "",
+      repo_owner: "",
+      repo_name: "",
+      label: template.trigger_kind === "cron" ? "" : template.trigger_label,
+    },
+    stages: template.stages.map((s) =>
+      makeStage(s.gate_kind, s.artifact_kind, s.name),
+    ),
+  }
+}

--- a/apps/dashboard/src/lib/templates/v0.json
+++ b/apps/dashboard/src/lib/templates/v0.json
@@ -1,0 +1,188 @@
+{
+  "version": 0,
+  "templates": [
+    {
+      "id": "auto-merge-on-green",
+      "name": "Auto-merge on green",
+      "scenario_class": "D",
+      "intent": "Auto-merge PRs labeled \"auto-merge\" once CI passes and a Verify gate confirms tests touch the changed code.",
+      "trigger_kind": "github_issue_webhook",
+      "trigger_label": "auto-merge",
+      "stages": [
+        {
+          "name": "CI-wait",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Verify (tests-touch-diff)",
+          "gate_kind": "governance",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Merge",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        }
+      ],
+      "primary_artifact_kind": "PR",
+      "factory_framing": "A QC checkpoint that lets clean PRs ship themselves."
+    },
+    {
+      "id": "spec-compliance-gate",
+      "name": "Spec-compliance gate",
+      "scenario_class": "D",
+      "intent": "Block merge unless the PR description links a spec issue (\"Closes #N\" or \"Part of #N\") OR the PR is labeled \"trivial\".",
+      "trigger_kind": "github_issue_webhook",
+      "trigger_label": "needs-spec-check",
+      "stages": [
+        {
+          "name": "Parse PR body",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Verify spec-link",
+          "gate_kind": "governance",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Gate (deny | allow)",
+          "gate_kind": "manual-approval",
+          "artifact_kind": "PR"
+        }
+      ],
+      "primary_artifact_kind": "PR",
+      "factory_framing": "Refuses any product not tied to a blueprint."
+    },
+    {
+      "id": "labeled-issue-summary",
+      "name": "Labeled-issue summary",
+      "scenario_class": "D",
+      "intent": "When an issue is labeled \"needs-summary\", spin up an agent session to produce a 5-bullet summary, attach it as a comment, gate by a Verify check that the comment contains all required sections.",
+      "trigger_kind": "github_issue_webhook",
+      "trigger_label": "needs-summary",
+      "stages": [
+        {
+          "name": "Agent session (Summarize)",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Issue"
+        },
+        {
+          "name": "Verify (sections present)",
+          "gate_kind": "governance",
+          "artifact_kind": "Issue"
+        },
+        {
+          "name": "Comment",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Issue"
+        }
+      ],
+      "primary_artifact_kind": "Issue",
+      "factory_framing": "Sends incoming orders through an agent station for triage."
+    },
+    {
+      "id": "release-notes-from-merged-prs",
+      "name": "Weekly release notes",
+      "scenario_class": "D",
+      "intent": "Every Friday at 10am, generate release notes from PRs merged in the last 7 days; Verify by checking each referenced PR exists and is merged; post to a draft GitHub Release.",
+      "trigger_kind": "cron",
+      "trigger_label": "0 10 * * 5",
+      "stages": [
+        {
+          "name": "List merged PRs",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Agent session (Draft notes)",
+          "gate_kind": "agent-session",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Verify (PRs exist and merged)",
+          "gate_kind": "governance",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Draft release",
+          "gate_kind": "agent-session",
+          "artifact_kind": "PR"
+        }
+      ],
+      "primary_artifact_kind": "PR",
+      "factory_framing": "Weekly inventory report from the production line.",
+      "cloud_only_note": "The 24/7 cron scheduler is Cloud-only; OSS can still preview this template's shape."
+    },
+    {
+      "id": "security-review-on-pr",
+      "name": "Security review on sensitive PRs",
+      "scenario_class": "D",
+      "intent": "For PRs touching files in a configured \"sensitive\" list, run a security-review agent session; require a human approve verdict before merge becomes allowed.",
+      "trigger_kind": "github_issue_webhook",
+      "trigger_label": "sensitive-area",
+      "stages": [
+        {
+          "name": "Path-glob filter",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Agent session (Security review)",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Session"
+        },
+        {
+          "name": "Human gate",
+          "gate_kind": "manual-approval",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Annotate PR",
+          "gate_kind": "agent-session",
+          "artifact_kind": "PR"
+        }
+      ],
+      "primary_artifact_kind": "PR",
+      "factory_framing": "Human inspection station for the sensitive line."
+    },
+    {
+      "id": "onsager-dogfood",
+      "name": "Onsager dogfood",
+      "scenario_class": "D",
+      "intent": "The workflow Onsager itself uses to ship its own code: spec issue → branch → PR → CI green → review → merge → close issue.",
+      "trigger_kind": "github_issue_webhook",
+      "trigger_label": "ready-to-implement",
+      "stages": [
+        {
+          "name": "Agent session (Implement per spec)",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Issue"
+        },
+        {
+          "name": "Verify (tests pass and touch new code)",
+          "gate_kind": "governance",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "CI-wait",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Review gate",
+          "gate_kind": "manual-approval",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "Merge & close",
+          "gate_kind": "external-check",
+          "artifact_kind": "PR"
+        }
+      ],
+      "primary_artifact_kind": "PR",
+      "factory_framing": "The production line that builds Onsager itself."
+    }
+  ]
+}

--- a/apps/dashboard/src/lib/templates/v0.json
+++ b/apps/dashboard/src/lib/templates/v0.json
@@ -150,11 +150,16 @@
     {
       "id": "onsager-dogfood",
       "name": "Onsager dogfood",
-      "scenario_class": "D",
+      "scenario_class": "A",
       "intent": "The workflow Onsager itself uses to ship its own code: spec issue → branch → PR → CI green → review → merge → close issue.",
       "trigger_kind": "github_issue_webhook",
       "trigger_label": "ready-to-implement",
       "stages": [
+        {
+          "name": "Branch",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Issue"
+        },
         {
           "name": "Agent session (Implement per spec)",
           "gate_kind": "agent-session",
@@ -163,6 +168,11 @@
         {
           "name": "Verify (tests pass and touch new code)",
           "gate_kind": "governance",
+          "artifact_kind": "PR"
+        },
+        {
+          "name": "PR",
+          "gate_kind": "agent-session",
           "artifact_kind": "PR"
         },
         {
@@ -176,9 +186,14 @@
           "artifact_kind": "PR"
         },
         {
-          "name": "Merge & close",
+          "name": "Merge",
           "gate_kind": "external-check",
           "artifact_kind": "PR"
+        },
+        {
+          "name": "Close",
+          "gate_kind": "agent-session",
+          "artifact_kind": "Issue"
         }
       ],
       "primary_artifact_kind": "PR",

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -52,6 +52,7 @@ import type {
   WorkflowDocument,
   WorkflowDraft,
 } from "@/components/factory/workflows/workflow-draft"
+import { type FtueTemplate, templateToDocument } from "@/lib/templates"
 
 // ─── Runtime types ──────────────────────────────────────────────────────────
 
@@ -501,13 +502,15 @@ export function ChatPage() {
 
   const isEmpty = turns.length === 0
 
-  // Pick a template: switch into a fresh draft seeded with the template
-  // and pre-fill the composer with a `Customize "<name>" for my project.`
-  // hint per spec #400.
+  // Pick a template (spec #406): create a fresh draft seeded with the
+  // template's document, record source + template_id on the outer draft
+  // (the spec #404 instrumentation hook), and pre-fill the composer with
+  // the template's intent so the agent's first reply has context.
   const handlePickTemplate = useCallback(
-    (_presetId: string, presetLabel: string, doc: WorkflowDocument) => {
-      newDraft("template", doc, presetLabel || "Untitled draft")
-      setPrompt(`Customize "${presetLabel}" for my project.`)
+    (template: FtueTemplate) => {
+      const doc = templateToDocument(template)
+      newDraft("template", doc, template.name, template.id)
+      setPrompt(`Customize "${template.name}" for my project. ${template.intent}`)
     },
     [newDraft],
   )
@@ -570,6 +573,7 @@ export function ChatPage() {
             <EmptyState
               onChip={setPrompt}
               onPickTemplate={handlePickTemplate}
+              selectedTemplateId={activeDraft?.template_id}
               showTemplateGallery={isFtue}
             />
           ) : (
@@ -664,11 +668,17 @@ const EXAMPLE_CHIPS = [
 
 interface EmptyStateProps {
   onChip: (text: string) => void
-  onPickTemplate: (presetId: string, presetLabel: string, doc: WorkflowDocument) => void
+  onPickTemplate: (template: FtueTemplate) => void
+  selectedTemplateId?: string
   showTemplateGallery: boolean
 }
 
-function EmptyState({ onChip, onPickTemplate, showTemplateGallery }: EmptyStateProps) {
+function EmptyState({
+  onChip,
+  onPickTemplate,
+  selectedTemplateId,
+  showTemplateGallery,
+}: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center gap-6 py-12 text-center">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
@@ -683,9 +693,7 @@ function EmptyState({ onChip, onPickTemplate, showTemplateGallery }: EmptyStateP
       </div>
       {showTemplateGallery && (
         <div className="w-full max-w-3xl px-2">
-          <TemplateGallery
-            onPick={(preset, doc) => onPickTemplate(preset.id, preset.label, doc)}
-          />
+          <TemplateGallery onPick={onPickTemplate} selectedId={selectedTemplateId} />
         </div>
       )}
       <div className="flex flex-wrap justify-center gap-2">
@@ -702,14 +710,16 @@ function EmptyState({ onChip, onPickTemplate, showTemplateGallery }: EmptyStateP
           </Button>
         ))}
       </div>
-      <p className="max-w-xs text-xs text-muted-foreground">
+      {/* Spec #408 location 1: factory-metaphor copy on the chat empty state. */}
+      <p className="max-w-md text-xs text-muted-foreground">
         <Sparkles className="mr-1 inline h-3 w-3" />
-        Cards along the way show what&apos;s about to change. Nothing ships
-        until you accept.
+        Cards along the way are inspection reports — what&apos;s about to
+        change at each QC checkpoint. Nothing ships until you accept.
       </p>
     </div>
   )
 }
+
 
 // ─── Conversation feed ────────────────────────────────────────────────────────
 

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -515,6 +515,20 @@ export function ChatPage() {
     [newDraft],
   )
 
+  // The "describe one yourself" chips are a separate authoring path from
+  // the template gallery. If the active draft was seeded from a template,
+  // open a fresh blank draft so the right-panel DAG preview doesn't keep
+  // showing a stale template shape that no longer matches the prompt.
+  const handleChipPick = useCallback(
+    (text: string) => {
+      setPrompt(text)
+      if (activeDraft?.source === "template") {
+        newDraft()
+      }
+    },
+    [activeDraft?.source, newDraft],
+  )
+
   return (
     <div className="grid h-full grid-cols-1 md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
       {/* ── Left panel: chat ────────────────────────────────────────── */}
@@ -571,7 +585,7 @@ export function ChatPage() {
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4">
           {isEmpty ? (
             <EmptyState
-              onChip={setPrompt}
+              onChip={handleChipPick}
               onPickTemplate={handlePickTemplate}
               selectedTemplateId={activeDraft?.template_id}
               showTemplateGallery={isFtue}

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -51,8 +51,8 @@ export function LandingPage() {
             <span className="font-semibold text-foreground">
               ③ Watch runs land.
             </span>{" "}
-            Every run shows its inspection reports — what each stage
-            verified, what it changed, what it produced.
+            Every run shows what each stage verified, what it changed,
+            and what it produced.
           </li>
         </ol>
       </section>

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -1,0 +1,77 @@
+import { Link } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+
+// Stub landing page (#399 owns the full hero). This file exists so the
+// factory-metaphor sentence from #408 location 4 has a concrete home;
+// route is wired but the unauthenticated entry-point redesign is the
+// scope of spec #399.
+export function LandingPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-12 px-6 py-16">
+      <header className="flex flex-col gap-4">
+        <h1 className="text-4xl font-bold tracking-tight">Onsager</h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Governed workflows for AI-augmented engineering work. When agents
+          write code, ship safely. Open source, runs anywhere.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Who this is for
+        </h2>
+        <p className="max-w-2xl text-muted-foreground">
+          Staff and principal engineers who already use AI coding agents on
+          personal or side projects, and want guardrails for what those
+          agents land.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What you do</h2>
+        <ol className="flex flex-col gap-3 text-muted-foreground">
+          <li>
+            <span className="font-semibold text-foreground">
+              ① Describe the policy in plain English.
+            </span>{" "}
+            The assistant proposes a workflow draft. You review the shape
+            before anything is created. Think of each policy as a production
+            line: an order comes in, the line moves the order through QC
+            checkpoints, the line outputs a finished product (a merged PR,
+            a triaged issue, a release note).
+          </li>
+          <li>
+            <span className="font-semibold text-foreground">
+              ② Bind the draft to a real repo.
+            </span>{" "}
+            Workspace, GitHub install, and project link up only when you
+            choose to make the draft real — not as up-front setup.
+          </li>
+          <li>
+            <span className="font-semibold text-foreground">
+              ③ Watch runs land.
+            </span>{" "}
+            Every run shows its inspection reports — what each stage
+            verified, what it changed, what it produced.
+          </li>
+        </ol>
+      </section>
+
+      <footer className="flex flex-wrap gap-3">
+        <Button render={<Link to="/login" />}>Get started</Button>
+        <Button
+          variant="outline"
+          render={
+            <a
+              href="https://github.com/onsager-ai/onsager"
+              target="_blank"
+              rel="noreferrer"
+            />
+          }
+        >
+          View on GitHub
+        </Button>
+      </footer>
+    </main>
+  )
+}

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs"
 import { ActiveRunsBanner } from "@/components/factory/workflows/ActiveRunsBanner"
+import { MetaphorBanner } from "@/components/factory/workflows/MetaphorBanner"
 import { ArtifactBadge } from "@/components/factory/workflows/ArtifactBadge"
 import { ArtifactFlowOverview } from "@/components/factory/workflows/ArtifactFlowOverview"
 import { WorkflowActions } from "@/components/factory/workflows/WorkflowActions"
@@ -128,6 +129,7 @@ export function WorkflowDetailPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
+      <MetaphorBanner />
       {/* Desktop-only page header. Mobile uses the global top bar. */}
       <div className="hidden space-y-2 md:block">
         <BackLink workspaceSlug={workspace.slug} />

--- a/apps/dashboard/tests/smoke/ftue-templates.test.tsx
+++ b/apps/dashboard/tests/smoke/ftue-templates.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import {
+  TEMPLATES,
+  getTemplate,
+  templateToDocument,
+  type FtueTemplate,
+} from "@/lib/templates"
+import { TemplateGallery } from "@/components/chat/TemplateGallery"
+import { makeDraft } from "@/lib/drafts"
+
+// The valid gate-kind set comes from `WorkflowGateKind` (apps/dashboard/src/
+// lib/api/types.ts) — these are the only stage discriminants the wire
+// accepts. New templates must use one of these; otherwise the DAG would
+// reference a substrate-unknown gate.
+const VALID_GATE_KINDS = new Set([
+  "agent-session",
+  "external-check",
+  "governance",
+  "manual-approval",
+])
+
+// Registered workflow artifact kinds from `crates/onsager-registry/src/
+// catalog.rs` (BUILTIN_WORKFLOW_KINDS). A template's stages and
+// primary_artifact_kind must match one of these — otherwise the workflow
+// can't be persisted and the spec's acceptance criterion #4 fails.
+const REGISTERED_ARTIFACT_KINDS = new Set(["Issue", "PR", "Deployment", "Session"])
+
+// Trigger taxonomy from `crates/onsager-registry/src/triggers.rs`. Per
+// spec #406's Substrate touchpoints, templates must reshape to a coarser
+// existing trigger rather than introducing a new TriggerKind.
+const REGISTERED_TRIGGER_KINDS = new Set([
+  "github_issue_webhook",
+  "github_pull_request_closed",
+  "github_workflow_run_completed",
+  "telegram_webhook",
+  "cron",
+  "delay",
+  "interval",
+  "spine_event",
+  "pg_notify",
+  "outbox_row",
+  "manual",
+  "replay",
+])
+
+describe("FTUE template manifest (#406)", () => {
+  it("ships six templates", () => {
+    expect(TEMPLATES).toHaveLength(6)
+  })
+
+  it("contains the locked template ids", () => {
+    const ids = TEMPLATES.map((t) => t.id)
+    expect(ids).toEqual([
+      "auto-merge-on-green",
+      "spec-compliance-gate",
+      "labeled-issue-summary",
+      "release-notes-from-merged-prs",
+      "security-review-on-pr",
+      "onsager-dogfood",
+    ])
+  })
+
+  it("is dominantly class D", () => {
+    const classD = TEMPLATES.filter((t) => t.scenario_class === "D").length
+    expect(classD).toBe(TEMPLATES.length)
+  })
+
+  it.each(TEMPLATES)(
+    "template $id stages reference valid gate kinds",
+    (template: FtueTemplate) => {
+      for (const stage of template.stages) {
+        expect(VALID_GATE_KINDS.has(stage.gate_kind)).toBe(true)
+      }
+    },
+  )
+
+  it.each(TEMPLATES)(
+    "template $id stage artifact kinds are registered",
+    (template: FtueTemplate) => {
+      for (const stage of template.stages) {
+        expect(REGISTERED_ARTIFACT_KINDS.has(stage.artifact_kind)).toBe(true)
+      }
+    },
+  )
+
+  it.each(TEMPLATES)(
+    "template $id primary_artifact_kind is registered",
+    (template: FtueTemplate) => {
+      expect(REGISTERED_ARTIFACT_KINDS.has(template.primary_artifact_kind)).toBe(true)
+    },
+  )
+
+  it.each(TEMPLATES)(
+    "template $id trigger_kind is registered",
+    (template: FtueTemplate) => {
+      expect(REGISTERED_TRIGGER_KINDS.has(template.trigger_kind)).toBe(true)
+    },
+  )
+
+  it.each(TEMPLATES)(
+    "template $id carries a non-empty factory_framing string",
+    (template: FtueTemplate) => {
+      expect(template.factory_framing.length).toBeGreaterThan(0)
+    },
+  )
+
+  it("locked factory_framing strings match #406 / #408 spec", () => {
+    const byId = Object.fromEntries(TEMPLATES.map((t) => [t.id, t.factory_framing]))
+    expect(byId["auto-merge-on-green"]).toBe(
+      "A QC checkpoint that lets clean PRs ship themselves.",
+    )
+    expect(byId["spec-compliance-gate"]).toBe(
+      "Refuses any product not tied to a blueprint.",
+    )
+    expect(byId["labeled-issue-summary"]).toBe(
+      "Sends incoming orders through an agent station for triage.",
+    )
+    expect(byId["release-notes-from-merged-prs"]).toBe(
+      "Weekly inventory report from the production line.",
+    )
+    expect(byId["security-review-on-pr"]).toBe(
+      "Human inspection station for the sensitive line.",
+    )
+    expect(byId["onsager-dogfood"]).toBe(
+      "The production line that builds Onsager itself.",
+    )
+  })
+})
+
+describe("templateToDocument", () => {
+  it("leaves trigger install/repo blank — binding (#402) fills them", () => {
+    const template = getTemplate("auto-merge-on-green")!
+    const doc = templateToDocument(template)
+    expect(doc.trigger.install_id).toBe("")
+    expect(doc.trigger.repo_owner).toBe("")
+    expect(doc.trigger.repo_name).toBe("")
+  })
+
+  it("projects stages with the template's gate kinds and names", () => {
+    const template = getTemplate("labeled-issue-summary")!
+    const doc = templateToDocument(template)
+    expect(doc.stages).toHaveLength(template.stages.length)
+    expect(doc.stages[0].gate_kind).toBe(template.stages[0].gate_kind)
+    expect(doc.stages[0].name).toBe(template.stages[0].name)
+  })
+
+  it("wraps into a WorkflowDraft carrying source + template_id (#404)", () => {
+    // The outer WorkflowDraft is where activation instrumentation reads
+    // provenance from — templateToDocument supplies the inner document,
+    // makeDraft composes the outer record.
+    const template = getTemplate("auto-merge-on-green")!
+    const draft = makeDraft(
+      "user_test",
+      "template",
+      templateToDocument(template),
+      template.name,
+      template.id,
+    )
+    expect(draft.source).toBe("template")
+    expect(draft.template_id).toBe("auto-merge-on-green")
+  })
+})
+
+describe("TemplateGallery", () => {
+  it("renders one card per template", () => {
+    render(<TemplateGallery onPick={() => {}} />)
+    for (const t of TEMPLATES) {
+      expect(screen.getByText(t.name)).toBeTruthy()
+      expect(screen.getByText(t.factory_framing)).toBeTruthy()
+    }
+  })
+
+  it("fires onPick when a card is clicked", () => {
+    const onPick = vi.fn()
+    render(<TemplateGallery onPick={onPick} />)
+    fireEvent.click(screen.getByText("Auto-merge on green"))
+    expect(onPick).toHaveBeenCalledTimes(1)
+    expect(onPick.mock.calls[0][0].id).toBe("auto-merge-on-green")
+  })
+
+  it("highlights the selected template", () => {
+    const { container } = render(
+      <TemplateGallery onPick={() => {}} selectedId="onsager-dogfood" />,
+    )
+    const selected = container.querySelector('[data-selected="true"]')
+    expect(selected).toBeTruthy()
+    expect(selected?.textContent).toContain("Onsager dogfood")
+  })
+})

--- a/apps/dashboard/tests/smoke/ftue-templates.test.tsx
+++ b/apps/dashboard/tests/smoke/ftue-templates.test.tsx
@@ -61,9 +61,14 @@ describe("FTUE template manifest (#406)", () => {
     ])
   })
 
-  it("is dominantly class D", () => {
+  it("is dominantly class D with a class-A signature bridge (#406)", () => {
+    // Spec #406: "Six templates, five class-D plus one class-A bridge."
+    // The bridge is the Dogfood signature scenario.
     const classD = TEMPLATES.filter((t) => t.scenario_class === "D").length
-    expect(classD).toBe(TEMPLATES.length)
+    const classA = TEMPLATES.filter((t) => t.scenario_class === "A").length
+    expect(classD).toBe(5)
+    expect(classA).toBe(1)
+    expect(getTemplate("onsager-dogfood")?.scenario_class).toBe("A")
   })
 
   it.each(TEMPLATES)(

--- a/apps/dashboard/tests/smoke/metaphor-banner.test.tsx
+++ b/apps/dashboard/tests/smoke/metaphor-banner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MetaphorBanner } from "@/components/factory/workflows/MetaphorBanner"
+
+const STORAGE_KEY = "onsager.metaphor_seen.workflow_detail"
+
+describe("MetaphorBanner (#408 location 5)", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("renders the locked copy on first visit", () => {
+    render(<MetaphorBanner />)
+    expect(
+      screen.getByText(
+        /This is your first production line\. Each stage is a work station; each gate is a QC checkpoint/,
+      ),
+    ).toBeTruthy()
+  })
+
+  it("hides after Got it is clicked and persists across remounts", () => {
+    const { unmount } = render(<MetaphorBanner />)
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/ }))
+    expect(screen.queryByText(/your first production line/)).toBeNull()
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1")
+
+    unmount()
+    render(<MetaphorBanner />)
+    expect(screen.queryByText(/your first production line/)).toBeNull()
+  })
+
+  it("stays hidden when localStorage is already set", () => {
+    window.localStorage.setItem(STORAGE_KEY, "1")
+    render(<MetaphorBanner />)
+    expect(screen.queryByText(/your first production line/)).toBeNull()
+  })
+})

--- a/apps/dashboard/tests/smoke/metaphor-banner.test.tsx
+++ b/apps/dashboard/tests/smoke/metaphor-banner.test.tsx
@@ -20,7 +20,7 @@ describe("MetaphorBanner (#408 location 5)", () => {
 
   it("hides after Got it is clicked and persists across remounts", () => {
     const { unmount } = render(<MetaphorBanner />)
-    fireEvent.click(screen.getByRole("button", { name: /Dismiss/ }))
+    fireEvent.click(screen.getByRole("button", { name: /Got it/ }))
     expect(screen.queryByText(/your first production line/)).toBeNull()
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1")
 


### PR DESCRIPTION
## Summary

Implements **#406** (Template library v0) and **#408** (Factory-metaphor vocabulary application). Both are Part of #397 (FTUE umbrella).

## Delivers

### #406 — Template library v0

- **`apps/dashboard/src/lib/templates/v0.json`** — six templates (five class-D + Dogfood) shipped as a single static JSON file. No runtime fetch, no portal route — consistent with the spec's "static is the simplest shape that works" decision.
- **`apps/dashboard/src/lib/templates/index.ts`** — typed loader + `templateToDraft()` projection that produces a fresh `WorkflowDraft` with `source: "template"` and `template_id` populated (the activation-instrumentation hook for #404 `ftue.drafted`).
- **`apps/dashboard/src/components/chat/TemplateGallery.tsx`** — horizontal scroll-strip of cards using shadcn `Card`. Card subtitle is the `factory_framing` one-liner (the canonical surfacing of the metaphor inside the product per #408 location 3). Class-D badge surfaces the scenario class to evaluators.
- **`apps/dashboard/src/pages/ChatPage.tsx`** — gallery rendered in the empty state; clicking a template populates the right-panel `WorkflowDAGPreview` and seeds a chat prompt referencing the template's intent.
- **`apps/dashboard/src/components/factory/workflows/workflow-draft.ts`** — extended `WorkflowDraft` with optional `source: WorkflowDraftSource` and `template_id?: string`. Spec #401 hooks; existing code paths keep working (fields are optional).

### #408 — Factory-metaphor copy

- **Location 1 (ChatPage callout)** — copy updated to `Cards along the way are inspection reports — what's about to change at each QC checkpoint. Nothing ships until you accept.`
- **Location 2 (FTUE preamble)** — `apps/dashboard/src/lib/chat/llm-client.ts` system prompt extended with the closing first-touch framing block ("end your first reply with a workflow draft proposal… production-line blueprint… work stations… QC checkpoints… use these framings once in the first reply, then drop back to standard vocabulary").
- **Location 3 (template card subtitles)** — locked `factory_framing` strings live in `v0.json` (delivered with #406).
- **Location 4 (landing page)** — `apps/dashboard/src/pages/LandingPage.tsx` ships as a **stub** with the locked metaphor sentence (`Think of each policy as a production line: an order comes in, the line moves the order through QC checkpoints, the line outputs a finished product...`) in a "What you do" block. Routed at `/landing`. The full landing hero is spec #399's scope — this is a carrier file so the metaphor sentence has a home and #399 doesn't have to invent a structure for it.
- **Location 5 (workflow-detail banner)** — `apps/dashboard/src/components/factory/workflows/MetaphorBanner.tsx`. Dismissible, persisted under `localStorage["onsager.metaphor_seen.workflow_detail"]` (global, not workspace-scoped, per spec OQ). Wired into `WorkflowDetailPage.tsx`.

## Tests

- `apps/dashboard/tests/smoke/ftue-templates.test.tsx` (40 tests) — invariants per spec acceptance criteria: six templates, locked ids, dominantly class D, locked `factory_framing` strings, every stage `gate_kind` ∈ `WorkflowGateKind`, every `artifact_kind` ∈ registered `BUILTIN_WORKFLOW_KINDS`, every `trigger_kind` ∈ registered taxonomy; `templateToDraft` sets `source`/`template_id` and leaves trigger blank for #402 binding; `TemplateGallery` renders one card per template and fires `onSelect` on click.
- `apps/dashboard/tests/smoke/metaphor-banner.test.tsx` (3 tests) — locked copy renders on first visit; "Got it" dismiss persists across remounts; localStorage `"1"` keeps it hidden.

All 157 dashboard tests pass; `tsc -b`, ESLint, `xtask lint-seams`, `xtask check-api-contract`, `xtask check-file-budget` are clean.

## Decisions / gaps to surface

These came up in implementation and are flagged here rather than silently:

1. **Artifact-kind mapping.** The spec lists `Release` (template 4), `Branch` / `CIRun` (template 6), `AgentSessionTranscript` (template 5) — none of which are in `crates/onsager-registry`'s `BUILTIN_WORKFLOW_KINDS` (`Issue`, `PR`, `Deployment`, `Session`). Acceptance criterion 4 mandates registered kinds, so templates use the closest registered match (`PR` for Release/Branch/CIRun, `Session` for AgentSessionTranscript). Registering the missing kinds is substrate work (frozen by ADRs 0009–0018, owner-only) and was deliberately not attempted here.
2. **Trigger reshape.** Spec acknowledges path-glob and per-PR-label triggers may not exist as distinct `TriggerKind`s; the spec authorizes a coarser-trigger reshape rather than blocking on a new TriggerKind. Templates use `github_issue_webhook` for label-style triggers and `cron` for the weekly release-notes schedule. The path-glob check (template 5) lives inside the first stage as `external-check`, not as a trigger predicate.
3. **Landing page is a stub.** Location 4 ships a `/landing` route as the carrier for the metaphor sentence — the full unauthenticated landing hero is spec #399's scope. The route is wired but `BarePathRedirect` still sends authenticated users to the workspace; the landing surface is reachable only via direct URL today. This avoids stepping on #399.
4. **Stage shapes are aspirational where executors are missing.** Spec #406 lists stage names like "Verify (tests-touch-diff)", "Path-glob filter", "Branch", etc. — many of which don't have dedicated executors in `crates/onsager-substrate/src/executors/` today. Each stage uses the closest `WorkflowGateKind` (`agent-session` / `external-check` / `governance` / `manual-approval`) and carries the spec's descriptive name in its display text. When a real Verify executor lands the template stays valid.
5. **End-to-end binding test.** Acceptance criterion "A template draft can be successfully bound (axis 5) end-to-end against a test repo, with at least one template (`auto-merge-on-green` is the recommended e2e target)." was not run — binding requires a real workspace + GitHub install (axis 5 / #402 work). The unit test exercises the template → draft projection up to but not including bind; e2e is web-testing skill territory once #402 lands.

## Test plan

- [ ] Visit `/workspaces/<slug>/chat` with empty turns — gallery renders six cards
- [ ] Click each card — DAG preview populates with the template's stages
- [ ] Verify the chat empty-state callout reads "Cards along the way are inspection reports — what's about to change at each QC checkpoint…"
- [ ] Visit `/workspaces/<slug>/workflows/<id>` on a fresh browser profile — metaphor banner renders; click "Got it" — banner persists dismissed across reload
- [ ] Visit `/landing` — "What you do" block contains the production-line sentence
- [ ] Send a fresh chat message with no prior turns — agent uses production-line framing once in its first reply (manual verification with a real Anthropic key)


---
_Generated by [Claude Code](https://claude.ai/code/session_011Rzmgq3akh4b6En3g43Tuo)_