### PR TITLE
feat(portal): reland propose_workflow_draft MCP tool

### DIFF
--- a/apps/dashboard/src/lib/mcp-tools.ts
+++ b/apps/dashboard/src/lib/mcp-tools.ts
@@ -111,6 +111,32 @@ const propose_workflow: McpToolBinding = {
   },
 }
 
+const propose_workflow_draft: McpToolBinding = {
+  name: "propose_workflow_draft",
+  category: "constructive",
+  title: (args) =>
+    `Propose draft${str(args, "name") ? ` · ${str(args, "name")}` : ""}`,
+  buildCard: (args) => {
+    const trigger = args.trigger as Record<string, unknown> | undefined
+    const label =
+      trigger && typeof trigger.label === "string" ? trigger.label : "(unset)"
+    return {
+      kind: "constructive",
+      title: `Propose workflow draft${str(args, "name") ? ` · ${str(args, "name")}` : ""}`,
+      summary: stagesSummary(args),
+      body: {
+        fields: [
+          field("Name", str(args, "name"), { editable: true, key: "name" }),
+          field("Trigger label", label),
+          field("Stages", stagesSummary(args)),
+        ],
+      },
+      commit: { label: "Save draft", intent: "primary" },
+      reject: { label: "Reject" },
+    }
+  },
+}
+
 const run_workflow: McpToolBinding = {
   name: "run_workflow",
   category: "destructive",
@@ -261,6 +287,7 @@ const propose_remediation: McpToolBinding = {
 
 const BINDINGS: McpToolBinding[] = [
   propose_workflow,
+  propose_workflow_draft,
   run_workflow,
   edit_workflow,
   schedule_workflow,

--- a/crates/onsager-portal/src/mcp/registry.rs
+++ b/crates/onsager-portal/src/mcp/registry.rs
@@ -98,6 +98,15 @@ fn build_registry() -> Vec<ToolDescriptor> {
             },
         },
         ToolDescriptor {
+            name: "propose_workflow_draft",
+            description: "Propose a workflow *draft* (no workspace, no install, no repo). Validates the `{name, trigger, stages}` shape and echoes it back so the dashboard can route through the FTUE HitlCard and into client-side draft storage. Drafts live in localStorage until the binding flow (#402) promotes them into a real spine workflow via `propose_workflow`. Use this tool from the workspace-less `/chat` entry; for workspace-scoped design use `propose_workflow` directly.",
+            category: ToolCategory::Constructive,
+            input_schema: super::input_schema::<tools::workflows::ProposeWorkflowDraftArgs>(),
+            invoke: |state, user, args| {
+                Box::pin(tools::workflows::propose_workflow_draft(state, user, args))
+            },
+        },
+        ToolDescriptor {
             name: "run_workflow",
             description: "Fire a workflow's `manual` trigger to start a new run. Workflow must be active and declare a matching manual trigger name.",
             category: ToolCategory::Destructive,

--- a/crates/onsager-portal/src/mcp/tools/workflows.rs
+++ b/crates/onsager-portal/src/mcp/tools/workflows.rs
@@ -137,6 +137,125 @@ pub async fn propose_workflow(state: &AppState, auth_user: &AuthUser, args: Valu
 }
 
 // =============================================================================
+// propose_workflow_draft
+// =============================================================================
+
+/// Arguments for `propose_workflow_draft` (spec #413, paired with the
+/// `onsager-ftue-chat` skill grant). The shape mirrors what the dashboard
+/// authors client-side as a `WorkflowDocument` — same `{name, trigger,
+/// stages}` triple as `propose_workflow`, but with no `workspace_id` and
+/// no `install_id` required (binding fills those in later, per #402).
+///
+/// Trigger is delivered as a flat object (the FTUE preamble steers the
+/// agent to a github-label shape today; non-label triggers are accepted
+/// as opaque key/values and round-trip into the binding flow).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProposeWorkflowDraftArgs {
+    pub name: String,
+    pub trigger: DraftTriggerInput,
+    pub stages: Vec<DraftStageInput>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct DraftTriggerInput {
+    /// Pre-bind: empty string. The binding step (#402) writes the
+    /// GitHub-App install record id.
+    #[serde(default)]
+    pub install_id: String,
+    /// Pre-bind: empty string. Binding writes the repo owner.
+    #[serde(default)]
+    pub repo_owner: String,
+    /// Pre-bind: empty string. Binding writes the repo name.
+    #[serde(default)]
+    pub repo_name: String,
+    /// GitHub label name (for label-style triggers) or a cron expression
+    /// (for schedule-style triggers). Templates round-trip this field
+    /// verbatim so cron strings survive draft → bind.
+    #[serde(default)]
+    pub label: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct DraftStageInput {
+    /// Stable string id. The dashboard canonicalises ids when the
+    /// document is committed; pre-commit the agent can pass any
+    /// non-empty string (`"stage-0"`, etc.).
+    pub id: String,
+    pub name: String,
+    pub gate_kind: GateKind,
+    /// Workspace-defined artifact-kind discriminator. The FTUE default
+    /// is `"Issue"`; non-FTUE flows may declare workspace-scoped kinds.
+    pub artifact_kind: String,
+    /// Free-form gate config (`{"prompt": "…"}` for `agent-session`,
+    /// etc.). Validated by the binding step when the draft is promoted.
+    #[serde(default)]
+    pub config: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkflowDraftEnvelope<'a> {
+    draft: ProposedDraft<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProposedDraft<'a> {
+    name: &'a str,
+    trigger: &'a DraftTriggerInput,
+    stages: &'a [DraftStageInput],
+}
+
+/// Echo a validated workflow draft. No DB writes — drafts live
+/// client-side per spec #401 until the binding flow (#402) promotes them
+/// into a real spine workflow via `propose_workflow`. The MCP boundary
+/// gives the chat agent a structured way to *propose* the draft to the
+/// dashboard, which routes the tool call through a `HitlCard` and into
+/// `useWorkflowDraft.setWorkflow`.
+pub async fn propose_workflow_draft(
+    _state: &AppState,
+    _auth_user: &AuthUser,
+    args: Value,
+) -> ToolResult {
+    let args: ProposeWorkflowDraftArgs = serde_json::from_value(args).map_err(|e| {
+        ToolError::InvalidParams(format!("invalid propose_workflow_draft args: {e}"))
+    })?;
+
+    if args.name.trim().is_empty() {
+        return Err(ToolError::InvalidParams("name is required".into()));
+    }
+    if args.stages.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "at least one stage is required".into(),
+        ));
+    }
+    for (i, stage) in args.stages.iter().enumerate() {
+        if stage.id.trim().is_empty() {
+            return Err(ToolError::InvalidParams(format!(
+                "stage[{i}].id is required"
+            )));
+        }
+        if stage.name.trim().is_empty() {
+            return Err(ToolError::InvalidParams(format!(
+                "stage[{i}].name is required"
+            )));
+        }
+        if stage.artifact_kind.trim().is_empty() {
+            return Err(ToolError::InvalidParams(format!(
+                "stage[{i}].artifact_kind is required"
+            )));
+        }
+    }
+
+    let envelope = WorkflowDraftEnvelope {
+        draft: ProposedDraft {
+            name: args.name.trim(),
+            trigger: &args.trigger,
+            stages: &args.stages,
+        },
+    };
+    serde_json::to_value(envelope).map_err(internal_serialize)
+}
+
+// =============================================================================
 // run_workflow
 // =============================================================================
 
@@ -376,4 +495,70 @@ pub(super) async fn load_workflow(
 
 fn internal_serialize(e: serde_json::Error) -> ToolError {
     ToolError::Internal(format!("response serialization failed: {e}"))
+}
+
+#[cfg(test)]
+mod propose_workflow_draft_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn draft_args() -> Value {
+        json!({
+            "name": "Triage every labeled issue",
+            "trigger": {
+                "install_id": "",
+                "repo_owner": "",
+                "repo_name": "",
+                "label": "needs-triage"
+            },
+            "stages": [
+                {
+                    "id": "stage-0",
+                    "name": "Triage agent",
+                    "gate_kind": "agent-session",
+                    "artifact_kind": "Issue",
+                    "config": { "prompt": "Classify this issue." }
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn parses_canonical_draft_shape() {
+        let parsed: ProposeWorkflowDraftArgs = serde_json::from_value(draft_args()).unwrap();
+        assert_eq!(parsed.name, "Triage every labeled issue");
+        assert_eq!(parsed.trigger.label, "needs-triage");
+        assert!(parsed.trigger.install_id.is_empty());
+        assert_eq!(parsed.stages.len(), 1);
+        assert_eq!(parsed.stages[0].gate_kind, GateKind::AgentSession);
+        assert_eq!(parsed.stages[0].artifact_kind, "Issue");
+    }
+
+    #[test]
+    fn empty_trigger_fields_default_to_blank_strings() {
+        let parsed: ProposeWorkflowDraftArgs = serde_json::from_value(json!({
+            "name": "Schedule-only draft",
+            "trigger": { "label": "0 9 * * 1" },
+            "stages": [
+                { "id": "s0", "name": "Generate", "gate_kind": "agent-session", "artifact_kind": "PR" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(parsed.trigger.install_id, "");
+        assert_eq!(parsed.trigger.repo_owner, "");
+        assert_eq!(parsed.trigger.repo_name, "");
+        assert_eq!(parsed.trigger.label, "0 9 * * 1");
+    }
+
+    #[test]
+    fn rejects_unknown_gate_kind() {
+        let bad = json!({
+            "name": "x",
+            "trigger": { "label": "l" },
+            "stages": [
+                { "id": "s0", "name": "x", "gate_kind": "not-a-gate", "artifact_kind": "Issue" }
+            ]
+        });
+        assert!(serde_json::from_value::<ProposeWorkflowDraftArgs>(bad).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Lands the portal-side registration of `propose_workflow_draft` to pair with the existing `onsager-ftue-chat` grant in the sibling skills bundle. Closes both halves of the deferred follow-up filed yesterday:

- **#412** — skills-bundle grant (already landed upstream in `onsager-ai/onsager-skills`)
- **#413** — portal-side reland (this PR)

## Why now

PR #410 deferred this registration to avoid tripping `xtask check-tools-and-skills` before the sibling repo's grant was in place. The sibling grant has since landed, leaving main latently red on the **reverse direction** of that lint: a skill grants a tool that doesn't exist. Every Rust-touching PR after #410 has been tripping this — PRs #415 and #416 are both red on it today. This PR clears the lint.

## What lands

- `crates/onsager-portal/src/mcp/tools/workflows.rs` — `propose_workflow_draft` handler. Validates a flat `{name, trigger, stages}` shape (mirrors the dashboard's `WorkflowDocument`) and echoes it back. **No DB writes, no `workspace_id`, no `install_id`** — drafts live client-side per spec #401 until binding (#402) promotes them via `propose_workflow`.
- `crates/onsager-portal/src/mcp/registry.rs` — registry entry. Category `Constructive`; schema derived from `schemars` per the registry SSOT.
- `apps/dashboard/src/lib/mcp-tools.ts` — typed binding so `check-hitl-coverage` (HITL principle 1, enforced mechanically) stays green. Renders as a constructive HitlCard with name / trigger label / stages summary; commit = "Save draft" (the dashboard's `useWorkflowDraft.setWorkflow` consumes the echoed shape).

## Tests

- 3 new unit tests in `propose_workflow_draft_tests` covering: canonical-shape parsing, default-blank trigger fields (cron expressions preserved in `label`), and unknown-gate-kind rejection.
- `xtask check-tools-and-skills`: 12 tools, 8 skills, all cross-references intact (verified locally against `onsager-ai/onsager-skills`).
- `xtask check-hitl-coverage`: 12 tools, 12 dashboard bindings.
- `cargo test -p onsager-portal --lib`: 157 passed.
- Dashboard: `pnpm tsc -b`, `pnpm lint`, `pnpm test` (167) clean.

## Test plan

- [ ] Once merged, PR #415 (#402 Binding flow) rebases and goes green on `check`.
- [ ] PR #416 (#407 Dogfood showcase) rebases and goes green on `check`.
- [ ] Restoring the FTUE preamble in `apps/dashboard/src/lib/chat/llm-client.ts` to encourage the tool call instead of prose is part of #400's full closure — not included here (per #413's scope split).

Closes #413
Closes #412
Part of #400
Part of #397

https://claude.ai/code/session_01BqrqT7wrzkWfaoiEQLcwh8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqrqT7wrzkWfaoiEQLcwh8)_