### PR TITLE
feat(ftue): activation instrumentation for the four-rung ladder (#404)

### DIFF
--- a/apps/dashboard/src/components/chat/BindDraftDialog.tsx
+++ b/apps/dashboard/src/components/chat/BindDraftDialog.tsx
@@ -31,6 +31,7 @@ import {
   type Workspace,
 } from "@/lib/api"
 import { markDraftBound } from "@/lib/drafts"
+import { trackActivation } from "@/lib/activation"
 import { documentToCreateRequest } from "@/components/factory/workflows/workflow-draft"
 import type { WorkflowDraft } from "@/components/factory/workflows/workflow-draft"
 import { RepoCombobox } from "@/components/factory/workflows/RepoCombobox"
@@ -435,6 +436,14 @@ function ProjectStep({
       queryClient.invalidateQueries({ queryKey: ["workflows"] })
       queryClient.invalidateQueries({
         queryKey: ["workspace-projects", workspace.id],
+      })
+      // Spec #404 rung 3 — Bound. Fired client-side from the dialog
+      // success path so the funnel records bind even if the user
+      // never navigates to the bound workflow detail page.
+      void trackActivation("ftue.bound", "dialog", {
+        draft_id: draft.id,
+        workspace_id: workspace.id,
+        workflow_id: id,
       })
       onBound(id)
     },

--- a/apps/dashboard/src/components/chat/WorkflowDAGPreview.tsx
+++ b/apps/dashboard/src/components/chat/WorkflowDAGPreview.tsx
@@ -17,6 +17,7 @@ import {
   workflowDocumentFromYaml,
   workflowDocumentToYaml,
 } from "@/lib/workflow-yaml"
+import { trackActivation } from "@/lib/activation"
 
 // Gate kind → human label + colour token
 const GATE_META: Record<string, { label: string; color: string }> = {
@@ -296,6 +297,16 @@ export function WorkflowDAGPreview({
 }: WorkflowDAGPreviewProps) {
   const [view, setView] = useState<ViewMode>("dag")
 
+  // Spec #404 rung 1 — Inspected. Fires on the first DAG↔YAML toggle
+  // in a browser; the activation client dedups so subsequent toggles
+  // are no-ops.
+  const switchView = (next: ViewMode) => {
+    if (next !== view) {
+      void trackActivation("ftue.inspected", "chat")
+    }
+    setView(next)
+  }
+
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col overflow-hidden border-l">
@@ -323,7 +334,7 @@ export function WorkflowDAGPreview({
                 size="sm"
                 variant={view === "dag" ? "default" : "ghost"}
                 className="h-6 rounded-full px-2.5 text-xs"
-                onClick={() => setView("dag")}
+                onClick={() => switchView("dag")}
               >
                 DAG
               </Button>
@@ -335,7 +346,7 @@ export function WorkflowDAGPreview({
                 size="sm"
                 variant={view === "yaml" ? "default" : "ghost"}
                 className="h-6 rounded-full px-2.5 text-xs"
-                onClick={() => setView("yaml")}
+                onClick={() => switchView("yaml")}
               >
                 YAML
               </Button>

--- a/apps/dashboard/src/lib/activation.ts
+++ b/apps/dashboard/src/lib/activation.ts
@@ -1,0 +1,189 @@
+// FTUE activation instrumentation (spec #404).
+//
+// Four events — `ftue.inspected`, `ftue.drafted`, `ftue.bound`,
+// `ftue.activated` — collapse onto one append-only sink at
+// `POST /api/activation`. The dashboard owns the first three; the
+// fourth is emitted server-side by the portal spine listener (see
+// `crates/onsager-portal/src/listeners/workflow_activated.rs`).
+//
+// Fire-once policy is enforced server-side via a UNIQUE constraint on
+// the dedup_key derived from `(event, user_id || anonymous_id,
+// primary-context-id)`. The client-side `firedOnce` cache below is a
+// performance optimization (avoid the request when we know we've fired
+// already in this browser) — not a correctness mechanism. Logging
+// out, clearing localStorage, or another device replaying the same
+// rung lands a duplicate POST that the server drops silently.
+//
+// Privacy:
+// - `anonymous_id` is a random UUID generated once per browser. It is
+//   not a fingerprint; clearing site storage forgets it.
+// - `context` carries identifiers (draft_id, workflow_id) but no PII
+//   (no email, no repo content, no chat-turn content) — the spec's
+//   Privacy section binds this contract.
+// - OSS opt-in: when `build-info.is_oss === true`, `trackActivation`
+//   short-circuits to a no-op unless the user has explicitly opted
+//   in via `setOssTelemetryOptIn(true)`. Cloud users are auto-opted
+//   in by ToS acceptance.
+
+import { api } from "@/lib/api"
+import { fetchBuildInfo } from "@/lib/build-info"
+
+const ANON_ID_KEY = "onsager.anon_id"
+const FIRED_ONCE_KEY = "onsager.activation.fired"
+const OSS_OPT_IN_KEY = "onsager.activation.oss_opt_in"
+
+export type ActivationEvent =
+  | "ftue.inspected"
+  | "ftue.drafted"
+  | "ftue.bound"
+  | "ftue.activated"
+
+export type ActivationSurface = "landing" | "chat" | "dialog" | "spine"
+
+export interface ActivationContext {
+  draft_id?: string
+  workspace_id?: string
+  workflow_id?: string
+  template_id?: string
+  run_id?: string
+  terminal_status?: "completed" | "failed" | "cancelled"
+}
+
+/** Read the localStorage UUID, generating one on first use. */
+export function getAnonymousId(): string {
+  if (typeof window === "undefined") return "ssr"
+  try {
+    let id = window.localStorage.getItem(ANON_ID_KEY)
+    if (!id) {
+      id =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `anon_${Math.random().toString(36).slice(2)}_${Date.now()}`
+      window.localStorage.setItem(ANON_ID_KEY, id)
+    }
+    return id
+  } catch {
+    // Private mode / quota — return an ephemeral id rather than
+    // throwing through every call site.
+    return "anon-ephemeral"
+  }
+}
+
+/** OSS telemetry opt-in toggle. Cloud ignores this. */
+export function isOssTelemetryOptedIn(): boolean {
+  if (typeof window === "undefined") return false
+  try {
+    return window.localStorage.getItem(OSS_OPT_IN_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+export function setOssTelemetryOptIn(optedIn: boolean): void {
+  if (typeof window === "undefined") return
+  try {
+    if (optedIn) {
+      window.localStorage.setItem(OSS_OPT_IN_KEY, "true")
+    } else {
+      window.localStorage.removeItem(OSS_OPT_IN_KEY)
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Client-side fire-once cache. The set of `(event, primary-id)` keys
+ * we've already POSTed in this browser. Stored under one localStorage
+ * key as a JSON array. Capped at 1000 entries — well above the four
+ * lifetime rungs per (draft|workflow) — to keep blob size bounded if
+ * a user creates many drafts.
+ */
+function loadFiredOnce(): Set<string> {
+  if (typeof window === "undefined") return new Set()
+  try {
+    const raw = window.localStorage.getItem(FIRED_ONCE_KEY)
+    if (!raw) return new Set()
+    const arr = JSON.parse(raw) as unknown
+    return new Set(Array.isArray(arr) ? (arr as string[]) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function saveFiredOnce(set: Set<string>): void {
+  if (typeof window === "undefined") return
+  try {
+    const arr = Array.from(set).slice(-1000)
+    window.localStorage.setItem(FIRED_ONCE_KEY, JSON.stringify(arr))
+  } catch {
+    /* ignore */
+  }
+}
+
+function dedupKey(event: ActivationEvent, context: ActivationContext): string {
+  switch (event) {
+    case "ftue.inspected":
+      return event
+    case "ftue.drafted":
+    case "ftue.bound":
+      return `${event}|${context.draft_id ?? ""}`
+    case "ftue.activated":
+      return `${event}|${context.workflow_id ?? ""}`
+  }
+}
+
+/**
+ * Fire one activation event. No-op when:
+ * - `event === "ftue.activated"` — emitted server-side only.
+ * - This (event, primary-id) already fired in this browser.
+ * - OSS without explicit opt-in.
+ *
+ * Best-effort: a 4xx / 5xx response is logged at debug and swallowed.
+ * The funnel may miss the row; the product flow must not break.
+ */
+export async function trackActivation(
+  event: ActivationEvent,
+  surface: ActivationSurface,
+  context: ActivationContext = {},
+): Promise<void> {
+  if (event === "ftue.activated") return
+
+  const fired = loadFiredOnce()
+  const key = dedupKey(event, context)
+  if (fired.has(key)) return
+
+  const buildInfo = await fetchBuildInfo()
+  const path: "cloud" | "oss" = buildInfo.is_oss ? "oss" : "cloud"
+  if (path === "oss" && !isOssTelemetryOptedIn()) return
+
+  try {
+    // `event === "ftue.activated"` is ruled out above; the typed
+    // request union accepts the remaining three.
+    await api.recordActivation({
+      event: event as "ftue.inspected" | "ftue.drafted" | "ftue.bound",
+      occurred_at: new Date().toISOString(),
+      anonymous_id: getAnonymousId(),
+      surface,
+      path,
+      context: context as Record<string, unknown>,
+    })
+    fired.add(key)
+    saveFiredOnce(fired)
+  } catch (err) {
+    console.debug("[activation] request failed", err)
+  }
+}
+
+/**
+ * Synchronous client-side check: "has this rung already fired in this
+ * browser?". Used by the OSS opt-in prompt UX — the first time the
+ * user hits the Drafted threshold, surface the opt-in copy *once*.
+ * The actual POST still re-checks the cache before sending.
+ */
+export function hasFiredLocally(
+  event: ActivationEvent,
+  context: ActivationContext = {},
+): boolean {
+  return loadFiredOnce().has(dedupKey(event, context))
+}

--- a/apps/dashboard/src/lib/activation.ts
+++ b/apps/dashboard/src/lib/activation.ts
@@ -49,6 +49,22 @@ export interface ActivationContext {
   terminal_status?: "completed" | "failed" | "cancelled"
 }
 
+/** Per-page-load fallback id. Held in module scope so every call site
+ * inside a single tab/session gets the same value when localStorage
+ * is unavailable (private mode, quota exhausted) — but different
+ * tabs/loads stay distinct so the funnel's distinct-actor count
+ * isn't collapsed onto a single shared constant. */
+let ephemeralAnonId: string | null = null
+
+function mintFallbackId(): string {
+  if (ephemeralAnonId) return ephemeralAnonId
+  ephemeralAnonId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? `eph_${crypto.randomUUID()}`
+      : `eph_${Math.random().toString(36).slice(2)}_${Date.now()}`
+  return ephemeralAnonId
+}
+
 /** Read the localStorage UUID, generating one on first use. */
 export function getAnonymousId(): string {
   if (typeof window === "undefined") return "ssr"
@@ -63,9 +79,11 @@ export function getAnonymousId(): string {
     }
     return id
   } catch {
-    // Private mode / quota — return an ephemeral id rather than
-    // throwing through every call site.
-    return "anon-ephemeral"
+    // Private mode / quota — return a per-page-load random id so
+    // distinct-actor counts don't collapse onto one shared
+    // constant. Persistence is lost across reloads in this branch,
+    // which is acceptable given private mode is itself ephemeral.
+    return mintFallbackId()
   }
 }
 

--- a/apps/dashboard/src/lib/api/activation.ts
+++ b/apps/dashboard/src/lib/api/activation.ts
@@ -1,0 +1,28 @@
+// Activation funnel API client (spec #404).
+//
+// One typed surface for the dashboard-emitted FTUE events. The
+// orchestration logic — dedup, anonymous_id, OSS opt-in — lives in
+// `@/lib/activation` and calls `recordActivation` for the network hop.
+
+import { request } from './client';
+
+export interface RecordActivationBody {
+  event: 'ftue.inspected' | 'ftue.drafted' | 'ftue.bound';
+  occurred_at: string;
+  anonymous_id: string;
+  surface: 'landing' | 'chat' | 'dialog' | 'spine';
+  path: 'cloud' | 'oss';
+  context: Record<string, unknown>;
+}
+
+export interface RecordActivationResponse {
+  recorded: boolean;
+}
+
+export const activation = {
+  recordActivation: (body: RecordActivationBody) =>
+    request<RecordActivationResponse>('/activation', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+};

--- a/apps/dashboard/src/lib/api/index.ts
+++ b/apps/dashboard/src/lib/api/index.ts
@@ -76,6 +76,7 @@ import { workflows } from './workflows';
 import { issues } from './issues';
 import { pulls } from './pulls';
 import { registry } from './registry';
+import { activation } from './activation';
 
 export const api = {
   ...sessions,
@@ -89,4 +90,5 @@ export const api = {
   ...issues,
   ...pulls,
   ...registry,
+  ...activation,
 };

--- a/apps/dashboard/src/lib/drafts.ts
+++ b/apps/dashboard/src/lib/drafts.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowDocument,
   WorkflowDraftSource,
 } from "@/components/factory/workflows/workflow-draft"
+import { trackActivation } from "@/lib/activation"
 
 /** Soft cap on stored drafts per user. Oldest by `updated_at` evicted. */
 const DRAFT_CAP = 50
@@ -138,6 +139,13 @@ export function saveDraft(
     merged = merged.slice(0, DRAFT_CAP)
   }
   writeDrafts(userId, merged)
+  // Spec #404 rung 2 — Drafted. Fires on the first `updated_at` write
+  // per (user, draft). The activation client dedups client-side and
+  // server-side; safe to call on every save.
+  void trackActivation("ftue.drafted", "chat", {
+    draft_id: next.id,
+    template_id: next.template_id,
+  })
   return merged
 }
 

--- a/crates/onsager-portal/migrations/009_activation_events.sql
+++ b/crates/onsager-portal/migrations/009_activation_events.sql
@@ -1,0 +1,41 @@
+-- Portal-owned schema: FTUE activation funnel events (spec #404).
+--
+-- The umbrella (#397) defines a four-rung activation ladder
+-- (Inspected → Drafted → Bound → Activated). This table is the
+-- append-only sink every rung writes to. Portal — not spine. Activation
+-- events are dashboard-telemetry semantics, not factory-coordination
+-- semantics; they don't belong on the event bus (per the seam rule,
+-- factory coordination ≠ user-behavior telemetry).
+--
+-- Fire-once-per-(user, draft|workflow) is enforced server-side via the
+-- UNIQUE constraint on `dedup_key`. The handler / listener compute the
+-- key from the closed event-name + context shape:
+--
+--   ftue.inspected: ftue.inspected|{user_id|anonymous_id}
+--   ftue.drafted  : ftue.drafted|{user_id|anonymous_id}|{draft_id}
+--   ftue.bound    : ftue.bound|{user_id}|{draft_id}
+--   ftue.activated: ftue.activated|{user_id}|{workflow_id}
+--
+-- `user_id` is intentionally TEXT without a FK to `users` for the same
+-- reason `portal_webhook_secrets` and `user_pats` skip the FK: keeps the
+-- portal migrations self-contained and lets pre-auth `ftue.inspected`
+-- rows (NULL user_id) coexist with authenticated rows.
+
+CREATE TABLE IF NOT EXISTS activation_events (
+    id           TEXT        PRIMARY KEY,
+    event        TEXT        NOT NULL,
+    occurred_at  TIMESTAMPTZ NOT NULL,
+    user_id      TEXT,
+    anonymous_id TEXT        NOT NULL,
+    surface      TEXT        NOT NULL,
+    path         TEXT        NOT NULL,
+    context      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    dedup_key    TEXT        NOT NULL UNIQUE,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Funnel reporting walks (event, user_id || anonymous_id) over an
+-- occurred_at range. The unique dedup_key index doesn't help that
+-- query; this one does.
+CREATE INDEX IF NOT EXISTS idx_activation_events_event_occurred
+    ON activation_events (event, occurred_at DESC);

--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -71,6 +71,12 @@ pub struct Config {
     /// self-hosters can point it at their own dogfood workflow.
     /// Configured via `SHOWCASE_DOGFOOD_WORKFLOW_ID`.
     pub showcase_dogfood_workflow_id: Option<String>,
+    /// Comma-separated `github_login` values granted access to the
+    /// internal `/api/admin/*` surface (spec #404 — activation funnel).
+    /// Empty means "no Cloud admins" — dev-login sessions are always
+    /// admins, so local development still works. Configured via
+    /// `ONSAGER_ADMIN_LOGINS`.
+    pub admin_github_logins: Vec<String>,
 }
 
 /// Default monthly per-workspace cap for `propose_remediation` AI
@@ -159,6 +165,7 @@ mod tests {
             remediation_monthly_cap_usd: DEFAULT_REMEDIATION_MONTHLY_CAP_USD,
             deployment: None,
             showcase_dogfood_workflow_id: None,
+            admin_github_logins: Vec::new(),
         }
     }
 

--- a/crates/onsager-portal/src/handlers/activation.rs
+++ b/crates/onsager-portal/src/handlers/activation.rs
@@ -1,0 +1,364 @@
+//! `/api/activation` and `/api/admin/activation-funnel` route handlers
+//! (spec #404).
+//!
+//! Four FTUE activation events — `ftue.inspected`, `ftue.drafted`,
+//! `ftue.bound`, `ftue.activated` — share one append-only sink. Three
+//! are fired from the dashboard (Inspected on first DAG/YAML toggle,
+//! Drafted on the first `WorkflowDraft.updated_at` write, Bound on the
+//! `BindDraftDialog` success path) and arrive via `POST /api/activation`;
+//! the fourth is emitted server-side by the `workflow_activated`
+//! spine listener (see `crates/onsager-portal/src/listeners/`).
+//!
+//! Fire-once is enforced server-side. The handler computes a `dedup_key`
+//! per the spec table — `event|user_id-or-anonymous_id|primary-context-id`
+//! — and inserts with `ON CONFLICT(dedup_key) DO NOTHING`. Client repeats
+//! drop silently.
+
+use std::convert::Infallible;
+
+use axum::Json;
+use axum::extract::{FromRequestParts, Query, State};
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::auth::{AuthUser, SessionKind};
+use crate::state::AppState;
+
+/// Newtype around `Option<AuthUser>` that does not 4xx on missing /
+/// invalid auth. The activation endpoint is the only handler that
+/// accepts both anonymous (pre-auth `ftue.inspected`) and authenticated
+/// traffic; everywhere else, `AuthUser` is required and the standard
+/// rejecting extractor is the right shape.
+pub struct OptionalAuthUser(pub Option<AuthUser>);
+
+impl FromRequestParts<AppState> for OptionalAuthUser {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(OptionalAuthUser(
+            AuthUser::from_request_parts(parts, state).await.ok(),
+        ))
+    }
+}
+
+/// Closed enum of activation event names. The wire format pins these
+/// four — anything else is rejected at the handler with a 400.
+const VALID_EVENTS: &[&str] = &[
+    "ftue.inspected",
+    "ftue.drafted",
+    "ftue.bound",
+    "ftue.activated",
+];
+
+const VALID_SURFACES: &[&str] = &["landing", "chat", "dialog", "spine"];
+const VALID_PATHS: &[&str] = &["cloud", "oss"];
+
+#[derive(Debug, Deserialize)]
+pub struct ActivationEventBody {
+    pub event: String,
+    pub occurred_at: DateTime<Utc>,
+    pub anonymous_id: String,
+    pub surface: String,
+    pub path: String,
+    #[serde(default)]
+    pub context: serde_json::Value,
+}
+
+/// POST /api/activation — record one rung crossing.
+///
+/// Auth is optional: `ftue.inspected` from cloud.onsager.ai (axis 2 /
+/// spec #399) fires before sign-in and carries a null `user_id`. We
+/// extract the auth user when present via the same cookie / PAT
+/// extractor, but a missing/invalid auth header is **not** an error
+/// here — the row is simply written with `user_id = NULL`.
+///
+/// `ftue.activated` from the dashboard path is rejected: that rung is
+/// authoritatively emitted by the spine listener, never by the client.
+/// The substrate already knows when a run terminates; coupling
+/// activation measurement to whether the user happens to view the page
+/// would re-introduce rejected-alternative #4.
+pub async fn record_activation(
+    State(state): State<AppState>,
+    OptionalAuthUser(auth_user): OptionalAuthUser,
+    Json(body): Json<ActivationEventBody>,
+) -> Response {
+    if !VALID_EVENTS.contains(&body.event.as_str()) {
+        return reject("unknown event name");
+    }
+    if !VALID_SURFACES.contains(&body.surface.as_str()) {
+        return reject("unknown surface");
+    }
+    if !VALID_PATHS.contains(&body.path.as_str()) {
+        return reject("unknown path");
+    }
+    if body.anonymous_id.trim().is_empty() {
+        return reject("anonymous_id required");
+    }
+    if !body.context.is_object() {
+        return reject("context must be an object");
+    }
+    if body.event == "ftue.activated" {
+        return reject("ftue.activated is emitted server-side only");
+    }
+
+    let user_id = auth_user.as_ref().map(|u| u.user_id.clone());
+    let dedup_key = match build_dedup_key(
+        &body.event,
+        user_id.as_deref(),
+        &body.anonymous_id,
+        &body.context,
+    ) {
+        Ok(k) => k,
+        Err(msg) => return reject(msg),
+    };
+
+    let id = Uuid::new_v4().to_string();
+    let res = sqlx::query(
+        "INSERT INTO activation_events \
+             (id, event, occurred_at, user_id, anonymous_id, surface, path, context, dedup_key) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+         ON CONFLICT (dedup_key) DO NOTHING",
+    )
+    .bind(&id)
+    .bind(&body.event)
+    .bind(body.occurred_at)
+    .bind(user_id.as_deref())
+    .bind(&body.anonymous_id)
+    .bind(&body.surface)
+    .bind(&body.path)
+    .bind(&body.context)
+    .bind(&dedup_key)
+    .execute(&state.pool)
+    .await;
+
+    match res {
+        Ok(result) => Json(serde_json::json!({
+            "recorded": result.rows_affected() > 0,
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, "activation_events insert failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "insert failed" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FunnelQuery {
+    /// Inclusive lower bound (ISO timestamp). Default: 30 days ago.
+    pub from: Option<DateTime<Utc>>,
+    /// Exclusive upper bound (ISO timestamp). Default: now.
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// GET /api/admin/activation-funnel — distinct-actor counts per rung.
+///
+/// Admin-gated. The spec calls for "existing role checks" but no such
+/// table exists today; pre-launch we gate on (a) `SessionKind::Dev`
+/// (always allowed — dev seed user is the only principal in local
+/// dev) or (b) the caller's `github_login` is listed in
+/// `ONSAGER_ADMIN_LOGINS`. Cloud deploys configure that env var; OSS
+/// self-hosters either set it or run under dev-login. A real
+/// workspace-membership-role surface is a follow-up.
+pub async fn get_funnel(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Query(q): Query<FunnelQuery>,
+) -> Response {
+    if !is_admin(&state, &auth_user) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "admin only" })),
+        )
+            .into_response();
+    }
+
+    let to = q.to.unwrap_or_else(Utc::now);
+    let from = q.from.unwrap_or_else(|| to - chrono::Duration::days(30));
+
+    let rows: Result<Vec<(String, i64)>, sqlx::Error> = sqlx::query_as(
+        "SELECT event, COUNT(DISTINCT COALESCE(user_id, anonymous_id))::BIGINT AS n \
+           FROM activation_events \
+          WHERE occurred_at >= $1 AND occurred_at < $2 \
+          GROUP BY event",
+    )
+    .bind(from)
+    .bind(to)
+    .fetch_all(&state.pool)
+    .await;
+
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "activation funnel query failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "query failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let mut counts = serde_json::Map::new();
+    for event in VALID_EVENTS {
+        counts.insert((*event).to_string(), serde_json::json!(0));
+    }
+    for (event, n) in rows {
+        counts.insert(event, serde_json::json!(n));
+    }
+
+    Json(serde_json::json!({
+        "from": from,
+        "to": to,
+        "counts": counts,
+    }))
+    .into_response()
+}
+
+fn is_admin(state: &AppState, auth_user: &AuthUser) -> bool {
+    if auth_user.session_kind == SessionKind::Dev {
+        return true;
+    }
+    let login = auth_user.github_login.to_ascii_lowercase();
+    state
+        .config
+        .admin_github_logins
+        .iter()
+        .any(|l| l.to_ascii_lowercase() == login)
+}
+
+fn build_dedup_key(
+    event: &str,
+    user_id: Option<&str>,
+    anonymous_id: &str,
+    context: &serde_json::Value,
+) -> Result<String, &'static str> {
+    let actor = user_id.unwrap_or(anonymous_id);
+    match event {
+        "ftue.inspected" => Ok(format!("ftue.inspected|{actor}")),
+        "ftue.drafted" => {
+            let draft_id = context
+                .get("draft_id")
+                .and_then(|v| v.as_str())
+                .ok_or("ftue.drafted requires context.draft_id")?;
+            Ok(format!("ftue.drafted|{actor}|{draft_id}"))
+        }
+        "ftue.bound" => {
+            let user_id = user_id.ok_or("ftue.bound requires authenticated user_id")?;
+            let draft_id = context
+                .get("draft_id")
+                .and_then(|v| v.as_str())
+                .ok_or("ftue.bound requires context.draft_id")?;
+            Ok(format!("ftue.bound|{user_id}|{draft_id}"))
+        }
+        // `ftue.activated` is rejected earlier — listed for completeness
+        // so the listener can reuse this helper.
+        "ftue.activated" => {
+            let user_id = user_id.ok_or("ftue.activated requires user_id")?;
+            let workflow_id = context
+                .get("workflow_id")
+                .and_then(|v| v.as_str())
+                .ok_or("ftue.activated requires context.workflow_id")?;
+            Ok(format!("ftue.activated|{user_id}|{workflow_id}"))
+        }
+        _ => Err("unknown event"),
+    }
+}
+
+fn reject(msg: &'static str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
+}
+
+/// Build a dedup key for a server-emitted `ftue.activated` row. Exposed
+/// to the spine listener so the activation table's UNIQUE constraint
+/// catches concurrent emitters (multiple `stage.advanced` events for
+/// the same workflow during a deploy bounce, etc.).
+pub(crate) fn activated_dedup_key(user_id: &str, workflow_id: &str) -> String {
+    format!("ftue.activated|{user_id}|{workflow_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_keys_match_spec_table() {
+        assert_eq!(
+            build_dedup_key("ftue.inspected", None, "anon-uuid", &serde_json::json!({})).unwrap(),
+            "ftue.inspected|anon-uuid"
+        );
+        assert_eq!(
+            build_dedup_key(
+                "ftue.inspected",
+                Some("user-1"),
+                "anon-uuid",
+                &serde_json::json!({})
+            )
+            .unwrap(),
+            "ftue.inspected|user-1"
+        );
+        assert_eq!(
+            build_dedup_key(
+                "ftue.drafted",
+                Some("user-1"),
+                "anon",
+                &serde_json::json!({ "draft_id": "d_1" })
+            )
+            .unwrap(),
+            "ftue.drafted|user-1|d_1"
+        );
+        assert_eq!(
+            build_dedup_key(
+                "ftue.bound",
+                Some("user-1"),
+                "anon",
+                &serde_json::json!({ "draft_id": "d_1" })
+            )
+            .unwrap(),
+            "ftue.bound|user-1|d_1"
+        );
+        assert_eq!(
+            activated_dedup_key("user-1", "wf_1"),
+            "ftue.activated|user-1|wf_1"
+        );
+    }
+
+    #[test]
+    fn dedup_key_rejects_missing_draft_id() {
+        let err = build_dedup_key(
+            "ftue.drafted",
+            Some("user-1"),
+            "anon",
+            &serde_json::json!({}),
+        )
+        .unwrap_err();
+        assert!(err.contains("draft_id"));
+    }
+
+    #[test]
+    fn ftue_bound_requires_user_id() {
+        let err = build_dedup_key(
+            "ftue.bound",
+            None,
+            "anon",
+            &serde_json::json!({ "draft_id": "d_1" }),
+        )
+        .unwrap_err();
+        assert!(err.contains("user_id"));
+    }
+}

--- a/crates/onsager-portal/src/handlers/activation.rs
+++ b/crates/onsager-portal/src/handlers/activation.rs
@@ -22,7 +22,7 @@ use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::auth::{AuthUser, SessionKind};
@@ -61,6 +61,7 @@ const VALID_SURFACES: &[&str] = &["landing", "chat", "dialog", "spine"];
 const VALID_PATHS: &[&str] = &["cloud", "oss"];
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActivationEventBody {
     pub event: String,
     pub occurred_at: DateTime<Utc>,
@@ -68,7 +69,27 @@ pub struct ActivationEventBody {
     pub surface: String,
     pub path: String,
     #[serde(default)]
-    pub context: serde_json::Value,
+    pub context: ActivationContext,
+}
+
+/// Closed-shape context payload. Matches the spec's interface verbatim;
+/// `deny_unknown_fields` rejects anything else at the wire boundary so
+/// the funnel contract is mechanically falsifiable.
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActivationContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_status: Option<String>,
 }
 
 /// POST /api/activation — record one rung crossing.
@@ -101,9 +122,6 @@ pub async fn record_activation(
     if body.anonymous_id.trim().is_empty() {
         return reject("anonymous_id required");
     }
-    if !body.context.is_object() {
-        return reject("context must be an object");
-    }
     if body.event == "ftue.activated" {
         return reject("ftue.activated is emitted server-side only");
     }
@@ -117,6 +135,10 @@ pub async fn record_activation(
     ) {
         Ok(k) => k,
         Err(msg) => return reject(msg),
+    };
+    let context_json = match serde_json::to_value(&body.context) {
+        Ok(v) => v,
+        Err(_) => return reject("context serialization failed"),
     };
 
     let id = Uuid::new_v4().to_string();
@@ -133,7 +155,7 @@ pub async fn record_activation(
     .bind(&body.anonymous_id)
     .bind(&body.surface)
     .bind(&body.path)
-    .bind(&body.context)
+    .bind(&context_json)
     .bind(&dedup_key)
     .execute(&state.pool)
     .await;
@@ -242,23 +264,23 @@ fn build_dedup_key(
     event: &str,
     user_id: Option<&str>,
     anonymous_id: &str,
-    context: &serde_json::Value,
+    context: &ActivationContext,
 ) -> Result<String, &'static str> {
     let actor = user_id.unwrap_or(anonymous_id);
     match event {
         "ftue.inspected" => Ok(format!("ftue.inspected|{actor}")),
         "ftue.drafted" => {
             let draft_id = context
-                .get("draft_id")
-                .and_then(|v| v.as_str())
+                .draft_id
+                .as_deref()
                 .ok_or("ftue.drafted requires context.draft_id")?;
             Ok(format!("ftue.drafted|{actor}|{draft_id}"))
         }
         "ftue.bound" => {
             let user_id = user_id.ok_or("ftue.bound requires authenticated user_id")?;
             let draft_id = context
-                .get("draft_id")
-                .and_then(|v| v.as_str())
+                .draft_id
+                .as_deref()
                 .ok_or("ftue.bound requires context.draft_id")?;
             Ok(format!("ftue.bound|{user_id}|{draft_id}"))
         }
@@ -267,8 +289,8 @@ fn build_dedup_key(
         "ftue.activated" => {
             let user_id = user_id.ok_or("ftue.activated requires user_id")?;
             let workflow_id = context
-                .get("workflow_id")
-                .and_then(|v| v.as_str())
+                .workflow_id
+                .as_deref()
                 .ok_or("ftue.activated requires context.workflow_id")?;
             Ok(format!("ftue.activated|{user_id}|{workflow_id}"))
         }
@@ -296,20 +318,22 @@ pub(crate) fn activated_dedup_key(user_id: &str, workflow_id: &str) -> String {
 mod tests {
     use super::*;
 
+    fn ctx_with_draft(draft_id: &str) -> ActivationContext {
+        ActivationContext {
+            draft_id: Some(draft_id.to_string()),
+            ..ActivationContext::default()
+        }
+    }
+
     #[test]
     fn dedup_keys_match_spec_table() {
+        let empty = ActivationContext::default();
         assert_eq!(
-            build_dedup_key("ftue.inspected", None, "anon-uuid", &serde_json::json!({})).unwrap(),
+            build_dedup_key("ftue.inspected", None, "anon-uuid", &empty).unwrap(),
             "ftue.inspected|anon-uuid"
         );
         assert_eq!(
-            build_dedup_key(
-                "ftue.inspected",
-                Some("user-1"),
-                "anon-uuid",
-                &serde_json::json!({})
-            )
-            .unwrap(),
+            build_dedup_key("ftue.inspected", Some("user-1"), "anon-uuid", &empty).unwrap(),
             "ftue.inspected|user-1"
         );
         assert_eq!(
@@ -317,19 +341,13 @@ mod tests {
                 "ftue.drafted",
                 Some("user-1"),
                 "anon",
-                &serde_json::json!({ "draft_id": "d_1" })
+                &ctx_with_draft("d_1"),
             )
             .unwrap(),
             "ftue.drafted|user-1|d_1"
         );
         assert_eq!(
-            build_dedup_key(
-                "ftue.bound",
-                Some("user-1"),
-                "anon",
-                &serde_json::json!({ "draft_id": "d_1" })
-            )
-            .unwrap(),
+            build_dedup_key("ftue.bound", Some("user-1"), "anon", &ctx_with_draft("d_1"),).unwrap(),
             "ftue.bound|user-1|d_1"
         );
         assert_eq!(
@@ -344,7 +362,7 @@ mod tests {
             "ftue.drafted",
             Some("user-1"),
             "anon",
-            &serde_json::json!({}),
+            &ActivationContext::default(),
         )
         .unwrap_err();
         assert!(err.contains("draft_id"));
@@ -352,13 +370,36 @@ mod tests {
 
     #[test]
     fn ftue_bound_requires_user_id() {
-        let err = build_dedup_key(
-            "ftue.bound",
-            None,
-            "anon",
-            &serde_json::json!({ "draft_id": "d_1" }),
-        )
-        .unwrap_err();
+        let err = build_dedup_key("ftue.bound", None, "anon", &ctx_with_draft("d_1")).unwrap_err();
         assert!(err.contains("user_id"));
+    }
+
+    #[test]
+    fn unknown_top_level_fields_are_rejected() {
+        let json = serde_json::json!({
+            "event": "ftue.drafted",
+            "occurred_at": "2026-05-19T00:00:00Z",
+            "anonymous_id": "a",
+            "surface": "chat",
+            "path": "cloud",
+            "context": { "draft_id": "d_1" },
+            "extra_field": "nope",
+        });
+        let err = serde_json::from_value::<ActivationEventBody>(json).unwrap_err();
+        assert!(err.to_string().contains("extra_field"), "{err}");
+    }
+
+    #[test]
+    fn unknown_context_keys_are_rejected() {
+        let json = serde_json::json!({
+            "event": "ftue.drafted",
+            "occurred_at": "2026-05-19T00:00:00Z",
+            "anonymous_id": "a",
+            "surface": "chat",
+            "path": "cloud",
+            "context": { "draft_id": "d_1", "secret_email": "me@x" },
+        });
+        let err = serde_json::from_value::<ActivationEventBody>(json).unwrap_err();
+        assert!(err.to_string().contains("secret_email"), "{err}");
     }
 }

--- a/crates/onsager-portal/src/handlers/mod.rs
+++ b/crates/onsager-portal/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP handlers — webhook ingress (split by GitHub event type) plus
 //! the user-facing `/api/auth/*` routes portal owns post-#222 Slice 5.
 
+pub mod activation;
 pub mod agent_ws;
 pub mod auth;
 pub mod build_info;

--- a/crates/onsager-portal/src/listeners/mod.rs
+++ b/crates/onsager-portal/src/listeners/mod.rs
@@ -1,1 +1,2 @@
 pub mod session_completed;
+pub mod workflow_activated;

--- a/crates/onsager-portal/src/listeners/workflow_activated.rs
+++ b/crates/onsager-portal/src/listeners/workflow_activated.rs
@@ -26,7 +26,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::Utc;
 use onsager_spine::factory_event::FactoryEventKind;
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 use sqlx::postgres::PgPool;
@@ -34,30 +33,39 @@ use uuid::Uuid;
 
 use crate::handlers::activation::activated_dedup_key;
 
-pub async fn run(pool: PgPool, store: EventStore) -> anyhow::Result<()> {
+pub async fn run(pool: PgPool, store: EventStore, is_oss: bool) -> anyhow::Result<()> {
     let handler = WorkflowActivated {
         pool: Arc::new(pool),
         store: store.clone(),
+        is_oss,
     };
-    Listener::new(store).run(handler).await
+    // Warm-start cursor — `ftue.activated` is a forward-looking signal;
+    // backfilling years of historical `stage.advanced` events on every
+    // process boot would log misleading "first activation" rows and
+    // run a DB lookup per event. `dedup_key` would still drop the
+    // duplicate inserts, but the work itself is wasted.
+    let since = store.max_event_id().await.ok().flatten();
+    Listener::new(store).with_since(since).run(handler).await
 }
 
 struct WorkflowActivated {
     pool: Arc<PgPool>,
     store: EventStore,
+    is_oss: bool,
 }
 
 impl WorkflowActivated {
     async fn handle_stage_advanced(&self, notification: &EventNotification) -> anyhow::Result<()> {
-        let kind = match notification.table.as_str() {
+        let ext_row = match notification.table.as_str() {
             "events_ext" => {
                 let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
                     return Ok(());
                 };
-                serde_json::from_value::<FactoryEventKind>(row.data)?
+                row
             }
             _ => return Ok(()),
         };
+        let kind = serde_json::from_value::<FactoryEventKind>(ext_row.data.clone())?;
 
         let FactoryEventKind::StageAdvanced {
             workflow_id,
@@ -75,10 +83,12 @@ impl WorkflowActivated {
             return Ok(());
         }
 
-        // Resolve the workflow's owner. Without a `created_by` we cannot
-        // attribute the activation rung to a user — skip silently.
+        // Resolve the workflow's owner. The spine `workflows` table is
+        // keyed by `workflow_id` (see migration 006). Without a
+        // `created_by` we cannot attribute the activation rung to a
+        // user — skip silently.
         let row: Option<(Option<String>,)> =
-            sqlx::query_as("SELECT created_by FROM workflows WHERE id = $1")
+            sqlx::query_as("SELECT created_by FROM workflows WHERE workflow_id = $1")
                 .bind(&workflow_id)
                 .fetch_optional(&*self.pool)
                 .await?;
@@ -97,17 +107,23 @@ impl WorkflowActivated {
             "workflow_id": workflow_id,
             "terminal_status": "completed",
         });
+        // Use the spine row's timestamp so reporting reflects when the
+        // run actually reached terminal state, not when the listener
+        // happened to process it.
+        let occurred_at = ext_row.created_at;
+        let path = if self.is_oss { "oss" } else { "cloud" };
 
         let res = sqlx::query(
             "INSERT INTO activation_events \
                  (id, event, occurred_at, user_id, anonymous_id, surface, path, context, dedup_key) \
-             VALUES ($1, 'ftue.activated', $2, $3, $4, 'spine', 'cloud', $5, $6) \
+             VALUES ($1, 'ftue.activated', $2, $3, $4, 'spine', $5, $6, $7) \
              ON CONFLICT (dedup_key) DO NOTHING",
         )
         .bind(&id)
-        .bind(Utc::now())
+        .bind(occurred_at)
         .bind(&user_id)
         .bind(&anonymous_id)
+        .bind(path)
         .bind(&context)
         .bind(&dedup_key)
         .execute(&*self.pool)
@@ -147,6 +163,6 @@ mod tests {
 
     #[allow(dead_code)]
     fn _type_check_run_signature(pool: PgPool, store: EventStore) {
-        std::mem::drop(run(pool, store));
+        std::mem::drop(run(pool, store, false));
     }
 }

--- a/crates/onsager-portal/src/listeners/workflow_activated.rs
+++ b/crates/onsager-portal/src/listeners/workflow_activated.rs
@@ -1,0 +1,152 @@
+//! Spine listener for `stage.advanced` → `ftue.activated` activation row
+//! (spec #404).
+//!
+//! The fourth rung of the FTUE activation ladder (Inspected → Drafted →
+//! Bound → Activated) is the moment a bound workflow's first run reaches
+//! a terminal stage status. The substrate is the truth: when an
+//! artifact moves past the final stage of its workflow, the spine emits
+//! `stage.advanced` with `to_stage_index: None`. This listener consumes
+//! that signal, resolves the workflow's `created_by` user, and writes
+//! the `ftue.activated` row into the portal-owned `activation_events`
+//! table — fire-once per (user, workflow) via the table's
+//! `dedup_key` UNIQUE constraint.
+//!
+//! Why not have the dashboard fire this? See rejected alternative #4 in
+//! the spec: coupling activation measurement to whether the user
+//! happens to view the run-detail page would mean a closed tab silently
+//! drops the rung. The substrate already knows.
+//!
+//! Failure / cancellation: today's spine vocabulary has no
+//! workflow-run-level terminal signal for failure (`node.failed` is per
+//! executor, not per run). v1 lights up the "completed" path only; the
+//! `terminal_status` field on the row is set to `completed`. When the
+//! substrate gains an explicit run-terminal event, extend the match
+//! below.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use onsager_spine::factory_event::FactoryEventKind;
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+use crate::handlers::activation::activated_dedup_key;
+
+pub async fn run(pool: PgPool, store: EventStore) -> anyhow::Result<()> {
+    let handler = WorkflowActivated {
+        pool: Arc::new(pool),
+        store: store.clone(),
+    };
+    Listener::new(store).run(handler).await
+}
+
+struct WorkflowActivated {
+    pool: Arc<PgPool>,
+    store: EventStore,
+}
+
+impl WorkflowActivated {
+    async fn handle_stage_advanced(&self, notification: &EventNotification) -> anyhow::Result<()> {
+        let kind = match notification.table.as_str() {
+            "events_ext" => {
+                let Some(row) = self.store.get_ext_event_by_id(notification.id).await? else {
+                    return Ok(());
+                };
+                serde_json::from_value::<FactoryEventKind>(row.data)?
+            }
+            _ => return Ok(()),
+        };
+
+        let FactoryEventKind::StageAdvanced {
+            workflow_id,
+            to_stage_index,
+            ..
+        } = kind
+        else {
+            return Ok(());
+        };
+
+        // Only the artifact-just-completed-the-final-stage transition is
+        // a workflow-run terminal status today. Mid-workflow advances
+        // are not activation moments.
+        if to_stage_index.is_some() {
+            return Ok(());
+        }
+
+        // Resolve the workflow's owner. Without a `created_by` we cannot
+        // attribute the activation rung to a user — skip silently.
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT created_by FROM workflows WHERE id = $1")
+                .bind(&workflow_id)
+                .fetch_optional(&*self.pool)
+                .await?;
+        let Some((Some(user_id),)) = row else {
+            tracing::debug!(
+                %workflow_id,
+                "ftue.activated: workflow has no created_by, skipping"
+            );
+            return Ok(());
+        };
+
+        let dedup_key = activated_dedup_key(&user_id, &workflow_id);
+        let id = Uuid::new_v4().to_string();
+        let anonymous_id = format!("server:{user_id}");
+        let context = serde_json::json!({
+            "workflow_id": workflow_id,
+            "terminal_status": "completed",
+        });
+
+        let res = sqlx::query(
+            "INSERT INTO activation_events \
+                 (id, event, occurred_at, user_id, anonymous_id, surface, path, context, dedup_key) \
+             VALUES ($1, 'ftue.activated', $2, $3, $4, 'spine', 'cloud', $5, $6) \
+             ON CONFLICT (dedup_key) DO NOTHING",
+        )
+        .bind(&id)
+        .bind(Utc::now())
+        .bind(&user_id)
+        .bind(&anonymous_id)
+        .bind(&context)
+        .bind(&dedup_key)
+        .execute(&*self.pool)
+        .await?;
+
+        if res.rows_affected() > 0 {
+            tracing::info!(
+                %workflow_id,
+                %user_id,
+                "ftue.activated: recorded"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EventHandler for WorkflowActivated {
+    async fn handle(&self, notification: EventNotification) -> anyhow::Result<()> {
+        if notification.event_type != "stage.advanced" {
+            return Ok(());
+        }
+        if let Err(e) = self.handle_stage_advanced(&notification).await {
+            tracing::warn!(
+                error = %e,
+                event_id = notification.id,
+                "workflow_activated listener: handler error"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    fn _type_check_run_signature(pool: PgPool, store: EventStore) {
+        std::mem::drop(run(pool, store));
+    }
+}

--- a/crates/onsager-portal/src/main.rs
+++ b/crates/onsager-portal/src/main.rs
@@ -91,6 +91,11 @@ enum Command {
         /// returns `{ enabled: false }`.
         #[arg(long, env = "SHOWCASE_DOGFOOD_WORKFLOW_ID")]
         showcase_dogfood_workflow_id: Option<String>,
+        /// Comma-separated `github_login` values granted access to
+        /// the internal `/api/admin/*` surface (spec #404). Empty in
+        /// dev — local dev-login sessions are always admins.
+        #[arg(long, env = "ONSAGER_ADMIN_LOGINS")]
+        admin_logins: Option<String>,
     },
     /// Backfill issues + PRs for an existing project.
     Backfill {
@@ -140,6 +145,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             remediation_monthly_cap_usd,
             deployment,
             showcase_dogfood_workflow_id,
+            admin_logins,
         } => {
             let allowlist = sso_return_host_allowlist
                 .as_deref()
@@ -180,6 +186,14 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 deployment: deployment.filter(|s| !s.trim().is_empty()),
                 showcase_dogfood_workflow_id: showcase_dogfood_workflow_id
                     .filter(|s| !s.trim().is_empty()),
+                admin_github_logins: admin_logins
+                    .map(|s| {
+                        s.split(',')
+                            .map(|p| p.trim().to_string())
+                            .filter(|p| !p.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             };
             tracing::info!(%bind, "onsager-portal: starting webhook server");
             onsager_portal::server::run(cfg).await

--- a/crates/onsager-portal/src/migrate.rs
+++ b/crates/onsager-portal/src/migrate.rs
@@ -67,6 +67,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "008_portal_remediation_calls",
         include_str!("../migrations/008_portal_remediation_calls.sql"),
     ),
+    (
+        "009_activation_events",
+        include_str!("../migrations/009_activation_events.sql"),
+    ),
 ];
 
 /// Apply all portal-owned table migrations. Idempotent — safe to call on

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -8,16 +8,17 @@ use axum::routing::{any, delete, get, post, put};
 use crate::config::Config;
 use crate::gate::GateClient;
 use crate::handlers::{
-    agent_ws, auth as auth_handlers, build_info as build_info_handlers, chat as chat_handlers,
-    credentials as credential_handlers, github_app as github_app_handlers,
-    governance as governance_handlers, installations as installation_handlers,
-    live_data as live_data_handlers, nodes as node_handlers, pats as pat_handlers,
-    projects as project_handlers, registry_events as registry_event_handlers,
-    registry_triggers as registry_trigger_handlers, runs as run_handlers,
-    sessions as session_handlers, showcase as showcase_handlers, spine as spine_handlers,
-    tasks as task_handlers, telegram_webhook, triggers as trigger_handlers, webhook,
-    workflow_kinds as workflow_kind_handlers, workflow_views as workflow_view_handlers,
-    workflows as workflow_handlers, workspaces as workspace_handlers,
+    activation as activation_handlers, agent_ws, auth as auth_handlers,
+    build_info as build_info_handlers, chat as chat_handlers, credentials as credential_handlers,
+    github_app as github_app_handlers, governance as governance_handlers,
+    installations as installation_handlers, live_data as live_data_handlers,
+    nodes as node_handlers, pats as pat_handlers, projects as project_handlers,
+    registry_events as registry_event_handlers, registry_triggers as registry_trigger_handlers,
+    runs as run_handlers, sessions as session_handlers, showcase as showcase_handlers,
+    spine as spine_handlers, tasks as task_handlers, telegram_webhook,
+    triggers as trigger_handlers, webhook, workflow_kinds as workflow_kind_handlers,
+    workflow_views as workflow_view_handlers, workflows as workflow_handlers,
+    workspaces as workspace_handlers,
 };
 use crate::proxy_cache::ProxyCache;
 use crate::state::AppState;
@@ -353,6 +354,20 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             "/api/showcase/dogfood",
             axum::routing::get(showcase_handlers::get_dogfood),
         )
+        // FTUE activation funnel (spec #404). `POST /api/activation`
+        // accepts the four `ftue.*` events from the dashboard;
+        // `GET /api/admin/activation-funnel` is the internal report.
+        // Auth on the POST is optional — pre-auth `ftue.inspected`
+        // arrives with no user_id — so the extractor is `Option<AuthUser>`
+        // inside the handler.
+        .route(
+            "/api/activation",
+            post(activation_handlers::record_activation),
+        )
+        .route(
+            "/api/admin/activation-funnel",
+            get(activation_handlers::get_funnel),
+        )
         // MCP server (ADR 0007 / #288). JSON-RPC 2.0 over HTTP — the
         // runtime-agnostic public contract for AI clients. Auth reuses
         // the `AuthUser` extractor (PAT or session); workspace-scoped
@@ -372,6 +387,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // Clone handles needed by background listeners before consuming state.
     let listener_pool = state.pool.clone();
     let listener_spine = state.spine.clone();
+    let activation_pool = state.pool.clone();
+    let activation_spine = state.spine.clone();
 
     let app = app.with_state(state);
 
@@ -383,6 +400,17 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             crate::listeners::session_completed::run(listener_pool, listener_spine).await
         {
             tracing::error!("portal: session_completed listener exited: {e}");
+        }
+    });
+
+    // Spawn the stage.advanced → ftue.activated listener (spec #404).
+    // Writes one activation row per (user, workflow) the first time a
+    // bound workflow's run reaches the final stage.
+    tokio::spawn(async move {
+        if let Err(e) =
+            crate::listeners::workflow_activated::run(activation_pool, activation_spine).await
+        {
+            tracing::error!("portal: workflow_activated listener exited: {e}");
         }
     });
 

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -389,6 +389,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let listener_spine = state.spine.clone();
     let activation_pool = state.pool.clone();
     let activation_spine = state.spine.clone();
+    let activation_is_oss = !state
+        .config
+        .deployment
+        .as_deref()
+        .is_some_and(|d| d.eq_ignore_ascii_case("cloud"));
 
     let app = app.with_state(state);
 
@@ -407,8 +412,12 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // Writes one activation row per (user, workflow) the first time a
     // bound workflow's run reaches the final stage.
     tokio::spawn(async move {
-        if let Err(e) =
-            crate::listeners::workflow_activated::run(activation_pool, activation_spine).await
+        if let Err(e) = crate::listeners::workflow_activated::run(
+            activation_pool,
+            activation_spine,
+            activation_is_oss,
+        )
+        .await
         {
             tracing::error!("portal: workflow_activated listener exited: {e}");
         }

--- a/xtask/src/lint_api_contract.rs
+++ b/xtask/src/lint_api_contract.rs
@@ -484,6 +484,10 @@ pub const EXTERNAL_ONLY_ROUTES: &[(&str, &str)] = &[
         "/api/showcase/dogfood",
         "Public Dogfood showcase projection (spec #407) — fetched from `pages/ShowcaseDogfoodPage.tsx` via a bespoke pre-auth fetch on an unauthenticated route. No `workspace_id` scoping; outside the `lib/api/` typed scanner.",
     ),
+    (
+        "/api/admin/activation-funnel",
+        "FTUE activation funnel report (spec #404). v1 is internal-only — \"the query runs, returns numbers\"; the admin dashboard surface is an explicit follow-up. Today this is exercised by ops humans hitting the URL directly (or via a future internal dashboard); no typed `request<T>` caller yet by design.",
+    ),
 ];
 
 /// Routes registered by stiglab (or any other factory subsystem) that


### PR DESCRIPTION
## Summary

Implements spec #404 — minimum instrumentation for the FTUE activation ladder (Inspected → Drafted → Bound → Activated) so the umbrella (#397) redesign is falsifiable.

- **Portal table + sink.** New migration `009_activation_events.sql` adds the append-only `activation_events` table with a `dedup_key` UNIQUE constraint (enforces fire-once per the spec's `(event, user|anon, primary-id)` shape). Portal-owned — activation telemetry isn't factory coordination, per the seam rule.
- **Portal endpoints.** `POST /api/activation` accepts the three dashboard-emitted events (optional auth, closed enum validation, `ON CONFLICT DO NOTHING`). `GET /api/admin/activation-funnel` returns distinct-actor counts per rung over a date range; admin-gated via dev-session or `ONSAGER_ADMIN_LOGINS` (new env var).
- **Spine listener.** `crates/onsager-portal/src/listeners/workflow_activated.rs` consumes `stage.advanced { to_stage_index: None }` — today's only workflow-run terminal signal — and writes `ftue.activated` rows server-side. The dashboard never emits this rung (per spec rejected alternative #4).
- **Dashboard.** New `@/lib/activation` module (anonymous_id, fire-once cache, OSS opt-in gating) + typed `@/lib/api/activation` client. Wired into `WorkflowDAGPreview` (DAG/YAML toggle → `ftue.inspected`), `lib/drafts.ts` (first save → `ftue.drafted`), `BindDraftDialog` (bind success → `ftue.bound`).
- **Lint exemption.** `/api/admin/activation-funnel` added to `EXTERNAL_ONLY_ROUTES` in `xtask/src/lint_api_contract.rs` — spec explicitly defers the dashboard surface ("v1 is 'the query runs, returns numbers'").

### Deliberate scope notes

- `ftue.activated` is wired off `stage.advanced` (the existing workflow-run terminal signal). The spec's `workflow_run.stage_status_changed` and the `failed`/`cancelled` terminal statuses are not in today's spine vocabulary; the listener has a TODO marker for when the substrate gains an explicit run-terminal event.
- Admin gating is the lightest mechanism that honors the spec's intent — no new tables. Real workspace-admin roles are a follow-up.

## Delivers

- [x] `activation_events` table + portal migration
- [x] `POST /api/activation` handler + server-side dedup
- [x] `GET /api/admin/activation-funnel` admin-gated handler
- [x] Spine listener for `ftue.activated` (completed-status path)
- [x] `@/lib/activation` client module (anonymous_id, OSS opt-in, fire-once)
- [x] Dashboard wiring for Inspected / Drafted / Bound

## Test plan

- [ ] `cargo test -p onsager-portal --lib activation` — dedup-key unit tests pass
- [ ] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`
- [ ] `cargo run -p xtask --quiet -- lint-seams / check-api-contract / check-events / check-file-budget`
- [ ] Dashboard `pnpm build` + `pnpm lint`
- [ ] Manual: in `just dev`, toggle DAG↔YAML on ChatPage → row appears in `activation_events` with `event='ftue.inspected'`
- [ ] Manual: save a draft → `ftue.drafted` row; bind via `BindDraftDialog` → `ftue.bound` row; run a workflow to terminal stage → `ftue.activated` row
- [ ] Manual: `GET /api/admin/activation-funnel` under dev login returns `{counts: {...}}`; under non-admin GitHub login returns 403

Closes #404
Part of #397

---
_Generated by [Claude Code](https://claude.ai/code/session_016xohYTA8tyqw6B1j5RD49Q)_