### PR TITLE
chore: install onsager-ai/dev-skills on SessionStart in cloud

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,5 +9,10 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Best-effort: a transient npm/registry/GitHub blip shouldn't fail the whole
+# session start. On failure we log a warning and let the session continue
+# without the bundle.
 echo "--- installing onsager-ai/dev-skills globally ---"
-npx -y skills add -g onsager-ai/dev-skills --skill '*' -a claude-code -y
+if ! npx -y skills add -g onsager-ai/dev-skills --skill '*' -a claude-code; then
+  echo "warning: onsager-ai/dev-skills install failed; session will start without the bundle." >&2
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# Cloud-only: in Claude Code on the web, every container starts fresh, so we
+# install the onsager-ai/dev-skills bundle into ~/.claude/skills/ on each
+# session start. Local terminal sessions are skipped so a developer's
+# hand-installed skills are left alone.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "--- installing onsager-ai/dev-skills globally ---"
+npx -y skills add -g onsager-ai/dev-skills --skill '*' -a claude-code -y

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

Adds a web-only `SessionStart` hook so Claude Code on the web sessions land with the cross-repo dev-skills bundle (`onsager-ai/dev-skills`) already installed under `~/.claude/skills/`. Local terminal sessions are untouched.

- `.claude/hooks/session-start.sh` — gates on `$CLAUDE_CODE_REMOTE=true`, then runs `npx -y skills add -g onsager-ai/dev-skills --skill '*' -a claude-code -y`. Idempotent — re-running just re-copies the latest skill contents.
- `.claude/settings.json` — registers the hook alongside the existing `UserPromptSubmit` and `PreToolUse` blocks; no other behavior changes.

## Why this is needed

Cloud containers start fresh on every session, so the `npx skills add -g …` install from CLAUDE.md's "Skills bundle" section needs to happen automatically — otherwise the first user prompt in a fresh cloud session has none of `issue-spec`, `plan-dag`, `ci-triage`, `web-testing`, `railway`, etc. available.

## Test plan

- [x] `bash .claude/hooks/session-start.sh` with `CLAUDE_CODE_REMOTE` unset → exits 0 silently (no-op).
- [x] `CLAUDE_CODE_REMOTE=true bash .claude/hooks/session-start.sh` → installs all 12 skills from `onsager-ai/dev-skills` under `~/.claude/skills/`.
- [ ] Start a fresh Claude Code on the web session on this branch; confirm dev-skills (issue-spec, plan-dag, ci-triage, web-testing, railway) load on first prompt.

## Why no spec issue

This is dev-tooling configuration for the cloud runtime — a direct follow-on to #423 (consolidation into `onsager-ai/dev-skills`) and lands in lockstep across the four consumer repos (`onsager-ai/duhem`, `onsager-ai/onsager-skills`, `codervisor/lean-spec`, `onsager-ai/telegramable`). No product surface, no schema, no events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4HRhMkEi4VJg3zM47Wbbo)_