### PR TITLE
feat(ftue): public Dogfood showcase at /showcase/dogfood

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -54,6 +54,11 @@ const ChatPage = lazy(() =>
 const LandingPage = lazy(() =>
   import("@/pages/LandingPage").then((m) => ({ default: m.LandingPage })),
 )
+const ShowcaseDogfoodPage = lazy(() =>
+  import("@/pages/ShowcaseDogfoodPage").then((m) => ({
+    default: m.ShowcaseDogfoodPage,
+  })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -175,10 +180,25 @@ function AppRoutes() {
     />
   )
 
+  // Public Dogfood showcase (spec #407). Same auth-pre-empt as
+  // /landing: an evaluator clicking "see live runs ↗" from the OSS
+  // README hits this route directly, with no session.
+  const showcaseRoute = (
+    <Route
+      path="/showcase/dogfood"
+      element={
+        <LazyRoute>
+          <ShowcaseDogfoodPage />
+        </LazyRoute>
+      }
+    />
+  )
+
   if (loading) {
     return (
       <Routes>
         {landingRoute}
+        {showcaseRoute}
         <Route path="*" element={<AppShellSkeleton />} />
       </Routes>
     )
@@ -187,6 +207,7 @@ function AppRoutes() {
   return (
     <Routes>
       {landingRoute}
+      {showcaseRoute}
       <Route
         path="/login"
         element={user ? <Navigate to="/" replace /> : <LoginPage />}

--- a/apps/dashboard/src/components/chat/TemplateGallery.tsx
+++ b/apps/dashboard/src/components/chat/TemplateGallery.tsx
@@ -81,6 +81,18 @@ function TemplateCard({
           {" · "}
           {triggerLabel(template.trigger_kind)}
         </div>
+        {template.id === "onsager-dogfood" ? (
+          // Spec #407 link-surfacing — the dogfood template card carries
+          // a "see live" pointer to the public showcase so an evaluator
+          // can confirm the template isn't aspirational.
+          <a
+            href="/showcase/dogfood"
+            onClick={(e) => e.stopPropagation()}
+            className="text-[11px] text-primary underline-offset-4 hover:underline"
+          >
+            See this template running on Onsager itself →
+          </a>
+        ) : null}
       </CardContent>
     </Card>
   )

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -14,6 +14,17 @@ export function LandingPage() {
           Governed workflows for AI-augmented engineering work. When agents
           write code, ship safely. Open source, runs anywhere.
         </p>
+        {/* Spec #407 trust-strip — locked copy. The link points at the
+            public Dogfood showcase, the live reference for the
+            Onsager-managing-Onsager claim. */}
+        <p className="text-sm text-muted-foreground">
+          <Link
+            to="/showcase/dogfood"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            Onsager is the factory that builds Onsager — see live runs ↗
+          </Link>
+        </p>
       </header>
 
       <section className="flex flex-col gap-3">

--- a/apps/dashboard/src/pages/ShowcaseDogfoodPage.tsx
+++ b/apps/dashboard/src/pages/ShowcaseDogfoodPage.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useState } from "react"
+import { OnsagerLogo } from "@/components/layout/OnsagerLogo"
+
+// Spec #407 — public, unauthenticated Dogfood showcase. The shape comes
+// from `GET /api/showcase/dogfood`; we don't reuse the dashboard's typed
+// `api` helper because that suite assumes authenticated routes and would
+// surface this surface in the auth probe path. The page renders
+// pre-auth from a top-level App.tsx route, so we fetch with plain
+// `fetch` to keep the dependency surface minimal.
+
+interface StageInfo {
+  index: number
+  executor_kind: string
+}
+
+interface RunStage {
+  index: number
+  executor_kind: string
+  status: "passed" | "failed" | "blocked" | "pending"
+}
+
+interface RunLink {
+  number: number
+  url: string | null
+}
+
+interface Run {
+  id: string
+  status: "passed" | "failed" | "blocked" | "pending"
+  stages: RunStage[]
+  spec: RunLink | null
+  pr: RunLink | null
+  started_at: string
+  updated_at: string
+}
+
+interface ShowcaseStats {
+  specs_shipped: number
+  prs_merged: number
+  verify_gates_passed: number
+}
+
+interface ShowcaseResponse {
+  enabled: boolean
+  workflow: {
+    name: string
+    stage_count: number
+    stages: StageInfo[]
+  } | null
+  runs: Run[]
+  stats_7d: ShowcaseStats
+  last_activity_at: string | null
+  is_quiet: boolean
+  generated_at: string
+}
+
+const REPO_URL = "https://github.com/onsager-ai/onsager"
+
+export function ShowcaseDogfoodPage() {
+  const [data, setData] = useState<ShowcaseResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/showcase/dogfood")
+      .then((r) => r.json())
+      .then((body: ShowcaseResponse) => {
+        if (!cancelled) setData(body)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          const msg = e instanceof Error ? e.message : String(e)
+          setError(msg)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-12 px-6 py-12">
+      <header className="flex items-center justify-between">
+        <a href="/" className="flex items-center gap-2 text-foreground">
+          <OnsagerLogo />
+          <span className="text-sm font-semibold">Onsager</span>
+        </a>
+        <a
+          href="/login"
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          Sign in →
+        </a>
+      </header>
+
+      <section className="flex flex-col gap-4">
+        <h1 className="text-3xl font-bold tracking-tight">
+          Onsager builds Onsager.
+        </h1>
+        {/* Spec #407 locked copy. Don't rewrite without amending the spec. */}
+        <p className="max-w-2xl text-base text-muted-foreground">
+          This page is produced by Onsager. The factory below ships the code
+          that built this page.
+        </p>
+        <WorkflowStrip workflow={data?.workflow ?? null} />
+      </section>
+
+      {error ? (
+        <p className="text-sm text-destructive">
+          Couldn&apos;t load runs: {error}. The factory itself is fine — this is
+          just the projection.
+        </p>
+      ) : null}
+
+      <StatsStrip stats={data?.stats_7d} />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-xl font-semibold tracking-tight">
+          Live runs from this factory.
+        </h2>
+        <RunsList data={data} />
+      </section>
+
+      <footer className="flex flex-col gap-1 border-t pt-6 text-sm text-muted-foreground">
+        <p>
+          Want this for your team? Self-host:{" "}
+          <a
+            href={REPO_URL}
+            className="text-foreground underline-offset-4 hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            github.com/onsager-ai/onsager
+          </a>{" "}
+          · Cloud:{" "}
+          <a
+            href="/signup"
+            className="text-foreground underline-offset-4 hover:underline"
+          >
+            app.onsager.ai/signup
+          </a>
+          .
+        </p>
+      </footer>
+    </main>
+  )
+}
+
+function WorkflowStrip({
+  workflow,
+}: {
+  workflow: ShowcaseResponse["workflow"]
+}) {
+  if (!workflow) {
+    return (
+      <div className="h-16 animate-pulse rounded-md border bg-muted/30" />
+    )
+  }
+  return (
+    <div className="flex w-full items-center gap-2 overflow-x-auto rounded-md border bg-muted/20 p-3">
+      {workflow.stages.map((stage, i) => (
+        <div key={stage.index} className="flex items-center gap-2">
+          {i > 0 ? (
+            <span aria-hidden className="text-muted-foreground">
+              →
+            </span>
+          ) : null}
+          <span className="whitespace-nowrap rounded border bg-background px-2 py-1 text-xs font-medium">
+            Stage {stage.index} · {stage.executor_kind}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function StatsStrip({ stats }: { stats: ShowcaseStats | undefined }) {
+  const counters: { label: string; value: number | string }[] = [
+    {
+      label: "Specs shipped this week",
+      value: stats?.specs_shipped ?? "—",
+    },
+    {
+      label: "PRs merged",
+      value: stats?.prs_merged ?? "—",
+    },
+    {
+      label: "Verify gates passed",
+      value: stats?.verify_gates_passed ?? "—",
+    },
+  ]
+  return (
+    <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {counters.map((c) => (
+        <div
+          key={c.label}
+          className="flex flex-col gap-1 rounded-md border bg-muted/20 p-4"
+        >
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            {c.label}
+          </span>
+          <span className="text-2xl font-bold tabular-nums">{c.value}</span>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+function RunsList({ data }: { data: ShowcaseResponse | null }) {
+  if (!data) {
+    return (
+      <ul className="flex flex-col gap-2">
+        {[0, 1, 2].map((i) => (
+          <li
+            key={i}
+            className="h-14 animate-pulse rounded-md border bg-muted/30"
+          />
+        ))}
+      </ul>
+    )
+  }
+  if (!data.enabled) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        The Dogfood workflow is not yet configured on this deployment. The
+        live reference will appear here once it&apos;s wired up.
+      </p>
+    )
+  }
+  if (data.runs.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No runs in the spine yet. The first run will appear here.
+      </p>
+    )
+  }
+  return (
+    <>
+      <ul className="flex flex-col gap-3">
+        {data.runs.map((run) => (
+          <RunRow key={run.id} run={run} />
+        ))}
+      </ul>
+      {data.is_quiet ? <QuietFooter at={data.last_activity_at} /> : null}
+    </>
+  )
+}
+
+function RunRow({ run }: { run: Run }) {
+  return (
+    <li className="flex flex-col gap-2 rounded-md border bg-card p-4">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+        <StatusPill status={run.status} />
+        {run.spec ? <SpecLink spec={run.spec} /> : null}
+        {run.pr ? <PrLink pr={run.pr} /> : null}
+        <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+          {formatRelative(run.updated_at)}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {run.stages.map((s) => (
+          <StagePill key={s.index} stage={s} />
+        ))}
+      </div>
+    </li>
+  )
+}
+
+function StatusPill({ status }: { status: Run["status"] }) {
+  const styles: Record<Run["status"], string> = {
+    passed: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+    failed: "bg-destructive/15 text-destructive",
+    blocked: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+    pending: "bg-muted text-muted-foreground",
+  }
+  return (
+    <span
+      className={`rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${styles[status]}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function StagePill({ stage }: { stage: RunStage }) {
+  const styles: Record<RunStage["status"], string> = {
+    passed: "border-emerald-500/40 bg-emerald-500/10",
+    failed: "border-destructive/50 bg-destructive/10",
+    blocked: "border-amber-500/50 bg-amber-500/10",
+    pending: "border-border bg-muted/40",
+  }
+  return (
+    <span
+      className={`whitespace-nowrap rounded border px-1.5 py-0.5 text-[11px] ${styles[stage.status]}`}
+      title={`Stage ${stage.index} · ${stage.executor_kind} · ${stage.status}`}
+    >
+      {stage.index}·{stage.executor_kind}
+    </span>
+  )
+}
+
+function SpecLink({ spec }: { spec: RunLink }) {
+  const label = `Spec #${spec.number}`
+  if (spec.url) {
+    return (
+      <a
+        href={spec.url}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium underline-offset-4 hover:underline"
+      >
+        {label}
+      </a>
+    )
+  }
+  return <span className="font-medium">{label}</span>
+}
+
+function PrLink({ pr }: { pr: RunLink }) {
+  const label = `PR #${pr.number}`
+  if (pr.url) {
+    return (
+      <a
+        href={pr.url}
+        target="_blank"
+        rel="noreferrer"
+        className="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+      >
+        {label}
+      </a>
+    )
+  }
+  return <span className="text-muted-foreground">{label}</span>
+}
+
+function QuietFooter({ at }: { at: string | null }) {
+  // Spec #407 quiet-week copy. We fill the timestamp into the placeholder
+  // the spec template leaves blank.
+  const rel = at ? formatRelative(at) : "never"
+  return (
+    <p className="mt-2 text-xs text-muted-foreground">
+      Last activity: {rel}. We don&apos;t run agents on weekends.
+    </p>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return iso
+  const now = Date.now()
+  const seconds = Math.floor((now - then) / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -64,6 +64,13 @@ pub struct Config {
     /// self-hosted enterprise deploys that want the OSS chrome.
     /// Configured via `ONSAGER_DEPLOYMENT`.
     pub deployment: Option<String>,
+    /// Pinned workflow_id for the public Dogfood showcase (spec #407).
+    /// When `None`, `GET /api/showcase/dogfood` short-circuits to
+    /// `{ enabled: false }`. The Cloud deploy sets this to the spine
+    /// workflow row that models Onsager-managing-Onsager; OSS
+    /// self-hosters can point it at their own dogfood workflow.
+    /// Configured via `SHOWCASE_DOGFOOD_WORKFLOW_ID`.
+    pub showcase_dogfood_workflow_id: Option<String>,
 }
 
 /// Default monthly per-workspace cap for `propose_remediation` AI
@@ -151,6 +158,7 @@ mod tests {
             telegram_webhook_secret: None,
             remediation_monthly_cap_usd: DEFAULT_REMEDIATION_MONTHLY_CAP_USD,
             deployment: None,
+            showcase_dogfood_workflow_id: None,
         }
     }
 

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -19,6 +19,7 @@ pub mod registry_events;
 pub mod registry_triggers;
 pub mod runs;
 pub mod sessions;
+pub mod showcase;
 pub mod spec_link;
 pub mod spine;
 pub mod tasks;

--- a/crates/onsager-portal/src/handlers/showcase.rs
+++ b/crates/onsager-portal/src/handlers/showcase.rs
@@ -132,9 +132,11 @@ pub async fn get_dogfood(State(state): State<AppState>) -> Response {
         Err(e) => {
             tracing::error!(error = %e, "showcase: projection failed");
             // Public surface — fail soft so a transient DB hiccup
-            // doesn't surface a 500 to an evaluator.
-            let mut b = disabled_payload();
-            b["error"] = json!("projection unavailable");
+            // doesn't surface a 500 to an evaluator. Reuse the
+            // disabled shape verbatim so the `{ enabled: false }`
+            // allow-list contract still holds; the failure signal is
+            // `enabled: false` plus the server-side log.
+            let b = disabled_payload();
             cache().put(b.clone());
             return Json(b).into_response();
         }
@@ -325,14 +327,15 @@ async fn project_run(
 /// kinds or DB ids from the URL. The 12-char prefix is plenty unique
 /// across 10 runs.
 fn run_status_id(artifact_id: &str) -> String {
-    let h = blake3_hex(artifact_id);
+    let h = fnv1a_hex(artifact_id);
     format!("run_{}", &h[..12])
 }
 
-fn blake3_hex(input: &str) -> String {
-    // Cheap deterministic hash without pulling a new crate: a u64
-    // FNV-1a is plenty for 10-runs uniqueness on the public surface.
-    // (Sticking to std avoids growing the dep graph for one helper.)
+/// FNV-1a 64-bit hash → lowercase hex. Non-cryptographic, deterministic,
+/// std-only. Plenty unique for the 10-runs surface; opacity here is
+/// "don't leak the internal `art_iss_<uuid>` shape", not adversarial
+/// resistance.
+fn fnv1a_hex(input: &str) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for byte in input.as_bytes() {
         hash ^= u64::from(*byte);
@@ -462,14 +465,17 @@ async fn compute_stats_7d(
     .get::<i64, _>(0);
 
     // PRs merged: `git.pr_merged` events scoped to the workflow's
-    // workspace, last 7 days. Workflow-level scoping would require
-    // joining each event to its run; workspace scoping is good enough
-    // for the dogfood instance where the workspace hosts only this one
-    // workflow.
+    // workspace, last 7 days. Filter on the indexed `workspace_id`
+    // column (migration 016) rather than a JSONB hint — the
+    // `FactoryEventKind::GitPrMerged` payload carries
+    // `(artifact_id, pr_number, merge_sha)` and no top-level
+    // `workspace_id`, so the legacy JSONB predicate would always
+    // miss. Workspace-level scoping is good enough for the dogfood
+    // instance where the workspace hosts only this one workflow.
     let prs_merged: i64 = sqlx::query(
         "SELECT COUNT(*)::BIGINT FROM events_ext \
           WHERE event_type = 'git.pr_merged' \
-            AND data->>'workspace_id' = $1 \
+            AND workspace_id = $1 \
             AND created_at >= NOW() - INTERVAL '7 days'",
     )
     .bind(workspace_id)
@@ -477,15 +483,17 @@ async fn compute_stats_7d(
     .await?
     .get::<i64, _>(0);
 
-    // Verify gates passed: `synodic.gate_verdict` events with verdict
-    // == 'allow'. Same workspace scoping as above. The verdict is
-    // tagged at the JSON top level by the enum's `tag = "verdict"`
-    // serde attribute on GateVerdict.
+    // Verify gates passed: `synodic.gate_verdict` events whose inner
+    // `GateVerdict` enum tag is `"allow"`. The enum lives at
+    // `data.verdict.verdict` (FactoryEventKind serializes as
+    // `{type, ..., verdict: <GateVerdict>}` and `GateVerdict` is
+    // `#[serde(tag = "verdict")]`). Same indexed-column scoping as
+    // above.
     let verify_passed: i64 = sqlx::query(
         "SELECT COUNT(*)::BIGINT FROM events_ext \
           WHERE event_type = 'synodic.gate_verdict' \
-            AND data->>'verdict' = 'allow' \
-            AND data->>'workspace_id' = $1 \
+            AND workspace_id = $1 \
+            AND data->'verdict'->>'verdict' = 'allow' \
             AND created_at >= NOW() - INTERVAL '7 days'",
     )
     .bind(workspace_id)

--- a/crates/onsager-portal/src/handlers/showcase.rs
+++ b/crates/onsager-portal/src/handlers/showcase.rs
@@ -1,0 +1,604 @@
+//! Public Dogfood showcase projection (spec #407).
+//!
+//! `GET /api/showcase/dogfood` is the read-only public surface that
+//! powers `app.onsager.ai/showcase/dogfood` — the live reference Axis 2's
+//! landing hero links to. The route is unauthenticated by design: the
+//! evaluator clicks "see live runs ↗" from an OSS README or a marketing
+//! page and lands on something concrete, with no auth wall.
+//!
+//! ## Sanitization (the load-bearing piece)
+//!
+//! The dashboard's authenticated workflow API surfaces internal state
+//! (full stage names, gate params, agent transcripts, governance
+//! verdicts, retry reasons). This route serves the same data through a
+//! strict allow-list: stage names are anonymized to `Stage N · <executor>`,
+//! spec issues expose only `(number, url)`, PRs only `(number, url)`,
+//! and nothing else from the artifact/event chain crosses the boundary.
+//! `tests/showcase_dogfood.rs` pins the response shape so future fields
+//! on the source tables can't accidentally leak.
+//!
+//! ## Freshness
+//!
+//! The projection is cached in-process for 60 seconds (the same TTL
+//! shape `proxy_cache` uses for live-hydration reads — different cache
+//! instance, distinct concern). Within a TTL window every request
+//! returns identical bytes; expiry triggers a single fresh build that
+//! the next caller sees. No coalescing — under genuine load two
+//! simultaneous misses will each rebuild, which is cheap because the
+//! projection is a handful of indexed reads.
+//!
+//! ## Configuration
+//!
+//! The workflow we project is selected by `SHOWCASE_DOGFOOD_WORKFLOW_ID`
+//! (Config::showcase_dogfood_workflow_id). When unset, the route
+//! short-circuits to `{ "enabled": false, ... }` so the static page can
+//! render a placeholder rather than 404. In production this env var
+//! pins the Onsager-managing-Onsager workflow row in the Cloud
+//! instance's internal workspace; OSS self-hosters can repoint it at
+//! their own dogfood workflow if they want.
+//!
+//! ## Quiet-week handling
+//!
+//! When the most recent run's `updated_at` is older than 7 days, the
+//! response sets `is_quiet = true` and the dashboard renders the
+//! "Last activity: <relative ts>" footer instead of inventing fake
+//! liveness. A red factory shows up as failed runs — that's the
+//! commitment behind the surface.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use sqlx::{PgPool, Row};
+
+use crate::state::AppState;
+use crate::workflow_db;
+
+/// How many runs the projection surfaces. Hardcoded per spec — 10 is
+/// enough to read a week's worth of activity at the current dogfood
+/// cadence without forcing the reader to scroll.
+const RUN_LIMIT: i64 = 10;
+
+/// TTL for the per-process projection cache. The spec pins 60s as the
+/// freshness floor; a static rather than env-tunable value keeps the
+/// public surface predictable across replicas.
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Cached projection payload. One slot, replaced atomically on miss.
+#[derive(Clone)]
+struct CachedPayload {
+    inserted: Instant,
+    body: Value,
+}
+
+/// Process-local single-slot cache. The showcase has exactly one
+/// resource (the dogfood workflow projection), so a HashMap would just
+/// add ceremony.
+#[derive(Default)]
+struct ProjectionCache {
+    slot: Mutex<Option<CachedPayload>>,
+}
+
+impl ProjectionCache {
+    fn get_fresh(&self) -> Option<Value> {
+        let slot = self.slot.lock().ok()?;
+        let entry = slot.as_ref()?;
+        if entry.inserted.elapsed() <= CACHE_TTL {
+            Some(entry.body.clone())
+        } else {
+            None
+        }
+    }
+
+    fn put(&self, body: Value) {
+        if let Ok(mut slot) = self.slot.lock() {
+            *slot = Some(CachedPayload {
+                inserted: Instant::now(),
+                body,
+            });
+        }
+    }
+}
+
+/// Lazily-initialized process-local cache. The handler shares one
+/// instance across requests; nothing else touches it.
+fn cache() -> &'static Arc<ProjectionCache> {
+    use std::sync::OnceLock;
+    static CELL: OnceLock<Arc<ProjectionCache>> = OnceLock::new();
+    CELL.get_or_init(|| Arc::new(ProjectionCache::default()))
+}
+
+/// GET /api/showcase/dogfood — public, unauthenticated, 60s cached.
+pub async fn get_dogfood(State(state): State<AppState>) -> Response {
+    if let Some(body) = cache().get_fresh() {
+        return Json(body).into_response();
+    }
+
+    let workflow_id = match state.config.showcase_dogfood_workflow_id.as_deref() {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            let body = disabled_payload();
+            cache().put(body.clone());
+            return Json(body).into_response();
+        }
+    };
+
+    let body = match build_projection(&state, workflow_id).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(error = %e, "showcase: projection failed");
+            // Public surface — fail soft so a transient DB hiccup
+            // doesn't surface a 500 to an evaluator.
+            let mut b = disabled_payload();
+            b["error"] = json!("projection unavailable");
+            cache().put(b.clone());
+            return Json(b).into_response();
+        }
+    };
+    cache().put(body.clone());
+    Json(body).into_response()
+}
+
+fn disabled_payload() -> Value {
+    json!({
+        "enabled": false,
+        "workflow": Value::Null,
+        "runs": [],
+        "stats_7d": {
+            "specs_shipped": 0,
+            "prs_merged": 0,
+            "verify_gates_passed": 0,
+        },
+        "last_activity_at": Value::Null,
+        "is_quiet": true,
+        "generated_at": Utc::now().to_rfc3339(),
+    })
+}
+
+#[derive(Debug)]
+struct StageMeta {
+    executor_kind: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct RunRow {
+    artifact_id: String,
+    kind: String,
+    state: String,
+    current_stage_index: Option<i32>,
+    workflow_parked_reason: Option<String>,
+    external_ref: Option<String>,
+    metadata: Value,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+/// Build the projection payload directly against the spine + portal
+/// pools. The HTTP handler is a thin wrapper that adds the 60s cache
+/// and serves the result over JSON; tests exercise this seam to assert
+/// the response shape without spinning up a full axum router.
+pub async fn build_projection_for_test(
+    spine: &PgPool,
+    portal: &PgPool,
+    workflow_id: &str,
+) -> anyhow::Result<Value> {
+    build_projection_inner(spine, portal, workflow_id).await
+}
+
+async fn build_projection(state: &AppState, workflow_id: &str) -> anyhow::Result<Value> {
+    build_projection_inner(state.spine.pool(), &state.pool, workflow_id).await
+}
+
+async fn build_projection_inner(
+    spine: &PgPool,
+    portal: &PgPool,
+    workflow_id: &str,
+) -> anyhow::Result<Value> {
+    let workflow = workflow_db::get_workflow(spine, workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("dogfood workflow {workflow_id} not found"))?;
+    let stages = workflow_db::list_stages_for_workflow(spine, workflow_id).await?;
+
+    let stage_meta: Vec<StageMeta> = stages
+        .iter()
+        .map(|s| StageMeta {
+            executor_kind: s.gate_kind.to_string(),
+        })
+        .collect();
+
+    let rows: Vec<RunRow> = sqlx::query_as::<_, RunRow>(
+        "SELECT artifact_id, kind, state, current_stage_index, workflow_parked_reason, \
+                external_ref, metadata, created_at, updated_at \
+           FROM artifacts \
+          WHERE workflow_id = $1 \
+          ORDER BY updated_at DESC \
+          LIMIT $2",
+    )
+    .bind(workflow_id)
+    .bind(RUN_LIMIT)
+    .fetch_all(spine)
+    .await?;
+
+    let mut runs = Vec::with_capacity(rows.len());
+    for row in &rows {
+        runs.push(project_run(spine, portal, row, &stage_meta).await?);
+    }
+
+    let last_activity_at = rows.first().map(|r| r.updated_at);
+    let is_quiet = last_activity_at
+        .map(|ts| (Utc::now() - ts).num_days() >= 7)
+        .unwrap_or(true);
+
+    let stats = compute_stats_7d(spine, workflow_id, &workflow.workspace_id).await?;
+
+    Ok(json!({
+        "enabled": true,
+        "workflow": {
+            "name": workflow.name,
+            "stage_count": stages.len(),
+            "stages": stage_meta
+                .iter()
+                .enumerate()
+                .map(|(i, m)| json!({
+                    "index": i + 1,
+                    "executor_kind": m.executor_kind,
+                }))
+                .collect::<Vec<_>>(),
+        },
+        "runs": runs,
+        "stats_7d": stats,
+        "last_activity_at": last_activity_at.map(|ts| ts.to_rfc3339()),
+        "is_quiet": is_quiet,
+        "generated_at": Utc::now().to_rfc3339(),
+    }))
+}
+
+/// Project a single run row + its stage chain into the sanitized public
+/// shape. Mirrors the status mapping in `handlers/workflows::project_run`
+/// — kept inline so the public projection can never drift to expose
+/// fields the authenticated route adds later.
+async fn project_run(
+    spine: &PgPool,
+    portal: &PgPool,
+    row: &RunRow,
+    stages: &[StageMeta],
+) -> anyhow::Result<Value> {
+    let current_idx = row
+        .current_stage_index
+        .and_then(|i| usize::try_from(i).ok());
+    let archived = row.state == "archived";
+    let released = row.state == "released";
+    let parked = row.workflow_parked_reason.is_some();
+
+    let stage_entries: Vec<Value> = stages
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let status = match (released, archived, parked, current_idx) {
+                (true, _, _, _) => "passed",
+                (_, true, _, Some(idx)) if i < idx => "passed",
+                (_, true, _, Some(idx)) if i == idx => "failed",
+                (_, true, _, _) => "pending",
+                (_, _, true, Some(idx)) if i < idx => "passed",
+                (_, _, true, Some(idx)) if i == idx => "blocked",
+                (_, _, _, Some(idx)) if i < idx => "passed",
+                _ => "pending",
+            };
+            json!({
+                "index": i + 1,
+                "executor_kind": m.executor_kind,
+                "status": status,
+            })
+        })
+        .collect();
+
+    let run_status = if released {
+        "passed"
+    } else if archived {
+        "failed"
+    } else if parked {
+        "blocked"
+    } else {
+        "pending"
+    };
+
+    let spec = spec_link_for_row(row);
+    let pr = pr_link_for_run(spine, portal, &row.artifact_id, &row.kind).await?;
+
+    Ok(json!({
+        "id": run_status_id(&row.artifact_id),
+        "status": run_status,
+        "stages": stage_entries,
+        "spec": spec,
+        "pr": pr,
+        "started_at": row.created_at.to_rfc3339(),
+        "updated_at": row.updated_at.to_rfc3339(),
+    }))
+}
+
+/// Opaque, deterministic id for a run on the public surface. Drops the
+/// internal `art_iss_<uuid>` shape so an evaluator can't infer artifact
+/// kinds or DB ids from the URL. The 12-char prefix is plenty unique
+/// across 10 runs.
+fn run_status_id(artifact_id: &str) -> String {
+    let h = blake3_hex(artifact_id);
+    format!("run_{}", &h[..12])
+}
+
+fn blake3_hex(input: &str) -> String {
+    // Cheap deterministic hash without pulling a new crate: a u64
+    // FNV-1a is plenty for 10-runs uniqueness on the public surface.
+    // (Sticking to std avoids growing the dep graph for one helper.)
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[derive(Debug)]
+struct SpecLink {
+    project_id: Option<String>,
+    issue_number: Option<u64>,
+}
+
+fn parse_external_ref(ext: &str) -> SpecLink {
+    let mut parts = ext.splitn(5, ':');
+    let _ = parts.next(); // "github"
+    let _ = parts.next(); // "project"
+    let project_id = parts.next().map(|s| s.to_string());
+    let _kind = parts.next(); // "issue" | "pr"
+    let number = parts.next().and_then(|s| s.parse::<u64>().ok());
+    SpecLink {
+        project_id,
+        issue_number: number,
+    }
+}
+
+fn spec_link_for_row(row: &RunRow) -> Value {
+    let Some(ext) = row.external_ref.as_deref() else {
+        return Value::Null;
+    };
+    if row.kind != "issue" {
+        return Value::Null;
+    }
+    let link = parse_external_ref(ext);
+    let (Some(_project_id), Some(number)) = (link.project_id.clone(), link.issue_number) else {
+        return Value::Null;
+    };
+    let repo = repo_from_metadata(&row.metadata);
+    let url = repo
+        .as_deref()
+        .map(|r| format!("https://github.com/{r}/issues/{number}"));
+    json!({
+        "number": number,
+        "url": url,
+    })
+}
+
+/// Best-effort `(owner, name)` extraction. The portal's webhook + spec
+/// listeners stamp `project_id`/`issue_number` into metadata but not
+/// the owner/name pair — the canonical mapping lives on the `projects`
+/// row. For v1 we leave URL construction up to the dashboard via the
+/// project lookup elsewhere; here we surface the link only when
+/// metadata carries an explicit `repo: "owner/name"` hint.
+fn repo_from_metadata(metadata: &Value) -> Option<String> {
+    metadata
+        .get("repo")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+async fn pr_link_for_run(
+    spine: &PgPool,
+    portal: &PgPool,
+    run_artifact_id: &str,
+    run_kind: &str,
+) -> anyhow::Result<Value> {
+    if run_kind != "issue" {
+        // PR-keyed runs surface the PR directly via their own external_ref.
+        return Ok(Value::Null);
+    }
+    // PR → issue linkage lives on `horizontal_lineage` (role='closes_issue').
+    // The reverse lookup finds the PR opened against this run's spec.
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT hl.artifact_id \
+           FROM horizontal_lineage hl \
+          WHERE hl.source_artifact_id = $1 AND hl.role = 'closes_issue' \
+          ORDER BY hl.id DESC LIMIT 1",
+    )
+    .bind(run_artifact_id)
+    .fetch_optional(portal)
+    .await?;
+    let Some((pr_artifact_id,)) = row else {
+        return Ok(Value::Null);
+    };
+    let pr: Option<(Option<String>, Value)> =
+        sqlx::query_as("SELECT external_ref, metadata FROM artifacts WHERE artifact_id = $1")
+            .bind(&pr_artifact_id)
+            .fetch_optional(spine)
+            .await?;
+    let Some((ext, meta)) = pr else {
+        return Ok(Value::Null);
+    };
+    let Some(ext) = ext else {
+        return Ok(Value::Null);
+    };
+    let link = parse_external_ref(&ext);
+    let Some(number) = link.issue_number else {
+        return Ok(Value::Null);
+    };
+    let repo = repo_from_metadata(&meta);
+    let url = repo
+        .as_deref()
+        .map(|r| format!("https://github.com/{r}/pull/{number}"));
+    Ok(json!({
+        "number": number,
+        "url": url,
+    }))
+}
+
+async fn compute_stats_7d(
+    spine: &PgPool,
+    workflow_id: &str,
+    workspace_id: &str,
+) -> anyhow::Result<Value> {
+    // Specs shipped: runs of this workflow that reached `released`
+    // in the last 7 days. One spec = one run = one released artifact.
+    let specs_shipped: i64 = sqlx::query(
+        "SELECT COUNT(*)::BIGINT FROM artifacts \
+          WHERE workflow_id = $1 \
+            AND state = 'released' \
+            AND updated_at >= NOW() - INTERVAL '7 days'",
+    )
+    .bind(workflow_id)
+    .fetch_one(spine)
+    .await?
+    .get::<i64, _>(0);
+
+    // PRs merged: `git.pr_merged` events scoped to the workflow's
+    // workspace, last 7 days. Workflow-level scoping would require
+    // joining each event to its run; workspace scoping is good enough
+    // for the dogfood instance where the workspace hosts only this one
+    // workflow.
+    let prs_merged: i64 = sqlx::query(
+        "SELECT COUNT(*)::BIGINT FROM events_ext \
+          WHERE event_type = 'git.pr_merged' \
+            AND data->>'workspace_id' = $1 \
+            AND created_at >= NOW() - INTERVAL '7 days'",
+    )
+    .bind(workspace_id)
+    .fetch_one(spine)
+    .await?
+    .get::<i64, _>(0);
+
+    // Verify gates passed: `synodic.gate_verdict` events with verdict
+    // == 'allow'. Same workspace scoping as above. The verdict is
+    // tagged at the JSON top level by the enum's `tag = "verdict"`
+    // serde attribute on GateVerdict.
+    let verify_passed: i64 = sqlx::query(
+        "SELECT COUNT(*)::BIGINT FROM events_ext \
+          WHERE event_type = 'synodic.gate_verdict' \
+            AND data->>'verdict' = 'allow' \
+            AND data->>'workspace_id' = $1 \
+            AND created_at >= NOW() - INTERVAL '7 days'",
+    )
+    .bind(workspace_id)
+    .fetch_one(spine)
+    .await?
+    .get::<i64, _>(0);
+
+    Ok(json!({
+        "specs_shipped": specs_shipped,
+        "prs_merged": prs_merged,
+        "verify_gates_passed": verify_passed,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_payload_shape() {
+        let body = disabled_payload();
+        assert_eq!(body["enabled"], json!(false));
+        assert_eq!(body["runs"], json!([]));
+        assert_eq!(body["is_quiet"], json!(true));
+        assert_eq!(body["stats_7d"]["specs_shipped"], json!(0));
+        assert_eq!(body["stats_7d"]["prs_merged"], json!(0));
+        assert_eq!(body["stats_7d"]["verify_gates_passed"], json!(0));
+        assert!(body.get("generated_at").is_some());
+    }
+
+    #[test]
+    fn parse_external_ref_extracts_pieces() {
+        let link = parse_external_ref("github:project:proj_abc:issue:407");
+        assert_eq!(link.project_id.as_deref(), Some("proj_abc"));
+        assert_eq!(link.issue_number, Some(407));
+
+        let link = parse_external_ref("github:project:proj_xyz:pr:412");
+        assert_eq!(link.project_id.as_deref(), Some("proj_xyz"));
+        assert_eq!(link.issue_number, Some(412));
+    }
+
+    #[test]
+    fn parse_external_ref_handles_garbage() {
+        let link = parse_external_ref("not-a-ref");
+        assert!(link.project_id.is_none() || link.issue_number.is_none());
+    }
+
+    #[test]
+    fn run_status_id_is_opaque_and_deterministic() {
+        let a = run_status_id("art_iss_abcdef1234567890abcdef1234567890");
+        let b = run_status_id("art_iss_abcdef1234567890abcdef1234567890");
+        assert_eq!(a, b);
+        assert!(a.starts_with("run_"));
+        assert_eq!(a.len(), "run_".len() + 12);
+        // Different inputs produce different outputs (probabilistically).
+        let c = run_status_id("art_iss_0000000000000000000000000000ffff");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn spec_link_only_emits_for_issue_kind() {
+        let row = RunRow {
+            artifact_id: "art_pr_x".into(),
+            kind: "pull_request".into(),
+            state: "released".into(),
+            current_stage_index: None,
+            workflow_parked_reason: None,
+            external_ref: Some("github:project:p1:pr:5".into()),
+            metadata: json!({"repo": "onsager-ai/onsager"}),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert_eq!(spec_link_for_row(&row), Value::Null);
+    }
+
+    #[test]
+    fn spec_link_constructs_url_when_repo_known() {
+        let row = RunRow {
+            artifact_id: "art_iss_x".into(),
+            kind: "issue".into(),
+            state: "released".into(),
+            current_stage_index: None,
+            workflow_parked_reason: None,
+            external_ref: Some("github:project:p1:issue:407".into()),
+            metadata: json!({"repo": "onsager-ai/onsager"}),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let v = spec_link_for_row(&row);
+        assert_eq!(v["number"], json!(407));
+        assert_eq!(
+            v["url"],
+            json!("https://github.com/onsager-ai/onsager/issues/407")
+        );
+    }
+
+    #[test]
+    fn spec_link_null_when_repo_unknown() {
+        // Without a `repo` hint we still emit the number so the
+        // dashboard could resolve it later. URL stays null.
+        let row = RunRow {
+            artifact_id: "art_iss_x".into(),
+            kind: "issue".into(),
+            state: "released".into(),
+            current_stage_index: None,
+            workflow_parked_reason: None,
+            external_ref: Some("github:project:p1:issue:407".into()),
+            metadata: json!({}),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let v = spec_link_for_row(&row);
+        assert_eq!(v["number"], json!(407));
+        assert_eq!(v["url"], Value::Null);
+    }
+}

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -86,6 +86,11 @@ enum Command {
         /// the workspace-less `/chat` entry per spec #398).
         #[arg(long, env = "ONSAGER_DEPLOYMENT")]
         deployment: Option<String>,
+        /// Pinned workflow_id for the public Dogfood showcase
+        /// (spec #407). When unset, `GET /api/showcase/dogfood`
+        /// returns `{ enabled: false }`.
+        #[arg(long, env = "SHOWCASE_DOGFOOD_WORKFLOW_ID")]
+        showcase_dogfood_workflow_id: Option<String>,
     },
     /// Backfill issues + PRs for an existing project.
     Backfill {
@@ -134,6 +139,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             telegram_webhook_secret,
             remediation_monthly_cap_usd,
             deployment,
+            showcase_dogfood_workflow_id,
         } => {
             let allowlist = sso_return_host_allowlist
                 .as_deref()
@@ -172,6 +178,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 remediation_monthly_cap_usd: remediation_monthly_cap_usd
                     .unwrap_or(onsager_portal::config::DEFAULT_REMEDIATION_MONTHLY_CAP_USD),
                 deployment: deployment.filter(|s| !s.trim().is_empty()),
+                showcase_dogfood_workflow_id: showcase_dogfood_workflow_id
+                    .filter(|s| !s.trim().is_empty()),
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -14,8 +14,8 @@ use crate::handlers::{
     live_data as live_data_handlers, nodes as node_handlers, pats as pat_handlers,
     projects as project_handlers, registry_events as registry_event_handlers,
     registry_triggers as registry_trigger_handlers, runs as run_handlers,
-    sessions as session_handlers, spine as spine_handlers, tasks as task_handlers,
-    telegram_webhook, triggers as trigger_handlers, webhook,
+    sessions as session_handlers, showcase as showcase_handlers, spine as spine_handlers,
+    tasks as task_handlers, telegram_webhook, triggers as trigger_handlers, webhook,
     workflow_kinds as workflow_kind_handlers, workflow_views as workflow_view_handlers,
     workflows as workflow_handlers, workspaces as workspace_handlers,
 };
@@ -341,6 +341,17 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/chat/completions",
             post(chat_handlers::create_chat_completion),
+        )
+        // Public Dogfood showcase (spec #407). Read-only projection of
+        // the Onsager-managing-Onsager workflow's recent runs. No auth,
+        // 60s in-process cache, sanitized to anonymized stage names +
+        // (number, url) spec/PR links — nothing else from the source
+        // tables crosses the boundary. Selection of which workflow to
+        // project is driven by `SHOWCASE_DOGFOOD_WORKFLOW_ID`; when
+        // unset the route returns `{ enabled: false }`.
+        .route(
+            "/api/showcase/dogfood",
+            axum::routing::get(showcase_handlers::get_dogfood),
         )
         // MCP server (ADR 0007 / #288). JSON-RPC 2.0 over HTTP — the
         // runtime-agnostic public contract for AI clients. Auth reuses

--- a/crates/onsager-portal/tests/showcase_dogfood.rs
+++ b/crates/onsager-portal/tests/showcase_dogfood.rs
@@ -1,0 +1,407 @@
+//! Integration tests for the public Dogfood showcase projection (spec #407).
+//!
+//! The contract under test is single-sentence: the public response
+//! contains only the allow-listed fields. The acceptance criterion is
+//! explicit — "verified by integration test: assert response shape
+//! contains *only* the allow-listed fields". This file pins that shape
+//! against a real Postgres so future PRs can't quietly add a leaking
+//! column to the projection.
+//!
+//! Skipped when `DATABASE_URL` is unset — the projection reads from
+//! spine tables that only the Postgres-backed harness exercises.
+
+use std::collections::BTreeSet;
+
+use chrono::Utc;
+use onsager_portal::handlers::showcase::build_projection_for_test;
+use onsager_portal::workflow::{GateKind, TriggerKind, Workflow, WorkflowStage};
+use onsager_portal::workflow_db;
+use serde_json::Value;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+/// Seed a workflow with the four gate kinds in declared order. The
+/// projection only reads `gate_kind` (the "executor_kind") + count, so
+/// the names here can be anything — the public response anonymizes them.
+async fn seed_dogfood_workflow(spine: &PgPool, workspace_id: &str) -> String {
+    let now = Utc::now();
+    let workflow_id = format!("wf_{}", Uuid::new_v4());
+    let wf = Workflow {
+        id: workflow_id.clone(),
+        workspace_id: workspace_id.into(),
+        name: "internal-dogfood-name-should-not-leak".into(),
+        trigger: TriggerKind::GithubIssueWebhook {
+            repo: "onsager-ai/onsager".into(),
+            label: "ready-to-implement".into(),
+        },
+        install_id: 1,
+        preset_id: Some("onsager-dogfood".into()),
+        active: true,
+        created_by: "tester".into(),
+        created_at: now,
+        updated_at: now,
+    };
+    let stages = vec![
+        WorkflowStage {
+            id: Uuid::new_v4().to_string(),
+            workflow_id: workflow_id.clone(),
+            seq: 0,
+            gate_kind: GateKind::AgentSession,
+            params: serde_json::json!({}),
+        },
+        WorkflowStage {
+            id: Uuid::new_v4().to_string(),
+            workflow_id: workflow_id.clone(),
+            seq: 1,
+            gate_kind: GateKind::Governance,
+            params: serde_json::json!({}),
+        },
+        WorkflowStage {
+            id: Uuid::new_v4().to_string(),
+            workflow_id: workflow_id.clone(),
+            seq: 2,
+            gate_kind: GateKind::ExternalCheck,
+            params: serde_json::json!({}),
+        },
+        WorkflowStage {
+            id: Uuid::new_v4().to_string(),
+            workflow_id: workflow_id.clone(),
+            seq: 3,
+            gate_kind: GateKind::ManualApproval,
+            params: serde_json::json!({}),
+        },
+    ];
+    workflow_db::insert_workflow_with_stages(spine, &wf, &stages)
+        .await
+        .expect("seed workflow");
+    workflow_id
+}
+
+async fn seed_issue_run(
+    spine: &PgPool,
+    workspace_id: &str,
+    workflow_id: &str,
+    project_id: &str,
+    issue_number: u64,
+    state: &str,
+    stage_index: Option<i32>,
+) -> String {
+    let artifact_id = format!("art_iss_{}", Uuid::new_v4().simple());
+    let external_ref = format!("github:project:{project_id}:issue:{issue_number}");
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, current_version, \
+             external_ref, workspace_id, metadata, workflow_id, current_stage_index) \
+         VALUES ($1, 'issue', NULL, NULL, 'tester', $2, 1, $3, $4, \
+                 jsonb_build_object('project_id', $5::text, \
+                                    'issue_number', $6::bigint, \
+                                    'repo', $7::text), \
+                 $8, $9)",
+    )
+    .bind(&artifact_id)
+    .bind(state)
+    .bind(&external_ref)
+    .bind(workspace_id)
+    .bind(project_id)
+    .bind(issue_number as i64)
+    .bind("onsager-ai/onsager")
+    .bind(workflow_id)
+    .bind(stage_index)
+    .execute(spine)
+    .await
+    .expect("seed issue run");
+    artifact_id
+}
+
+async fn seed_pr_for_issue(
+    spine: &PgPool,
+    portal: &PgPool,
+    workspace_id: &str,
+    issue_artifact_id: &str,
+    project_id: &str,
+    pr_number: u64,
+) -> String {
+    let pr_artifact_id = format!("art_pr_{}", Uuid::new_v4().simple());
+    let external_ref = format!("github:project:{project_id}:pr:{pr_number}");
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, current_version, \
+             external_ref, workspace_id, metadata) \
+         VALUES ($1, 'pull_request', NULL, NULL, 'tester', 'released', 1, $2, $3, \
+                 jsonb_build_object('project_id', $4::text, \
+                                    'pr_number', $5::bigint, \
+                                    'repo', $6::text))",
+    )
+    .bind(&pr_artifact_id)
+    .bind(&external_ref)
+    .bind(workspace_id)
+    .bind(project_id)
+    .bind(pr_number as i64)
+    .bind("onsager-ai/onsager")
+    .execute(spine)
+    .await
+    .expect("seed PR artifact");
+
+    // horizontal_lineage lives on the portal connection per
+    // onsager-portal's split-pool convention (#222).
+    sqlx::query(
+        "INSERT INTO horizontal_lineage \
+            (artifact_id, source_artifact_id, source_version, role) \
+         VALUES ($1, $2, 1, 'closes_issue')",
+    )
+    .bind(&pr_artifact_id)
+    .bind(issue_artifact_id)
+    .execute(portal)
+    .await
+    .expect("link PR → issue");
+    pr_artifact_id
+}
+
+async fn cleanup_workflow(spine: &PgPool, portal: &PgPool, workflow_id: &str) {
+    // Drop horizontal_lineage rows that point at this workflow's artifacts.
+    let _ = sqlx::query(
+        "DELETE FROM horizontal_lineage hl \
+          USING artifacts a \
+          WHERE (hl.artifact_id = a.artifact_id OR hl.source_artifact_id = a.artifact_id) \
+            AND a.workflow_id = $1",
+    )
+    .bind(workflow_id)
+    .execute(portal)
+    .await;
+    let _ = sqlx::query("DELETE FROM artifacts WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .execute(spine)
+        .await;
+    let _ = sqlx::query("DELETE FROM workflows WHERE workflow_id = $1")
+        .bind(workflow_id)
+        .execute(spine)
+        .await;
+}
+
+/// The allow-list this test pins. New top-level keys here are deliberate
+/// public-API expansions — adding one without updating this set is a
+/// regression. Per-run nested keys live in `RUN_ALLOWED_KEYS`.
+const TOP_LEVEL_ALLOWED_KEYS: &[&str] = &[
+    "enabled",
+    "workflow",
+    "runs",
+    "stats_7d",
+    "last_activity_at",
+    "is_quiet",
+    "generated_at",
+];
+
+const RUN_ALLOWED_KEYS: &[&str] = &[
+    "id",
+    "status",
+    "stages",
+    "spec",
+    "pr",
+    "started_at",
+    "updated_at",
+];
+
+const STAGE_ALLOWED_KEYS: &[&str] = &["index", "executor_kind", "status"];
+
+const WORKFLOW_ALLOWED_KEYS: &[&str] = &["name", "stage_count", "stages"];
+
+const STATS_KEYS: &[&str] = &["specs_shipped", "prs_merged", "verify_gates_passed"];
+
+fn object_keys(v: &Value) -> BTreeSet<String> {
+    v.as_object()
+        .map(|o| o.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn allow_set(allowed: &[&str]) -> BTreeSet<String> {
+    allowed.iter().map(|s| s.to_string()).collect()
+}
+
+#[tokio::test]
+async fn projection_exposes_only_allow_listed_fields() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let portal = spine.clone();
+    let workspace_id = format!("ws-showcase-{}", Uuid::new_v4());
+    let workflow_id = seed_dogfood_workflow(&spine, &workspace_id).await;
+
+    // Released run with a linked PR — exercises the "passed" status path
+    // plus the PR-link lookup.
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let issue_id = seed_issue_run(
+        &spine,
+        &workspace_id,
+        &workflow_id,
+        &project_id,
+        407,
+        "released",
+        Some(3),
+    )
+    .await;
+    let _pr_id =
+        seed_pr_for_issue(&spine, &portal, &workspace_id, &issue_id, &project_id, 412).await;
+
+    // In-flight run, parked at stage 1.
+    let _ = seed_issue_run(
+        &spine,
+        &workspace_id,
+        &workflow_id,
+        &project_id,
+        408,
+        "under_review",
+        Some(1),
+    )
+    .await;
+
+    let body = build_projection_for_test(&spine, &portal, &workflow_id)
+        .await
+        .expect("projection succeeds");
+
+    // Top-level shape.
+    assert_eq!(
+        object_keys(&body),
+        allow_set(TOP_LEVEL_ALLOWED_KEYS),
+        "top-level keys must be exactly the allow-list"
+    );
+    assert_eq!(body["enabled"], Value::Bool(true));
+
+    // Workflow block: no `id`, no `workspace_id`, no `created_by`, no
+    // `trigger`. Only the user-visible shape.
+    assert_eq!(
+        object_keys(&body["workflow"]),
+        allow_set(WORKFLOW_ALLOWED_KEYS),
+        "workflow block keys must be exactly the allow-list"
+    );
+    let workflow_stages = body["workflow"]["stages"].as_array().expect("stages array");
+    assert_eq!(workflow_stages.len(), 4);
+    for (i, s) in workflow_stages.iter().enumerate() {
+        let keys: BTreeSet<String> = object_keys(s);
+        assert_eq!(
+            keys,
+            ["index", "executor_kind"]
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<BTreeSet<_>>(),
+            "workflow.stages[{i}] must only carry index + executor_kind"
+        );
+    }
+
+    // Stats block shape.
+    assert_eq!(
+        object_keys(&body["stats_7d"]),
+        allow_set(STATS_KEYS),
+        "stats_7d must contain exactly the three counter keys"
+    );
+
+    // Per-run shape.
+    let runs = body["runs"].as_array().expect("runs array");
+    assert_eq!(runs.len(), 2, "two seeded runs surface");
+    for run in runs {
+        assert_eq!(
+            object_keys(run),
+            allow_set(RUN_ALLOWED_KEYS),
+            "per-run keys must be exactly the allow-list",
+        );
+        // The opaque id never includes the raw artifact_id.
+        let id = run["id"].as_str().expect("run id is string");
+        assert!(id.starts_with("run_"));
+        assert!(!id.contains("art_iss"));
+        assert!(!id.contains("art_pr"));
+
+        // Stage entries carry only the documented keys.
+        let stages = run["stages"].as_array().expect("stages array");
+        assert_eq!(stages.len(), 4);
+        for s in stages {
+            assert_eq!(
+                object_keys(s),
+                allow_set(STAGE_ALLOWED_KEYS),
+                "per-stage keys must be exactly the allow-list"
+            );
+            // No leaked stage name from the workflow_stages table.
+            assert!(!s.as_object().unwrap().contains_key("name"));
+        }
+    }
+
+    // Released run must carry a PR link with just (number, url).
+    let released = runs
+        .iter()
+        .find(|r| r["status"] == Value::String("passed".into()))
+        .expect("released run present");
+    let pr = &released["pr"];
+    let pr_obj = pr.as_object().expect("pr is an object");
+    let pr_keys: BTreeSet<String> = pr_obj.keys().cloned().collect();
+    assert_eq!(
+        pr_keys,
+        ["number", "url"]
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<BTreeSet<_>>(),
+        "pr block carries only number + url"
+    );
+    assert_eq!(pr["number"], Value::Number(412.into()));
+
+    // Spec link carries only (number, url) too — no title, no body, no
+    // labels.
+    let spec = &released["spec"];
+    let spec_obj = spec.as_object().expect("spec is an object");
+    let spec_keys: BTreeSet<String> = spec_obj.keys().cloned().collect();
+    assert_eq!(
+        spec_keys,
+        ["number", "url"]
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<BTreeSet<_>>(),
+        "spec block carries only number + url"
+    );
+
+    // Internal workflow name does not leak. The spec mandates "Stages
+    // are anonymized to 'Stage 1 / Stage 2 / ...' plus their executor
+    // kind — no internal repo paths, no spec body content beyond title."
+    // We expose the workflow's name (which is a user-chosen string)
+    // here, so we only assert that nothing in the stages array carries
+    // any internal stage name.
+    for run in runs {
+        for stage in run["stages"].as_array().unwrap() {
+            assert!(
+                !stage.as_object().unwrap().contains_key("name"),
+                "stage entries must not carry the internal stage name"
+            );
+            assert!(
+                !stage.as_object().unwrap().contains_key("params"),
+                "stage entries must not carry gate params"
+            );
+        }
+    }
+
+    cleanup_workflow(&spine, &portal, &workflow_id).await;
+}
+
+#[tokio::test]
+async fn projection_marks_quiet_when_no_recent_activity() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let portal = spine.clone();
+    let workspace_id = format!("ws-showcase-quiet-{}", Uuid::new_v4());
+    let workflow_id = seed_dogfood_workflow(&spine, &workspace_id).await;
+
+    // No runs seeded. The projection should mark itself quiet rather
+    // than pretend something is live.
+    let body = build_projection_for_test(&spine, &portal, &workflow_id)
+        .await
+        .expect("projection succeeds");
+    assert_eq!(body["is_quiet"], Value::Bool(true));
+    assert_eq!(body["last_activity_at"], Value::Null);
+    assert_eq!(body["runs"].as_array().unwrap().len(), 0);
+    assert_eq!(body["stats_7d"]["specs_shipped"], Value::Number(0.into()));
+
+    cleanup_workflow(&spine, &portal, &workflow_id).await;
+}

--- a/crates/onsager-portal/tests/showcase_dogfood.rs
+++ b/crates/onsager-portal/tests/showcase_dogfood.rs
@@ -162,6 +162,53 @@ async fn seed_pr_for_issue(
     pr_artifact_id
 }
 
+/// Seed a `git.pr_merged` extension event for the given workspace. The
+/// stats query filters on the indexed `workspace_id` column (migration
+/// 016) — the variant data carries no top-level `workspace_id`, so a
+/// JSONB-only predicate would never match.
+async fn seed_git_pr_merged_event(spine: &PgPool, workspace_id: &str, pr_number: i64) {
+    sqlx::query(
+        "INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, workspace_id) \
+         VALUES ($1, 'git', 'git.pr_merged', \
+                 jsonb_build_object('type', 'git_pr_merged', \
+                                    'pr_number', $2::bigint, \
+                                    'artifact_id', $3::text, \
+                                    'merge_sha', 'deadbeef'), \
+                 '{}'::jsonb, $4)",
+    )
+    .bind(format!("pr-stream-{pr_number}"))
+    .bind(pr_number)
+    .bind(format!("art_pr_{pr_number}"))
+    .bind(workspace_id)
+    .execute(spine)
+    .await
+    .expect("seed git.pr_merged event");
+}
+
+/// Seed a `synodic.gate_verdict` event with the given verdict tag. The
+/// stats query reads `data->'verdict'->>'verdict'` to match the
+/// `GateVerdict` enum's `#[serde(tag = "verdict")]` shape — i.e. the
+/// envelope serializes as `{type, gate_id, ..., verdict: {verdict, ...}}`.
+async fn seed_gate_verdict_event(spine: &PgPool, workspace_id: &str, verdict: &str) {
+    let payload = serde_json::json!({
+        "type": "synodic_gate_verdict",
+        "gate_id": format!("gate-{verdict}"),
+        "artifact_id": "art_some",
+        "gate_point": "merge",
+        "verdict": { "verdict": verdict },
+    });
+    sqlx::query(
+        "INSERT INTO events_ext (stream_id, namespace, event_type, data, metadata, workspace_id) \
+         VALUES ($1, 'synodic', 'synodic.gate_verdict', $2, '{}'::jsonb, $3)",
+    )
+    .bind(format!("gate-{verdict}"))
+    .bind(&payload)
+    .bind(workspace_id)
+    .execute(spine)
+    .await
+    .expect("seed synodic.gate_verdict event");
+}
+
 async fn cleanup_workflow(spine: &PgPool, portal: &PgPool, workflow_id: &str) {
     // Drop horizontal_lineage rows that point at this workflow's artifacts.
     let _ = sqlx::query(
@@ -179,6 +226,13 @@ async fn cleanup_workflow(spine: &PgPool, portal: &PgPool, workflow_id: &str) {
         .await;
     let _ = sqlx::query("DELETE FROM workflows WHERE workflow_id = $1")
         .bind(workflow_id)
+        .execute(spine)
+        .await;
+}
+
+async fn cleanup_workspace_events(spine: &PgPool, workspace_id: &str) {
+    let _ = sqlx::query("DELETE FROM events_ext WHERE workspace_id = $1")
+        .bind(workspace_id)
         .execute(spine)
         .await;
 }
@@ -381,6 +435,75 @@ async fn projection_exposes_only_allow_listed_fields() {
     }
 
     cleanup_workflow(&spine, &portal, &workflow_id).await;
+    cleanup_workspace_events(&spine, &workspace_id).await;
+}
+
+#[tokio::test]
+async fn projection_counts_recent_events_into_stats() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let portal = spine.clone();
+    let workspace_id = format!("ws-showcase-stats-{}", Uuid::new_v4());
+    let workflow_id = seed_dogfood_workflow(&spine, &workspace_id).await;
+
+    // Two released runs in the workspace → specs_shipped = 2.
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let _ = seed_issue_run(
+        &spine,
+        &workspace_id,
+        &workflow_id,
+        &project_id,
+        407,
+        "released",
+        Some(3),
+    )
+    .await;
+    let _ = seed_issue_run(
+        &spine,
+        &workspace_id,
+        &workflow_id,
+        &project_id,
+        408,
+        "released",
+        Some(3),
+    )
+    .await;
+
+    // Three merged-PR events and two allow verdicts (plus a deny that
+    // mustn't count).
+    seed_git_pr_merged_event(&spine, &workspace_id, 412).await;
+    seed_git_pr_merged_event(&spine, &workspace_id, 413).await;
+    seed_git_pr_merged_event(&spine, &workspace_id, 414).await;
+    seed_gate_verdict_event(&spine, &workspace_id, "allow").await;
+    seed_gate_verdict_event(&spine, &workspace_id, "allow").await;
+    seed_gate_verdict_event(&spine, &workspace_id, "deny").await;
+
+    let body = build_projection_for_test(&spine, &portal, &workflow_id)
+        .await
+        .expect("projection succeeds");
+
+    // The acceptance criterion is "Counters reflect actual data for the
+    // last 7 calendar days" — pin the wire format the dashboard reads.
+    assert_eq!(
+        body["stats_7d"]["specs_shipped"],
+        Value::Number(2.into()),
+        "specs_shipped counts released runs of this workflow"
+    );
+    assert_eq!(
+        body["stats_7d"]["prs_merged"],
+        Value::Number(3.into()),
+        "prs_merged counts git.pr_merged events in the workspace"
+    );
+    assert_eq!(
+        body["stats_7d"]["verify_gates_passed"],
+        Value::Number(2.into()),
+        "verify_gates_passed counts only `allow` verdicts in the workspace"
+    );
+
+    cleanup_workflow(&spine, &portal, &workflow_id).await;
+    cleanup_workspace_events(&spine, &workspace_id).await;
 }
 
 #[tokio::test]
@@ -404,4 +527,5 @@ async fn projection_marks_quiet_when_no_recent_activity() {
     assert_eq!(body["stats_7d"]["specs_shipped"], Value::Number(0.into()));
 
     cleanup_workflow(&spine, &portal, &workflow_id).await;
+    cleanup_workspace_events(&spine, &workspace_id).await;
 }

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -480,6 +480,10 @@ pub const EXTERNAL_ONLY_ROUTES: &[(&str, &str)] = &[
         "/api/build-info",
         "Runtime deployment descriptor (spec #398) — fetched from `lib/build-info.ts` via a bespoke fetch before any workspace scope exists. No auth, no workspace_id; outside the `lib/api/` typed scanner.",
     ),
+    (
+        "/api/showcase/dogfood",
+        "Public Dogfood showcase projection (spec #407) — fetched from `pages/ShowcaseDogfoodPage.tsx` via a bespoke pre-auth fetch on an unauthenticated route. No `workspace_id` scoping; outside the `lib/api/` typed scanner.",
+    ),
 ];
 
 /// Routes registered by stiglab (or any other factory subsystem) that


### PR DESCRIPTION
## Summary

Per spec #407: build the live reference Axis 2's landing trust-strip links to — the public Dogfood showcase at `/showcase/dogfood`.

- **New portal route** `GET /api/showcase/dogfood` — unauthenticated, projects the last 10 runs of the Onsager-managing-Onsager workflow plus 7-day counters (specs shipped / PRs merged / verify gates passed) through a strict field allow-list. Stage names anonymized to `Stage N · <executor>`; spec issues and PRs surface only `(number, url)` — no transcripts, no governance verdicts, no internal stage names cross the boundary. 60s in-process cache; fails soft to `{ enabled: false }` when `SHOWCASE_DOGFOOD_WORKFLOW_ID` is unset (pre-deploy / OSS without configuration) or the projection errors.
- **New dashboard page** at `/showcase/dogfood` (unauthenticated, pre-empts auth probe like `/landing`): hero with the locked "This page is produced by Onsager" copy, anonymized workflow-stage strip, three-counter stats strip, last-10 runs with status + spec/PR links, quiet-week footer when no activity in 7 days.
- **Trust-strip on `LandingPage`** with locked copy `Onsager is the factory that builds Onsager — see live runs ↗`.
- **`onsager-dogfood` template card** in `TemplateGallery` surfaces a "see this template running on Onsager itself →" pointer.

## What's pinned by tests

`crates/onsager-portal/tests/showcase_dogfood.rs` is the contract test. It seeds a workflow + linked artifacts against a real Postgres and asserts the response top-level / per-run / per-stage / workflow / stats key sets are **exactly** the allow-list — so any future column added to `artifacts` / `workflow_stages` can't quietly leak into the public surface without updating the allow-list (and being deliberate about it). Unit tests cover the projection helpers (external-ref parsing, spec-link construction, opaque run-id hashing).

## Out of scope (deferred per spec)

- Per-IP rate limit (open question in spec, 60s cache is the throttle for v1).
- Workspace + workflow deployment in the production Cloud instance — one-time ops, tracked under spec's "Touches".
- Maintenance-banner fallback for persistent workflow failures — `is_quiet` covers the "no recent activity" case honestly; persistent-failure copy is a follow-up if it becomes a real problem.

## Test plan

- [x] `cargo test -p onsager-portal --lib` — projection helpers
- [x] `DATABASE_URL=… cargo test -p onsager-portal --test showcase_dogfood` — allow-list shape pin against real Postgres
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- lint-seams` / `check-api-contract` / `check-events` / `check-file-budget`
- [x] `pnpm --filter dashboard tsc --noEmit` + `lint` + `test` + `build`
- [ ] Manual smoke against `/showcase/dogfood` once `SHOWCASE_DOGFOOD_WORKFLOW_ID` is wired in the Cloud preview

Closes #407

https://claude.ai/code/session_015AdDT5doAmzxM3D3zhkUVc

---
_Generated by [Claude Code](https://claude.ai/code/session_015AdDT5doAmzxM3D3zhkUVc)_