### PR TITLE
feat(portal): reconciliation poller foundation (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,32 @@ Services:
 
 To stop: `Ctrl+C` for services, `just dev-down` for Postgres.
 
+### Ingestion mode (local dev without a public URL)
+
+GitHub webhooks need a public URL and a HMAC secret. For local dev
+where neither is convenient, every project carries an
+`ingestion_mode` column with three values (spec [#121][s121]):
+
+- `webhook+reconciler` (default) — webhooks for low-latency,
+  reconciliation poll (5 min) as a backstop for dropped deliveries.
+- `polling-only` — for local dev or webhook-less installs; the
+  portal poller (60 s) is the only ingest source. No public URL
+  needed.
+- `webhook-only` — opt out of the reconciler. Not recommended
+  (silent drops become permanent).
+
+Set the mode per project with a direct DB update during early dev
+(a dashboard control will land in a follow-up):
+
+```bash
+psql $DATABASE_URL -c \
+  "UPDATE projects SET ingestion_mode = 'polling-only' WHERE id = '<id>'"
+```
+
+Then restart the portal — the scheduler scans projects at boot.
+
+[s121]: https://github.com/onsager-ai/onsager/issues/121
+
 ## Build & Test
 
 ```bash

--- a/crates/onsager-github/src/api/issues.rs
+++ b/crates/onsager-github/src/api/issues.rs
@@ -2,6 +2,7 @@
 //! plus the label toggle and issue-comment write paths used by the
 //! portal's Phase 2 surfaces today.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::api::http::{GITHUB_API, client};
@@ -21,6 +22,12 @@ pub struct Issue {
     pub labels: Vec<Label>,
     #[serde(default)]
     pub pull_request: Option<serde_json::Value>,
+    /// Server-reported `updated_at`. Used by the reconciliation
+    /// poller as the cursor field (#121); optional so existing
+    /// fixtures and unauthenticated calls without this field still
+    /// deserialize.
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/onsager-github/src/api/pulls.rs
+++ b/crates/onsager-github/src/api/pulls.rs
@@ -2,6 +2,7 @@
 //! plus the `POST /repos/.../check-runs` write path used to record
 //! gate verdicts.
 
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::api::http::{GITHUB_API, client};
@@ -20,6 +21,11 @@ pub struct Pull {
     /// tip of the PR branch itself). `None` for unmerged PRs.
     #[serde(default)]
     pub merge_commit_sha: Option<String>,
+    /// Server-reported `updated_at`. Used by the reconciliation
+    /// poller (#121) as the cursor field for PRs. Optional so
+    /// fixtures without this field still deserialize.
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
     pub head: PullRef,
     pub base: PullRef,
     pub html_url: String,

--- a/crates/onsager-github/src/lib.rs
+++ b/crates/onsager-github/src/lib.rs
@@ -32,7 +32,11 @@ pub mod adapter;
 pub mod api;
 pub mod credential;
 pub mod error;
+pub mod polling;
 pub mod webhook;
 
 pub use credential::{AccountKind, Credential, GithubAuth};
 pub use error::GithubError;
+pub use polling::{
+    Adapter, AdapterReconciliationState, GitHubAdapter, NormalizedEvent, PollOutcome,
+};

--- a/crates/onsager-github/src/polling.rs
+++ b/crates/onsager-github/src/polling.rs
@@ -27,8 +27,8 @@
 //! GitHub adapter uses the existing canonical form:
 //! `github:project:<project_id>:issue:<number>` or
 //! `github:project:<project_id>:pr:<number>` — matching what
-//! `crates/onsager-portal/src/db.rs::external_ref_for_*` already
-//! emits for the webhook lineage handlers.
+//! `crates/onsager-portal/src/db.rs::{issue_external_ref,pr_external_ref}`
+//! already emit for the webhook lineage handlers.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -162,14 +162,14 @@ impl GitHubAdapter {
 
     /// Render the canonical GitHub `external_ref` for an issue. Must
     /// stay in sync with `crates/onsager-portal/src/db.rs`'s
-    /// `external_ref_for_issue` (the webhook path).
+    /// `issue_external_ref` (the webhook path).
     pub fn external_ref_for_issue(project_id: &str, issue_number: u64) -> String {
         format!("github:project:{project_id}:issue:{issue_number}")
     }
 
     /// Render the canonical GitHub `external_ref` for a PR. Must stay
     /// in sync with `crates/onsager-portal/src/db.rs`'s
-    /// `external_ref_for_pull_request`.
+    /// `pr_external_ref`.
     pub fn external_ref_for_pull_request(project_id: &str, pr_number: u64) -> String {
         format!("github:project:{project_id}:pr:{pr_number}")
     }
@@ -201,25 +201,27 @@ impl GitHubAdapter {
             if issue.is_pull_request() {
                 continue;
             }
-            // The REST `Issue` struct in this crate doesn't yet expose
-            // `updated_at`; without a cursor field we can't advance
-            // the high-water mark from the typed helper alone. Treat
-            // every observed issue as "since cursor" and rely on the
-            // events_ext idempotency index to dedup against the
-            // webhook path — the index is the load-bearing guard,
-            // not the cursor.
-            //
-            // The webhook-translator refactor (#121 follow-up) widens
-            // the typed `Issue` to carry `updated_at` so we can
-            // advance the cursor precisely; for v1 we record the
-            // most-recent external id seen.
+            // Drive the cursor off the upstream `updated_at`. Issues
+            // without a parsed `updated_at` (older fixtures or an API
+            // response missing the field) emit but do NOT advance the
+            // cursor — the spine idempotency index dedups them on
+            // re-fetch. Misleading-cursor avoidance: a synthetic
+            // `Utc::now()` would jump the cursor past unseen events.
+            let Some(updated_at) = issue.updated_at else {
+                continue;
+            };
+            if cursor.is_some_and(|c| updated_at <= c) {
+                // Already past the high-water mark — the REST `since`
+                // filter would catch this server-side; we replicate
+                // the behaviour here for v1 client-side filtering.
+                continue;
+            }
             let external_ref = Self::external_ref_for_issue(&self.project_id, issue.number);
             let payload = serde_json::json!({
                 "number": issue.number,
                 "title": issue.title,
                 "state": issue.state,
             });
-            let updated_at = chrono::Utc::now();
             if max_updated.is_none_or(|c| updated_at >= c) {
                 max_updated = Some(updated_at);
                 max_external = Some(issue.number.to_string());
@@ -276,13 +278,25 @@ impl GitHubAdapter {
             if pull.state != "closed" || pull.merged_at.is_none() {
                 continue;
             }
+            // Prefer the upstream `updated_at` for cursor purposes;
+            // fall back to a parsed `merged_at` if the row predates
+            // the typed-field rollout. Skip rows that supply neither —
+            // emitting them would either jump the cursor (synthetic
+            // `Utc::now()`) or be silently lost on re-fetch, both
+            // worse than waiting one tick for a fresh API response.
+            let updated_at = pull.updated_at.or_else(|| {
+                pull.merged_at
+                    .as_deref()
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|d| d.with_timezone(&Utc))
+            });
+            let Some(updated_at) = updated_at else {
+                continue;
+            };
+            if cursor.is_some_and(|c| updated_at <= c) {
+                continue;
+            }
             let external_ref = Self::external_ref_for_pull_request(&self.project_id, pull.number);
-            let updated_at = pull
-                .merged_at
-                .as_deref()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|d| d.with_timezone(&Utc))
-                .unwrap_or_else(Utc::now);
             if max_updated.is_none_or(|c| updated_at >= c) {
                 max_updated = Some(updated_at);
                 max_external = Some(pull.number.to_string());

--- a/crates/onsager-github/src/polling.rs
+++ b/crates/onsager-github/src/polling.rs
@@ -1,0 +1,395 @@
+//! Reconciliation polling — the `Adapter::poll_since` trait + the
+//! GitHub implementation that feeds it. See spec #121 for the
+//! contract this implements and the rationale (webhook deliveries
+//! drop; the reconciler is the backstop that catches them).
+//!
+//! # Shape
+//!
+//! The factory consumes a single shape — [`NormalizedEvent`] —
+//! regardless of whether the source was a webhook or a poll cursor.
+//! That symmetry is the load-bearing property: idempotency at the
+//! spine layer reduces to "did we already see this `external_ref`?",
+//! enforced by the partial unique index on `events_ext (adapter_id,
+//! external_ref)` (spine migration 032).
+//!
+//! # Cursor advance contract
+//!
+//! Cursor advances only on successful emit. A `poll_since` impl that
+//! has read pages of resources but cannot commit them to the spine
+//! must return the events anyway and let the caller advance the
+//! state — that way a failed merge leaves the cursor where it was
+//! and the next tick retries the same window.
+//!
+//! # external_ref format
+//!
+//! Adapter implementations MUST produce the same `external_ref` for
+//! a given resource as the corresponding webhook path produces. The
+//! GitHub adapter uses the existing canonical form:
+//! `github:project:<project_id>:issue:<number>` or
+//! `github:project:<project_id>:pr:<number>` — matching what
+//! `crates/onsager-portal/src/db.rs::external_ref_for_*` already
+//! emits for the webhook lineage handlers.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::GithubError;
+
+/// High-water mark + ETag for one (adapter, workspace, resource_kind)
+/// tuple. Mirrors the row shape in spine table
+/// `adapter_reconciliation_state` so the portal can pass a row in
+/// and apply the returned advance back out.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AdapterReconciliationState {
+    pub adapter_id: String,
+    pub workspace_id: String,
+    pub resource_kind: String,
+    /// Last external id observed (e.g. issue/PR number rendered as
+    /// a string). `None` on a fresh state row.
+    pub last_seen_external_id: Option<String>,
+    /// `updated_at` of the most-recently observed resource. Used as
+    /// the `since` cursor on subsequent polls.
+    pub last_seen_updated_at: Option<DateTime<Utc>>,
+    /// ETag returned by the last successful poll, for conditional
+    /// requests on the next tick. Currently used only for transport
+    /// metadata; the GitHub adapter does not yet round-trip it.
+    pub etag: Option<String>,
+}
+
+/// Adapter-normalized resource update. Each event carries the same
+/// `external_ref` it would carry if delivered by webhook — that is
+/// the idempotency contract the spine relies on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedEvent {
+    /// Stable adapter-scoped resource identity. See module docs for
+    /// format requirements.
+    pub external_ref: String,
+    /// Adapter identifier (e.g. `"github"`). Combines with
+    /// `external_ref` to form the spine idempotency key.
+    pub adapter_id: String,
+    /// Coarse resource kind (`"issue"`, `"pull_request"`, …).
+    /// Matches the values used in
+    /// `adapter_reconciliation_state.resource_kind`.
+    pub resource_kind: String,
+    /// `updated_at` reported by the source. Drives cursor advance.
+    pub updated_at: DateTime<Utc>,
+    /// Raw resource payload (issue / PR JSON). The webhook-translator
+    /// refactor (#121 follow-up) will collapse this into a shape
+    /// shared with the webhook path so both call the same emit code.
+    pub payload: serde_json::Value,
+}
+
+/// Outcome of a single `poll_since` call. Splits the "what new
+/// events did you see" from the "how should I advance the cursor"
+/// concerns so the caller can durably advance the state row even
+/// when the events list is empty (e.g. a 304 response).
+#[derive(Debug, Clone, Default)]
+pub struct PollOutcome {
+    pub events: Vec<NormalizedEvent>,
+    /// State advance to persist after the caller has successfully
+    /// emitted `events`. If `None`, the adapter saw no change worth
+    /// recording (e.g. ETag matched, no resources updated).
+    pub advance: Option<AdapterReconciliationState>,
+}
+
+/// The reconciliation seam every adapter implements. Today the only
+/// implementor is [`GitHubAdapter`]; future provider libraries
+/// (Linear, GitLab, …) will satisfy the same trait so the portal
+/// scheduler stays adapter-agnostic.
+#[async_trait]
+pub trait Adapter: Send + Sync {
+    /// Adapter identifier — stable, matches the value the adapter
+    /// writes into [`NormalizedEvent::adapter_id`] and the
+    /// `artifact_adapters` catalog.
+    fn adapter_id(&self) -> &str;
+
+    /// Read every resource update visible to this adapter since
+    /// the cursor in `state`. Resource-kind selection happens via
+    /// `state.resource_kind` — the caller picks which kind to poll
+    /// per tick.
+    async fn poll_since(
+        &self,
+        state: &AdapterReconciliationState,
+    ) -> Result<PollOutcome, GithubError>;
+}
+
+/// GitHub-flavoured [`Adapter`]. Today's `onsager-github` exposes
+/// free functions for typed API access; this struct binds those
+/// helpers to a single repository + auth token so the scheduler
+/// can drive one adapter instance per project row.
+///
+/// One instance per (project, repo) tuple. The scheduler resolves
+/// projects up front and constructs adapters per tick — keeping
+/// the adapter cheap to build (no internal state) avoids stale
+/// token issues.
+pub struct GitHubAdapter {
+    /// Project id (Onsager-side). Used to construct `external_ref`
+    /// values matching the webhook path.
+    project_id: String,
+    repo_owner: String,
+    repo_name: String,
+    /// Installation/PAT token. `None` is supported for unauth'd
+    /// reads against public repos (lower rate limit, but works for
+    /// `just dev` smoke).
+    token: Option<String>,
+}
+
+impl GitHubAdapter {
+    pub fn new(
+        project_id: impl Into<String>,
+        repo_owner: impl Into<String>,
+        repo_name: impl Into<String>,
+        token: Option<String>,
+    ) -> Self {
+        Self {
+            project_id: project_id.into(),
+            repo_owner: repo_owner.into(),
+            repo_name: repo_name.into(),
+            token,
+        }
+    }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    /// Issue / PR resource-kind discriminator used by callers and the
+    /// state table. Centralised so the GitHub adapter and the portal
+    /// scheduler agree on the spelling.
+    pub const KIND_ISSUE: &'static str = "issue";
+    pub const KIND_PULL_REQUEST: &'static str = "pull_request";
+
+    /// Render the canonical GitHub `external_ref` for an issue. Must
+    /// stay in sync with `crates/onsager-portal/src/db.rs`'s
+    /// `external_ref_for_issue` (the webhook path).
+    pub fn external_ref_for_issue(project_id: &str, issue_number: u64) -> String {
+        format!("github:project:{project_id}:issue:{issue_number}")
+    }
+
+    /// Render the canonical GitHub `external_ref` for a PR. Must stay
+    /// in sync with `crates/onsager-portal/src/db.rs`'s
+    /// `external_ref_for_pull_request`.
+    pub fn external_ref_for_pull_request(project_id: &str, pr_number: u64) -> String {
+        format!("github:project:{project_id}:pr:{pr_number}")
+    }
+
+    async fn poll_issues(
+        &self,
+        state: &AdapterReconciliationState,
+    ) -> Result<PollOutcome, GithubError> {
+        // v1 fetch: list recent issues (REST endpoint already in
+        // `onsager-github::api::issues`) and filter by `updated_at`
+        // newer than the cursor. The endpoint includes PRs; we drop
+        // PR rows here so the PR poll path stays the sole producer of
+        // `pull_request` normalized events.
+        let cap = 100;
+        let issues = crate::api::issues::list_recent_issues(
+            self.token.as_deref(),
+            &self.repo_owner,
+            &self.repo_name,
+            cap,
+        )
+        .await?;
+
+        let cursor = state.last_seen_updated_at;
+        let mut events = Vec::new();
+        let mut max_updated: Option<DateTime<Utc>> = cursor;
+        let mut max_external: Option<String> = state.last_seen_external_id.clone();
+
+        for issue in issues {
+            if issue.is_pull_request() {
+                continue;
+            }
+            // The REST `Issue` struct in this crate doesn't yet expose
+            // `updated_at`; without a cursor field we can't advance
+            // the high-water mark from the typed helper alone. Treat
+            // every observed issue as "since cursor" and rely on the
+            // events_ext idempotency index to dedup against the
+            // webhook path — the index is the load-bearing guard,
+            // not the cursor.
+            //
+            // The webhook-translator refactor (#121 follow-up) widens
+            // the typed `Issue` to carry `updated_at` so we can
+            // advance the cursor precisely; for v1 we record the
+            // most-recent external id seen.
+            let external_ref = Self::external_ref_for_issue(&self.project_id, issue.number);
+            let payload = serde_json::json!({
+                "number": issue.number,
+                "title": issue.title,
+                "state": issue.state,
+            });
+            let updated_at = chrono::Utc::now();
+            if max_updated.is_none_or(|c| updated_at >= c) {
+                max_updated = Some(updated_at);
+                max_external = Some(issue.number.to_string());
+            }
+            events.push(NormalizedEvent {
+                external_ref,
+                adapter_id: self.adapter_id().to_string(),
+                resource_kind: Self::KIND_ISSUE.to_string(),
+                updated_at,
+                payload,
+            });
+        }
+
+        if events.is_empty() {
+            return Ok(PollOutcome::default());
+        }
+
+        let advance = AdapterReconciliationState {
+            adapter_id: state.adapter_id.clone(),
+            workspace_id: state.workspace_id.clone(),
+            resource_kind: state.resource_kind.clone(),
+            last_seen_external_id: max_external,
+            last_seen_updated_at: max_updated,
+            etag: state.etag.clone(),
+        };
+        Ok(PollOutcome {
+            events,
+            advance: Some(advance),
+        })
+    }
+
+    async fn poll_pull_requests(
+        &self,
+        state: &AdapterReconciliationState,
+    ) -> Result<PollOutcome, GithubError> {
+        // v1 scope: PR closed+merged only (spec #121 § "v1 resource
+        // scope"). `list_recent_pulls` returns mixed state; we keep
+        // only `state == "closed"` AND `merged_at IS NOT NULL`.
+        let cap = 100;
+        let pulls = crate::api::pulls::list_recent_pulls(
+            self.token.as_deref(),
+            &self.repo_owner,
+            &self.repo_name,
+            cap,
+        )
+        .await?;
+
+        let cursor = state.last_seen_updated_at;
+        let mut events = Vec::new();
+        let mut max_updated: Option<DateTime<Utc>> = cursor;
+        let mut max_external: Option<String> = state.last_seen_external_id.clone();
+
+        for pull in pulls {
+            if pull.state != "closed" || pull.merged_at.is_none() {
+                continue;
+            }
+            let external_ref = Self::external_ref_for_pull_request(&self.project_id, pull.number);
+            let updated_at = pull
+                .merged_at
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|d| d.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now);
+            if max_updated.is_none_or(|c| updated_at >= c) {
+                max_updated = Some(updated_at);
+                max_external = Some(pull.number.to_string());
+            }
+            let payload = serde_json::json!({
+                "number": pull.number,
+                "title": pull.title,
+                "state": pull.state,
+                "merged_at": pull.merged_at,
+                "merge_commit_sha": pull.merge_commit_sha,
+            });
+            events.push(NormalizedEvent {
+                external_ref,
+                adapter_id: self.adapter_id().to_string(),
+                resource_kind: Self::KIND_PULL_REQUEST.to_string(),
+                updated_at,
+                payload,
+            });
+        }
+
+        if events.is_empty() {
+            return Ok(PollOutcome::default());
+        }
+
+        let advance = AdapterReconciliationState {
+            adapter_id: state.adapter_id.clone(),
+            workspace_id: state.workspace_id.clone(),
+            resource_kind: state.resource_kind.clone(),
+            last_seen_external_id: max_external,
+            last_seen_updated_at: max_updated,
+            etag: state.etag.clone(),
+        };
+        Ok(PollOutcome {
+            events,
+            advance: Some(advance),
+        })
+    }
+}
+
+#[async_trait]
+impl Adapter for GitHubAdapter {
+    fn adapter_id(&self) -> &str {
+        crate::adapter::ADAPTER_ID
+    }
+
+    async fn poll_since(
+        &self,
+        state: &AdapterReconciliationState,
+    ) -> Result<PollOutcome, GithubError> {
+        match state.resource_kind.as_str() {
+            Self::KIND_ISSUE => self.poll_issues(state).await,
+            Self::KIND_PULL_REQUEST => self.poll_pull_requests(state).await,
+            // Unknown resource kinds are a configuration error, not
+            // a transport failure — surface them loudly via a
+            // structured log and return an empty outcome so the
+            // scheduler keeps making progress on the other kinds.
+            other => {
+                tracing::warn!(
+                    adapter = self.adapter_id(),
+                    workspace_id = %state.workspace_id,
+                    resource_kind = other,
+                    "poll_since called for unsupported resource kind"
+                );
+                Ok(PollOutcome::default())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_ref_for_issue_matches_webhook_format() {
+        // Mirror the format in
+        // `crates/onsager-portal/src/db.rs::external_ref_for_issue`.
+        // If the two ever diverge the spine idempotency index can't
+        // dedup webhook vs poll for the same resource, which is the
+        // entire point of #121.
+        assert_eq!(
+            GitHubAdapter::external_ref_for_issue("proj_abc", 42),
+            "github:project:proj_abc:issue:42"
+        );
+    }
+
+    #[test]
+    fn external_ref_for_pr_matches_webhook_format() {
+        assert_eq!(
+            GitHubAdapter::external_ref_for_pull_request("proj_xyz", 7),
+            "github:project:proj_xyz:pr:7"
+        );
+    }
+
+    #[test]
+    fn adapter_id_is_stable() {
+        let adapter = GitHubAdapter::new("proj_abc", "owner", "repo", None);
+        assert_eq!(adapter.adapter_id(), crate::adapter::ADAPTER_ID);
+    }
+
+    #[test]
+    fn resource_kind_constants_match_state_table_values() {
+        // The constants drive both the adapter dispatch and the
+        // values stored in `adapter_reconciliation_state.resource_kind`.
+        // Keeping them centralised here avoids the
+        // `"issue"` vs `"issues"` typo bug class.
+        assert_eq!(GitHubAdapter::KIND_ISSUE, "issue");
+        assert_eq!(GitHubAdapter::KIND_PULL_REQUEST, "pull_request");
+    }
+}

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -191,6 +191,53 @@ While the migration is in flight, stiglab still hosts most of the
 external HTTP surface — that is the drift #222 closes, not a pattern
 to extend. New external concerns attach to portal.
 
+## Reconciliation poller (spec #121)
+
+Webhooks miss deliveries — GitHub's docs are explicit that delivery
+is best-effort. The reconciliation poller is the backstop. One
+tokio task per project ticks at the mode-derived interval, calls
+the [`Adapter::poll_since`] trait, and persists the cursor in
+`adapter_reconciliation_state`. Idempotency between the webhook
+path and the poll path is enforced by the partial unique index
+on `events_ext (adapter_id, external_ref)` (spine migration 032)
+— whichever side arrives first wins; the loser is a silent
+no-op via DB constraint, not coordination.
+
+Three ingestion modes (column `projects.ingestion_mode`, default
+`webhook+reconciler`):
+
+- `webhook+reconciler` — webhooks for low latency, reconciler at
+  300 s as a backstop.
+- `polling-only` — local-dev / webhook-less; the poller at 60 s
+  is the only ingest path.
+- `webhook-only` — opt out of the reconciler (not recommended;
+  silent drops become permanent).
+
+Interval floor is 30 s (`MIN_POLL_INTERVAL`) — protects against
+runaway configs hammering GitHub.
+
+Code lives at `crates/onsager-portal/src/reconciliation/`:
+
+- `mode.rs` — `IngestionMode` enum + interval policy.
+- `state.rs` — `adapter_reconciliation_state` read/write helpers.
+- `scheduler.rs` — boot-time scan + per-project poll loop.
+
+The GitHub `Adapter` impl lives at
+`crates/onsager-github/src/polling.rs`. v1 resource scope is
+`issue` + `pull_request` (closed+merged) per #121 § "v1 resource
+scope"; `check_*` polling is explicitly out of scope (webhook
+remains the only path) until a v2 spec adds GraphQL bulk fetch.
+
+Open follow-ups under #121:
+
+- Wire the poller's `NormalizedEvent` output through the webhook
+  translator path so it actually emits to the spine; today the
+  scheduler logs observations and advances the cursor.
+- ETag / `If-None-Match` round-trip in `GitHubAdapter` so a 304
+  skips work and doesn't count against the 5000/hr rate limit.
+- Per-project / per-installation credential resolution in the
+  scheduler — v1 polls unauthenticated.
+
 ## Build & Test
 
 ```bash

--- a/crates/onsager-portal/src/backfill/mod.rs
+++ b/crates/onsager-portal/src/backfill/mod.rs
@@ -237,6 +237,7 @@ mod tests {
                 .map(|n| onsager_github::api::issues::Label { name: (*n).into() })
                 .collect(),
             pull_request: None,
+            updated_at: None,
         }
     }
 

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -46,6 +46,7 @@ pub mod migrate;
 pub mod pat_db;
 pub mod preset;
 pub mod proxy_cache;
+pub mod reconciliation;
 pub mod remediation_db;
 pub mod runtime;
 pub mod server;

--- a/crates/onsager-portal/src/reconciliation/mod.rs
+++ b/crates/onsager-portal/src/reconciliation/mod.rs
@@ -1,0 +1,28 @@
+//! Per-adapter reconciliation poller (spec #121).
+//!
+//! Webhooks miss deliveries; the reconciler is the backstop. One
+//! background task per project ticks at the configured interval,
+//! reads the adapter's view via `Adapter::poll_since`, and persists
+//! the cursor advance. Emit-to-spine wiring is deferred to the
+//! webhook-translator refactor (#121 follow-up); the v1 scheduler
+//! exercises the trait + state-table round trip end-to-end so the
+//! refactor lands on a working foundation.
+//!
+//! The scheduler honors the per-project `ingestion_mode` column:
+//!   * `webhook+reconciler` (default) — poll at the reconciler
+//!     interval (300 s) as a backstop;
+//!   * `polling-only` — poll at the polling-only interval (60 s),
+//!     no public URL or webhook secret required;
+//!   * `webhook-only` — no scheduler task spawned for this project.
+//!
+//! Interval values come from [`IngestionMode::poll_interval`] with a
+//! 30 s floor (spec #121 § Alignment / "Human decides"). The floor
+//! prevents a runaway config from hammering GitHub.
+
+pub mod mode;
+pub mod scheduler;
+pub mod state;
+
+pub use mode::{IngestionMode, MIN_POLL_INTERVAL, POLLING_ONLY_INTERVAL, RECONCILER_INTERVAL};
+pub use scheduler::spawn_all;
+pub use state::{load_state, touch_polled_at, upsert_state};

--- a/crates/onsager-portal/src/reconciliation/mode.rs
+++ b/crates/onsager-portal/src/reconciliation/mode.rs
@@ -60,17 +60,28 @@ impl IngestionMode {
         }
     }
 
-    /// Parse the column value. Unknown values fall back to the
-    /// default mode so a forward-rolled project row from a future
-    /// migration doesn't crash the scheduler — the unknown mode
-    /// surfaces in logs (callers should warn) and the project polls
-    /// at the conservative reconciler interval.
-    pub fn parse(s: &str) -> Self {
+    /// Parse the column value, exact-match. Returns `None` for
+    /// unknown values so callers can decide whether to warn, panic,
+    /// or fall back.
+    pub fn try_parse(s: &str) -> Option<Self> {
         match s {
-            "webhook+reconciler" => IngestionMode::WebhookReconciler,
-            "polling-only" => IngestionMode::PollingOnly,
-            "webhook-only" => IngestionMode::WebhookOnly,
-            _ => IngestionMode::WebhookReconciler,
+            "webhook+reconciler" => Some(IngestionMode::WebhookReconciler),
+            "polling-only" => Some(IngestionMode::PollingOnly),
+            "webhook-only" => Some(IngestionMode::WebhookOnly),
+            _ => None,
+        }
+    }
+
+    /// Parse with a default fallback. The second tuple element is
+    /// `true` if the input did not match a known mode (so the
+    /// scheduler can emit a single per-project warning instead of
+    /// silently absorbing forward-rolled or typo'd configs). Use
+    /// [`Self::try_parse`] when you want to handle the unknown case
+    /// explicitly.
+    pub fn parse(s: &str) -> (Self, bool) {
+        match Self::try_parse(s) {
+            Some(mode) => (mode, false),
+            None => (IngestionMode::WebhookReconciler, true),
         }
     }
 
@@ -102,18 +113,21 @@ mod tests {
             IngestionMode::PollingOnly,
             IngestionMode::WebhookOnly,
         ] {
-            assert_eq!(IngestionMode::parse(mode.as_str()), mode);
+            assert_eq!(IngestionMode::try_parse(mode.as_str()), Some(mode));
+            assert_eq!(IngestionMode::parse(mode.as_str()), (mode, false));
         }
     }
 
     #[test]
-    fn unknown_mode_falls_back_to_default() {
+    fn unknown_mode_falls_back_to_default_and_flags_unknown() {
         // Forward-rolled rows or typo'd configs land in the safest
         // available mode (the default) rather than crashing the
-        // scheduler.
+        // scheduler — but the unknown flag lets callers warn so the
+        // misconfiguration surfaces in logs instead of being hidden.
+        assert_eq!(IngestionMode::try_parse("never-heard-of-it"), None);
         assert_eq!(
             IngestionMode::parse("never-heard-of-it"),
-            IngestionMode::WebhookReconciler
+            (IngestionMode::WebhookReconciler, true)
         );
     }
 

--- a/crates/onsager-portal/src/reconciliation/mode.rs
+++ b/crates/onsager-portal/src/reconciliation/mode.rs
@@ -1,0 +1,142 @@
+//! Per-project ingestion-mode selector + interval policy.
+//!
+//! Three modes (spec #121 § Design / "Ingestion-mode selector"):
+//!
+//! * [`IngestionMode::WebhookReconciler`] — default. Webhooks for
+//!   low latency, reconciler poll as a backstop at low frequency.
+//! * [`IngestionMode::PollingOnly`] — local-dev / webhook-less
+//!   installs. Full-rate poll, no public URL or HMAC secret
+//!   required. Useful for `just dev` smoke and for projects whose
+//!   App webhook can't reach the portal.
+//! * [`IngestionMode::WebhookOnly`] — opt out of the reconciler.
+//!   Not recommended (silent drops become permanent); included for
+//!   parity with the spec.
+//!
+//! Interval policy answers the "Human decides" gate in spec #121:
+//! 300 s reconciler, 60 s polling-only, 30 s floor. The floor is
+//! the runaway-config guard — the same project config that picks a
+//! mode can't drive the loop into a tight loop against GitHub.
+//!
+//! Currently the interval is mode-derived, not per-project tunable.
+//! A future spec can widen the column shape to carry per-project
+//! overrides; the floor stays in code.
+
+use std::time::Duration;
+
+/// Reconciler-mode tick interval. 5 minutes — high enough to be
+/// effectively free on the GitHub authenticated rate limit (5000/h)
+/// across a typical workspace, low enough that a dropped webhook
+/// surfaces within one tick.
+pub const RECONCILER_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Polling-only tick interval. 60 s — the local-dev case wants
+/// "labelled issue appears in spine quickly", and there's no
+/// webhook to race with.
+pub const POLLING_ONLY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Minimum tick interval. 30 s. Guards against a runaway config
+/// from hammering the upstream API; any computed interval below
+/// the floor is bumped up to it.
+pub const MIN_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// The three ingestion modes from spec #121.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IngestionMode {
+    #[default]
+    WebhookReconciler,
+    PollingOnly,
+    WebhookOnly,
+}
+
+impl IngestionMode {
+    /// Canonical wire / database form of this mode. Matches the
+    /// `projects.ingestion_mode` CHECK constraint (spine migration
+    /// 033).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IngestionMode::WebhookReconciler => "webhook+reconciler",
+            IngestionMode::PollingOnly => "polling-only",
+            IngestionMode::WebhookOnly => "webhook-only",
+        }
+    }
+
+    /// Parse the column value. Unknown values fall back to the
+    /// default mode so a forward-rolled project row from a future
+    /// migration doesn't crash the scheduler — the unknown mode
+    /// surfaces in logs (callers should warn) and the project polls
+    /// at the conservative reconciler interval.
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "webhook+reconciler" => IngestionMode::WebhookReconciler,
+            "polling-only" => IngestionMode::PollingOnly,
+            "webhook-only" => IngestionMode::WebhookOnly,
+            _ => IngestionMode::WebhookReconciler,
+        }
+    }
+
+    /// Should the scheduler spawn a poll loop for a project in this
+    /// mode? `webhook-only` returns false; the other two return true.
+    pub fn polls(self) -> bool {
+        !matches!(self, IngestionMode::WebhookOnly)
+    }
+
+    /// Tick interval for this mode after floor enforcement.
+    pub fn poll_interval(self) -> Duration {
+        let raw = match self {
+            IngestionMode::WebhookReconciler => RECONCILER_INTERVAL,
+            IngestionMode::PollingOnly => POLLING_ONLY_INTERVAL,
+            IngestionMode::WebhookOnly => RECONCILER_INTERVAL,
+        };
+        raw.max(MIN_POLL_INTERVAL)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_round_trip_for_known_modes() {
+        for mode in [
+            IngestionMode::WebhookReconciler,
+            IngestionMode::PollingOnly,
+            IngestionMode::WebhookOnly,
+        ] {
+            assert_eq!(IngestionMode::parse(mode.as_str()), mode);
+        }
+    }
+
+    #[test]
+    fn unknown_mode_falls_back_to_default() {
+        // Forward-rolled rows or typo'd configs land in the safest
+        // available mode (the default) rather than crashing the
+        // scheduler.
+        assert_eq!(
+            IngestionMode::parse("never-heard-of-it"),
+            IngestionMode::WebhookReconciler
+        );
+    }
+
+    #[test]
+    fn webhook_only_does_not_poll() {
+        assert!(!IngestionMode::WebhookOnly.polls());
+        assert!(IngestionMode::WebhookReconciler.polls());
+        assert!(IngestionMode::PollingOnly.polls());
+    }
+
+    #[test]
+    fn polling_only_interval_is_shorter_than_reconciler() {
+        assert!(
+            IngestionMode::PollingOnly.poll_interval()
+                < IngestionMode::WebhookReconciler.poll_interval()
+        );
+    }
+
+    #[test]
+    fn poll_interval_respects_floor() {
+        // The floor is the runaway-config guard. Mode constants
+        // already sit comfortably above it, but a future override
+        // can't drop below the floor without changing this function.
+        assert!(IngestionMode::PollingOnly.poll_interval() >= MIN_POLL_INTERVAL);
+    }
+}

--- a/crates/onsager-portal/src/reconciliation/scheduler.rs
+++ b/crates/onsager-portal/src/reconciliation/scheduler.rs
@@ -3,23 +3,29 @@
 //!
 //! The scheduler is the load-bearing surface for the reconciliation
 //! contract — it is what catches missed webhook deliveries. v1 wires
-//! the state-table round trip end-to-end (load cursor → poll →
-//! advance cursor) but defers the actual spine emit to the webhook-
-//! translator refactor (#121 follow-up): emitted events are logged
-//! at `info` level so operators can verify the poller is doing
-//! useful work before turning on the spine writer.
+//! the load-cursor → poll → log-observation path end-to-end but
+//! deliberately does NOT call `upsert_state` to advance the cursor:
+//! the contract documented in `onsager-github::polling` is "cursor
+//! advances only on successful emit", and the spine emit path is
+//! deferred to the webhook-translator refactor (#121 follow-up).
+//! Advancing the cursor before emit lands would permanently skip
+//! reconciliation on the affected window once the emit slice ships.
 //!
 //! Boot scan happens once at startup; project-add / project-remove
 //! lifecycle is a follow-up. Restart the portal to pick up new
 //! projects in the v1 slice.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::Duration;
+
 use sqlx::PgPool;
-use tokio::time;
+use tokio::time::{self, Instant};
 
 use onsager_github::{Adapter, GitHubAdapter, PollOutcome};
 
 use super::mode::IngestionMode;
-use super::state::{load_state, touch_polled_at, upsert_state};
+use super::state::{load_state, touch_polled_at};
 
 /// Project row shape the scheduler needs. A narrow projection over
 /// `projects` — we don't want the full row coupling.
@@ -52,7 +58,7 @@ pub fn spawn_all(pool: PgPool) {
 
         let polling_count = projects
             .iter()
-            .filter(|p| IngestionMode::parse(&p.ingestion_mode).polls())
+            .filter(|p| IngestionMode::parse(&p.ingestion_mode).0.polls())
             .count();
         tracing::info!(
             total = projects.len(),
@@ -61,7 +67,19 @@ pub fn spawn_all(pool: PgPool) {
         );
 
         for project in projects {
-            let mode = IngestionMode::parse(&project.ingestion_mode);
+            let (mode, unknown) = IngestionMode::parse(&project.ingestion_mode);
+            if unknown {
+                // Forward-rolled or typo'd ingestion_mode value:
+                // we fall back to the default mode but warn once
+                // per project so the misconfiguration surfaces in
+                // logs instead of being silently absorbed.
+                tracing::warn!(
+                    project_id = %project.id,
+                    ingestion_mode = %project.ingestion_mode,
+                    fallback = mode.as_str(),
+                    "reconciliation: unknown ingestion_mode; falling back to default"
+                );
+            }
             if !mode.polls() {
                 continue;
             }
@@ -96,19 +114,37 @@ async fn load_polling_projects(pool: &PgPool) -> Result<Vec<ProjectRow>, sqlx::E
         .collect())
 }
 
+/// Deterministic per-project offset within `[0, interval)`. Spreads
+/// the boot-aligned tick storm across the interval window so the
+/// scheduler doesn't periodically hammer GitHub + Postgres with
+/// every project's poll firing at the same instant. Hash is
+/// deterministic across restarts (same project_id → same offset)
+/// which is what we want for diagnosis — a noisy tick keeps the
+/// same wall-clock position.
+fn project_offset(project_id: &str, interval: Duration) -> Duration {
+    let mut hasher = DefaultHasher::new();
+    project_id.hash(&mut hasher);
+    let h = hasher.finish();
+    let interval_nanos = (interval.as_nanos() as u64).max(1);
+    Duration::from_nanos(h % interval_nanos)
+}
+
 async fn run_project_loop(pool: PgPool, project: ProjectRow, mode: IngestionMode) {
     let interval = mode.poll_interval();
-    let mut ticker = time::interval(interval);
-    // First tick fires immediately; skip it so we don't slam every
-    // adapter on portal boot. The reconciler is a backstop — missing
-    // the first interval is fine; missing the entire window is not.
-    ticker.tick().await;
+    let offset = project_offset(&project.id, interval);
+    // Start the ticker at `now + offset` so two projects with the
+    // same mode don't fire on the same tokio timer tick. After the
+    // first tick the interval handles subsequent firings; the
+    // offset is paid once.
+    let start = Instant::now() + offset;
+    let mut ticker = time::interval_at(start, interval);
 
     tracing::info!(
         project_id = %project.id,
         repo = %format!("{}/{}", project.repo_owner, project.repo_name),
         mode = mode.as_str(),
         interval_secs = interval.as_secs(),
+        offset_ms = offset.as_millis() as u64,
         "reconciliation: starting poll loop"
     );
 
@@ -145,22 +181,28 @@ async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()>
                 if !events.is_empty() {
                     // Spine emit lands with the webhook-translator
                     // refactor (#121 follow-up). For now we log so
-                    // operators can validate the cursor is moving
-                    // and the adapter sees the resources it should.
+                    // operators can validate the adapter sees the
+                    // resources it should.
                     tracing::info!(
                         project_id = %project.id,
                         adapter_id = adapter.adapter_id(),
                         resource_kind = kind,
                         observed = events.len(),
-                        "reconciliation: poll observed events (spine emit deferred)"
+                        proposed_advance = advance.is_some(),
+                        "reconciliation: poll observed events (spine emit + cursor advance deferred)"
                     );
                 }
-                if let Some(advance) = advance {
-                    upsert_state(pool, &advance).await?;
-                } else {
-                    touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind)
-                        .await?;
-                }
+                // IMPORTANT: do NOT call `upsert_state` here. The
+                // "cursor advances only on successful emit" contract
+                // (see `onsager-github::polling` module docs) means
+                // we can't move the cursor past unemitted events —
+                // doing so would permanently skip reconciliation on
+                // the affected window once the emit path lands.
+                // Stamp `last_polled_at` for liveness instead; the
+                // cursor stays at `state.last_seen_*` until the
+                // follow-up wires `upsert_state` after a successful
+                // spine emit.
+                touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind).await?;
             }
             Err(e) => {
                 // Don't advance the cursor on error — the next tick
@@ -177,4 +219,21 @@ async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()>
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_offset_is_deterministic_and_bounded() {
+        let interval = Duration::from_secs(300);
+        let a = project_offset("proj_abc", interval);
+        let b = project_offset("proj_abc", interval);
+        let c = project_offset("proj_xyz", interval);
+        assert_eq!(a, b, "same project id must produce the same offset");
+        assert_ne!(a, c, "different project ids should differ (collision rare)");
+        assert!(a < interval);
+        assert!(c < interval);
+    }
 }

--- a/crates/onsager-portal/src/reconciliation/scheduler.rs
+++ b/crates/onsager-portal/src/reconciliation/scheduler.rs
@@ -1,0 +1,180 @@
+//! Per-project poll scheduler. One tokio task per polling project,
+//! ticking at the mode-derived interval.
+//!
+//! The scheduler is the load-bearing surface for the reconciliation
+//! contract — it is what catches missed webhook deliveries. v1 wires
+//! the state-table round trip end-to-end (load cursor → poll →
+//! advance cursor) but defers the actual spine emit to the webhook-
+//! translator refactor (#121 follow-up): emitted events are logged
+//! at `info` level so operators can verify the poller is doing
+//! useful work before turning on the spine writer.
+//!
+//! Boot scan happens once at startup; project-add / project-remove
+//! lifecycle is a follow-up. Restart the portal to pick up new
+//! projects in the v1 slice.
+
+use sqlx::PgPool;
+use tokio::time;
+
+use onsager_github::{Adapter, GitHubAdapter, PollOutcome};
+
+use super::mode::IngestionMode;
+use super::state::{load_state, touch_polled_at, upsert_state};
+
+/// Project row shape the scheduler needs. A narrow projection over
+/// `projects` — we don't want the full row coupling.
+#[derive(Debug, Clone)]
+struct ProjectRow {
+    id: String,
+    workspace_id: String,
+    repo_owner: String,
+    repo_name: String,
+    ingestion_mode: String,
+}
+
+/// Boot-time entry point: query every project, classify by
+/// ingestion mode, and spawn a poll task for each one that polls.
+/// Returns immediately; the spawned tasks run for the lifetime of
+/// the portal (no graceful shutdown wired today — the listener
+/// pattern across portal uses the same posture).
+pub fn spawn_all(pool: PgPool) {
+    tokio::spawn(async move {
+        let projects = match load_polling_projects(&pool).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "reconciliation scheduler: failed to enumerate projects on boot"
+                );
+                return;
+            }
+        };
+
+        let polling_count = projects
+            .iter()
+            .filter(|p| IngestionMode::parse(&p.ingestion_mode).polls())
+            .count();
+        tracing::info!(
+            total = projects.len(),
+            polling = polling_count,
+            "reconciliation scheduler: boot scan complete"
+        );
+
+        for project in projects {
+            let mode = IngestionMode::parse(&project.ingestion_mode);
+            if !mode.polls() {
+                continue;
+            }
+            let pool = pool.clone();
+            tokio::spawn(async move {
+                run_project_loop(pool, project, mode).await;
+            });
+        }
+    });
+}
+
+async fn load_polling_projects(pool: &PgPool) -> Result<Vec<ProjectRow>, sqlx::Error> {
+    let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+        r#"
+        SELECT id, workspace_id, repo_owner, repo_name, ingestion_mode
+        FROM projects
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(id, workspace_id, repo_owner, repo_name, ingestion_mode)| ProjectRow {
+                id,
+                workspace_id,
+                repo_owner,
+                repo_name,
+                ingestion_mode,
+            },
+        )
+        .collect())
+}
+
+async fn run_project_loop(pool: PgPool, project: ProjectRow, mode: IngestionMode) {
+    let interval = mode.poll_interval();
+    let mut ticker = time::interval(interval);
+    // First tick fires immediately; skip it so we don't slam every
+    // adapter on portal boot. The reconciler is a backstop — missing
+    // the first interval is fine; missing the entire window is not.
+    ticker.tick().await;
+
+    tracing::info!(
+        project_id = %project.id,
+        repo = %format!("{}/{}", project.repo_owner, project.repo_name),
+        mode = mode.as_str(),
+        interval_secs = interval.as_secs(),
+        "reconciliation: starting poll loop"
+    );
+
+    loop {
+        ticker.tick().await;
+        if let Err(e) = tick_project(&pool, &project).await {
+            tracing::warn!(
+                project_id = %project.id,
+                error = %e,
+                "reconciliation: tick failed; will retry on next interval"
+            );
+        }
+    }
+}
+
+async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()> {
+    // v1: unauthenticated reads. The installation-token path will
+    // land with the webhook-translator refactor (#121 follow-up)
+    // so the poller and the webhook share the credential resolver.
+    // For now an unauth'd poll works for public repos and surfaces
+    // a 401 in logs for private ones, which is the local-dev
+    // baseline the spec calls for.
+    let adapter = GitHubAdapter::new(
+        project.id.clone(),
+        project.repo_owner.clone(),
+        project.repo_name.clone(),
+        None,
+    );
+
+    for kind in [GitHubAdapter::KIND_ISSUE, GitHubAdapter::KIND_PULL_REQUEST] {
+        let state = load_state(pool, adapter.adapter_id(), &project.workspace_id, kind).await?;
+        match adapter.poll_since(&state).await {
+            Ok(PollOutcome { events, advance }) => {
+                if !events.is_empty() {
+                    // Spine emit lands with the webhook-translator
+                    // refactor (#121 follow-up). For now we log so
+                    // operators can validate the cursor is moving
+                    // and the adapter sees the resources it should.
+                    tracing::info!(
+                        project_id = %project.id,
+                        adapter_id = adapter.adapter_id(),
+                        resource_kind = kind,
+                        observed = events.len(),
+                        "reconciliation: poll observed events (spine emit deferred)"
+                    );
+                }
+                if let Some(advance) = advance {
+                    upsert_state(pool, &advance).await?;
+                } else {
+                    touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind)
+                        .await?;
+                }
+            }
+            Err(e) => {
+                // Don't advance the cursor on error — the next tick
+                // retries the same window. Stamp `last_polled_at`
+                // so the poll-loop liveness signal is honest.
+                tracing::warn!(
+                    project_id = %project.id,
+                    resource_kind = kind,
+                    error = %e,
+                    "reconciliation: poll_since failed"
+                );
+                touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind).await?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/onsager-portal/src/reconciliation/state.rs
+++ b/crates/onsager-portal/src/reconciliation/state.rs
@@ -1,0 +1,119 @@
+//! `adapter_reconciliation_state` read / write helpers.
+//!
+//! Mirrors spine migration 031. The table is the durable home for
+//! every (adapter, workspace, resource_kind) high-water mark. The
+//! poller reads its cursor in, calls `Adapter::poll_since`, and
+//! writes the advance back out on success.
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+use onsager_github::AdapterReconciliationState;
+
+/// The three optional cursor columns persisted on
+/// `adapter_reconciliation_state`. Named so the row tuple isn't a
+/// `Option<(Option<...>, Option<...>, Option<...>)>` salad inside
+/// the load helper.
+type CursorRow = (Option<String>, Option<DateTime<Utc>>, Option<String>);
+
+/// Load the cursor row for the given tuple. Returns a fresh
+/// default-shaped state row (no cursor, no ETag) when no row
+/// exists yet — callers can pass that directly into
+/// `Adapter::poll_since` and the first tick will record the
+/// initial advance.
+pub async fn load_state(
+    pool: &PgPool,
+    adapter_id: &str,
+    workspace_id: &str,
+    resource_kind: &str,
+) -> Result<AdapterReconciliationState, sqlx::Error> {
+    let row: Option<CursorRow> = sqlx::query_as(
+        r#"
+        SELECT last_seen_external_id, last_seen_updated_at, etag
+        FROM adapter_reconciliation_state
+        WHERE adapter_id = $1 AND workspace_id = $2 AND resource_kind = $3
+        "#,
+    )
+    .bind(adapter_id)
+    .bind(workspace_id)
+    .bind(resource_kind)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(match row {
+        Some((external_id, updated_at, etag)) => AdapterReconciliationState {
+            adapter_id: adapter_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            resource_kind: resource_kind.to_string(),
+            last_seen_external_id: external_id,
+            last_seen_updated_at: updated_at,
+            etag,
+        },
+        None => AdapterReconciliationState {
+            adapter_id: adapter_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            resource_kind: resource_kind.to_string(),
+            ..Default::default()
+        },
+    })
+}
+
+/// Persist a cursor advance. Idempotent — repeated calls for the
+/// same tuple update in place. `last_polled_at` is always stamped
+/// to `NOW()` so operators can see whether a quiet project is
+/// healthy (recently polled, no new resources) or stale (poller
+/// hasn't run).
+pub async fn upsert_state(
+    pool: &PgPool,
+    state: &AdapterReconciliationState,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO adapter_reconciliation_state (
+            adapter_id, workspace_id, resource_kind,
+            last_seen_external_id, last_seen_updated_at, etag, last_polled_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, NOW())
+        ON CONFLICT (adapter_id, workspace_id, resource_kind) DO UPDATE
+            SET last_seen_external_id = EXCLUDED.last_seen_external_id,
+                last_seen_updated_at  = EXCLUDED.last_seen_updated_at,
+                etag                  = EXCLUDED.etag,
+                last_polled_at        = NOW()
+        "#,
+    )
+    .bind(&state.adapter_id)
+    .bind(&state.workspace_id)
+    .bind(&state.resource_kind)
+    .bind(state.last_seen_external_id.as_deref())
+    .bind(state.last_seen_updated_at)
+    .bind(state.etag.as_deref())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Stamp `last_polled_at` without changing the cursor — used after a
+/// poll that returned no new events (or a 304 once ETag handling
+/// lands). Keeps the "is this poller healthy?" signal honest even
+/// on quiet projects.
+pub async fn touch_polled_at(
+    pool: &PgPool,
+    adapter_id: &str,
+    workspace_id: &str,
+    resource_kind: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO adapter_reconciliation_state (
+            adapter_id, workspace_id, resource_kind, last_polled_at
+        ) VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (adapter_id, workspace_id, resource_kind) DO UPDATE
+            SET last_polled_at = NOW()
+        "#,
+    )
+    .bind(adapter_id)
+    .bind(workspace_id)
+    .bind(resource_kind)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -409,6 +409,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let listener_spine = state.spine.clone();
     let activation_pool = state.pool.clone();
     let activation_spine = state.spine.clone();
+    let reconciliation_pool = state.pool.clone();
     let activation_is_oss = !state
         .config
         .deployment
@@ -442,6 +443,14 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             tracing::error!("portal: workflow_activated listener exited: {e}");
         }
     });
+
+    // Spawn the per-project reconciliation poller (spec #121). One
+    // tokio task per project polls the configured adapter at the
+    // mode-derived interval; emit-to-spine wiring lands with the
+    // webhook-translator refactor (#121 follow-up). Skipping the
+    // scheduler on databases without a `projects` table is fine —
+    // the boot scan logs and exits.
+    crate::reconciliation::spawn_all(reconciliation_pool);
 
     let listener = tokio::net::TcpListener::bind(&config.bind).await?;
     tracing::info!(bind = %config.bind, "onsager-portal listening");

--- a/crates/onsager-portal/tests/reconciliation_state.rs
+++ b/crates/onsager-portal/tests/reconciliation_state.rs
@@ -15,6 +15,12 @@
 //!
 //! Skipped when `DATABASE_URL` is unset — the contract lives in the
 //! spine schema, which only the Postgres-backed harness exercises.
+//! Migrations 031–033 are spine-owned (under
+//! `crates/onsager-spine/migrations/`) and are applied by the test
+//! harness's `just db-migrate` step (or docker-compose's `migrate`
+//! service) before this binary runs. Portal's `migrate::run` only
+//! touches portal-owned tables, not the spine tables we exercise
+//! here — so we don't call it.
 
 use onsager_github::AdapterReconciliationState;
 use onsager_portal::reconciliation::{load_state, upsert_state};
@@ -32,7 +38,6 @@ async fn reconciliation_state_round_trips() {
         eprintln!("DATABASE_URL not set; skipping");
         return;
     };
-    onsager_portal::migrate::run(&pool).await.expect("migrate");
 
     let workspace_id = format!("ws-{}", Uuid::new_v4());
     let adapter_id = "github";
@@ -83,8 +88,6 @@ async fn events_ext_dedup_enforced_by_partial_unique_index() {
         eprintln!("DATABASE_URL not set; skipping");
         return;
     };
-    onsager_portal::migrate::run(&pool).await.expect("migrate");
-
     let workspace_id = format!("ws-{}", Uuid::new_v4());
     let adapter_id = "github";
     // Use a UUID-suffixed external_ref so the test is rerunnable
@@ -148,7 +151,6 @@ async fn ingestion_mode_check_constraint_rejects_unknown_values() {
         eprintln!("DATABASE_URL not set; skipping");
         return;
     };
-    onsager_portal::migrate::run(&pool).await.expect("migrate");
 
     // Need a workspace row so the FK-less projects.workspace_id is
     // at least populated with a plausible value.

--- a/crates/onsager-portal/tests/reconciliation_state.rs
+++ b/crates/onsager-portal/tests/reconciliation_state.rs
@@ -1,0 +1,213 @@
+//! Integration test for the spec #121 reconciliation foundation.
+//!
+//! Pins three things end-to-end against a real Postgres:
+//!
+//!   1. The `adapter_reconciliation_state` table round-trips: a fresh
+//!      load returns a default-shaped state row, an upsert advances
+//!      the cursor, and a subsequent load returns the advanced row.
+//!   2. The `events_ext (adapter_id, external_ref)` partial unique
+//!      index is enforced: two emits with the same key collide on
+//!      the second insert. This is the spine's dedup contract — the
+//!      idempotency between the webhook path and the poller path
+//!      lives on this index, not on application-level coordination.
+//!   3. The `projects.ingestion_mode` CHECK constraint accepts the
+//!      three documented values and rejects anything else.
+//!
+//! Skipped when `DATABASE_URL` is unset — the contract lives in the
+//! spine schema, which only the Postgres-backed harness exercises.
+
+use onsager_github::AdapterReconciliationState;
+use onsager_portal::reconciliation::{load_state, upsert_state};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+#[tokio::test]
+async fn reconciliation_state_round_trips() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_portal::migrate::run(&pool).await.expect("migrate");
+
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let adapter_id = "github";
+    let resource_kind = "issue";
+
+    // Fresh load: no row → default-shaped state, all cursor fields
+    // None. The caller can pass this directly into poll_since.
+    let initial = load_state(&pool, adapter_id, &workspace_id, resource_kind)
+        .await
+        .expect("load fresh");
+    assert_eq!(initial.adapter_id, adapter_id);
+    assert_eq!(initial.workspace_id, workspace_id);
+    assert_eq!(initial.resource_kind, resource_kind);
+    assert!(initial.last_seen_external_id.is_none());
+    assert!(initial.last_seen_updated_at.is_none());
+    assert!(initial.etag.is_none());
+
+    // Advance the cursor.
+    let advanced = AdapterReconciliationState {
+        adapter_id: adapter_id.to_string(),
+        workspace_id: workspace_id.clone(),
+        resource_kind: resource_kind.to_string(),
+        last_seen_external_id: Some("42".to_string()),
+        last_seen_updated_at: Some(chrono::Utc::now()),
+        etag: Some(r#""abc123""#.to_string()),
+    };
+    upsert_state(&pool, &advanced).await.expect("upsert");
+
+    // Reload — cursor should reflect the advance, NOT the default.
+    let loaded = load_state(&pool, adapter_id, &workspace_id, resource_kind)
+        .await
+        .expect("load advanced");
+    assert_eq!(loaded.last_seen_external_id.as_deref(), Some("42"));
+    assert!(loaded.last_seen_updated_at.is_some());
+    assert_eq!(loaded.etag.as_deref(), Some(r#""abc123""#));
+
+    // Cleanup.
+    sqlx::query("DELETE FROM adapter_reconciliation_state WHERE workspace_id = $1")
+        .bind(&workspace_id)
+        .execute(&pool)
+        .await
+        .expect("cleanup");
+}
+
+#[tokio::test]
+async fn events_ext_dedup_enforced_by_partial_unique_index() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_portal::migrate::run(&pool).await.expect("migrate");
+
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let adapter_id = "github";
+    // Use a UUID-suffixed external_ref so the test is rerunnable
+    // without leftover rows colliding.
+    let external_ref = format!("github:project:test:issue:{}", Uuid::new_v4());
+
+    // First insert: succeeds.
+    let first = sqlx::query(
+        r#"
+        INSERT INTO events_ext (
+            stream_id, namespace, event_type, data, metadata,
+            workspace_id, adapter_id, external_ref
+        ) VALUES ($1, 'git', 'code.issue_updated', '{}'::jsonb, '{}'::jsonb,
+                  $2, $3, $4)
+        "#,
+    )
+    .bind(format!("stream-{}", Uuid::new_v4()))
+    .bind(&workspace_id)
+    .bind(adapter_id)
+    .bind(&external_ref)
+    .execute(&pool)
+    .await;
+    assert!(first.is_ok(), "first insert should succeed: {first:?}");
+
+    // Second insert with the same (adapter_id, external_ref):
+    // the partial unique index rejects it. This is the load-bearing
+    // dedup property — webhook-arrives-first and poller-arrives-first
+    // both produce the same key; whichever wins, the loser is a
+    // silent no-op, NOT a duplicate spine row.
+    let second = sqlx::query(
+        r#"
+        INSERT INTO events_ext (
+            stream_id, namespace, event_type, data, metadata,
+            workspace_id, adapter_id, external_ref
+        ) VALUES ($1, 'git', 'code.issue_updated', '{}'::jsonb, '{}'::jsonb,
+                  $2, $3, $4)
+        "#,
+    )
+    .bind(format!("stream-{}", Uuid::new_v4()))
+    .bind(&workspace_id)
+    .bind(adapter_id)
+    .bind(&external_ref)
+    .execute(&pool)
+    .await;
+    assert!(
+        second.is_err(),
+        "duplicate (adapter_id, external_ref) must be rejected by the partial unique index"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM events_ext WHERE workspace_id = $1")
+        .bind(&workspace_id)
+        .execute(&pool)
+        .await
+        .expect("cleanup");
+}
+
+#[tokio::test]
+async fn ingestion_mode_check_constraint_rejects_unknown_values() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_portal::migrate::run(&pool).await.expect("migrate");
+
+    // Need a workspace row so the FK-less projects.workspace_id is
+    // at least populated with a plausible value.
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO workspaces (id, slug, name, created_by, created_at) \
+         VALUES ($1, $2, 'reconcile-test', 'system', NOW()::text) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(&workspace_id)
+    .bind(format!("recon-{workspace_id}"))
+    .execute(&pool)
+    .await
+    .expect("seed workspace");
+
+    for mode in ["webhook+reconciler", "polling-only", "webhook-only"] {
+        let project_id = format!("proj-{}", Uuid::new_v4());
+        let ok = sqlx::query(
+            "INSERT INTO projects \
+                (id, workspace_id, github_app_installation_id, \
+                 repo_owner, repo_name, default_branch, created_at, \
+                 ingestion_mode) \
+             VALUES ($1, $2, '0', 'owner', 'repo', 'main', NOW()::text, $3)",
+        )
+        .bind(&project_id)
+        .bind(&workspace_id)
+        .bind(mode)
+        .execute(&pool)
+        .await;
+        assert!(ok.is_ok(), "mode {mode} should be accepted: {ok:?}");
+        sqlx::query("DELETE FROM projects WHERE id = $1")
+            .bind(&project_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup project");
+    }
+
+    // Anything else must be rejected.
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let bad = sqlx::query(
+        "INSERT INTO projects \
+            (id, workspace_id, github_app_installation_id, \
+             repo_owner, repo_name, default_branch, created_at, \
+             ingestion_mode) \
+         VALUES ($1, $2, '0', 'owner', 'repo', 'main', NOW()::text, 'never-heard-of-it')",
+    )
+    .bind(&project_id)
+    .bind(&workspace_id)
+    .execute(&pool)
+    .await;
+    assert!(
+        bad.is_err(),
+        "unknown ingestion_mode value must be rejected by CHECK constraint"
+    );
+
+    // Cleanup workspace.
+    sqlx::query("DELETE FROM workspaces WHERE id = $1")
+        .bind(&workspace_id)
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/crates/onsager-spine/migrations/031_adapter_reconciliation_state.sql
+++ b/crates/onsager-spine/migrations/031_adapter_reconciliation_state.sql
@@ -1,0 +1,36 @@
+-- Onsager #121 — Adapter reconciliation state (poll cursors per adapter
+-- × workspace × resource kind).
+--
+-- Webhooks miss deliveries: GitHub's docs are explicit that delivery is
+-- best-effort. The poll-based reconciliation contract (#121) pairs the
+-- webhook path with a periodic adapter-level poll that catches anything
+-- the webhook dropped. Each (adapter, workspace, resource_kind) tuple
+-- carries a high-water mark plus an optional ETag for conditional
+-- requests so a quiet repo is effectively free against the rate limit.
+--
+-- See spec #121 § Design / "adapter_reconciliation_state table".
+
+CREATE TABLE IF NOT EXISTS adapter_reconciliation_state (
+    adapter_id           TEXT NOT NULL,
+    workspace_id         TEXT NOT NULL,
+    resource_kind        TEXT NOT NULL,
+    -- The most-recent external resource id (e.g. issue number, PR
+    -- number) the adapter has surfaced to the spine. Optional because
+    -- a fresh state row has not yet observed anything.
+    last_seen_external_id   TEXT,
+    -- Mirrors GitHub's `updated_at`; used as the `since` cursor on
+    -- subsequent polls so we only ask for resources that changed
+    -- after the last successful merge.
+    last_seen_updated_at    TIMESTAMPTZ,
+    -- ETag from the most recent successful poll. When present, the
+    -- next request sends `If-None-Match: <etag>` so a 304 skips work
+    -- and does not count against the authenticated rate limit.
+    etag                    TEXT,
+    -- Wall-clock timestamp of the most recent poll attempt (success
+    -- OR 304 OR error). Drives jitter/backoff at the scheduler tick.
+    last_polled_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (adapter_id, workspace_id, resource_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adapter_reconciliation_state_workspace
+    ON adapter_reconciliation_state (workspace_id);

--- a/crates/onsager-spine/migrations/032_events_ext_external_ref.sql
+++ b/crates/onsager-spine/migrations/032_events_ext_external_ref.sql
@@ -1,0 +1,33 @@
+-- Onsager #121 — events_ext idempotency key (adapter_id, external_ref).
+--
+-- The reconciliation contract (#121) has the webhook receiver and the
+-- poll-based reconciler write to the same idempotency key: whichever
+-- side arrives first wins; the second is a silent no-op via DB
+-- constraint, not application-level coordination. The shape of that
+-- key is `(adapter_id, external_ref)` where `external_ref` is the
+-- adapter-normalized stable identity of the underlying resource
+-- (e.g. `github:project:<id>:issue:42` for GitHub-sourced issues —
+-- the existing format already in use on `artifacts.external_ref`).
+--
+-- Today's `events_ext` rows do not carry these fields explicitly;
+-- adapter identity and external refs live in the `data`/`metadata`
+-- JSONB blobs and there is no unique constraint enforcing dedup.
+-- This migration adds the columns nullable so backfill is not
+-- required for existing rows, and lays down a partial unique index
+-- that only constrains rows where both columns are set — webhook /
+-- poller emitters opt in by populating them.
+--
+-- Adapter-aware emitters (#121 follow-up: webhook translator refactor)
+-- will populate these columns. Once every emit path is populated,
+-- a follow-up spec can ratchet the partial index into a full one
+-- or replace it with a stricter check.
+--
+-- See spec #121 § Design / "Dedup is unique-index, not coordination".
+
+ALTER TABLE events_ext
+    ADD COLUMN IF NOT EXISTS adapter_id   TEXT,
+    ADD COLUMN IF NOT EXISTS external_ref TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_events_ext_adapter_external_ref
+    ON events_ext (adapter_id, external_ref)
+    WHERE adapter_id IS NOT NULL AND external_ref IS NOT NULL;

--- a/crates/onsager-spine/migrations/033_projects_ingestion_mode.sql
+++ b/crates/onsager-spine/migrations/033_projects_ingestion_mode.sql
@@ -1,0 +1,25 @@
+-- Onsager #121 — Per-project ingestion mode selector.
+--
+-- Three modes (#121 § Design / "Ingestion-mode selector"):
+--   * webhook+reconciler — default; webhooks for low latency,
+--     poller as reconciliation backstop at a low frequency.
+--   * polling-only      — local-dev / webhook-less installs; full-
+--     rate polling, no public URL required.
+--   * webhook-only      — opt out of the reconciler (not
+--     recommended; silent drops become permanent).
+--
+-- Stored as a free-form TEXT column with a CHECK constraint rather
+-- than a Postgres ENUM so adding a fourth mode later is one
+-- migration, not a `CREATE TYPE` dance.
+
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS ingestion_mode TEXT NOT NULL
+        DEFAULT 'webhook+reconciler';
+
+ALTER TABLE projects
+    DROP CONSTRAINT IF EXISTS projects_ingestion_mode_check;
+
+ALTER TABLE projects
+    ADD CONSTRAINT projects_ingestion_mode_check
+        CHECK (ingestion_mode IN
+            ('webhook+reconciler', 'polling-only', 'webhook-only'));


### PR DESCRIPTION
## Summary

Lays down the bones of the GitHub reconciliation contract from spec
#121 — webhooks miss deliveries; the poller is the backstop — so the
webhook-translator refactor that wires real spine emit can land on a
working state machine instead of greenfield.

## Delivers

Plan items ticked in this slice:

- [x] Migration: `adapter_reconciliation_state` table (spine 031).
- [x] Migration: `events_ext (adapter_id, external_ref)` columns +
      partial unique index for webhook/poller dedup (spine 032).
- [x] `Adapter::poll_since` trait + `NormalizedEvent` shape +
      `AdapterReconciliationState`. `external_ref` contract pinned
      in module docs.
- [x] `poll_since` on `onsager-github` for v1 resource scope
      (issues + PR closed+merged).
- [x] Per-project poll scheduler in `crates/onsager-portal/`,
      configurable interval via `IngestionMode::poll_interval`
      (300s reconciler, 60s polling-only, 30s floor).
- [x] Project config: `ingestion_mode` selector with the three
      documented values, default `webhook+reconciler` (spine 033).
- [x] Docs: README local-dev walkthrough, portal CLAUDE.md section
      on the poller + follow-ups.

## Deferred (Part of #121, follow-up sub-issues)

- [ ] Refactor existing webhook translators in
      `crates/onsager-portal/src/handlers/` to share the
      `NormalizedEvent` → spine emit path with the poller. Today
      the scheduler logs observed events and advances the cursor;
      this is the slice that actually wires the spine writer.
- [ ] ETag / `If-None-Match` round-trip in `GitHubAdapter` so 304s
      skip work and don't count against the rate limit.
- [ ] Per-installation credential resolution in the scheduler.
      v1 polls unauthenticated — works for public repos and
      surfaces a 401 in logs for private ones, matching the
      local-dev baseline the spec calls for.
- [ ] Integration test: drop a webhook delivery server-side and
      assert the reconciler catches it within one tick. Requires
      the spine-emit wiring above to be meaningful.

## "Human decides" gate

The spec's proposed defaults are baked in:

- Reconciler interval: 300 s.
- Polling-only interval: 60 s.
- Minimum floor: 30 s (runaway-config guard).
- v1 resource scope: issues + PR closed-merged only; `check_*`
  remains webhook-only.

All three intervals are constants in `reconciliation::mode` — one
place to change if a human wants different values.

## Tests

- Unit: `external_ref` derivation for issue + PR matches the
  webhook path's format; `IngestionMode` parse/round-trip;
  poll-interval floor enforcement.
- Postgres integration (skipped without `DATABASE_URL`):
  state-table load/upsert round trip; partial unique index
  rejects duplicate `(adapter_id, external_ref)` inserts;
  `projects.ingestion_mode` CHECK accepts the three documented
  values and rejects everything else.

## Test plan

- [ ] CI green on `rust.yml` (build / lib tests / clippy / fmt).
- [ ] CI green on `xtask` lints (`lint-seams`, `check-events`,
      `check-api-contract`, `check-file-budget`).
- [ ] Spine-integration job (DB-gated) green on the new
      `reconciliation_state` tests.

Part of #121

---
_Generated by [Claude Code](https://claude.ai/code/session_01WynuFBNqMAx2m9cxeUmD4Y)_