### PR TITLE
feat(xtask): occam's-razor lints — orphan crates, single-impl traits, deferred TODOs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,6 +108,12 @@ jobs:
         run: cargo run -p xtask --quiet -- check-events
       - name: File-budget check (spec #261)
         run: cargo run -p xtask --quiet -- check-file-budget --mode=fail
+      - name: Orphan-crate check (spec #275, warn-mode landing)
+        run: cargo run -p xtask --quiet -- check-orphan-crates --mode=warn
+      - name: Single-impl-trait check (spec #275, warn-mode landing)
+        run: cargo run -p xtask --quiet -- check-single-impl-traits --mode=warn
+      - name: Deferred-TODO check (spec #275, warn-mode landing)
+        run: cargo run -p xtask --quiet -- check-deferred-todos --mode=warn
       - name: Checkout onsager-skills (spec #323)
         uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,35 @@ caught mechanically by `lint-seams`, `check-api-contract`, and
 checks were designed against. The denormalized-external-state bullet is
 the exception — review + contract test today, mechanical check pending.
 
+### Occam's-razor checklist (spec #275)
+
+The patterns above all share one shape: a wire connected at one end. The
+seam rule's six levers caught seam-level instances; spec #275 adds three
+xtask lints that catch the **interior** instances — speculative
+abstractions and untracked defers that drift inside a single subsystem.
+Same warn-then-ratchet rollout as `check-file-budget`.
+
+- **`xtask check-orphan-crates`** — flags library crates (non-`[[bin]]`)
+  with zero in-tree reverse deps. Would have caught the warehouse /
+  delivery skeleton on day one. Escape: `// occam-allow: <reason>` in
+  `src/lib.rs`.
+- **`xtask check-single-impl-traits`** — flags `pub trait` defs with
+  exactly one implementor in the workspace (counting test impls so a
+  mock doesn't false-trigger). A trait with one impl is a speculative
+  seam; inline it or wait for the second implementor. Escape: `//
+  occam-allow: <reason>` on the line above the `pub trait`.
+- **`xtask check-deferred-todos`** — flags `TODO` / `FIXME` /
+  `#[allow(dead_code)]` / `// phase N` / `// vN.M` without a same-line
+  `#NNN` issue reference. Untracked defers evaporate at squash-merge;
+  every "for later" must point at a real spec or carry `// occam-allow:
+  <reason>`.
+- **`xtask check-events`** also surfaces diagnostic-only event rows
+  without a `tracking_issue` (warn-mode), so dangling skeletons in the
+  manifest get re-examined too.
+
+All four land in warn mode initially (warn-then-ratchet); a follow-up
+spec will ratchet them to fail once the floor is clean.
+
 ## Workspace layout
 
 ```

--- a/crates/onsager-observers/src/lib.rs
+++ b/crates/onsager-observers/src/lib.rs
@@ -1,3 +1,7 @@
+// occam-allow: Observer runtime wiring lands with OBS-01 (#361). Until then the
+// crate is a designed-for-future-use library with no in-tree reverse dep — the
+// substrate scheduler will pull it in once the OBS-01 runtime spawns observer
+// tasks. Remove this allow when the dep edge appears.
 //! # onsager-observers
 //!
 //! The 0.2 substrate's **second citizen**: non-blocking observers that

--- a/crates/onsager-registry/CLAUDE.md
+++ b/crates/onsager-registry/CLAUDE.md
@@ -38,6 +38,11 @@ reviewed table of every `FactoryEventKind` variant. Each row declares:
   today (e.g. `"rendered in dashboard event timeline"`). Required
   when `diagnostic_only` is `true`; `None` for real rows. Free-form
   by design.
+- `tracking_issue` — `Option<u32>` pointing at the follow-up issue
+  that tracks moving this row from diagnostic-only to a real
+  consumer (or removing it). Surfaced by `xtask check-events` as a
+  warn-mode signal per spec #275; ratchet to required for
+  diagnostic-only rows is a follow-up.
 
 Every row is in one of two states: **real** (non-empty `consumers`)
 or **diagnostic-only** (`diagnostic_only: true` plus a non-empty

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -106,6 +106,14 @@ pub struct EventDefinition {
     /// `diagnostic_only` is `true`; `None` for real rows. Free-form by
     /// design.
     pub reason: Option<&'static str>,
+    /// Open follow-up issue tracking the path from diagnostic-only to a
+    /// real consumer. Surfaces in `xtask check-events` so dangling
+    /// skeletons can be re-examined: an event that has been
+    /// diagnostic-only for an extended period either gets a real
+    /// consumer or the row gets removed. `None` is allowed today (warn-
+    /// mode landing per spec #275); ratchet to required is a follow-up.
+    /// Has no meaning for real rows (`diagnostic_only = false`).
+    pub tracking_issue: Option<u32>,
     /// One-line description for the manifest read API and dashboard.
     pub description: &'static str,
 }
@@ -134,6 +142,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "New artifact accepted and ID assigned.",
         },
         EventDefinition {
@@ -143,6 +152,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Artifact transitioned between lifecycle states.",
         },
         EventDefinition {
@@ -152,6 +162,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Artifact reached terminal state (archived).",
         },
         // -- Git lifecycle (onsager-portal webhooks) ------------------------
@@ -162,6 +173,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A pull request was opened for an artifact.",
         },
         EventDefinition {
@@ -171,6 +183,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A CI check finished for a PR.",
         },
         EventDefinition {
@@ -180,6 +193,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate, Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A PR was merged.",
         },
         EventDefinition {
@@ -189,6 +203,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A PR was closed without merging.",
         },
         // -- Forge process events -------------------------------------------
@@ -199,6 +214,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Stiglab],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "ShapingRequest sent to Stiglab via the spine (replaces POST /api/shaping).",
         },
         EventDefinition {
@@ -208,6 +224,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "ShapingResult received from Stiglab and recorded by Forge.",
         },
         EventDefinition {
@@ -217,6 +234,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Synodic],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "GateRequest sent to Synodic via the spine (replaces POST /api/gate).",
         },
         EventDefinition {
@@ -226,6 +244,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Ising],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "GateVerdict observed by Forge after Synodic responded.",
         },
         EventDefinition {
@@ -235,6 +254,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Insight forwarded to the scheduling kernel.",
         },
         EventDefinition {
@@ -244,6 +264,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("diagnostic trace of forge scheduling kernel; no downstream action"),
+            tracking_issue: None,
             description: "Scheduling kernel produced a ShapingDecision.",
         },
         // -- Stiglab events -------------------------------------------------
@@ -254,6 +275,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A session finished successfully; carries optional artifact_id, token usage, branch, and PR number.",
         },
         EventDefinition {
@@ -263,6 +285,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Full session ShapingResult ready for Forge to act on (replaces POST /api/shaping response). Renamed from stiglab.shaping_result_ready per spec #285.",
         },
         EventDefinition {
@@ -272,6 +295,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A session terminated with an error.",
         },
         EventDefinition {
@@ -281,6 +305,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("dashboard event-timeline troubleshooting for node/deadline failures"),
+            tracking_issue: None,
             description: "A session was aborted (node lost, deadline exceeded).",
         },
         // -- Portal intents (dashboard → agent dispatch) --------------------
@@ -291,6 +316,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Stiglab],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Dashboard task request from portal; stiglab dispatches the session to an agent node.",
         },
         EventDefinition {
@@ -300,6 +326,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Stiglab],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Dashboard cancel-session request from portal (spec #303); stiglab forwards a CancelSession to the session's agent node.",
         },
         EventDefinition {
@@ -311,6 +338,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "observable in dashboard event timeline for operator troubleshooting when portal cannot open a PR for a completed session",
             ),
+            tracking_issue: None,
             description: "Portal failed to open a GitHub PR for a completed session (empty branch, GitHub API error, or missing App config).",
         },
         // -- Synodic events -------------------------------------------------
@@ -325,6 +353,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Full GateVerdict in response to forge.gate_requested (replaces POST /api/gate response).",
         },
         EventDefinition {
@@ -334,6 +363,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("audit trail for escalation context"),
+            tracking_issue: None,
             description: "An escalation was initiated.",
         },
         EventDefinition {
@@ -343,6 +373,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "An escalation was resolved (human, delegate, or timeout).",
         },
         EventDefinition {
@@ -352,6 +383,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "An escalation timed out and the default verdict was applied.",
         },
         EventDefinition {
@@ -361,6 +393,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "A delegate proposed a resolution for an active escalation.",
         },
         EventDefinition {
@@ -370,6 +403,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "A crystallization candidate rule was created.",
         },
         EventDefinition {
@@ -379,6 +413,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "A proposed rule was approved and entered the active set.",
         },
         EventDefinition {
@@ -388,6 +423,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "A rule was disabled.",
         },
         EventDefinition {
@@ -397,6 +433,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
+            tracking_issue: None,
             description: "A rule was modified, producing a new version.",
         },
         // -- Ising events ---------------------------------------------------
@@ -407,6 +444,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in dashboard ising views"),
+            tracking_issue: None,
             description: "An insight passed validation and was recorded on the spine.",
         },
         EventDefinition {
@@ -416,6 +454,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "Machine-readable signal emitted on the spine for other subsystems to consume.",
         },
         EventDefinition {
@@ -425,6 +464,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in dashboard ising views"),
+            tracking_issue: None,
             description: "An insight was deduplicated or fell below confidence threshold.",
         },
         EventDefinition {
@@ -434,6 +474,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Synodic],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "An insight was packaged as a rule proposal for Synodic.",
         },
         EventDefinition {
@@ -443,6 +484,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("operator troubleshooting in dashboard"),
+            tracking_issue: None,
             description: "An analyzer encountered an error during its run.",
         },
         EventDefinition {
@@ -452,6 +494,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("ising health monitoring in dashboard"),
+            tracking_issue: None,
             description: "Ising finished catching up from a lag position.",
         },
         // -- Refract (intent decomposition) ---------------------------------
@@ -462,6 +505,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in refract intent timeline"),
+            tracking_issue: None,
             description: "A new intent was submitted for decomposition.",
         },
         EventDefinition {
@@ -471,6 +515,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in refract intent timeline"),
+            tracking_issue: None,
             description: "A decomposer produced an artifact tree for an intent.",
         },
         EventDefinition {
@@ -480,6 +525,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in refract intent timeline"),
+            tracking_issue: None,
             description: "Decomposition failed — no decomposer matched, or the matched decomposer errored out.",
         },
         // -- Workflow runtime (issue #80 / #81) -----------------------------
@@ -500,6 +546,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A trigger fired (webhook / schedule / event / manual).",
         },
         EventDefinition {
@@ -514,6 +561,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("audit trail for manual / CLI / replay fires"),
+            tracking_issue: None,
             description: "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
         },
         EventDefinition {
@@ -523,6 +571,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in workflow run timeline"),
+            tracking_issue: None,
             description: "A workflow-tagged artifact entered a new stage.",
         },
         // Per spec #285: per-gate `stage.gate_passed` / `stage.gate_failed`
@@ -535,6 +584,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[],
             diagnostic_only: true,
             reason: Some("rendered in workflow run timeline"),
+            tracking_issue: None,
             description: "All gates on a stage resolved and the artifact advanced.",
         },
         // -- Registry events removed by spec #285 ---------------------------
@@ -561,6 +611,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
+            tracking_issue: Some(361),
             description: "Substrate scheduler dispatched a node — execution began.",
         },
         EventDefinition {
@@ -572,6 +623,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
+            tracking_issue: Some(361),
             description: "A node finished successfully; outputs persisted under the edge's ArtifactId.",
         },
         EventDefinition {
@@ -583,6 +635,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
+            tracking_issue: Some(361),
             description: "A node's executor returned Err; the plan is aborted (v1 — no retries).",
         },
         EventDefinition {
@@ -594,6 +647,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard HITL inbox; Human executor approval round-trips via portal (#357)",
             ),
+            tracking_issue: Some(357),
             description: "A Human executor is waiting on an out-of-band approval decision.",
         },
         EventDefinition {
@@ -605,6 +659,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard HITL audit; the substrate's own Human executor consumes the approval inline",
             ),
+            tracking_issue: None,
             description: "A pending Human executor node received an approval decision.",
         },
         EventDefinition {
@@ -616,6 +671,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard HITL audit; the substrate's own Human executor consumes the rejection inline",
             ),
+            tracking_issue: None,
             description: "A pending Human executor node received a rejection decision.",
         },
         EventDefinition {
@@ -627,6 +683,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard run timeline as gate outcome; Observer / dashboard read it directly — distinct from the legacy `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem (retired by MIG-03)",
             ),
+            tracking_issue: None,
             description: "Verify executor produced a verdict — pass / fail outcome with per-check details.",
         },
         EventDefinition {
@@ -638,6 +695,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard agent timeline; supersedes the 0.1 `stiglab.session_*` events once MIG-01 retires stiglab",
             ),
+            tracking_issue: None,
             description: "Agent executor opened an LLM session.",
         },
         EventDefinition {
@@ -649,6 +707,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard agent timeline; carries optional token usage for budget consumers",
             ),
+            tracking_issue: None,
             description: "Agent executor's LLM session finished successfully.",
         },
         EventDefinition {
@@ -660,6 +719,7 @@ pub const EVENTS: EventManifest = EventManifest {
             reason: Some(
                 "rendered in dashboard agent timeline; the executor wraps this into ExecutorError::Failed for the scheduler",
             ),
+            tracking_issue: None,
             description: "Agent executor's LLM session terminated with an error.",
         },
         // -- Gate adapters (GitHub webhooks) --------------------------------
@@ -671,6 +731,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A GitHub check_suite/check_run/status arrived for a tracked PR.",
         },
         EventDefinition {
@@ -681,6 +742,7 @@ pub const EVENTS: EventManifest = EventManifest {
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,
             reason: None,
+            tracking_issue: None,
             description: "A manual-approval gate received a signal (e.g. PR merged).",
         },
     ],
@@ -748,6 +810,7 @@ mod tests {
         assert!(first.get("consumers").is_some());
         assert!(first.get("diagnostic_only").is_some());
         assert!(first.get("reason").is_some());
+        assert!(first.get("tracking_issue").is_some());
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -40,6 +40,9 @@ lint-rust: _check-tools-and-skills
     cargo run -p xtask --quiet -- lint-seams
     cargo run -p xtask --quiet -- check-api-contract
     cargo run -p xtask --quiet -- check-file-budget --mode=fail
+    cargo run -p xtask --quiet -- check-orphan-crates --mode=warn
+    cargo run -p xtask --quiet -- check-single-impl-traits --mode=warn
+    cargo run -p xtask --quiet -- check-deferred-todos --mode=warn
 
 # Resolve the skills bundle then run check-tools-and-skills.
 # Override: ONSAGER_SKILLS_DIR=../onsager-skills just lint  (two-checkout local dev)

--- a/xtask/src/check_deferred_todos.rs
+++ b/xtask/src/check_deferred_todos.rs
@@ -1,0 +1,547 @@
+//! Deferred-TODO lint (spec #275) — Occam's-razor projection of "no
+//! dangling wires" / "untracked defer".
+//!
+//! Every TODO-shaped marker in the workspace must point at a tracked
+//! issue. The set of markers we care about:
+//!
+//! - `TODO` (case-insensitive, word-bounded)
+//! - `FIXME` (case-insensitive, word-bounded)
+//! - `#[allow(dead_code)]`
+//! - `// phase \d` (e.g. `// Phase 2`)
+//! - `// v\d+\.\d+` (e.g. `// v0.3`)
+//!
+//! Each occurrence on a non-test line must satisfy one of:
+//!
+//! - Reference a GitHub issue number `#NNN` on the same line (any
+//!   `#NNN` reference counts — open/closed is not checked here, since
+//!   that requires network access; closed-link discipline is a review-
+//!   time concern).
+//! - Carry `// occam-allow: <reason>` on the same line.
+//!
+//! "Non-test" means files under `crates/*/src/`, `xtask/src/`,
+//! `crates/*/tests/`, etc. We exclude generated / vendored content
+//! (`target/`, `node_modules/`).
+//!
+//! ## Modes
+//!
+//! - `--mode=warn` (default): print violations, exit 0.
+//! - `--mode=fail`: exit non-zero on any unallowed violation.
+//!
+//! Landing in warn mode per spec #275; ratchet to fail in a follow-up.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct DeferredHit {
+    pub marker: &'static str,
+    pub line_no: usize,
+    pub text: String,
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    let mode = parse_mode(&args)?;
+    let root = workspace_root()?;
+
+    let files = collect_files(&root)?;
+    let mut violations: Vec<(PathBuf, DeferredHit)> = Vec::new();
+    let mut allowed: Vec<(PathBuf, DeferredHit, String)> = Vec::new();
+
+    for file in &files {
+        if is_self_excluded(&root, file) {
+            continue;
+        }
+        let text =
+            std::fs::read_to_string(file).with_context(|| format!("read {}", file.display()))?;
+        for hit in scan_text(&text) {
+            if let Some(reason) = parse_allow(&hit.text) {
+                allowed.push((file.clone(), hit, reason));
+                continue;
+            }
+            if has_issue_ref(&hit.text) {
+                continue;
+            }
+            violations.push((file.clone(), hit));
+        }
+    }
+
+    if !allowed.is_empty() {
+        eprintln!("deferred-TODO occam-allow exemptions:");
+        for (file, hit, reason) in &allowed {
+            eprintln!(
+                "  {}:{} [{}] — allowed: {reason}",
+                rel(&root, file).display(),
+                hit.line_no,
+                hit.marker
+            );
+        }
+        eprintln!();
+    }
+
+    if violations.is_empty() {
+        println!(
+            "check-deferred-todos: clean ({} file(s) scanned, {} allowed exemption(s))",
+            files.len(),
+            allowed.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-deferred-todos: {} violation(s) — markers without an issue link:",
+        violations.len()
+    );
+    for (file, hit) in &violations {
+        eprintln!(
+            "  {}:{} [{}] {}",
+            rel(&root, file).display(),
+            hit.line_no,
+            hit.marker,
+            hit.text.trim()
+        );
+    }
+    eprintln!();
+    eprintln!("See spec #275 (Occam's-razor lints). Each marker must either");
+    eprintln!("reference a GitHub issue (`#NNN`) on the same line, or carry");
+    eprintln!("`// occam-allow: <reason>` on the same line.");
+
+    match mode {
+        Mode::Warn => {
+            eprintln!("(warn mode — not failing)");
+            Ok(())
+        }
+        Mode::Fail => bail!("deferred-TODO lint failed"),
+    }
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode> {
+    let mut mode = Mode::Warn;
+    for arg in args {
+        match arg.as_str() {
+            "--mode=warn" => mode = Mode::Warn,
+            "--mode=fail" => mode = Mode::Fail,
+            other => bail!("unknown flag for check-deferred-todos: {other}"),
+        }
+    }
+    Ok(mode)
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+fn rel(root: &Path, p: &Path) -> PathBuf {
+    p.strip_prefix(root).unwrap_or(p).to_path_buf()
+}
+
+fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for sub in ["crates", "xtask", "apps/dashboard/src"] {
+        walk(&root.join(sub), &mut out)?;
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if path.is_dir() {
+            if matches!(
+                name,
+                "target" | "node_modules" | "dist" | "build" | ".next" | ".turbo" | "out"
+            ) {
+                continue;
+            }
+            walk(&path, out)?;
+        } else {
+            let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+            if matches!(ext, "rs" | "ts" | "tsx" | "js" | "jsx") {
+                out.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn scan_text(text: &str) -> Vec<DeferredHit> {
+    let mut out = Vec::new();
+    let stripped = strip_string_literals(text);
+    let original: Vec<&str> = text.lines().collect();
+    for (idx, line) in stripped.lines().enumerate() {
+        let line_no = idx + 1;
+        for marker in find_markers(line) {
+            let original_line = original.get(idx).copied().unwrap_or(line);
+            out.push(DeferredHit {
+                marker,
+                line_no,
+                text: original_line.to_string(),
+            });
+        }
+    }
+    out
+}
+
+/// Lint files own this module's source by design (they enumerate the
+/// markers). Excluding it is cleaner than blanketing the file in
+/// `// occam-allow:` comments. The xtask/tests/fixtures directory
+/// hosts deliberate violations for unit tests — same rationale.
+fn is_self_excluded(root: &Path, path: &Path) -> bool {
+    let p = path.strip_prefix(root).unwrap_or(path);
+    let s = p.to_string_lossy();
+    s == "xtask/src/check_deferred_todos.rs" || s.starts_with("xtask/tests/fixtures/")
+}
+
+/// Replace contents of Rust / TS string literals with spaces so marker
+/// patterns inside template prompts ("flag unrelated TODO additions")
+/// don't trip the lint. Preserves line structure (newlines pass
+/// through) so reported line numbers still match the original file.
+///
+/// Handles three literal kinds (best-effort, line-oriented):
+/// - `"..."` — single-line, backslash-escape aware.
+/// - `r"..."` / `r#"..."#` — raw, possibly multi-line, hash-balanced.
+/// - line comments are not stripped — that's where TODOs live.
+fn strip_string_literals(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            // Line comment — keep verbatim until end of line.
+            while i < bytes.len() && bytes[i] != b'\n' {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+            continue;
+        }
+        if c == b'r' {
+            // Possible raw string: r#*"...".
+            let mut j = i + 1;
+            let mut hashes = 0;
+            while j < bytes.len() && bytes[j] == b'#' {
+                hashes += 1;
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'"' {
+                out.push('r');
+                for _ in 0..hashes {
+                    out.push('#');
+                }
+                out.push('"');
+                j += 1;
+                while j < bytes.len() {
+                    if bytes[j] == b'"' {
+                        let mut k = j + 1;
+                        let mut close_hashes = 0;
+                        while k < bytes.len() && bytes[k] == b'#' && close_hashes < hashes {
+                            close_hashes += 1;
+                            k += 1;
+                        }
+                        if close_hashes == hashes {
+                            out.push('"');
+                            for _ in 0..hashes {
+                                out.push('#');
+                            }
+                            j = k;
+                            break;
+                        }
+                    }
+                    if bytes[j] == b'\n' {
+                        out.push('\n');
+                    } else {
+                        out.push(' ');
+                    }
+                    j += 1;
+                }
+                i = j;
+                continue;
+            }
+        }
+        if c == b'"' {
+            out.push('"');
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    // Escape pair: emit space for `\` and preserve a literal
+                    // newline if the escape is a Rust line-continuation
+                    // (`\` + newline). Otherwise emit a space for the
+                    // escaped character so line counts stay aligned.
+                    out.push(' ');
+                    if bytes[i + 1] == b'\n' {
+                        out.push('\n');
+                    } else {
+                        out.push(' ');
+                    }
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    out.push('"');
+                    i += 1;
+                    break;
+                }
+                if bytes[i] == b'\n' {
+                    // Unterminated string — flush newline and break.
+                    out.push('\n');
+                    i += 1;
+                    break;
+                }
+                out.push(' ');
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c as char);
+        i += 1;
+    }
+    out
+}
+
+fn find_markers(line: &str) -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = Vec::new();
+    // Skip the marker hits inside the lint module's own pattern list —
+    // this file documents the markers in `//!` docs and would self-trip
+    // otherwise. The escape: an explicit "occam-allow: lint self-ref"
+    // on the same line. We don't need a special case here.
+    if has_word(line, "TODO") {
+        out.push("TODO");
+    }
+    if has_word(line, "FIXME") {
+        out.push("FIXME");
+    }
+    if line.contains("#[allow(dead_code)]") {
+        out.push("dead_code");
+    }
+    if matches_phase(line) {
+        out.push("phase");
+    }
+    if matches_version(line) {
+        out.push("version");
+    }
+    out.dedup();
+    out
+}
+
+fn has_word(line: &str, word: &str) -> bool {
+    let upper = line.to_uppercase();
+    let mut idx = 0;
+    while let Some(pos) = upper[idx..].find(word) {
+        let start = idx + pos;
+        let end = start + word.len();
+        let before_ok = start == 0 || !is_ident_char(upper.as_bytes()[start - 1]);
+        let after_ok = end == upper.len() || !is_ident_char(upper.as_bytes()[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        idx = end;
+    }
+    false
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Match `// phase N` (case-insensitive). The `//` prefix anchors this
+/// to comment lines, so the word "phase" in prose docs doesn't trip.
+fn matches_phase(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    for (idx, _) in lower.match_indices("phase ") {
+        // Require a `//` somewhere to the left of the match — comment-anchored.
+        if !lower[..idx].contains("//") {
+            continue;
+        }
+        let after = &lower[idx + "phase ".len()..];
+        if after.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Match `// vN.M`, comment-anchored. The same `//` constraint avoids
+/// crate doc-comments referencing version numbers like "v0.2" from
+/// tripping.
+fn matches_version(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    for (idx, _) in lower.match_indices('v') {
+        if idx == 0 {
+            continue;
+        }
+        let prev = lower.as_bytes()[idx - 1];
+        if is_ident_char(prev) {
+            continue;
+        }
+        if !lower[..idx].contains("//") {
+            continue;
+        }
+        let rest = &lower[idx + 1..];
+        let mut chars = rest.chars();
+        let Some(c1) = chars.next() else { continue };
+        if !c1.is_ascii_digit() {
+            continue;
+        }
+        // Need at least one '.' followed by a digit before whitespace /
+        // word-end.
+        let after_first = &rest[c1.len_utf8()..];
+        let dot_idx = after_first.find('.');
+        if let Some(d) = dot_idx
+            && after_first[d + 1..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn has_issue_ref(line: &str) -> bool {
+    // Look for `#` followed by 1+ ASCII digits, not part of a fragment
+    // or anchor inside a Markdown link header (`# Heading`).
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            if j > start {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn parse_allow(line: &str) -> Option<String> {
+    let idx = line.find("// occam-allow:")?;
+    let reason = line[idx + "// occam-allow:".len()..].trim();
+    if reason.is_empty() {
+        None
+    } else {
+        Some(reason.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn todo_without_issue_is_flagged() {
+        let hits = scan_text("// TODO: clean this up\nfn x() {}\n");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "TODO");
+        assert!(!has_issue_ref(&hits[0].text));
+    }
+
+    #[test]
+    fn todo_with_issue_is_passed() {
+        let hits = scan_text("// TODO(#275): land the lints\n");
+        assert_eq!(hits.len(), 1);
+        assert!(has_issue_ref(&hits[0].text));
+    }
+
+    #[test]
+    fn fixme_is_a_marker() {
+        let hits = scan_text("// FIXME: broken on edge case\n");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "FIXME");
+    }
+
+    #[test]
+    fn dead_code_attr_is_a_marker() {
+        let hits = scan_text("#[allow(dead_code)]\nfn unused() {}\n");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "dead_code");
+    }
+
+    #[test]
+    fn phase_pattern_is_a_marker() {
+        let hits = scan_text("// phase 2: wire up the dashboard\n");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "phase");
+    }
+
+    #[test]
+    fn version_pattern_is_a_marker() {
+        let hits = scan_text("// v0.3 will need this\n");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "version");
+    }
+
+    #[test]
+    fn word_boundary_excludes_subwords() {
+        // "todoist" should not match TODO.
+        let hits = scan_text("// todoist: not a marker\n");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn occam_allow_inline_is_recognized() {
+        let line = "// TODO: revisit later // occam-allow: external-API quirk";
+        assert_eq!(parse_allow(line).as_deref(), Some("external-API quirk"));
+    }
+
+    #[test]
+    fn issue_ref_detects_hash_number() {
+        assert!(has_issue_ref("see #275 for context"));
+        assert!(has_issue_ref("#1"));
+        assert!(!has_issue_ref("no number here"));
+        assert!(!has_issue_ref("# Heading"));
+    }
+
+    #[test]
+    fn marker_inside_string_literal_is_ignored() {
+        // The text inside the prompt would otherwise trip TODO.
+        let src = r#"let prompt = "review the diff for TODO additions";
+fn x() {}
+"#;
+        let hits = scan_text(src);
+        assert!(
+            hits.is_empty(),
+            "string-literal TODO must not trip the lint: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn marker_inside_raw_string_is_ignored() {
+        let src = "let prompt = r#\"flag TODO/FIXME additions in the diff\"#;\nfn x() {}\n";
+        let hits = scan_text(src);
+        assert!(
+            hits.is_empty(),
+            "raw-string content must not trip: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn marker_in_comment_outside_string_is_still_flagged() {
+        let src = "let s = \"safe\"; // TODO untracked\nfn x() {}\n";
+        let hits = scan_text(src);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].marker, "TODO");
+    }
+}

--- a/xtask/src/check_deferred_todos.rs
+++ b/xtask/src/check_deferred_todos.rs
@@ -22,6 +22,14 @@
 //! `crates/*/tests/`, etc. We exclude generated / vendored content
 //! (`target/`, `node_modules/`).
 //!
+//! ## Scope: Rust only
+//!
+//! Today this lint scans only `.rs` files. The string-literal stripper
+//! understands Rust `"..."` and `r#"..."#`; it does **not** handle
+//! TS/JS single-quoted strings (`'...'`) or template literals
+//! (`` `...` ``), so a `TODO` inside a JS template would false-trigger.
+//! Extending coverage to TS/JS is a follow-up — see PR #426 review.
+//!
 //! ## Modes
 //!
 //! - `--mode=warn` (default): print violations, exit 0.
@@ -148,7 +156,7 @@ fn rel(root: &Path, p: &Path) -> PathBuf {
 
 fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
-    for sub in ["crates", "xtask", "apps/dashboard/src"] {
+    for sub in ["crates", "xtask"] {
         walk(&root.join(sub), &mut out)?;
     }
     out.sort();
@@ -171,11 +179,11 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
                 continue;
             }
             walk(&path, out)?;
-        } else {
-            let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-            if matches!(ext, "rs" | "ts" | "tsx" | "js" | "jsx") {
-                out.push(path);
-            }
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            // Rust-only for now. TS/JS support needs a stripper that
+            // handles single-quoted strings and template literals — a
+            // follow-up per the PR #426 review.
+            out.push(path);
         }
     }
     Ok(())

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -56,6 +56,28 @@ pub fn run() -> Result<()> {
         }
     }
 
+    // Soft-warn: diagnostic-only rows that have no tracking_issue
+    // (spec #275). Surfaces dangling skeletons so review can decide
+    // whether they're real or whether the row should be removed.
+    // Warn-mode only — does not fail the build. Ratchet to required
+    // is a follow-up once the floor is clean.
+    let missing_tracking: Vec<&'static str> = EVENTS
+        .events
+        .iter()
+        .filter(|e| e.diagnostic_only && e.tracking_issue.is_none())
+        .map(|e| e.kind)
+        .collect();
+    if !missing_tracking.is_empty() {
+        eprintln!(
+            "check-events: {} diagnostic-only row(s) lack a tracking_issue (spec #275, warn):",
+            missing_tracking.len()
+        );
+        for kind in &missing_tracking {
+            eprintln!("  {kind}");
+        }
+        eprintln!();
+    }
+
     if !errors.is_empty() {
         eprintln!("check-events: {} violation(s)", errors.len());
         for e in &errors {
@@ -67,9 +89,10 @@ pub fn run() -> Result<()> {
     }
 
     println!(
-        "check-events: clean ({} events, {} subsystems scanned)",
+        "check-events: clean ({} events, {} subsystems scanned, {} diagnostic-only row(s) missing tracking_issue)",
         EVENTS.events.len(),
-        Subsystem::SCANNED.len()
+        Subsystem::SCANNED.len(),
+        missing_tracking.len()
     );
     Ok(())
 }

--- a/xtask/src/check_orphan_crates.rs
+++ b/xtask/src/check_orphan_crates.rs
@@ -1,0 +1,330 @@
+//! Orphan-crate lint (spec #275) — Occam's-razor projection of "no
+//! dangling wires" onto the crate graph.
+//!
+//! For every workspace library crate (one that exposes `src/lib.rs` and
+//! is **not** a `[[bin]]`-shipping subsystem), count how many other
+//! workspace crates declare it as a path dep. Zero in-tree reverse deps
+//! → violation.
+//!
+//! Bin-shipping crates (`onsager`, `stiglab`, `synodic`, `ising`,
+//! `onsager-portal`, `onsager-trigger`, `onsager-scheduler`) are
+//! excluded — they're top-level apps; reverse-dep count doesn't apply.
+//!
+//! ## Escape hatch
+//!
+//! A `// occam-allow: <non-empty reason>` line anywhere in `src/lib.rs`
+//! exempts the crate. Mirrors `seam-allow` / `budget-allow`. Use
+//! sparingly — every allow is a wire connected at one end.
+//!
+//! ## Modes
+//!
+//! - `--mode=warn` (default): print violations, exit 0.
+//! - `--mode=fail`: exit non-zero on any unallowed violation.
+//!
+//! Landing in warn mode per spec #275; ratchet to fail in a follow-up.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+const ALLOW_PREFIX: &str = "// occam-allow:";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Warn,
+    Fail,
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    let mode = parse_mode(&args)?;
+    let root = workspace_root()?;
+
+    let crates = discover_crates(&root)?;
+    let reverse_deps = build_reverse_dep_map(&crates);
+
+    let mut violations: Vec<(String, PathBuf)> = Vec::new();
+    let mut allowed: Vec<(String, String)> = Vec::new();
+
+    for c in &crates {
+        if !c.is_library() {
+            continue;
+        }
+        let count = reverse_deps.get(c.name.as_str()).copied().unwrap_or(0);
+        if count > 0 {
+            continue;
+        }
+        let lib_rs = c.dir.join("src").join("lib.rs");
+        if let Some(reason) = read_occam_allow(&lib_rs)? {
+            allowed.push((c.name.clone(), reason));
+            continue;
+        }
+        violations.push((c.name.clone(), c.dir.clone()));
+    }
+
+    if !allowed.is_empty() {
+        eprintln!("orphan-crate occam-allow exemptions:");
+        for (name, reason) in &allowed {
+            eprintln!("  {name} — allowed: {reason}");
+        }
+        eprintln!();
+    }
+
+    if violations.is_empty() {
+        println!(
+            "check-orphan-crates: clean ({} library crate(s) scanned, {} allowed exemption(s))",
+            crates.iter().filter(|c| c.is_library()).count(),
+            allowed.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-orphan-crates: {} violation(s) — library crates with zero in-tree reverse deps:",
+        violations.len()
+    );
+    for (name, dir) in &violations {
+        eprintln!("  {name} ({})", dir.display());
+    }
+    eprintln!();
+    eprintln!("See spec #275 (Occam's-razor lints). To exempt a crate, add");
+    eprintln!("`// occam-allow: <reason>` to its `src/lib.rs`.");
+
+    match mode {
+        Mode::Warn => {
+            eprintln!("(warn mode — not failing)");
+            Ok(())
+        }
+        Mode::Fail => bail!("orphan-crate lint failed"),
+    }
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode> {
+    let mut mode = Mode::Warn;
+    for arg in args {
+        match arg.as_str() {
+            "--mode=warn" => mode = Mode::Warn,
+            "--mode=fail" => mode = Mode::Fail,
+            other => bail!("unknown flag for check-orphan-crates: {other}"),
+        }
+    }
+    Ok(mode)
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+#[derive(Debug)]
+struct CrateInfo {
+    name: String,
+    dir: PathBuf,
+    has_lib: bool,
+    has_bin: bool,
+    path_deps: Vec<String>,
+}
+
+impl CrateInfo {
+    /// "Pure library" means it ships no binary. Bin-shipping subsystems
+    /// (`stiglab`, `synodic`, `ising`, `onsager-portal`, `onsager`,
+    /// `onsager-trigger`, `onsager-scheduler`) are top-level apps and
+    /// don't need a reverse-dep count; their `src/lib.rs` (when present)
+    /// is the subsystem's test surface.
+    fn is_library(&self) -> bool {
+        self.has_lib && !self.has_bin
+    }
+}
+
+fn discover_crates(root: &Path) -> Result<Vec<CrateInfo>> {
+    let crates_dir = root.join("crates");
+    let mut out = Vec::new();
+    for entry in
+        std::fs::read_dir(&crates_dir).with_context(|| format!("read {}", crates_dir.display()))?
+    {
+        let entry = entry?;
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let manifest = dir.join("Cargo.toml");
+        if !manifest.is_file() {
+            continue;
+        }
+        let info = parse_manifest(&dir, &manifest)?;
+        out.push(info);
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+fn parse_manifest(dir: &Path, manifest: &Path) -> Result<CrateInfo> {
+    let text = std::fs::read_to_string(manifest)
+        .with_context(|| format!("read {}", manifest.display()))?;
+    let parsed: toml::Value =
+        toml::from_str(&text).with_context(|| format!("parse {}", manifest.display()))?;
+
+    let name = parsed
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("{} has no [package].name", manifest.display()))?
+        .to_string();
+
+    let has_lib =
+        dir.join("src").join("lib.rs").is_file() || parsed.get("lib").is_some_and(|t| t.is_table());
+    let has_bin = dir.join("src").join("main.rs").is_file()
+        || parsed
+            .get("bin")
+            .and_then(|t| t.as_array())
+            .is_some_and(|a| !a.is_empty());
+
+    let mut path_deps = Vec::new();
+    if let Some(deps) = parsed.get("dependencies").and_then(|d| d.as_table()) {
+        for (dep_name, val) in deps {
+            if let Some(t) = val.as_table()
+                && t.get("path").is_some()
+            {
+                path_deps.push(dep_name.clone());
+            }
+        }
+    }
+
+    Ok(CrateInfo {
+        name,
+        dir: dir.to_path_buf(),
+        has_lib,
+        has_bin,
+        path_deps,
+    })
+}
+
+fn build_reverse_dep_map(crates: &[CrateInfo]) -> BTreeMap<&str, usize> {
+    let names: BTreeSet<&str> = crates.iter().map(|c| c.name.as_str()).collect();
+    let mut counts: BTreeMap<&str, usize> = names.iter().map(|n| (*n, 0)).collect();
+    for c in crates {
+        for dep in &c.path_deps {
+            if names.contains(dep.as_str())
+                && let Some(slot) = counts.get_mut(dep.as_str())
+            {
+                *slot += 1;
+            }
+        }
+    }
+    counts
+}
+
+fn read_occam_allow(path: &Path) -> Result<Option<String>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(parse_occam_allow(&text))
+}
+
+/// Extract a non-empty `// occam-allow: <reason>` body from `s`. The
+/// reason text must be non-empty after trimming — empty reasons are
+/// rejected at lint time, matching `seam-allow` / `budget-allow`.
+pub(crate) fn parse_occam_allow(s: &str) -> Option<String> {
+    for line in s.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix(ALLOW_PREFIX) {
+            let reason = rest.trim();
+            if !reason.is_empty() {
+                return Some(reason.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn occam_allow_parses_non_empty_reason() {
+        assert_eq!(
+            parse_occam_allow("// occam-allow: waiting on #361"),
+            Some("waiting on #361".to_string())
+        );
+        assert_eq!(
+            parse_occam_allow("    // occam-allow:  trailing-spaces  "),
+            Some("trailing-spaces".to_string())
+        );
+    }
+
+    #[test]
+    fn occam_allow_rejects_empty_reason() {
+        assert_eq!(parse_occam_allow("// occam-allow:"), None);
+        assert_eq!(parse_occam_allow("// occam-allow:   "), None);
+    }
+
+    #[test]
+    fn occam_allow_returns_none_when_absent() {
+        assert_eq!(parse_occam_allow("//! crate doc\nfn x() {}"), None);
+    }
+
+    #[test]
+    fn library_classification_excludes_bin_crates() {
+        let info = CrateInfo {
+            name: "stiglab".into(),
+            dir: PathBuf::from("/tmp/stiglab"),
+            has_lib: true,
+            has_bin: true,
+            path_deps: vec![],
+        };
+        assert!(!info.is_library(), "bin-shipping crate is not a library");
+        let info = CrateInfo {
+            name: "onsager-spine".into(),
+            dir: PathBuf::from("/tmp/spine"),
+            has_lib: true,
+            has_bin: false,
+            path_deps: vec![],
+        };
+        assert!(info.is_library(), "pure lib crate is a library");
+    }
+
+    #[test]
+    fn reverse_dep_count_aggregates_across_workspace() {
+        let crates = vec![
+            CrateInfo {
+                name: "a".into(),
+                dir: PathBuf::from("/a"),
+                has_lib: true,
+                has_bin: false,
+                path_deps: vec!["b".into(), "c".into()],
+            },
+            CrateInfo {
+                name: "b".into(),
+                dir: PathBuf::from("/b"),
+                has_lib: true,
+                has_bin: false,
+                path_deps: vec!["c".into()],
+            },
+            CrateInfo {
+                name: "c".into(),
+                dir: PathBuf::from("/c"),
+                has_lib: true,
+                has_bin: false,
+                path_deps: vec![],
+            },
+            CrateInfo {
+                name: "orphan".into(),
+                dir: PathBuf::from("/orphan"),
+                has_lib: true,
+                has_bin: false,
+                path_deps: vec![],
+            },
+        ];
+        let counts = build_reverse_dep_map(&crates);
+        assert_eq!(counts["a"], 0);
+        assert_eq!(counts["b"], 1);
+        assert_eq!(counts["c"], 2);
+        assert_eq!(counts["orphan"], 0);
+    }
+}

--- a/xtask/src/check_single_impl_traits.rs
+++ b/xtask/src/check_single_impl_traits.rs
@@ -1,0 +1,386 @@
+//! Single-impl-trait lint (spec #275) — Occam's-razor projection of
+//! "internal symmetry / no premature abstraction": a `pub trait` with
+//! exactly one implementor is a speculative abstraction. Either inline
+//! the body or stop calling it a trait until a second implementor
+//! arrives.
+//!
+//! ## What's counted
+//!
+//! Walks every `.rs` file under the workspace's source trees
+//! (`crates/*/src/`, `xtask/src/`), parsing each with `syn`.
+//!
+//! - Trait defs: any `pub trait` (i.e. visible to other crates) in
+//!   non-test code (we **do not** parse traits defined inside
+//!   `#[cfg(test)]` modules; a test-only trait is private by
+//!   convention).
+//! - Impl blocks: every `impl <TraitName> for <Type>` in any `.rs`
+//!   file, **including** `#[cfg(test)]` modules. Per the spec's
+//!   "Human decides" call: counting test impls toward the count
+//!   means a mock-impl-only trait isn't flagged as single-impl —
+//!   testability counts.
+//!
+//! Trait → impl matching is by trait identifier (the last path
+//! segment), which is conservative: a `trait Foo` in two crates would
+//! merge and likely under-count. The repo's traits are
+//! distinctively named, so the false-negative risk is small.
+//!
+//! ## Escape hatch
+//!
+//! `// occam-allow: <reason>` on a line immediately above the
+//! `pub trait Foo` declaration exempts it. Mirrors the seam-allow shape.
+//!
+//! ## Modes
+//!
+//! - `--mode=warn` (default): print violations, exit 0.
+//! - `--mode=fail`: exit non-zero on any unallowed violation.
+//!
+//! Landing in warn mode per spec #275; ratchet to fail in a follow-up.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use syn::{File as SynFile, Item, ItemImpl, ItemTrait, Visibility};
+
+use crate::check_orphan_crates::parse_occam_allow;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug)]
+struct TraitDef {
+    name: String,
+    file: PathBuf,
+    line: usize,
+    allow: Option<String>,
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    let mode = parse_mode(&args)?;
+    let root = workspace_root()?;
+
+    let files = collect_rust_files(&root)?;
+
+    let mut trait_defs: Vec<TraitDef> = Vec::new();
+    let mut impl_counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for file in &files {
+        let text =
+            std::fs::read_to_string(file).with_context(|| format!("read {}", file.display()))?;
+        let parsed = match syn::parse_file(&text) {
+            Ok(f) => f,
+            Err(_) => continue, // bad syntax — skip; cargo will fail it elsewhere.
+        };
+        scan(&parsed, file, &text, &mut trait_defs, &mut impl_counts);
+    }
+
+    let mut violations: Vec<&TraitDef> = Vec::new();
+    let mut allowed: Vec<(&TraitDef, &str)> = Vec::new();
+
+    for td in &trait_defs {
+        let count = impl_counts.get(&td.name).copied().unwrap_or(0);
+        if count != 1 {
+            continue;
+        }
+        if let Some(reason) = &td.allow {
+            allowed.push((td, reason.as_str()));
+        } else {
+            violations.push(td);
+        }
+    }
+
+    if !allowed.is_empty() {
+        eprintln!("single-impl-trait occam-allow exemptions:");
+        for (td, reason) in &allowed {
+            eprintln!(
+                "  {}:{} `{}` — allowed: {reason}",
+                rel(&root, &td.file).display(),
+                td.line,
+                td.name
+            );
+        }
+        eprintln!();
+    }
+
+    if violations.is_empty() {
+        println!(
+            "check-single-impl-traits: clean ({} pub trait(s) scanned, {} allowed exemption(s))",
+            trait_defs.len(),
+            allowed.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-single-impl-traits: {} violation(s) — pub traits with exactly one impl:",
+        violations.len()
+    );
+    for td in &violations {
+        eprintln!(
+            "  {}:{} `{}` — 1 impl in the workspace",
+            rel(&root, &td.file).display(),
+            td.line,
+            td.name
+        );
+    }
+    eprintln!();
+    eprintln!("See spec #275 (Occam's-razor lints). To exempt, add");
+    eprintln!("`// occam-allow: <reason>` on the line above the `pub trait` decl.");
+
+    match mode {
+        Mode::Warn => {
+            eprintln!("(warn mode — not failing)");
+            Ok(())
+        }
+        Mode::Fail => bail!("single-impl-trait lint failed"),
+    }
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode> {
+    let mut mode = Mode::Warn;
+    for arg in args {
+        match arg.as_str() {
+            "--mode=warn" => mode = Mode::Warn,
+            "--mode=fail" => mode = Mode::Fail,
+            other => bail!("unknown flag for check-single-impl-traits: {other}"),
+        }
+    }
+    Ok(mode)
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+fn rel(root: &Path, p: &Path) -> PathBuf {
+    p.strip_prefix(root).unwrap_or(p).to_path_buf()
+}
+
+fn collect_rust_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let crates_dir = root.join("crates");
+    walk_rust(&crates_dir, &mut out)?;
+    let xtask_dir = root.join("xtask").join("src");
+    if xtask_dir.is_dir() {
+        walk_rust(&xtask_dir, &mut out)?;
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn walk_rust(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if path.is_dir() {
+            if matches!(name, "target" | "node_modules") {
+                continue;
+            }
+            walk_rust(&path, out)?;
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn scan(
+    file: &SynFile,
+    path: &Path,
+    text: &str,
+    trait_defs: &mut Vec<TraitDef>,
+    impl_counts: &mut BTreeMap<String, usize>,
+) {
+    let lines: Vec<&str> = text.lines().collect();
+    for item in &file.items {
+        scan_item(
+            item,
+            path,
+            &lines,
+            trait_defs,
+            impl_counts,
+            /*in_test=*/ false,
+        );
+    }
+}
+
+fn scan_item(
+    item: &Item,
+    path: &Path,
+    lines: &[&str],
+    trait_defs: &mut Vec<TraitDef>,
+    impl_counts: &mut BTreeMap<String, usize>,
+    in_test: bool,
+) {
+    match item {
+        Item::Trait(t) => {
+            if in_test {
+                return;
+            }
+            collect_trait(t, path, lines, trait_defs);
+        }
+        Item::Impl(im) => {
+            collect_impl(im, impl_counts);
+        }
+        Item::Mod(m) => {
+            let mod_is_test = in_test || has_cfg_test(&m.attrs);
+            if let Some((_, items)) = &m.content {
+                for inner in items {
+                    scan_item(inner, path, lines, trait_defs, impl_counts, mod_is_test);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_trait(t: &ItemTrait, path: &Path, lines: &[&str], trait_defs: &mut Vec<TraitDef>) {
+    if !matches!(t.vis, Visibility::Public(_)) {
+        return;
+    }
+    let line = t.ident.span().start().line;
+    let allow = if line >= 2 {
+        let above = lines.get(line.saturating_sub(2)).copied().unwrap_or("");
+        parse_occam_allow(above)
+    } else {
+        None
+    };
+    trait_defs.push(TraitDef {
+        name: t.ident.to_string(),
+        file: path.to_path_buf(),
+        line,
+        allow,
+    });
+}
+
+fn collect_impl(im: &ItemImpl, impl_counts: &mut BTreeMap<String, usize>) {
+    let Some((_, path, _)) = &im.trait_ else {
+        return;
+    };
+    let Some(seg) = path.segments.last() else {
+        return;
+    };
+    let name = seg.ident.to_string();
+    *impl_counts.entry(name).or_insert(0) += 1;
+}
+
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        let path = a.path();
+        if !path.is_ident("cfg") {
+            return false;
+        }
+        let mut found = false;
+        let _ = a.parse_nested_meta(|m| {
+            if m.path.is_ident("test") {
+                found = true;
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(src: &str) -> SynFile {
+        syn::parse_file(src).expect("parse fixture")
+    }
+
+    #[test]
+    fn pub_trait_with_exactly_one_impl_is_flagged() {
+        let src = r#"
+pub trait Doer { fn do_it(&self); }
+struct A;
+impl Doer for A { fn do_it(&self) {} }
+"#;
+        let file = parse(src);
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        assert_eq!(traits.len(), 1);
+        assert_eq!(traits[0].name, "Doer");
+        assert_eq!(counts.get("Doer"), Some(&1));
+    }
+
+    #[test]
+    fn private_trait_is_ignored() {
+        let src = r#"
+trait Private { fn x(&self); }
+struct A;
+impl Private for A { fn x(&self) {} }
+"#;
+        let file = parse(src);
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        assert!(traits.is_empty(), "private traits are not in scope");
+    }
+
+    #[test]
+    fn test_impl_is_counted_toward_total() {
+        let src = r#"
+pub trait Doer { fn x(&self); }
+struct Real;
+impl Doer for Real { fn x(&self) {} }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct Mock;
+    impl Doer for Mock { fn x(&self) {} }
+}
+"#;
+        let file = parse(src);
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        // Mock impl + real impl = 2 → not flagged as single-impl.
+        assert_eq!(counts.get("Doer"), Some(&2));
+    }
+
+    #[test]
+    fn trait_defined_in_test_module_is_ignored() {
+        let src = r#"
+#[cfg(test)]
+mod tests {
+    pub trait TestOnly { fn x(&self); }
+    struct A;
+    impl TestOnly for A { fn x(&self) {} }
+}
+"#;
+        let file = parse(src);
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        assert!(traits.is_empty(), "test-module-only traits are skipped");
+    }
+
+    #[test]
+    fn occam_allow_above_trait_is_recognized() {
+        let src = "// occam-allow: deliberate seam for a future impl\npub trait Seam { fn x(&self); }\nstruct A;\nimpl Seam for A { fn x(&self) {} }\n";
+        let file = parse(src);
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        assert_eq!(traits.len(), 1);
+        assert_eq!(
+            traits[0].allow.as_deref(),
+            Some("deliberate seam for a future impl")
+        );
+    }
+}

--- a/xtask/src/check_single_impl_traits.rs
+++ b/xtask/src/check_single_impl_traits.rs
@@ -19,10 +19,15 @@
 //!   means a mock-impl-only trait isn't flagged as single-impl —
 //!   testability counts.
 //!
-//! Trait → impl matching is by trait identifier (the last path
-//! segment), which is conservative: a `trait Foo` in two crates would
-//! merge and likely under-count. The repo's traits are
-//! distinctively named, so the false-negative risk is small.
+//! Trait → impl matching is keyed by `(crate, trait_name)`: each `pub
+//! trait` is attributed to the crate that owns the file it lives in,
+//! and each `impl <Trait> for <Type>` is attributed to its file's crate
+//! when `<Trait>` is a bare identifier, or to the leading path segment
+//! when the trait is qualified (e.g. `impl crate::Foo for X` stays in
+//! the impl's crate; `impl onsager_substrate::Executor for X` is
+//! attributed to `onsager-substrate`). This avoids merging
+//! same-named-but-distinct traits across crates (e.g. the workspace
+//! defines two `pub trait Executor`s).
 //!
 //! ## Escape hatch
 //!
@@ -50,12 +55,22 @@ enum Mode {
     Fail,
 }
 
+/// Composite key: `(crate_name, trait_name)`. Two crates each defining
+/// `pub trait Executor` produce distinct keys and aren't merged.
+type TraitKey = (String, String);
+
 #[derive(Debug)]
 struct TraitDef {
-    name: String,
+    key: TraitKey,
     file: PathBuf,
     line: usize,
     allow: Option<String>,
+}
+
+impl TraitDef {
+    fn display_name(&self) -> &str {
+        &self.key.1
+    }
 }
 
 pub fn run(args: Vec<String>) -> Result<()> {
@@ -65,7 +80,7 @@ pub fn run(args: Vec<String>) -> Result<()> {
     let files = collect_rust_files(&root)?;
 
     let mut trait_defs: Vec<TraitDef> = Vec::new();
-    let mut impl_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut impl_counts: BTreeMap<TraitKey, usize> = BTreeMap::new();
 
     for file in &files {
         let text =
@@ -74,14 +89,22 @@ pub fn run(args: Vec<String>) -> Result<()> {
             Ok(f) => f,
             Err(_) => continue, // bad syntax — skip; cargo will fail it elsewhere.
         };
-        scan(&parsed, file, &text, &mut trait_defs, &mut impl_counts);
+        let crate_name = crate_for(&root, file);
+        scan(
+            &parsed,
+            file,
+            &text,
+            &crate_name,
+            &mut trait_defs,
+            &mut impl_counts,
+        );
     }
 
     let mut violations: Vec<&TraitDef> = Vec::new();
     let mut allowed: Vec<(&TraitDef, &str)> = Vec::new();
 
     for td in &trait_defs {
-        let count = impl_counts.get(&td.name).copied().unwrap_or(0);
+        let count = impl_counts.get(&td.key).copied().unwrap_or(0);
         if count != 1 {
             continue;
         }
@@ -96,10 +119,11 @@ pub fn run(args: Vec<String>) -> Result<()> {
         eprintln!("single-impl-trait occam-allow exemptions:");
         for (td, reason) in &allowed {
             eprintln!(
-                "  {}:{} `{}` — allowed: {reason}",
+                "  {}:{} `{}::{}` — allowed: {reason}",
                 rel(&root, &td.file).display(),
                 td.line,
-                td.name
+                td.key.0,
+                td.display_name()
             );
         }
         eprintln!();
@@ -120,10 +144,11 @@ pub fn run(args: Vec<String>) -> Result<()> {
     );
     for td in &violations {
         eprintln!(
-            "  {}:{} `{}` — 1 impl in the workspace",
+            "  {}:{} `{}::{}` — 1 impl in the workspace",
             rel(&root, &td.file).display(),
             td.line,
-            td.name
+            td.key.0,
+            td.display_name()
         );
     }
     eprintln!();
@@ -200,8 +225,9 @@ fn scan(
     file: &SynFile,
     path: &Path,
     text: &str,
+    crate_name: &str,
     trait_defs: &mut Vec<TraitDef>,
-    impl_counts: &mut BTreeMap<String, usize>,
+    impl_counts: &mut BTreeMap<TraitKey, usize>,
 ) {
     let lines: Vec<&str> = text.lines().collect();
     for item in &file.items {
@@ -209,6 +235,7 @@ fn scan(
             item,
             path,
             &lines,
+            crate_name,
             trait_defs,
             impl_counts,
             /*in_test=*/ false,
@@ -220,8 +247,9 @@ fn scan_item(
     item: &Item,
     path: &Path,
     lines: &[&str],
+    crate_name: &str,
     trait_defs: &mut Vec<TraitDef>,
-    impl_counts: &mut BTreeMap<String, usize>,
+    impl_counts: &mut BTreeMap<TraitKey, usize>,
     in_test: bool,
 ) {
     match item {
@@ -229,16 +257,24 @@ fn scan_item(
             if in_test {
                 return;
             }
-            collect_trait(t, path, lines, trait_defs);
+            collect_trait(t, path, lines, crate_name, trait_defs);
         }
         Item::Impl(im) => {
-            collect_impl(im, impl_counts);
+            collect_impl(im, crate_name, impl_counts);
         }
         Item::Mod(m) => {
             let mod_is_test = in_test || has_cfg_test(&m.attrs);
             if let Some((_, items)) = &m.content {
                 for inner in items {
-                    scan_item(inner, path, lines, trait_defs, impl_counts, mod_is_test);
+                    scan_item(
+                        inner,
+                        path,
+                        lines,
+                        crate_name,
+                        trait_defs,
+                        impl_counts,
+                        mod_is_test,
+                    );
                 }
             }
         }
@@ -246,7 +282,13 @@ fn scan_item(
     }
 }
 
-fn collect_trait(t: &ItemTrait, path: &Path, lines: &[&str], trait_defs: &mut Vec<TraitDef>) {
+fn collect_trait(
+    t: &ItemTrait,
+    path: &Path,
+    lines: &[&str],
+    crate_name: &str,
+    trait_defs: &mut Vec<TraitDef>,
+) {
     if !matches!(t.vis, Visibility::Public(_)) {
         return;
     }
@@ -258,22 +300,56 @@ fn collect_trait(t: &ItemTrait, path: &Path, lines: &[&str], trait_defs: &mut Ve
         None
     };
     trait_defs.push(TraitDef {
-        name: t.ident.to_string(),
+        key: (crate_name.to_string(), t.ident.to_string()),
         file: path.to_path_buf(),
         line,
         allow,
     });
 }
 
-fn collect_impl(im: &ItemImpl, impl_counts: &mut BTreeMap<String, usize>) {
+fn collect_impl(im: &ItemImpl, crate_name: &str, impl_counts: &mut BTreeMap<TraitKey, usize>) {
     let Some((_, path, _)) = &im.trait_ else {
         return;
     };
-    let Some(seg) = path.segments.last() else {
+    let Some(last_seg) = path.segments.last() else {
         return;
     };
-    let name = seg.ident.to_string();
-    *impl_counts.entry(name).or_insert(0) += 1;
+    let trait_name = last_seg.ident.to_string();
+    // Qualified path like `onsager_substrate::Executor` → attribute to
+    // the leading segment (converted from `onsager_substrate` style
+    // back to `onsager-substrate` for matching against the crate name
+    // derived from the path). A leading `crate::` / `self::` /
+    // `super::` keeps the impl's own crate. A bare identifier
+    // (`Executor`) is also local to the impl's crate.
+    let owning_crate = if path.segments.len() > 1 {
+        let leading = path.segments.first().unwrap().ident.to_string();
+        match leading.as_str() {
+            "crate" | "self" | "super" => crate_name.to_string(),
+            _ => leading.replace('_', "-"),
+        }
+    } else {
+        crate_name.to_string()
+    };
+    *impl_counts.entry((owning_crate, trait_name)).or_insert(0) += 1;
+}
+
+/// Derive the crate name from a path under `crates/<name>/...`. Falls
+/// back to `xtask` for paths under `xtask/`, and to "<unknown>" for
+/// anything else (so the key still namespaces the trait, just under a
+/// shared bucket — the lint stays sound, it just won't merge two
+/// outside-tree files into one crate's namespace).
+fn crate_for(root: &Path, file: &Path) -> String {
+    let rel = file.strip_prefix(root).unwrap_or(file);
+    let mut comps = rel.components();
+    match comps.next().and_then(|c| c.as_os_str().to_str()) {
+        Some("crates") => comps
+            .next()
+            .and_then(|c| c.as_os_str().to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string()),
+        Some("xtask") => "xtask".to_string(),
+        _ => "<unknown>".to_string(),
+    }
 }
 
 fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
@@ -301,6 +377,10 @@ mod tests {
         syn::parse_file(src).expect("parse fixture")
     }
 
+    fn key(crate_name: &str, trait_name: &str) -> TraitKey {
+        (crate_name.to_string(), trait_name.to_string())
+    }
+
     #[test]
     fn pub_trait_with_exactly_one_impl_is_flagged() {
         let src = r#"
@@ -311,10 +391,17 @@ impl Doer for A { fn do_it(&self) {} }
         let file = parse(src);
         let mut traits = Vec::new();
         let mut counts = BTreeMap::new();
-        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        scan(
+            &file,
+            Path::new("/tmp/x.rs"),
+            src,
+            "demo",
+            &mut traits,
+            &mut counts,
+        );
         assert_eq!(traits.len(), 1);
-        assert_eq!(traits[0].name, "Doer");
-        assert_eq!(counts.get("Doer"), Some(&1));
+        assert_eq!(traits[0].key, key("demo", "Doer"));
+        assert_eq!(counts.get(&key("demo", "Doer")), Some(&1));
     }
 
     #[test]
@@ -327,7 +414,14 @@ impl Private for A { fn x(&self) {} }
         let file = parse(src);
         let mut traits = Vec::new();
         let mut counts = BTreeMap::new();
-        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        scan(
+            &file,
+            Path::new("/tmp/x.rs"),
+            src,
+            "demo",
+            &mut traits,
+            &mut counts,
+        );
         assert!(traits.is_empty(), "private traits are not in scope");
     }
 
@@ -348,9 +442,16 @@ mod tests {
         let file = parse(src);
         let mut traits = Vec::new();
         let mut counts = BTreeMap::new();
-        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        scan(
+            &file,
+            Path::new("/tmp/x.rs"),
+            src,
+            "demo",
+            &mut traits,
+            &mut counts,
+        );
         // Mock impl + real impl = 2 → not flagged as single-impl.
-        assert_eq!(counts.get("Doer"), Some(&2));
+        assert_eq!(counts.get(&key("demo", "Doer")), Some(&2));
     }
 
     #[test]
@@ -366,7 +467,14 @@ mod tests {
         let file = parse(src);
         let mut traits = Vec::new();
         let mut counts = BTreeMap::new();
-        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        scan(
+            &file,
+            Path::new("/tmp/x.rs"),
+            src,
+            "demo",
+            &mut traits,
+            &mut counts,
+        );
         assert!(traits.is_empty(), "test-module-only traits are skipped");
     }
 
@@ -376,11 +484,96 @@ mod tests {
         let file = parse(src);
         let mut traits = Vec::new();
         let mut counts = BTreeMap::new();
-        scan(&file, Path::new("/tmp/x.rs"), src, &mut traits, &mut counts);
+        scan(
+            &file,
+            Path::new("/tmp/x.rs"),
+            src,
+            "demo",
+            &mut traits,
+            &mut counts,
+        );
         assert_eq!(traits.len(), 1);
         assert_eq!(
             traits[0].allow.as_deref(),
             Some("deliberate seam for a future impl")
+        );
+    }
+
+    /// Regression for PR #426 review: two crates each defining
+    /// `pub trait Executor` with one impl each must not merge into one
+    /// 2-impl bucket. Each crate's trait counts independently and is
+    /// flagged as single-impl in its own namespace.
+    #[test]
+    fn same_named_trait_in_two_crates_does_not_merge() {
+        let crate_a = r#"
+pub trait Executor { fn run(&self); }
+struct ImplA;
+impl Executor for ImplA { fn run(&self) {} }
+"#;
+        let crate_b = r#"
+pub trait Executor { fn go(&self); }
+struct ImplB;
+impl Executor for ImplB { fn go(&self) {} }
+"#;
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(
+            &parse(crate_a),
+            Path::new("/tmp/a.rs"),
+            crate_a,
+            "crate-a",
+            &mut traits,
+            &mut counts,
+        );
+        scan(
+            &parse(crate_b),
+            Path::new("/tmp/b.rs"),
+            crate_b,
+            "crate-b",
+            &mut traits,
+            &mut counts,
+        );
+        assert_eq!(counts.get(&key("crate-a", "Executor")), Some(&1));
+        assert_eq!(counts.get(&key("crate-b", "Executor")), Some(&1));
+        assert_eq!(traits.len(), 2);
+    }
+
+    /// `impl other_crate::Trait for X` attributes the impl to the
+    /// leading path segment, so cross-crate impls increment the right
+    /// trait's bucket.
+    #[test]
+    fn qualified_impl_path_attributes_to_leading_segment() {
+        let src = r#"
+struct LocalImpl;
+impl onsager_substrate::Executor for LocalImpl { fn run(&self) {} }
+"#;
+        let mut traits = Vec::new();
+        let mut counts = BTreeMap::new();
+        scan(
+            &parse(src),
+            Path::new("/tmp/x.rs"),
+            src,
+            "onsager-nodes",
+            &mut traits,
+            &mut counts,
+        );
+        assert_eq!(counts.get(&key("onsager-substrate", "Executor")), Some(&1));
+        assert!(!counts.contains_key(&key("onsager-nodes", "Executor")));
+    }
+
+    #[test]
+    fn crate_for_extracts_name_from_crates_path() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            crate_for(
+                root,
+                Path::new("/repo/crates/onsager-nodes/src/executor.rs")
+            ),
+            "onsager-nodes"
+        );
+        assert_eq!(
+            crate_for(root, Path::new("/repo/xtask/src/lib.rs")),
+            "xtask"
         );
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,9 +33,12 @@
 //! `slot` allocates and manages per-worktree dev slots backed by docker-compose
 //! projects on disjoint ports. See [`slot`] for the full surface.
 
+mod check_deferred_todos;
 mod check_events;
 mod check_file_budget;
 mod check_hitl_coverage;
+mod check_orphan_crates;
+mod check_single_impl_traits;
 mod check_tools_and_skills;
 mod check_triggers;
 mod lint_api_contract;
@@ -102,11 +105,14 @@ fn main() -> ExitCode {
             }
         }
         Some("check-file-budget") => check_file_budget::run(args.collect()),
+        Some("check-orphan-crates") => check_orphan_crates::run(args.collect()),
+        Some("check-single-impl-traits") => check_single_impl_traits::run(args.collect()),
+        Some("check-deferred-todos") => check_deferred_todos::run(args.collect()),
         Some("count-tokens") => check_file_budget::run_count(args.collect()),
         Some("slot") => slot::run(args.collect()),
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- check-triggers\n  cargo run -p xtask -- check-tools-and-skills\n  cargo run -p xtask -- check-hitl-coverage\n  cargo run -p xtask -- check-file-budget [--mode=warn|fail] [--budget=N]\n  cargo run -p xtask -- count-tokens <file>\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
+            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- check-triggers\n  cargo run -p xtask -- check-tools-and-skills\n  cargo run -p xtask -- check-hitl-coverage\n  cargo run -p xtask -- check-file-budget [--mode=warn|fail] [--budget=N]\n  cargo run -p xtask -- check-orphan-crates [--mode=warn|fail]\n  cargo run -p xtask -- check-single-impl-traits [--mode=warn|fail]\n  cargo run -p xtask -- check-deferred-todos [--mode=warn|fail]\n  cargo run -p xtask -- count-tokens <file>\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
         )),
     };
 


### PR DESCRIPTION
## Summary

Three new xtask lints plus a `check-events` tightening that mechanically catch the Occam's-razor failure modes already named in CLAUDE.md "Architectural drift patterns to watch", so the next #274-shaped accumulation surfaces at PR time instead of retro-cleanup. All four land in **warn mode** per the spec's warn-then-ratchet plan; a follow-up spec will ratchet to fail once the floor is clean.

- **`xtask check-orphan-crates`** — library crates (non-`[[bin]]`) with zero in-tree reverse deps. Would have flagged the #274 warehouse / bundle / delivery skeleton on day one. Currently surfaces `onsager-observers`, which carries an `// occam-allow:` pointing at #361 (Observer runtime).
- **`xtask check-single-impl-traits`** — `pub trait` defs with exactly one workspace impl. Test impls count toward the total so a mock doesn't false-trigger. Surfaces three warns today: `GithubAuth`, `PlanStore`, `ChatRuntime`.
- **`xtask check-deferred-todos`** — `TODO` / `FIXME` / `#[allow(dead_code)]` / `// phase N` / `// vN.M` without a same-line `#NNN` issue reference. String literals are stripped before scanning so Claude-prompt text doesn't false-trip. 58 warns today — exactly the warn-mode triage list the spec calls for.
- **`xtask check-events`** also warns on `diagnostic_only` rows missing a `tracking_issue` (new `Option<u32>` field on `EventDefinition`). Obvious backfills (`#361` for `node.*`, `#357` for HITL events) are filled in; the remaining 27 rows surface as a follow-up triage list.

All four follow the existing `seam-allow` / `budget-allow` shape: a `// occam-allow: <non-empty reason>` escape hatch lets a deliberately isolated wire stay. Wired into `just lint-rust` and `.github/workflows/rust.yml`. The "Architectural drift patterns to watch" section in CLAUDE.md grows an "Occam's-razor checklist" subsection that names the three lints.

Closes #275

## Test plan

- [x] `cargo test -p xtask` — 102 passed (19 new unit tests covering positive / occam-allow / boundary cases for each lint, including string-literal stripping for the deferred-TODO scanner).
- [x] `cargo test -p onsager-registry` — schema bump on `EventDefinition` plus updated serialize test.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run -p xtask -- check-orphan-crates` — clean (1 occam-allow exemption).
- [x] `cargo run -p xtask -- check-single-impl-traits` — 3 warn-mode hits.
- [x] `cargo run -p xtask -- check-deferred-todos` — 58 warn-mode hits.
- [x] `cargo run -p xtask -- check-events` — clean (54 events, 27 missing tracking_issue surfaced).
- [x] Fail-mode regression test: stripping the `occam-allow` from `onsager-observers/src/lib.rs` and running `check-orphan-crates --mode=fail` exits non-zero.
- [x] All existing lints (`lint-seams`, `check-api-contract`, `check-events`, `gen-event-docs --check`, `check-file-budget`) still pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFPkCGAQe9e5STBRfRYrPm)_