### PR TITLE
feat(ftue): inline Cloud-vs-OSS surfacing at the three natural limits

### DIFF
--- a/apps/dashboard/src/components/chat/DraftStrip.tsx
+++ b/apps/dashboard/src/components/chat/DraftStrip.tsx
@@ -8,6 +8,11 @@ export interface DraftStripProps {
   onSwitch: (id: string) => void
   onNew: () => void
   onDelete: (id: string) => void
+  // Spec #405: OSS persists drafts in localStorage so each device has
+  // its own copy. The footer below makes that constraint visible
+  // without nagging — Cloud (server-side draft sync, future) shows
+  // nothing.
+  isOss?: boolean
 }
 
 // Spec #401's lightweight draft-quick-access strip. One chip per stored
@@ -19,10 +24,12 @@ export function DraftStrip({
   onSwitch,
   onNew,
   onDelete,
+  isOss = false,
 }: DraftStripProps) {
   if (drafts.length === 0) return null
   return (
-    <div className="flex shrink-0 items-center gap-1.5 overflow-x-auto border-b px-3 py-1.5">
+    <div className="flex shrink-0 flex-col gap-1 border-b px-3 py-1.5">
+      <div className="flex items-center gap-1.5 overflow-x-auto">
       {drafts.map((d) => {
         const isActive = d.id === activeId
         return (
@@ -68,6 +75,12 @@ export function DraftStrip({
         <Plus className="mr-1 h-3 w-3" />
         New draft
       </Button>
+      </div>
+      {isOss && (
+        <p className="text-[10px] text-muted-foreground/70">
+          Drafts on this device.
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/hooks/useOSSFlag.ts
+++ b/apps/dashboard/src/hooks/useOSSFlag.ts
@@ -1,0 +1,19 @@
+// Cloud-vs-OSS capability boundary (spec #405).
+//
+// Returns `true` when the portal reports `is_oss: true` via
+// `GET /api/build-info`. Wraps `useBuildInfo` so callers can ask "are
+// we OSS?" without ceremony: undefined / loading / errored all resolve
+// to `false`, matching the anti-nagware default (when in doubt, the
+// surface is silent, not promotional).
+//
+// Used at the three Cloud-vs-OSS surfacing points:
+//   - Workflow detail page Runs tab — 7-day retention cap line.
+//   - Workflow detail page trigger panel — scheduler limitation line.
+//   - Chat draft strip — "Drafts on this device." footer.
+
+import { useBuildInfo } from "@/lib/build-info"
+
+export function useOSSFlag(): boolean {
+  const buildInfo = useBuildInfo()
+  return buildInfo?.is_oss ?? false
+}

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -581,6 +581,7 @@ export function ChatPage() {
           onSwitch={switchDraft}
           onNew={() => newDraft()}
           onDelete={deleteById}
+          isOss={isOss}
         />
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4">
           {isEmpty ? (

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -30,7 +30,17 @@ import { WorkflowSessionsCard } from "@/components/factory/workflows/WorkflowSes
 import { WorkflowVerdictsTab } from "@/components/factory/workflows/WorkflowVerdictsTab"
 import { outputArtifactKind } from "@/components/factory/workflows/workflow-meta"
 import { usePageHeader } from "@/components/layout/PageHeader"
+import { useOSSFlag } from "@/hooks/useOSSFlag"
 import { useActiveWorkspace } from "@/lib/workspace"
+
+// Spec #405: Cloud-vs-OSS surfacing on the workflow detail page is
+// inline at the natural limit, not promotional. The `schedule` trigger
+// category covers `cron` / `delay` / `interval` kind tags — i.e.
+// triggers that need an always-on scheduler. Sourced from the trigger
+// registry (`crates/onsager-registry/src/triggers.rs`). Keeping the set
+// inline avoids a second registry fetch on this page; if the registry
+// gains another `Schedule`-category kind, add it here.
+const SCHEDULE_TRIGGER_KIND_TAGS = new Set(["cron", "delay", "interval"])
 
 const STATUS_VARIANT: Record<StageRunStatus, "default" | "secondary" | "destructive" | "outline"> = {
   pending: "outline",
@@ -61,6 +71,7 @@ function readTabFromHash(): TabValue {
 export function WorkflowDetailPage() {
   const { id = "" } = useParams<{ id: string }>()
   const workspace = useActiveWorkspace()
+  const isOss = useOSSFlag()
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["workflow", id],
@@ -170,7 +181,7 @@ export function WorkflowDetailPage() {
         </TabsList>
 
         <TabsContent value="definition" className="space-y-4 pt-4 md:space-y-6">
-          <DefinitionTab workflow={workflow} />
+          <DefinitionTab workflow={workflow} isOss={isOss} />
         </TabsContent>
 
         <TabsContent value="runs" className="space-y-4 pt-4 md:space-y-6">
@@ -183,6 +194,7 @@ export function WorkflowDetailPage() {
             runs={runs}
             stageIds={workflow.stages.map((s) => s.id)}
             workspaceSlug={workspace.slug}
+            isOss={isOss}
           />
           <WorkflowEventsCard workflowId={workflow.id} runs={runs} />
           <WorkflowSessionsCard runs={runs} />
@@ -205,9 +217,12 @@ export function WorkflowDetailPage() {
 
 function DefinitionTab({
   workflow,
+  isOss,
 }: {
   workflow: NonNullable<Awaited<ReturnType<typeof api.getWorkflow>>["workflow"]>
+  isOss: boolean
 }) {
+  const isSchedule = SCHEDULE_TRIGGER_KIND_TAGS.has(workflow.trigger.kind_tag)
   return (
     <Card>
       <CardHeader className="px-4 pb-2 pt-4 md:px-6">
@@ -222,6 +237,23 @@ function DefinitionTab({
             triggerLabel={workflow.trigger.label ?? ""}
             stages={workflow.stages}
           />
+          {/* Spec #405: OSS users running schedule triggers (cron /
+              delay / interval) discover the always-on-scheduler limit
+              here, where it bites. The line is inline, not a modal. */}
+          {isOss && isSchedule && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Runs while this Onsager process is running. For 24/7
+              schedules,{" "}
+              <a
+                href="https://app.onsager.ai"
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                use Cloud →
+              </a>
+            </p>
+          )}
         </div>
         {workflow.stages.map((s, i) => {
           const output = outputArtifactKind(s.gate_kind, s.artifact_kind)
@@ -267,15 +299,27 @@ function RunsList({
   runs,
   stageIds,
   workspaceSlug,
+  isOss,
 }: {
   runs: WorkflowRun[]
   stageIds: string[]
   workspaceSlug: string
+  isOss: boolean
 }) {
   return (
     <Card>
       <CardHeader className="px-4 pb-2 pt-4 md:px-6">
         <CardTitle className="text-base">Run history</CardTitle>
+        {/* Spec #405: OSS dashboards cap the run-history view at 7
+            days; the line surfaces the Cloud value (90-day retention)
+            at the moment the user hits the wall. Informative, not
+            promotional. The actual retention enforcement is a follow-
+            up spec; this is the surfacing half. */}
+        {isOss && (
+          <p className="text-xs text-muted-foreground">
+            Showing last 7 days · Cloud retains 90.
+          </p>
+        )}
       </CardHeader>
       <CardContent className="space-y-3 px-4 pb-4 md:px-6">
         {runs.length === 0 ? (

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -42,6 +42,22 @@ import { useActiveWorkspace } from "@/lib/workspace"
 // gains another `Schedule`-category kind, add it here.
 const SCHEDULE_TRIGGER_KIND_TAGS = new Set(["cron", "delay", "interval"])
 
+// Spec #405's run-history view cap on OSS. The locked copy promises
+// "Showing last 7 days"; this is the cutoff that keeps the list
+// honest. Cloud (full server response) does not apply the filter.
+// Hoisted out of the component so `Date.now()` lives outside the
+// render body (the `react-hooks/purity` rule rejects impure calls
+// in render).
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+function filterRunsToLastSevenDays(runs: WorkflowRun[]): WorkflowRun[] {
+  const cutoff = Date.now() - SEVEN_DAYS_MS
+  return runs.filter((r) => {
+    const t = Date.parse(r.started_at)
+    return Number.isNaN(t) || t >= cutoff
+  })
+}
+
 const STATUS_VARIANT: Record<StageRunStatus, "default" | "secondary" | "destructive" | "outline"> = {
   pending: "outline",
   blocked: "secondary",
@@ -89,7 +105,14 @@ export function WorkflowDetailPage() {
     refetchInterval: 5000,
   })
   const workflow = data?.workflow
-  const runs = useMemo(() => runsData?.runs ?? [], [runsData])
+  // Spec #405: keep the OSS "Showing last 7 days" copy truthful.
+  // Backend retention enforcement is the follow-up "Cloud retention
+  // job" spec; the dashboard cap is a view-side filter so the line
+  // and the list agree. Cloud renders the full server response.
+  const runs = useMemo(() => {
+    const all = runsData?.runs ?? []
+    return isOss ? filterRunsToLastSevenDays(all) : all
+  }, [runsData, isOss])
 
   const [tab, setTab] = useState<TabValue>(() => readTabFromHash())
 
@@ -247,7 +270,7 @@ function DefinitionTab({
               <a
                 href="https://app.onsager.ai"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="underline underline-offset-2 hover:text-foreground"
               >
                 use Cloud →

--- a/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
+++ b/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { WorkflowDetailPage } from "@/pages/WorkflowDetailPage"
+import { DraftStrip } from "@/components/chat/DraftStrip"
+
+// Spec #405: Cloud-vs-OSS capability boundary surfacing. Three inline
+// lines surface only when `is_oss === true`, exactly where the user is
+// hitting the natural limit. This test pins each of the three locations
+// behaves correctly with and without the OSS flag.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  getWorkflow: vi.fn(),
+  getWorkflowRuns: vi.fn(),
+  listWorkflows: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return { ...actual, api: apiMock }
+})
+
+const buildInfoMock = vi.hoisted(() => ({ useOSSFlag: vi.fn() }))
+vi.mock("@/hooks/useOSSFlag", () => buildInfoMock)
+
+import { WorkspaceScope } from "@/lib/workspace"
+
+const workspace = {
+  id: "ws_1",
+  slug: "acme",
+  name: "Acme",
+  created_by: "u1",
+  created_at: "2026-01-01",
+}
+
+function makeWorkflow(kindTag: string) {
+  return {
+    workflow: {
+      id: "wf_1",
+      workspace_id: "ws_1",
+      name: "Issue → PR",
+      preset: null,
+      status: "active",
+      trigger: {
+        kind: "github-label",
+        install_id: "42",
+        repo_owner: "onsager-ai",
+        repo_name: "onsager",
+        label: "factory",
+        kind_tag: kindTag,
+      },
+      stages: [
+        {
+          id: "s_1",
+          name: "Triage",
+          gate_kind: "agent-session",
+          artifact_kind: "Issue",
+          config: {},
+        },
+      ],
+      created_at: "2026-04-22T00:00:00Z",
+      updated_at: "2026-04-22T00:00:00Z",
+    },
+  }
+}
+
+function renderWorkflow(hash: string) {
+  // Tab state seeds from `window.location.hash` (not from React Router),
+  // so we mirror the existing detail-page test pattern and pin the
+  // browser-side URL before render. MemoryRouter alone does not set
+  // window.location.
+  window.history.replaceState(
+    null,
+    "",
+    `/workspaces/acme/workflows/wf_1${hash}`,
+  )
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/workspaces/acme/workflows/wf_1${hash}`]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route
+                    path="workflows/:id"
+                    element={<WorkflowDetailPage />}
+                  />
+                </Routes>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("Spec #405 — OSS capability-boundary surfacing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState(null, "", "/workspaces/acme/workflows/wf_1")
+    apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+    apiMock.getWorkflowRuns.mockResolvedValue({ runs: [] })
+    apiMock.listWorkflows.mockResolvedValue({ workflows: [] })
+  })
+  afterEach(() => {
+    window.location.hash = ""
+  })
+
+  it("renders the 7-day cap line on the Runs tab when OSS", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(true)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("github_issue_webhook"))
+    renderWorkflow("#runs")
+    await waitFor(() =>
+      expect(
+        screen.getByText("Showing last 7 days · Cloud retains 90."),
+      ).toBeTruthy(),
+    )
+  })
+
+  it("hides the 7-day cap line on the Runs tab when Cloud", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(false)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("github_issue_webhook"))
+    renderWorkflow("#runs")
+    // Wait for the Run history card to render before asserting absence.
+    await screen.findByText("Run history")
+    expect(
+      screen.queryByText("Showing last 7 days · Cloud retains 90."),
+    ).toBeNull()
+  })
+
+  it("renders the scheduler limitation line on schedule triggers when OSS", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(true)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("cron"))
+    renderWorkflow("#definition")
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Runs while this Onsager process is running\. For 24\/7 schedules/,
+        ),
+      ).toBeTruthy(),
+    )
+    const link = screen.getByRole("link", { name: /use Cloud/ })
+    expect(link.getAttribute("href")).toBe("https://app.onsager.ai")
+  })
+
+  it("hides the scheduler limitation line on non-schedule triggers", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(true)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("github_issue_webhook"))
+    renderWorkflow("#definition")
+    // Definition tab renders the Flow / stages; wait for the canonical
+    // stage marker, then assert the schedule copy is absent.
+    await screen.findByText("Stages")
+    expect(
+      screen.queryByText(/Runs while this Onsager process is running/),
+    ).toBeNull()
+  })
+
+  it("hides the scheduler limitation line on schedule triggers when Cloud", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(false)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("cron"))
+    renderWorkflow("#definition")
+    await screen.findByText("Stages")
+    expect(
+      screen.queryByText(/Runs while this Onsager process is running/),
+    ).toBeNull()
+  })
+})
+
+describe("Spec #405 — DraftStrip OSS footer", () => {
+  const draft = {
+    id: "d_1",
+    name: "Untitled draft",
+    updated_at: new Date().toISOString(),
+    workflow: { name: "", stages: [], trigger: null },
+    template_id: undefined,
+    // The strip only reads `id`, `name`, `updated_at`; cast keeps the
+    // test fixture small without dragging in the full draft shape.
+  } as unknown as Parameters<typeof DraftStrip>[0]["drafts"][number]
+
+  it("renders the `Drafts on this device.` footer when OSS", () => {
+    render(
+      <DraftStrip
+        drafts={[draft]}
+        activeId={draft.id}
+        onSwitch={() => {}}
+        onNew={() => {}}
+        onDelete={() => {}}
+        isOss={true}
+      />,
+    )
+    expect(screen.getByText("Drafts on this device.")).toBeTruthy()
+  })
+
+  it("hides the footer when Cloud", () => {
+    render(
+      <DraftStrip
+        drafts={[draft]}
+        activeId={draft.id}
+        onSwitch={() => {}}
+        onNew={() => {}}
+        onDelete={() => {}}
+        isOss={false}
+      />,
+    )
+    expect(screen.queryByText("Drafts on this device.")).toBeNull()
+  })
+
+  it("hides the footer when there are no drafts (strip is hidden entirely)", () => {
+    const { container } = render(
+      <DraftStrip
+        drafts={[]}
+        activeId={null}
+        onSwitch={() => {}}
+        onNew={() => {}}
+        onDelete={() => {}}
+        isOss={true}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
+++ b/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
@@ -142,6 +142,61 @@ describe("Spec #405 — OSS capability-boundary surfacing", () => {
     ).toBeNull()
   })
 
+  it("filters runs older than 7 days on OSS so the locked copy stays truthful", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(true)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("github_issue_webhook"))
+    const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+    const ancient = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    apiMock.getWorkflowRuns.mockResolvedValue({
+      runs: [
+        {
+          id: "run_recent",
+          workflow_id: "wf_1",
+          artifact_id: "art_recent",
+          status: "passed",
+          stages: [],
+          started_at: recent,
+          updated_at: recent,
+        },
+        {
+          id: "run_ancient",
+          workflow_id: "wf_1",
+          artifact_id: "art_ancient",
+          status: "passed",
+          stages: [],
+          started_at: ancient,
+          updated_at: ancient,
+        },
+      ],
+    })
+    renderWorkflow("#runs")
+    await screen.findByText("Run history")
+    await waitFor(() => expect(screen.queryByText("art_recent")).toBeTruthy())
+    expect(screen.queryByText("art_ancient")).toBeNull()
+  })
+
+  it("keeps runs older than 7 days when Cloud (no client-side cap)", async () => {
+    buildInfoMock.useOSSFlag.mockReturnValue(false)
+    apiMock.getWorkflow.mockResolvedValue(makeWorkflow("github_issue_webhook"))
+    const ancient = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    apiMock.getWorkflowRuns.mockResolvedValue({
+      runs: [
+        {
+          id: "run_ancient",
+          workflow_id: "wf_1",
+          artifact_id: "art_ancient",
+          status: "passed",
+          stages: [],
+          started_at: ancient,
+          updated_at: ancient,
+        },
+      ],
+    })
+    renderWorkflow("#runs")
+    await screen.findByText("Run history")
+    await waitFor(() => expect(screen.queryByText("art_ancient")).toBeTruthy())
+  })
+
   it("renders the scheduler limitation line on schedule triggers when OSS", async () => {
     buildInfoMock.useOSSFlag.mockReturnValue(true)
     apiMock.getWorkflow.mockResolvedValue(makeWorkflow("cron"))


### PR DESCRIPTION
## Summary

Spec #405: v1 capability-boundary surfacing — three inline lines on the OSS dashboard, sourced from `/api/build-info`'s `is_oss` flag. Anti-nagware: no modal, no banner, no sidebar nag. If a user never asks for 90-day history, never sets up a schedule trigger, and never uses two devices, they never see Cloud-vs-OSS framing in-app.

## Delivers

- **Run history cap** — Workflow detail page Runs tab inserts `Showing last 7 days · Cloud retains 90.` in the Run history card header.
- **Schedule trigger limit** — Workflow detail page Definition tab inserts `Runs while this Onsager process is running. For 24/7 schedules, use Cloud →` inside the Flow panel when the trigger's `kind_tag` is `cron` / `delay` / `interval`. Link target is `https://app.onsager.ai` (no tracking param, per spec).
- **Draft device note** — `DraftStrip` footer renders `Drafts on this device.` when at least one draft is shown.
- **`useOSSFlag()` hook** — thin boolean wrapper around `useBuildInfo()`. Defaults to `false` on loading / fetch failure so a flaky portal doesn't accidentally flash OSS surfaces on Cloud (the safe direction per the anti-nagware commitment).

Backend already exists: `/api/build-info` landed with spec #398; this PR is the OSS-side surfacing.

## What this does NOT do

Per the spec's "What this spec does NOT do" section, retention enforcement, cross-device draft sync, and the hosted scheduler are out of scope and each ship as their own follow-up. This PR is the surfacing half only.

## Test plan

- [x] `pnpm test --run ftue-oss-boundary workflow-detail-tabs` — 12 passed (new file + the existing detail-tab regression suite).
- [x] `pnpm build` — TypeScript build green.
- [x] `pnpm lint` — clean.
- [x] `cargo run -p xtask --quiet -- check-api-contract` — clean; `/api/build-info` continues to match its allowlist exemption.
- [x] `cargo run -p xtask -- check-file-budget` — clean.

Closes #405

---
_Generated by [Claude Code](https://claude.ai/code/session_015Hos5nnLtNYQQLjzqFxDKa)_