### PR TITLE
feat(portal): wire reconciliation poller to spine emit

### DIFF
--- a/crates/onsager-github/src/api/issues.rs
+++ b/crates/onsager-github/src/api/issues.rs
@@ -11,7 +11,12 @@ use crate::error::GithubError;
 /// An issue as returned by `GET /repos/{owner}/{repo}/issues`. GitHub's
 /// REST API includes pull requests in this endpoint; the
 /// `pull_request` field distinguishes them.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// `Serialize` is implemented so the reconciliation poller can stash
+/// the full typed shape on a [`crate::NormalizedEvent`] payload and
+/// the portal scheduler can round-trip it back into this struct when
+/// it calls the shared translator.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Issue {
     pub number: u64,
     pub title: String,

--- a/crates/onsager-github/src/api/pulls.rs
+++ b/crates/onsager-github/src/api/pulls.rs
@@ -3,13 +3,18 @@
 //! gate verdicts.
 
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api::http::{GITHUB_API, client};
 use crate::error::GithubError;
 
 /// A pull request as returned by `GET /repos/{owner}/{repo}/pulls`.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// `Serialize` is implemented so the reconciliation poller can stash
+/// the full typed shape on a [`crate::NormalizedEvent`] payload and
+/// the portal scheduler can round-trip it back into this struct when
+/// it calls the shared translator.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Pull {
     pub number: u64,
     pub title: String,
@@ -32,14 +37,14 @@ pub struct Pull {
     pub user: PullUser,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PullRef {
     #[serde(rename = "ref")]
     pub ref_name: String,
     pub sha: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PullUser {
     pub login: String,
 }

--- a/crates/onsager-github/src/polling.rs
+++ b/crates/onsager-github/src/polling.rs
@@ -217,11 +217,15 @@ impl GitHubAdapter {
                 continue;
             }
             let external_ref = Self::external_ref_for_issue(&self.project_id, issue.number);
-            let payload = serde_json::json!({
-                "number": issue.number,
-                "title": issue.title,
-                "state": issue.state,
-            });
+            // Stash the full typed `Issue` on the payload so the
+            // portal scheduler can round-trip it through
+            // `serde_json::from_value` and feed the shared translator
+            // a typed shape (matching the webhook path). Serializing
+            // the API row is cheaper than re-fetching it and keeps
+            // the (poller ↔ webhook) input symmetry the
+            // reconciliation contract relies on.
+            let payload =
+                serde_json::to_value(&issue).map_err(|e| GithubError::Decode(e.to_string()))?;
             if max_updated.is_none_or(|c| updated_at >= c) {
                 max_updated = Some(updated_at);
                 max_external = Some(issue.number.to_string());
@@ -301,13 +305,10 @@ impl GitHubAdapter {
                 max_updated = Some(updated_at);
                 max_external = Some(pull.number.to_string());
             }
-            let payload = serde_json::json!({
-                "number": pull.number,
-                "title": pull.title,
-                "state": pull.state,
-                "merged_at": pull.merged_at,
-                "merge_commit_sha": pull.merge_commit_sha,
-            });
+            // See the issue-poll branch above for why we stash the
+            // full typed shape.
+            let payload =
+                serde_json::to_value(&pull).map_err(|e| GithubError::Decode(e.to_string()))?;
             events.push(NormalizedEvent {
                 external_ref,
                 adapter_id: self.adapter_id().to_string(),

--- a/crates/onsager-portal/CLAUDE.md
+++ b/crates/onsager-portal/CLAUDE.md
@@ -230,9 +230,11 @@ remains the only path) until a v2 spec adds GraphQL bulk fetch.
 
 Open follow-ups under #121:
 
-- Wire the poller's `NormalizedEvent` output through the webhook
-  translator path so it actually emits to the spine; today the
-  scheduler logs observations and advances the cursor.
+- Spine-emit wiring **landed** via spec #430 — the scheduler now
+  routes each observed update through `reconciliation::translator`,
+  emits via `reconciliation::emit`, and advances the cursor only on
+  a no-failure batch. Dedup against webhook deliveries happens at the
+  `(adapter_id, external_ref)` partial unique index on `events_ext`.
 - ETag / `If-None-Match` round-trip in `GitHubAdapter` so a 304
   skips work and doesn't count against the 5000/hr rate limit.
 - Per-project / per-installation credential resolution in the

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -224,8 +224,8 @@ pub async fn handle(
     // against any reconciliation-poller emit for the same resource
     // update. Best-effort: when project resolution fails we still
     // emit, just without the dedup key, matching pre-#430 behavior.
-    let decorated = decorate_routed_with_dedup(&state, &parsed, install_id, routed).await;
-    emit_routed_events(&state.spine, decorated, workspace_id, "portal").await;
+    let decorated = decorate_routed_with_dedup(&state, &parsed, &installation.id, routed).await;
+    let _ = emit_routed_events(&state.spine, decorated, workspace_id, "portal").await;
 
     let body = outcome.unwrap_or_else(|_| serde_json::json!({"event": event, "ignored": true}));
     (StatusCode::ACCEPTED, Json(body)).into_response()
@@ -393,14 +393,17 @@ async fn route_workflow_events(
 ///
 /// The `external_ref` is keyed on Onsager-side `project_id`, so we
 /// resolve `(install, owner, repo) → project` once for the delivery
-/// and reuse it. When the project can't be resolved (e.g. opt-in not
-/// completed), the event is emitted *without* a dedup key — at worst
-/// a reconciliation tick will write a duplicate row, which is a
+/// and reuse it. The caller passes the already-resolved
+/// installation row id from `handle()` so we don't re-query the
+/// `github_app_installations` table on every webhook delivery. When
+/// the project can't be resolved (e.g. opt-in not completed), the
+/// event is emitted *without* a dedup key — at worst a
+/// reconciliation tick will write a duplicate row, which is a
 /// degradation of dedup, not of correctness.
 async fn decorate_routed_with_dedup(
     state: &AppState,
     payload: &Value,
-    install_id: i64,
+    installation_id: &str,
     events: Vec<RoutedEvent>,
 ) -> Vec<RoutedEvent> {
     let repo_owner = payload
@@ -414,22 +417,13 @@ async fn decorate_routed_with_dedup(
     if repo_owner.is_empty() || repo_name.is_empty() {
         return events;
     }
-    let installation_id =
-        match crate::db::find_installation_by_install_id(&state.pool, install_id).await {
-            Ok(Some(row)) => row.id,
+    let project =
+        match crate::db::find_project_for_repo(&state.pool, installation_id, repo_owner, repo_name)
+            .await
+        {
+            Ok(Some(p)) => p,
             _ => return events,
         };
-    let project = match crate::db::find_project_for_repo(
-        &state.pool,
-        &installation_id,
-        repo_owner,
-        repo_name,
-    )
-    .await
-    {
-        Ok(Some(p)) => p,
-        _ => return events,
-    };
 
     events
         .into_iter()

--- a/crates/onsager-portal/src/handlers/webhook.rs
+++ b/crates/onsager-portal/src/handlers/webhook.rs
@@ -24,10 +24,13 @@ use onsager_github::webhook::{SignatureCheck, verify_signature};
 use onsager_spine::webhook_routing::{
     RoutedEvent, WorkflowTrigger, route_check_event, route_issues_labeled,
     route_pull_request_closed, route_pull_request_closed_workflows,
-    route_workflow_run_completed_workflows, spine_namespace,
+    route_workflow_run_completed_workflows,
 };
 
+use crate::db::{issue_external_ref, pr_external_ref};
 use crate::handlers::{issues, pull_request};
+use crate::reconciliation::emit::emit_routed_events;
+use crate::reconciliation::translator::GITHUB_ADAPTER_ID;
 use crate::state::AppState;
 
 /// Header GitHub sends with the event type (e.g. `pull_request`,
@@ -216,7 +219,13 @@ pub async fn handle(
     // portal's row struct still uses the legacy field name (cleanup
     // tracked separately).
     let workspace_id = installation.tenant_id.as_str();
-    emit_routed_events(&state, routed, workspace_id).await;
+    // Stamp (adapter_id, external_ref) per-event so the spine's
+    // partial unique index (migration 032) deduplicates this delivery
+    // against any reconciliation-poller emit for the same resource
+    // update. Best-effort: when project resolution fails we still
+    // emit, just without the dedup key, matching pre-#430 behavior.
+    let decorated = decorate_routed_with_dedup(&state, &parsed, install_id, routed).await;
+    emit_routed_events(&state.spine, decorated, workspace_id, "portal").await;
 
     let body = outcome.unwrap_or_else(|_| serde_json::json!({"event": event, "ignored": true}));
     (StatusCode::ACCEPTED, Json(body)).into_response()
@@ -377,46 +386,93 @@ async fn route_workflow_events(
     }
 }
 
-async fn emit_routed_events(state: &AppState, events: Vec<RoutedEvent>, workspace_id: &str) {
-    for ev in events {
-        let mut data = match serde_json::to_value(&ev.kind) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("failed to serialize spine event: {e}");
-                continue;
-            }
+/// Decorate the routed events with the `(adapter_id, external_ref)`
+/// dedup key the reconciliation poller also stamps. The spine partial
+/// unique index on `events_ext (adapter_id, external_ref)` then
+/// collapses webhook/reconciler races to one row (spec #430).
+///
+/// The `external_ref` is keyed on Onsager-side `project_id`, so we
+/// resolve `(install, owner, repo) → project` once for the delivery
+/// and reuse it. When the project can't be resolved (e.g. opt-in not
+/// completed), the event is emitted *without* a dedup key — at worst
+/// a reconciliation tick will write a duplicate row, which is a
+/// degradation of dedup, not of correctness.
+async fn decorate_routed_with_dedup(
+    state: &AppState,
+    payload: &Value,
+    install_id: i64,
+    events: Vec<RoutedEvent>,
+) -> Vec<RoutedEvent> {
+    let repo_owner = payload
+        .pointer("/repository/owner/login")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let repo_name = payload
+        .pointer("/repository/name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if repo_owner.is_empty() || repo_name.is_empty() {
+        return events;
+    }
+    let installation_id =
+        match crate::db::find_installation_by_install_id(&state.pool, install_id).await {
+            Ok(Some(row)) => row.id,
+            _ => return events,
         };
-        // Stamp workspace_id (#164) so downstream consumers — including
-        // the workspace-scoped `/api/spine/events` listing — can filter
-        // by workspace without re-resolving the install. The
-        // `TriggerFired` payload already includes its workflow's
-        // workspace; we don't overwrite it (a missing entry is the
-        // common case for `gate.*` events from check / PR webhooks).
-        if let Some(obj) = data.as_object_mut() {
-            obj.entry("workspace_id".to_string())
-                .or_insert(serde_json::Value::String(workspace_id.to_string()));
+    let project = match crate::db::find_project_for_repo(
+        &state.pool,
+        &installation_id,
+        repo_owner,
+        repo_name,
+    )
+    .await
+    {
+        Ok(Some(p)) => p,
+        _ => return events,
+    };
+
+    events
+        .into_iter()
+        .map(|ev| match dedup_key_for(&ev, &project.id) {
+            Some(external_ref) => ev.with_dedup(GITHUB_ADAPTER_ID, external_ref),
+            None => ev,
+        })
+        .collect()
+}
+
+/// Compute the `external_ref` for one routed event under a given
+/// project. Returns `None` for event kinds whose dedup key we don't
+/// yet model (those continue to emit without a dedup key — a
+/// reconciler race on those is currently impossible because the
+/// reconciler doesn't emit them either).
+fn dedup_key_for(ev: &RoutedEvent, project_id: &str) -> Option<String> {
+    use onsager_spine::FactoryEventKind as K;
+    match &ev.kind {
+        K::TriggerFired {
+            workflow_id,
+            payload,
+            ..
+        } => {
+            // Per-(resource, workflow) dedup. We don't know the resource
+            // identity from the `TriggerFired` payload alone (it
+            // carries `issue_number` for issue-triggers, `pr_number`
+            // for PR-triggers). Sniff which is present.
+            let issue_number = payload.get("issue_number").and_then(Value::as_u64);
+            let pr_number = payload.get("pr_number").and_then(Value::as_u64);
+            let resource = match (issue_number, pr_number) {
+                (Some(n), _) => issue_external_ref(project_id, n),
+                (None, Some(n)) => pr_external_ref(project_id, n),
+                _ => return None,
+            };
+            Some(format!("{resource}:trigger:{workflow_id}"))
         }
-        let namespace = spine_namespace(&ev.kind);
-        let metadata = onsager_spine::EventMetadata {
-            correlation_id: None,
-            causation_id: None,
-            actor: "portal".to_string(),
-        };
-        if let Err(e) = state
-            .spine
-            .append_ext(
-                workspace_id,
-                &ev.kind.stream_id(),
-                namespace,
-                ev.kind.event_type(),
-                data,
-                &metadata,
-                None,
-            )
-            .await
-        {
-            tracing::warn!("failed to emit webhook-sourced spine event: {e}");
-        }
+        K::GateManualApprovalSignal { pr_number, .. } => Some(format!(
+            "{}:manual_approval",
+            pr_external_ref(project_id, *pr_number)
+        )),
+        // `gate.check_updated` is webhook-only in v1 (reconciler
+        // doesn't poll `check_*`) so no race exists to dedup against.
+        _ => None,
     }
 }
 

--- a/crates/onsager-portal/src/reconciliation/emit.rs
+++ b/crates/onsager-portal/src/reconciliation/emit.rs
@@ -1,0 +1,119 @@
+//! Shared spine-emit pipeline for routed webhook / reconciler events.
+//!
+//! The webhook handler at `handlers/webhook.rs::route_workflow_events`
+//! and the reconciliation poller at `scheduler.rs::tick_project` both
+//! converge on this function: serialize each [`RoutedEvent`]'s kind,
+//! stamp the workspace_id (#164), and append to `events_ext`. When the
+//! event carries a dedup key (`adapter_id`, `external_ref`) we use
+//! [`EventStore::append_ext_dedup`] — the partial unique index on
+//! `events_ext (adapter_id, external_ref)` (spine migration 032)
+//! collapses webhook/reconciler races to one row, silently.
+//!
+//! Returns the number of events that were *actually* persisted (i.e.
+//! not deduplicated). The poller uses this only as a diagnostic
+//! signal — it advances the cursor on `Ok(_)` regardless, since a
+//! dedupe means "the sibling path already covered this update".
+
+use onsager_spine::{EventMetadata, EventStore, RoutedEvent, spine_namespace};
+use serde_json::Value;
+
+/// Emit a batch of routed events, stamping `workspace_id` on each and
+/// applying `(adapter_id, external_ref)` dedup when both are set.
+///
+/// Errors are logged and skipped — one bad event must not stop the
+/// rest of the batch. Returns the number of rows actually written
+/// (skipped/deduplicated rows aren't counted).
+pub async fn emit_routed_events(
+    spine: &EventStore,
+    events: Vec<RoutedEvent>,
+    workspace_id: &str,
+    actor: &str,
+) -> usize {
+    let mut written = 0usize;
+    for ev in events {
+        let mut data = match serde_json::to_value(&ev.kind) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("failed to serialize spine event: {e}");
+                continue;
+            }
+        };
+        // Stamp workspace_id (#164) so downstream consumers — including
+        // the workspace-scoped `/api/spine/events` listing — can filter
+        // by workspace without re-resolving the install. The
+        // `TriggerFired` payload already includes its workflow's
+        // workspace; we don't overwrite it (a missing entry is the
+        // common case for `gate.*` events from check / PR webhooks).
+        if let Some(obj) = data.as_object_mut() {
+            obj.entry("workspace_id".to_string())
+                .or_insert(Value::String(workspace_id.to_string()));
+        }
+        let namespace = spine_namespace(&ev.kind);
+        let stream_id = ev.kind.stream_id();
+        let event_type = ev.kind.event_type();
+        let metadata = EventMetadata {
+            correlation_id: None,
+            causation_id: None,
+            actor: actor.to_string(),
+        };
+
+        match (ev.adapter_id.as_deref(), ev.external_ref.as_deref()) {
+            (Some(adapter_id), Some(external_ref)) => {
+                match spine
+                    .append_ext_dedup(
+                        workspace_id,
+                        &stream_id,
+                        namespace,
+                        event_type,
+                        data,
+                        &metadata,
+                        adapter_id,
+                        external_ref,
+                    )
+                    .await
+                {
+                    Ok(Some(_id)) => {
+                        written += 1;
+                    }
+                    Ok(None) => {
+                        // Sibling path (webhook ↔ reconciler) already
+                        // wrote this resource update — silent no-op
+                        // per the dedup contract.
+                        tracing::debug!(
+                            adapter_id,
+                            external_ref,
+                            event_type,
+                            "spine event deduplicated against existing (adapter_id, external_ref)"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            adapter_id,
+                            external_ref,
+                            "failed to emit deduped spine event: {e}"
+                        );
+                    }
+                }
+            }
+            _ => {
+                if let Err(e) = spine
+                    .append_ext(
+                        workspace_id,
+                        &stream_id,
+                        namespace,
+                        event_type,
+                        data,
+                        &metadata,
+                        None,
+                    )
+                    .await
+                {
+                    tracing::warn!("failed to emit spine event: {e}");
+                } else {
+                    written += 1;
+                }
+            }
+        }
+    }
+    written
+}

--- a/crates/onsager-portal/src/reconciliation/emit.rs
+++ b/crates/onsager-portal/src/reconciliation/emit.rs
@@ -9,32 +9,68 @@
 //! `events_ext (adapter_id, external_ref)` (spine migration 032)
 //! collapses webhook/reconciler races to one row, silently.
 //!
-//! Returns the number of events that were *actually* persisted (i.e.
-//! not deduplicated). The poller uses this only as a diagnostic
-//! signal — it advances the cursor on `Ok(_)` regardless, since a
-//! dedupe means "the sibling path already covered this update".
+//! The return value separates three outcomes the poller's cursor
+//! advance depends on:
+//!   * `written` — a brand-new row landed.
+//!   * `deduped` — the sibling path already wrote this resource
+//!     update; treated as success because the spine is consistent.
+//!   * `failed` — a DB write returned an error (caller should retry
+//!     by *not* advancing the cursor).
+//!
+//! The reconciler's "advance only on successful emit" contract uses
+//! `failed == 0` as the gate; treating dedup as success is correct
+//! because the row already exists.
 
 use onsager_spine::{EventMetadata, EventStore, RoutedEvent, spine_namespace};
 use serde_json::Value;
 
+/// Outcome of a batch emit. Counts are disjoint: every event lands
+/// in exactly one of `written`, `deduped`, or `failed`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EmitOutcome {
+    /// New rows successfully inserted.
+    pub written: usize,
+    /// Inserts collapsed by the partial unique index — the sibling
+    /// path (webhook ↔ reconciler) already wrote the same resource
+    /// update. Treated as success for cursor-advance purposes.
+    pub deduped: usize,
+    /// DB writes that errored. When `> 0` the caller (poller) MUST
+    /// NOT advance its reconciliation cursor — the next tick has to
+    /// retry the same window.
+    pub failed: usize,
+}
+
+impl EmitOutcome {
+    /// All events landed (no errors). Dedup counts as success.
+    pub fn all_succeeded(&self) -> bool {
+        self.failed == 0
+    }
+}
+
 /// Emit a batch of routed events, stamping `workspace_id` on each and
 /// applying `(adapter_id, external_ref)` dedup when both are set.
 ///
-/// Errors are logged and skipped — one bad event must not stop the
-/// rest of the batch. Returns the number of rows actually written
-/// (skipped/deduplicated rows aren't counted).
+/// Errors are logged AND counted into [`EmitOutcome::failed`] so the
+/// caller can decide whether to advance its cursor. We intentionally
+/// keep going on the first failure — one bad event must not stop the
+/// rest of the batch from landing (the unaffected events will still
+/// dedup correctly on a future retry).
 pub async fn emit_routed_events(
     spine: &EventStore,
     events: Vec<RoutedEvent>,
     workspace_id: &str,
     actor: &str,
-) -> usize {
-    let mut written = 0usize;
+) -> EmitOutcome {
+    let mut outcome = EmitOutcome::default();
     for ev in events {
         let mut data = match serde_json::to_value(&ev.kind) {
             Ok(v) => v,
             Err(e) => {
+                // Encoding the in-process enum should not fail; if it
+                // does we count it as a failure so the cursor doesn't
+                // advance over an event we never tried to write.
                 tracing::error!("failed to serialize spine event: {e}");
+                outcome.failed += 1;
                 continue;
             }
         };
@@ -72,9 +108,7 @@ pub async fn emit_routed_events(
                     )
                     .await
                 {
-                    Ok(Some(_id)) => {
-                        written += 1;
-                    }
+                    Ok(Some(_id)) => outcome.written += 1,
                     Ok(None) => {
                         // Sibling path (webhook ↔ reconciler) already
                         // wrote this resource update — silent no-op
@@ -85,6 +119,7 @@ pub async fn emit_routed_events(
                             event_type,
                             "spine event deduplicated against existing (adapter_id, external_ref)"
                         );
+                        outcome.deduped += 1;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -92,28 +127,29 @@ pub async fn emit_routed_events(
                             external_ref,
                             "failed to emit deduped spine event: {e}"
                         );
+                        outcome.failed += 1;
                     }
                 }
             }
-            _ => {
-                if let Err(e) = spine
-                    .append_ext(
-                        workspace_id,
-                        &stream_id,
-                        namespace,
-                        event_type,
-                        data,
-                        &metadata,
-                        None,
-                    )
-                    .await
-                {
+            _ => match spine
+                .append_ext(
+                    workspace_id,
+                    &stream_id,
+                    namespace,
+                    event_type,
+                    data,
+                    &metadata,
+                    None,
+                )
+                .await
+            {
+                Ok(_) => outcome.written += 1,
+                Err(e) => {
                     tracing::warn!("failed to emit spine event: {e}");
-                } else {
-                    written += 1;
+                    outcome.failed += 1;
                 }
-            }
+            },
         }
     }
-    written
+    outcome
 }

--- a/crates/onsager-portal/src/reconciliation/mod.rs
+++ b/crates/onsager-portal/src/reconciliation/mod.rs
@@ -1,12 +1,14 @@
-//! Per-adapter reconciliation poller (spec #121).
+//! Per-adapter reconciliation poller (spec #121, spine-emit half
+//! landed via spec #430).
 //!
 //! Webhooks miss deliveries; the reconciler is the backstop. One
 //! background task per project ticks at the configured interval,
-//! reads the adapter's view via `Adapter::poll_since`, and persists
-//! the cursor advance. Emit-to-spine wiring is deferred to the
-//! webhook-translator refactor (#121 follow-up); the v1 scheduler
-//! exercises the trait + state-table round trip end-to-end so the
-//! refactor lands on a working foundation.
+//! reads the adapter's view via `Adapter::poll_since`, routes each
+//! observed update through the shared [`translator`] into
+//! `RoutedEvent`s, and persists them on the spine via
+//! [`emit::emit_routed_events`]. The cursor advances only when the
+//! batch emit succeeds (`(adapter_id, external_ref)` dedup makes
+//! retrying an already-written event a silent no-op).
 //!
 //! The scheduler honors the per-project `ingestion_mode` column:
 //!   * `webhook+reconciler` (default) — poll at the reconciler
@@ -25,10 +27,8 @@ pub mod scheduler;
 pub mod state;
 pub mod translator;
 
-pub use emit::emit_routed_events;
+pub use emit::{EmitOutcome, emit_routed_events};
 pub use mode::{IngestionMode, MIN_POLL_INTERVAL, POLLING_ONLY_INTERVAL, RECONCILER_INTERVAL};
 pub use scheduler::spawn_all;
 pub use state::{load_state, touch_polled_at, upsert_state};
-pub use translator::{
-    GITHUB_ADAPTER_ID, issue_external_ref, pr_external_ref, translate_issue, translate_pull_request,
-};
+pub use translator::{GITHUB_ADAPTER_ID, translate_issue, translate_pull_request};

--- a/crates/onsager-portal/src/reconciliation/mod.rs
+++ b/crates/onsager-portal/src/reconciliation/mod.rs
@@ -19,10 +19,16 @@
 //! 30 s floor (spec #121 § Alignment / "Human decides"). The floor
 //! prevents a runaway config from hammering GitHub.
 
+pub mod emit;
 pub mod mode;
 pub mod scheduler;
 pub mod state;
+pub mod translator;
 
+pub use emit::emit_routed_events;
 pub use mode::{IngestionMode, MIN_POLL_INTERVAL, POLLING_ONLY_INTERVAL, RECONCILER_INTERVAL};
 pub use scheduler::spawn_all;
 pub use state::{load_state, touch_polled_at, upsert_state};
+pub use translator::{
+    GITHUB_ADAPTER_ID, issue_external_ref, pr_external_ref, translate_issue, translate_pull_request,
+};

--- a/crates/onsager-portal/src/reconciliation/scheduler.rs
+++ b/crates/onsager-portal/src/reconciliation/scheduler.rs
@@ -2,30 +2,43 @@
 //! ticking at the mode-derived interval.
 //!
 //! The scheduler is the load-bearing surface for the reconciliation
-//! contract — it is what catches missed webhook deliveries. v1 wires
-//! the load-cursor → poll → log-observation path end-to-end but
-//! deliberately does NOT call `upsert_state` to advance the cursor:
-//! the contract documented in `onsager-github::polling` is "cursor
-//! advances only on successful emit", and the spine emit path is
-//! deferred to the webhook-translator refactor (#121 follow-up).
-//! Advancing the cursor before emit lands would permanently skip
-//! reconciliation on the affected window once the emit slice ships.
+//! contract — it is what catches missed webhook deliveries. Each
+//! tick:
+//!
+//!   1. Loads the cursor for `(adapter, workspace, resource_kind)`.
+//!   2. Calls `Adapter::poll_since` and gets a `Vec<NormalizedEvent>`
+//!      plus a proposed cursor advance.
+//!   3. Routes every event through the shared
+//!      [`super::translator`] (the same one the webhook handler calls
+//!      after parsing) and emits the resulting `RoutedEvent`s via
+//!      [`super::emit::emit_routed_events`]. `(adapter_id,
+//!      external_ref)` dedup on `events_ext` collapses any race with
+//!      a sibling webhook delivery to a silent no-op.
+//!   4. Advances the cursor only on successful emit — the
+//!      "advance only on emit" contract from
+//!      `onsager-github::polling` means a failure leaves the cursor
+//!      where it was so the next tick retries the same window.
 //!
 //! Boot scan happens once at startup; project-add / project-remove
 //! lifecycle is a follow-up. Restart the portal to pick up new
 //! projects in the v1 slice.
 
+use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
+use onsager_github::api::issues::Issue;
+use onsager_github::api::pulls::Pull;
+use onsager_github::{Adapter, GitHubAdapter, NormalizedEvent, PollOutcome};
+use onsager_spine::{EventStore, RoutedEvent, WorkflowMatch, WorkflowTrigger};
 use sqlx::PgPool;
 use tokio::time::{self, Instant};
 
-use onsager_github::{Adapter, GitHubAdapter, PollOutcome};
-
+use super::emit::emit_routed_events;
 use super::mode::IngestionMode;
-use super::state::{load_state, touch_polled_at};
+use super::state::{load_state, touch_polled_at, upsert_state};
+use super::translator::{translate_issue, translate_pull_request};
 
 /// Project row shape the scheduler needs. A narrow projection over
 /// `projects` — we don't want the full row coupling.
@@ -43,7 +56,7 @@ struct ProjectRow {
 /// Returns immediately; the spawned tasks run for the lifetime of
 /// the portal (no graceful shutdown wired today — the listener
 /// pattern across portal uses the same posture).
-pub fn spawn_all(pool: PgPool) {
+pub fn spawn_all(pool: PgPool, spine: EventStore) {
     tokio::spawn(async move {
         let projects = match load_polling_projects(&pool).await {
             Ok(rows) => rows,
@@ -84,8 +97,9 @@ pub fn spawn_all(pool: PgPool) {
                 continue;
             }
             let pool = pool.clone();
+            let spine = spine.clone();
             tokio::spawn(async move {
-                run_project_loop(pool, project, mode).await;
+                run_project_loop(pool, spine, project, mode).await;
             });
         }
     });
@@ -129,7 +143,12 @@ fn project_offset(project_id: &str, interval: Duration) -> Duration {
     Duration::from_nanos(h % interval_nanos)
 }
 
-async fn run_project_loop(pool: PgPool, project: ProjectRow, mode: IngestionMode) {
+async fn run_project_loop(
+    pool: PgPool,
+    spine: EventStore,
+    project: ProjectRow,
+    mode: IngestionMode,
+) {
     let interval = mode.poll_interval();
     let offset = project_offset(&project.id, interval);
     // Start the ticker at `now + offset` so two projects with the
@@ -150,7 +169,7 @@ async fn run_project_loop(pool: PgPool, project: ProjectRow, mode: IngestionMode
 
     loop {
         ticker.tick().await;
-        if let Err(e) = tick_project(&pool, &project).await {
+        if let Err(e) = tick_project(&pool, &spine, &project).await {
             tracing::warn!(
                 project_id = %project.id,
                 error = %e,
@@ -160,13 +179,16 @@ async fn run_project_loop(pool: PgPool, project: ProjectRow, mode: IngestionMode
     }
 }
 
-async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()> {
-    // v1: unauthenticated reads. The installation-token path will
-    // land with the webhook-translator refactor (#121 follow-up)
-    // so the poller and the webhook share the credential resolver.
-    // For now an unauth'd poll works for public repos and surfaces
-    // a 401 in logs for private ones, which is the local-dev
-    // baseline the spec calls for.
+async fn tick_project(
+    pool: &PgPool,
+    spine: &EventStore,
+    project: &ProjectRow,
+) -> anyhow::Result<()> {
+    // v1: unauthenticated reads. Per-installation credential
+    // resolution is a deferred follow-up listed on spec #430 (open
+    // questions / Alignment). For now an unauth'd poll works for
+    // public repos and surfaces a 401 in logs for private ones,
+    // which is the local-dev baseline the spec calls for.
     let adapter = GitHubAdapter::new(
         project.id.clone(),
         project.repo_owner.clone(),
@@ -178,31 +200,32 @@ async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()>
         let state = load_state(pool, adapter.adapter_id(), &project.workspace_id, kind).await?;
         match adapter.poll_since(&state).await {
             Ok(PollOutcome { events, advance }) => {
-                if !events.is_empty() {
-                    // Spine emit lands with the webhook-translator
-                    // refactor (#121 follow-up). For now we log so
-                    // operators can validate the adapter sees the
-                    // resources it should.
+                let observed = events.len();
+                let emit_ok = emit_normalized(pool, spine, project, kind, &events).await;
+                // Advance the cursor ONLY when emit succeeded. The
+                // "cursor advances only on successful emit" contract
+                // (see `onsager-github::polling`) means a failure
+                // leaves the cursor where it was so the next tick
+                // retries the same window. Dedup at the spine layer
+                // turns the retry of an already-emitted event into a
+                // silent no-op.
+                if emit_ok && let Some(advanced) = advance.as_ref() {
+                    upsert_state(pool, advanced).await?;
                     tracing::info!(
                         project_id = %project.id,
                         adapter_id = adapter.adapter_id(),
                         resource_kind = kind,
-                        observed = events.len(),
-                        proposed_advance = advance.is_some(),
-                        "reconciliation: poll observed events (spine emit + cursor advance deferred)"
+                        observed,
+                        "reconciliation: poll emitted + cursor advanced"
                     );
+                } else {
+                    // Stamp `last_polled_at` so the liveness signal
+                    // is honest even when there were no events to
+                    // emit, or when the emit pipeline failed and we
+                    // intentionally did not advance.
+                    touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind)
+                        .await?;
                 }
-                // IMPORTANT: do NOT call `upsert_state` here. The
-                // "cursor advances only on successful emit" contract
-                // (see `onsager-github::polling` module docs) means
-                // we can't move the cursor past unemitted events —
-                // doing so would permanently skip reconciliation on
-                // the affected window once the emit path lands.
-                // Stamp `last_polled_at` for liveness instead; the
-                // cursor stays at `state.last_seen_*` until the
-                // follow-up wires `upsert_state` after a successful
-                // spine emit.
-                touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind).await?;
             }
             Err(e) => {
                 // Don't advance the cursor on error — the next tick
@@ -219,6 +242,165 @@ async fn tick_project(pool: &PgPool, project: &ProjectRow) -> anyhow::Result<()>
         }
     }
     Ok(())
+}
+
+/// Translate a batch of [`NormalizedEvent`]s for one resource kind
+/// into [`RoutedEvent`]s via the shared translator and emit them to
+/// the spine. Returns `true` when every event in the batch was
+/// translated and emit was attempted without an error; the caller
+/// uses this signal to decide whether to advance the cursor. An
+/// empty batch is a trivial success.
+async fn emit_normalized(
+    pool: &PgPool,
+    spine: &EventStore,
+    project: &ProjectRow,
+    resource_kind: &str,
+    events: &[NormalizedEvent],
+) -> bool {
+    if events.is_empty() {
+        return true;
+    }
+    let mut routed: Vec<RoutedEvent> = Vec::new();
+
+    for ev in events {
+        match resource_kind {
+            GitHubAdapter::KIND_ISSUE => {
+                match serde_json::from_value::<Issue>(ev.payload.clone()) {
+                    Ok(issue) => {
+                        let by_label = match collect_label_workflows(pool, project, &issue).await {
+                            Ok(m) => m,
+                            Err(e) => {
+                                tracing::warn!(
+                                    project_id = %project.id,
+                                    issue_number = issue.number,
+                                    error = %e,
+                                    "reconciliation: failed to load label workflows"
+                                );
+                                return false;
+                            }
+                        };
+                        if by_label.is_empty() {
+                            continue;
+                        }
+                        routed.extend(translate_issue(
+                            &issue,
+                            &project.repo_owner,
+                            &project.repo_name,
+                            Some(&project.id),
+                            &by_label,
+                        ));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            project_id = %project.id,
+                            external_ref = %ev.external_ref,
+                            error = %e,
+                            "reconciliation: failed to parse Issue payload"
+                        );
+                        return false;
+                    }
+                }
+            }
+            GitHubAdapter::KIND_PULL_REQUEST => {
+                match serde_json::from_value::<Pull>(ev.payload.clone()) {
+                    Ok(pull) => {
+                        let candidates =
+                            match crate::workflow_db::find_active_pull_request_closed_workflows(
+                                pool,
+                                &project.repo_owner,
+                                &project.repo_name,
+                            )
+                            .await
+                            {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        project_id = %project.id,
+                                        pr_number = pull.number,
+                                        error = %e,
+                                        "reconciliation: failed to load PR workflows"
+                                    );
+                                    return false;
+                                }
+                            };
+                        let triggers: Vec<WorkflowTrigger> = candidates
+                            .into_iter()
+                            .map(|w| WorkflowTrigger {
+                                id: w.id,
+                                workspace_id: w.workspace_id,
+                                trigger: w.trigger,
+                            })
+                            .collect();
+                        routed.extend(translate_pull_request(
+                            &pull,
+                            &project.repo_owner,
+                            &project.repo_name,
+                            Some(&project.id),
+                            &triggers,
+                        ));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            project_id = %project.id,
+                            external_ref = %ev.external_ref,
+                            error = %e,
+                            "reconciliation: failed to parse Pull payload"
+                        );
+                        return false;
+                    }
+                }
+            }
+            other => {
+                tracing::warn!(
+                    project_id = %project.id,
+                    resource_kind = other,
+                    "reconciliation: unsupported resource_kind"
+                );
+            }
+        }
+    }
+
+    emit_routed_events(spine, routed, &project.workspace_id, "portal-reconciler").await;
+    true
+}
+
+/// Look up the workflows that match each of `issue`'s labels. The
+/// poller has no `labeled` action context (only the current shape of
+/// the issue), so we query per-label. Empty map → nothing to fire.
+async fn collect_label_workflows(
+    pool: &PgPool,
+    project: &ProjectRow,
+    issue: &Issue,
+) -> anyhow::Result<HashMap<String, Vec<WorkflowMatch>>> {
+    let mut by_label: HashMap<String, Vec<WorkflowMatch>> = HashMap::new();
+    // The poller polls unauthenticated in v1, so we have no
+    // install_id to scope by. Use the workspace-scoped query so a
+    // matching workflow on this project's workspace is found
+    // regardless of install_id — when the credential follow-up
+    // lands, scope tightens to (install_id, repo, label).
+    for label in &issue.labels {
+        let workflows = crate::workflow_db::find_active_github_workflows_for_label_in_workspace(
+            pool,
+            &project.workspace_id,
+            &project.repo_owner,
+            &project.repo_name,
+            &label.name,
+        )
+        .await?;
+        if workflows.is_empty() {
+            continue;
+        }
+        let matches: Vec<WorkflowMatch> = workflows
+            .into_iter()
+            .map(|w| WorkflowMatch {
+                id: w.id,
+                workspace_id: w.workspace_id,
+                trigger_kind_tag: w.trigger.kind_tag().to_string(),
+            })
+            .collect();
+        by_label.insert(label.name.clone(), matches);
+    }
+    Ok(by_label)
 }
 
 #[cfg(test)]

--- a/crates/onsager-portal/src/reconciliation/scheduler.rs
+++ b/crates/onsager-portal/src/reconciliation/scheduler.rs
@@ -35,7 +35,7 @@ use onsager_spine::{EventStore, RoutedEvent, WorkflowMatch, WorkflowTrigger};
 use sqlx::PgPool;
 use tokio::time::{self, Instant};
 
-use super::emit::emit_routed_events;
+use super::emit::{EmitOutcome, emit_routed_events};
 use super::mode::IngestionMode;
 use super::state::{load_state, touch_polled_at, upsert_state};
 use super::translator::{translate_issue, translate_pull_request};
@@ -201,21 +201,52 @@ async fn tick_project(
         match adapter.poll_since(&state).await {
             Ok(PollOutcome { events, advance }) => {
                 let observed = events.len();
-                let emit_ok = emit_normalized(pool, spine, project, kind, &events).await;
-                // Advance the cursor ONLY when emit succeeded. The
-                // "cursor advances only on successful emit" contract
-                // (see `onsager-github::polling`) means a failure
-                // leaves the cursor where it was so the next tick
-                // retries the same window. Dedup at the spine layer
-                // turns the retry of an already-emitted event into a
-                // silent no-op.
-                if emit_ok && let Some(advanced) = advance.as_ref() {
+                // Advance the cursor ONLY when every event in the
+                // batch landed (or was already deduped against a
+                // sibling-path write). The "cursor advances only on
+                // successful emit" contract from
+                // `onsager-github::polling` means any DB write
+                // failure leaves the cursor where it was so the next
+                // tick retries the same window — dedup at the spine
+                // layer turns the retry of an already-emitted event
+                // into a silent no-op.
+                let outcome = match emit_normalized(pool, spine, project, kind, &events).await {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::warn!(
+                            project_id = %project.id,
+                            adapter_id = adapter.adapter_id(),
+                            resource_kind = kind,
+                            error = %e,
+                            "reconciliation: emit pipeline errored; cursor will not advance"
+                        );
+                        touch_polled_at(pool, adapter.adapter_id(), &project.workspace_id, kind)
+                            .await?;
+                        continue;
+                    }
+                };
+                if outcome.failed > 0 {
+                    tracing::warn!(
+                        project_id = %project.id,
+                        adapter_id = adapter.adapter_id(),
+                        resource_kind = kind,
+                        written = outcome.written,
+                        deduped = outcome.deduped,
+                        failed = outcome.failed,
+                        "reconciliation: partial emit failure; cursor will not advance"
+                    );
+                }
+                if outcome.all_succeeded()
+                    && let Some(advanced) = advance.as_ref()
+                {
                     upsert_state(pool, advanced).await?;
                     tracing::info!(
                         project_id = %project.id,
                         adapter_id = adapter.adapter_id(),
                         resource_kind = kind,
                         observed,
+                        written = outcome.written,
+                        deduped = outcome.deduped,
                         "reconciliation: poll emitted + cursor advanced"
                     );
                 } else {
@@ -246,39 +277,34 @@ async fn tick_project(
 
 /// Translate a batch of [`NormalizedEvent`]s for one resource kind
 /// into [`RoutedEvent`]s via the shared translator and emit them to
-/// the spine. Returns `true` when every event in the batch was
-/// translated and emit was attempted without an error; the caller
-/// uses this signal to decide whether to advance the cursor. An
-/// empty batch is a trivial success.
+/// the spine. The returned [`EmitOutcome`] carries `written` /
+/// `deduped` / `failed` counts — the caller (`tick_project`) gates
+/// the cursor advance on `failed == 0` so any DB write failure (or
+/// pre-emit failure like a parse error) keeps the cursor pinned for
+/// the next tick to retry.
+///
+/// Returns `Err(_)` only on a DB-level error while loading the
+/// workflow lookup — the caller propagates it up via `?` and the
+/// tick loop logs and retries on the next interval.
 async fn emit_normalized(
     pool: &PgPool,
     spine: &EventStore,
     project: &ProjectRow,
     resource_kind: &str,
     events: &[NormalizedEvent],
-) -> bool {
+) -> anyhow::Result<EmitOutcome> {
     if events.is_empty() {
-        return true;
+        return Ok(EmitOutcome::default());
     }
     let mut routed: Vec<RoutedEvent> = Vec::new();
+    let mut pre_emit_failures: usize = 0;
 
     for ev in events {
         match resource_kind {
             GitHubAdapter::KIND_ISSUE => {
                 match serde_json::from_value::<Issue>(ev.payload.clone()) {
                     Ok(issue) => {
-                        let by_label = match collect_label_workflows(pool, project, &issue).await {
-                            Ok(m) => m,
-                            Err(e) => {
-                                tracing::warn!(
-                                    project_id = %project.id,
-                                    issue_number = issue.number,
-                                    error = %e,
-                                    "reconciliation: failed to load label workflows"
-                                );
-                                return false;
-                            }
-                        };
+                        let by_label = collect_label_workflows(pool, project, &issue).await?;
                         if by_label.is_empty() {
                             continue;
                         }
@@ -291,13 +317,18 @@ async fn emit_normalized(
                         ));
                     }
                     Err(e) => {
+                        // A bad payload is a deserialize bug, not a
+                        // transport failure — count it as failed so the
+                        // cursor doesn't skip past it on the next tick
+                        // (a redeploy with the fix re-runs the same
+                        // window).
                         tracing::warn!(
                             project_id = %project.id,
                             external_ref = %ev.external_ref,
                             error = %e,
                             "reconciliation: failed to parse Issue payload"
                         );
-                        return false;
+                        pre_emit_failures += 1;
                     }
                 }
             }
@@ -305,24 +336,12 @@ async fn emit_normalized(
                 match serde_json::from_value::<Pull>(ev.payload.clone()) {
                     Ok(pull) => {
                         let candidates =
-                            match crate::workflow_db::find_active_pull_request_closed_workflows(
+                            crate::workflow_db::find_active_pull_request_closed_workflows(
                                 pool,
                                 &project.repo_owner,
                                 &project.repo_name,
                             )
-                            .await
-                            {
-                                Ok(c) => c,
-                                Err(e) => {
-                                    tracing::warn!(
-                                        project_id = %project.id,
-                                        pr_number = pull.number,
-                                        error = %e,
-                                        "reconciliation: failed to load PR workflows"
-                                    );
-                                    return false;
-                                }
-                            };
+                            .await?;
                         let triggers: Vec<WorkflowTrigger> = candidates
                             .into_iter()
                             .map(|w| WorkflowTrigger {
@@ -346,7 +365,7 @@ async fn emit_normalized(
                             error = %e,
                             "reconciliation: failed to parse Pull payload"
                         );
-                        return false;
+                        pre_emit_failures += 1;
                     }
                 }
             }
@@ -360,8 +379,10 @@ async fn emit_normalized(
         }
     }
 
-    emit_routed_events(spine, routed, &project.workspace_id, "portal-reconciler").await;
-    true
+    let mut outcome =
+        emit_routed_events(spine, routed, &project.workspace_id, "portal-reconciler").await;
+    outcome.failed += pre_emit_failures;
+    Ok(outcome)
 }
 
 /// Look up the workflows that match each of `issue`'s labels. The

--- a/crates/onsager-portal/src/reconciliation/translator.rs
+++ b/crates/onsager-portal/src/reconciliation/translator.rs
@@ -1,18 +1,21 @@
-//! Typed-shape webhook translator — the shared seam between the live
-//! webhook handler and the reconciliation poller.
+//! Typed-shape translator — the poller's path from observed GitHub
+//! resources to spine `RoutedEvent`s.
 //!
-//! Both call paths converge on this module: a `(parsed shape →
-//! Vec<RoutedEvent> → emit)` pipeline that produces the same spine
-//! events regardless of whether GitHub delivered them over a webhook
-//! or the poller observed them via REST. The webhook handler parses
-//! its `serde_json::Value` payload as today and then delegates to
-//! these functions; the poller hands typed `Issue` / `Pull` shapes
-//! straight in.
+//! The reconciliation poller (`scheduler.rs::tick_project`) hands a
+//! typed `Issue` / `Pull` straight in and gets back the events the
+//! spine expects. The webhook handler keeps using the spine-side
+//! `route_*` family (`onsager_spine::webhook_routing::{
+//! route_issues_labeled, route_pull_request_closed, ...}`) — those
+//! routers and the functions here share a contract, not a call site:
+//! both produce identical `RoutedEvent.kind` shapes for the same
+//! resource update, and both populate the same dedup key
+//! (`(adapter_id, external_ref)`) so the webhook ↔ poller race
+//! collapses on the spine migration 032 partial unique index.
 //!
-//! Symmetry is the load-bearing property — the
-//! `(adapter_id, external_ref)` dedup index (spine migration 032)
-//! collapses webhook/poller races to one events_ext row only because
-//! both sides emit the same shapes with the same dedup key.
+//! Byte-equivalence of `RoutedEvent.kind` between the two paths is
+//! exercised by the
+//! `webhook_and_poller_paths_produce_equivalent_routed_events_*`
+//! tests in this module.
 //!
 //! v1 resource scope (matches #121): issues + PR closed-merged only.
 //! `check_*` stays webhook-only (`route_check_event` on the spine).
@@ -29,30 +32,21 @@ use onsager_spine::{
     trigger::TriggerKind, trigger_source,
 };
 
+use crate::db::{issue_external_ref, pr_external_ref};
+
 /// Adapter identifier the GitHub translator stamps on emitted
 /// events for the (adapter_id, external_ref) dedup index. Centralised
 /// so the webhook and poller agree on the spelling and the partial
 /// unique index actually collapses races.
 pub const GITHUB_ADAPTER_ID: &str = "github";
 
-/// Render the canonical GitHub `external_ref` for an issue. Must
-/// match `onsager_github::GitHubAdapter::external_ref_for_issue` and
-/// `crate::db::issue_external_ref` so the dedup index sees both
-/// emitters' rows as the same key.
-pub fn issue_external_ref(project_id: &str, issue_number: u64) -> String {
-    format!("github:project:{project_id}:issue:{issue_number}")
-}
-
-/// Render the canonical GitHub `external_ref` for a pull request.
-pub fn pr_external_ref(project_id: &str, pr_number: u64) -> String {
-    format!("github:project:{project_id}:pr:{pr_number}")
-}
-
 /// Decorate the `TriggerFired` events with a per-workflow dedup key.
 /// We append `:trigger:<workflow_id>` to the resource-level ref so two
 /// workflows matching the same issue don't dedup against each other —
 /// only webhook + poller races for the *same* (issue, workflow) pair
-/// collapse.
+/// collapse. The resource-level prefix comes from
+/// `crate::db::{issue_external_ref, pr_external_ref}` so a webhook
+/// emit and a poller emit produce the same key.
 fn trigger_external_ref(resource_ref: &str, workflow_id: &str) -> String {
     format!("{resource_ref}:trigger:{workflow_id}")
 }

--- a/crates/onsager-portal/src/reconciliation/translator.rs
+++ b/crates/onsager-portal/src/reconciliation/translator.rs
@@ -1,0 +1,402 @@
+//! Typed-shape webhook translator — the shared seam between the live
+//! webhook handler and the reconciliation poller.
+//!
+//! Both call paths converge on this module: a `(parsed shape →
+//! Vec<RoutedEvent> → emit)` pipeline that produces the same spine
+//! events regardless of whether GitHub delivered them over a webhook
+//! or the poller observed them via REST. The webhook handler parses
+//! its `serde_json::Value` payload as today and then delegates to
+//! these functions; the poller hands typed `Issue` / `Pull` shapes
+//! straight in.
+//!
+//! Symmetry is the load-bearing property — the
+//! `(adapter_id, external_ref)` dedup index (spine migration 032)
+//! collapses webhook/poller races to one events_ext row only because
+//! both sides emit the same shapes with the same dedup key.
+//!
+//! v1 resource scope (matches #121): issues + PR closed-merged only.
+//! `check_*` stays webhook-only (`route_check_event` on the spine).
+
+use std::collections::HashMap;
+
+use onsager_github::api::{
+    issues::{Issue, Label},
+    pulls::Pull,
+};
+use onsager_spine::webhook_routing::WorkflowTrigger;
+use onsager_spine::{
+    FactoryEventKind, IssueTriggerContext, RoutedEvent, WorkflowMatch, build_trigger_fired_events,
+    trigger::TriggerKind, trigger_source,
+};
+
+/// Adapter identifier the GitHub translator stamps on emitted
+/// events for the (adapter_id, external_ref) dedup index. Centralised
+/// so the webhook and poller agree on the spelling and the partial
+/// unique index actually collapses races.
+pub const GITHUB_ADAPTER_ID: &str = "github";
+
+/// Render the canonical GitHub `external_ref` for an issue. Must
+/// match `onsager_github::GitHubAdapter::external_ref_for_issue` and
+/// `crate::db::issue_external_ref` so the dedup index sees both
+/// emitters' rows as the same key.
+pub fn issue_external_ref(project_id: &str, issue_number: u64) -> String {
+    format!("github:project:{project_id}:issue:{issue_number}")
+}
+
+/// Render the canonical GitHub `external_ref` for a pull request.
+pub fn pr_external_ref(project_id: &str, pr_number: u64) -> String {
+    format!("github:project:{project_id}:pr:{pr_number}")
+}
+
+/// Decorate the `TriggerFired` events with a per-workflow dedup key.
+/// We append `:trigger:<workflow_id>` to the resource-level ref so two
+/// workflows matching the same issue don't dedup against each other —
+/// only webhook + poller races for the *same* (issue, workflow) pair
+/// collapse.
+fn trigger_external_ref(resource_ref: &str, workflow_id: &str) -> String {
+    format!("{resource_ref}:trigger:{workflow_id}")
+}
+
+/// Translate an [`Issue`] into the `Vec<RoutedEvent>` the spine
+/// expects. For each label on the issue that matches a workflow's
+/// configured trigger label, one `TriggerFired` is produced.
+///
+/// `matched_workflows_by_label` is keyed on the label string — the
+/// caller (webhook or poller) restricts the keyspace to the labels
+/// it wants to consider:
+/// - The webhook handler passes a single-entry map with the
+///   just-added label, preserving today's "fire once per labeled
+///   delivery" semantics.
+/// - The poller passes every current label, since it has no
+///   action context (only "this issue is currently shaped like
+///   this"). The spine dedup index collapses the inevitable replay.
+pub fn translate_issue(
+    issue: &Issue,
+    repo_owner: &str,
+    repo_name: &str,
+    project_id: Option<&str>,
+    matched_workflows_by_label: &HashMap<String, Vec<WorkflowMatch>>,
+) -> Vec<RoutedEvent> {
+    let mut out = Vec::new();
+    let resource_ref = project_id.map(|pid| issue_external_ref(pid, issue.number));
+    for Label { name } in &issue.labels {
+        let Some(workflows) = matched_workflows_by_label.get(name) else {
+            continue;
+        };
+        let events = build_trigger_fired_events(
+            &IssueTriggerContext {
+                repo_owner,
+                repo_name,
+                issue_number: issue.number,
+                title: &issue.title,
+                label: name,
+                source: trigger_source::WEBHOOK,
+                replayed_by: None,
+            },
+            workflows,
+        );
+        // Decorate with per-(resource, workflow) dedup keys so a
+        // webhook delivery and a poller observation of the same
+        // labeled issue + workflow collapse to one events_ext row.
+        for (ev, wf) in events.into_iter().zip(workflows.iter()) {
+            let decorated = match resource_ref.as_deref() {
+                Some(r) => ev.with_dedup(GITHUB_ADAPTER_ID, trigger_external_ref(r, &wf.id)),
+                None => ev,
+            };
+            out.push(decorated);
+        }
+    }
+    out
+}
+
+/// Translate a [`Pull`] into the `Vec<RoutedEvent>` the spine expects.
+/// A closed+merged PR yields a `GateManualApprovalSignal` plus one
+/// `TriggerFired` per matching `github_pull_request_closed` workflow
+/// whose predicate accepts the delivered `merged` flag.
+///
+/// `matched` is the candidate set the caller queried — the
+/// translator applies the per-workflow predicate (`merged`) and drops
+/// non-matches, mirroring `route_pull_request_closed_workflows` on
+/// the spine.
+pub fn translate_pull_request(
+    pull: &Pull,
+    repo_owner: &str,
+    repo_name: &str,
+    project_id: Option<&str>,
+    matched: &[WorkflowTrigger],
+) -> Vec<RoutedEvent> {
+    let mut out = Vec::new();
+    if pull.state != "closed" {
+        return out;
+    }
+    let merged = pull.merged_at.is_some();
+    let resource_ref = project_id.map(|pid| pr_external_ref(pid, pull.number));
+
+    if merged {
+        let ev = RoutedEvent::new(FactoryEventKind::GateManualApprovalSignal {
+            repo_owner: repo_owner.to_string(),
+            repo_name: repo_name.to_string(),
+            pr_number: pull.number,
+            source: "github.pull_request.closed".to_string(),
+        });
+        let ev = match resource_ref.as_deref() {
+            Some(r) => ev.with_dedup(GITHUB_ADAPTER_ID, format!("{r}:manual_approval")),
+            None => ev,
+        };
+        out.push(ev);
+    }
+
+    for w in matched {
+        let predicate_match = match &w.trigger {
+            TriggerKind::GithubPullRequestClosed { predicate, .. } => match predicate {
+                Some(p) => p.merged.is_none_or(|want| want == merged),
+                None => true,
+            },
+            _ => false,
+        };
+        if !predicate_match {
+            continue;
+        }
+        let payload = serde_json::json!({
+            "repo_owner": repo_owner,
+            "repo_name": repo_name,
+            "pr_number": pull.number,
+            "title": pull.title,
+            "head_branch": pull.head.ref_name,
+            "base_branch": pull.base.ref_name,
+            "merged": merged,
+            "workspace_id": w.workspace_id,
+            "source": trigger_source::WEBHOOK,
+            "trigger_kind": "github_pull_request_closed",
+        });
+        let ev = RoutedEvent::new(FactoryEventKind::TriggerFired {
+            workflow_id: w.id.clone(),
+            trigger_kind: "github_pull_request_closed".to_string(),
+            payload,
+        });
+        let ev = match resource_ref.as_deref() {
+            Some(r) => ev.with_dedup(GITHUB_ADAPTER_ID, trigger_external_ref(r, &w.id)),
+            None => ev,
+        };
+        out.push(ev);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onsager_github::api::issues::{Issue, Label};
+    use onsager_github::api::pulls::{Pull, PullRef, PullUser};
+    use onsager_spine::trigger::PullRequestClosedPredicate;
+
+    fn sample_issue(labels: Vec<&str>) -> Issue {
+        Issue {
+            number: 42,
+            title: "fix the bug".into(),
+            state: "open".into(),
+            body: None,
+            labels: labels
+                .into_iter()
+                .map(|n| Label { name: n.into() })
+                .collect(),
+            pull_request: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_pull(state: &str, merged: bool) -> Pull {
+        Pull {
+            number: 11,
+            title: "merge me".into(),
+            state: state.into(),
+            merged_at: merged.then(|| "2026-05-20T00:00:00Z".to_string()),
+            merge_commit_sha: merged.then(|| "abc123".into()),
+            updated_at: None,
+            head: PullRef {
+                ref_name: "feature".into(),
+                sha: "deadbeef".into(),
+            },
+            base: PullRef {
+                ref_name: "main".into(),
+                sha: "cafebabe".into(),
+            },
+            html_url: "https://github.com/acme/widgets/pull/11".into(),
+            user: PullUser {
+                login: "alice".into(),
+            },
+        }
+    }
+
+    fn sample_match(id: &str) -> WorkflowMatch {
+        WorkflowMatch {
+            id: id.into(),
+            workspace_id: "ws1".into(),
+            trigger_kind_tag: "github_issue_webhook".into(),
+        }
+    }
+
+    #[test]
+    fn translate_issue_fires_per_matched_label() {
+        let issue = sample_issue(vec!["spec", "feat"]);
+        let mut by_label = HashMap::new();
+        by_label.insert("spec".into(), vec![sample_match("wf_a")]);
+        // No entry for "feat" → ignored.
+        let out = translate_issue(&issue, "acme", "widgets", Some("proj_x"), &by_label);
+        assert_eq!(out.len(), 1);
+        match &out[0].kind {
+            FactoryEventKind::TriggerFired { workflow_id, .. } => assert_eq!(workflow_id, "wf_a"),
+            _ => panic!("expected TriggerFired"),
+        }
+        assert_eq!(out[0].adapter_id.as_deref(), Some(GITHUB_ADAPTER_ID));
+        assert_eq!(
+            out[0].external_ref.as_deref(),
+            Some("github:project:proj_x:issue:42:trigger:wf_a")
+        );
+    }
+
+    #[test]
+    fn translate_issue_dedup_blank_without_project_id() {
+        let issue = sample_issue(vec!["spec"]);
+        let mut by_label = HashMap::new();
+        by_label.insert("spec".into(), vec![sample_match("wf_a")]);
+        let out = translate_issue(&issue, "acme", "widgets", None, &by_label);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].external_ref.is_none());
+        assert!(out[0].adapter_id.is_none());
+    }
+
+    fn pr_workflow(merged_predicate: Option<bool>) -> WorkflowTrigger {
+        WorkflowTrigger {
+            id: "wf_pr".into(),
+            workspace_id: "ws1".into(),
+            trigger: TriggerKind::GithubPullRequestClosed {
+                repo: "acme/widgets".into(),
+                predicate: merged_predicate.map(|m| PullRequestClosedPredicate { merged: Some(m) }),
+            },
+        }
+    }
+
+    #[test]
+    fn translate_pull_request_merged_emits_manual_approval_and_trigger() {
+        let pull = sample_pull("closed", true);
+        let workflows = vec![pr_workflow(Some(true))];
+        let out = translate_pull_request(&pull, "acme", "widgets", Some("proj_x"), &workflows);
+        assert_eq!(out.len(), 2);
+
+        let manual_approval = out
+            .iter()
+            .find(|e| matches!(e.kind, FactoryEventKind::GateManualApprovalSignal { .. }))
+            .expect("manual approval");
+        assert_eq!(
+            manual_approval.external_ref.as_deref(),
+            Some("github:project:proj_x:pr:11:manual_approval")
+        );
+
+        let trigger = out
+            .iter()
+            .find(|e| matches!(e.kind, FactoryEventKind::TriggerFired { .. }))
+            .expect("trigger fired");
+        assert_eq!(
+            trigger.external_ref.as_deref(),
+            Some("github:project:proj_x:pr:11:trigger:wf_pr")
+        );
+    }
+
+    #[test]
+    fn translate_pull_request_unmerged_drops_manual_approval() {
+        let pull = sample_pull("closed", false);
+        let workflows = vec![pr_workflow(None)];
+        let out = translate_pull_request(&pull, "acme", "widgets", Some("proj_x"), &workflows);
+        // Manual-approval is merged-only. Trigger fires (predicate None
+        // accepts any merged flag).
+        assert_eq!(out.len(), 1);
+        match &out[0].kind {
+            FactoryEventKind::TriggerFired { payload, .. } => {
+                assert_eq!(payload.get("merged").and_then(|v| v.as_bool()), Some(false));
+            }
+            _ => panic!("expected TriggerFired"),
+        }
+    }
+
+    #[test]
+    fn translate_pull_request_open_drops_everything() {
+        let pull = sample_pull("open", false);
+        let out = translate_pull_request(
+            &pull,
+            "acme",
+            "widgets",
+            Some("proj_x"),
+            &[pr_workflow(None)],
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn webhook_and_poller_paths_produce_equivalent_routed_events_for_labeled_issue() {
+        // The spec's "byte-equivalent RoutedEvent sets" contract:
+        // given matching input shapes, the webhook router and the
+        // poller translator must produce the same `kind`. The dedup
+        // fields differ by design (only the poller stamps them in
+        // unit-test scope; the webhook handler does it later via
+        // `decorate_routed_with_dedup`) so we compare on `kind`.
+        let payload = serde_json::json!({
+            "action": "labeled",
+            "issue": {
+                "number": 42,
+                "title": "fix the bug",
+                "state": "open",
+                "labels": [{"name": "spec"}],
+            },
+            "label": {"name": "spec"},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let workflows = vec![sample_match("wf_a")];
+        let from_webhook = onsager_spine::route_issues_labeled(&payload, &workflows);
+
+        let issue = sample_issue(vec!["spec"]);
+        let mut by_label = HashMap::new();
+        by_label.insert("spec".to_string(), workflows.clone());
+        let from_poller = translate_issue(&issue, "acme", "widgets", None, &by_label);
+
+        assert_eq!(from_webhook.len(), 1);
+        assert_eq!(from_poller.len(), 1);
+        assert_eq!(
+            from_webhook[0].kind, from_poller[0].kind,
+            "webhook and poller must emit identical TriggerFired kinds"
+        );
+    }
+
+    #[test]
+    fn webhook_and_poller_paths_produce_equivalent_routed_events_for_merged_pr() {
+        let payload = serde_json::json!({
+            "action": "closed",
+            "pull_request": {"number": 11, "merged": true},
+            "repository": {"name": "widgets", "owner": {"login": "acme"}},
+        });
+        let from_webhook = onsager_spine::route_pull_request_closed(&payload);
+
+        let pull = sample_pull("closed", true);
+        let from_poller = translate_pull_request(&pull, "acme", "widgets", None, &[]);
+
+        // Webhook path returns Option<RoutedEvent> for the manual-
+        // approval signal; poller returns Vec. Find the manual-
+        // approval event on each side and compare kinds.
+        let webhook_kind = &from_webhook.expect("webhook emits manual approval").kind;
+        let poller_kind = &from_poller
+            .iter()
+            .find(|e| matches!(e.kind, FactoryEventKind::GateManualApprovalSignal { .. }))
+            .expect("poller emits manual approval")
+            .kind;
+        assert_eq!(webhook_kind, poller_kind);
+    }
+
+    #[test]
+    fn translate_pull_request_predicate_misses_drops_trigger() {
+        let pull = sample_pull("closed", false);
+        // Predicate says "merged only".
+        let workflows = vec![pr_workflow(Some(true))];
+        let out = translate_pull_request(&pull, "acme", "widgets", Some("proj_x"), &workflows);
+        assert!(out.is_empty());
+    }
+}

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -410,6 +410,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let activation_pool = state.pool.clone();
     let activation_spine = state.spine.clone();
     let reconciliation_pool = state.pool.clone();
+    let reconciliation_spine = state.spine.clone();
     let activation_is_oss = !state
         .config
         .deployment
@@ -446,11 +447,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // Spawn the per-project reconciliation poller (spec #121). One
     // tokio task per project polls the configured adapter at the
-    // mode-derived interval; emit-to-spine wiring lands with the
-    // webhook-translator refactor (#121 follow-up). Skipping the
-    // scheduler on databases without a `projects` table is fine —
-    // the boot scan logs and exits.
-    crate::reconciliation::spawn_all(reconciliation_pool);
+    // mode-derived interval, routes the observed updates through the
+    // shared translator, and emits to the spine (spec #430). Skipping
+    // the scheduler on databases without a `projects` table is fine
+    // — the boot scan logs and exits.
+    crate::reconciliation::spawn_all(reconciliation_pool, reconciliation_spine);
 
     let listener = tokio::net::TcpListener::bind(&config.bind).await?;
     tracing::info!(bind = %config.bind, "onsager-portal listening");

--- a/crates/onsager-portal/tests/poller_emits_to_spine.rs
+++ b/crates/onsager-portal/tests/poller_emits_to_spine.rs
@@ -22,8 +22,7 @@
 use std::collections::HashMap;
 
 use onsager_github::api::issues::{Issue, Label};
-use onsager_portal::reconciliation::emit::emit_routed_events;
-use onsager_portal::reconciliation::translator::{GITHUB_ADAPTER_ID, translate_issue};
+use onsager_portal::reconciliation::{GITHUB_ADAPTER_ID, emit_routed_events, translate_issue};
 use onsager_spine::{EventStore, WorkflowMatch};
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
@@ -70,8 +69,9 @@ async fn poller_emit_lands_with_dedup_key() {
 
     let routed = translate_issue(&issue, "acme", "widgets", Some(&project_id), &by_label);
     assert_eq!(routed.len(), 1, "translator must produce one TriggerFired");
-    let written = emit_routed_events(&spine, routed, &workspace_id, "test").await;
-    assert_eq!(written, 1, "emit must persist the routed event");
+    let outcome = emit_routed_events(&spine, routed, &workspace_id, "test").await;
+    assert_eq!(outcome.written, 1, "emit must persist the routed event");
+    assert_eq!(outcome.failed, 0);
 
     // Pin: the row carries the dedup key the partial unique index
     // (adapter_id, external_ref) checks. A second emit must collapse.
@@ -99,11 +99,13 @@ async fn poller_emit_lands_with_dedup_key() {
     // dedup index — the load-bearing property the webhook/reconciler
     // race relies on.
     let routed_again = translate_issue(&issue, "acme", "widgets", Some(&project_id), &by_label);
-    let second_written = emit_routed_events(&spine, routed_again, &workspace_id, "test").await;
+    let second = emit_routed_events(&spine, routed_again, &workspace_id, "test").await;
+    assert_eq!(second.written, 0, "no new rows on re-emit");
     assert_eq!(
-        second_written, 0,
+        second.deduped, 1,
         "re-emit must be deduped by the partial unique index"
     );
+    assert_eq!(second.failed, 0);
 
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM events_ext \

--- a/crates/onsager-portal/tests/poller_emits_to_spine.rs
+++ b/crates/onsager-portal/tests/poller_emits_to_spine.rs
@@ -1,0 +1,126 @@
+//! Integration test for spec #430 — poller wires through to the spine.
+//!
+//! Simulates a missed webhook delivery: an issue gets a workflow-
+//! matching label on GitHub, but the webhook never arrives. The
+//! reconciliation poller observes the issue via REST (here, via the
+//! shared translator with hand-built shapes — the GitHub HTTP layer
+//! is not exercised), translates to `Vec<RoutedEvent>`, and emits
+//! through `emit_routed_events`. This test pins the contract that
+//! the resulting `events_ext` row exists and carries the
+//! `(adapter_id, external_ref)` dedup key from spine migration 032.
+//!
+//! Skipped when `DATABASE_URL` is unset — the contract lives in the
+//! spine schema.
+//!
+//! The test does NOT spin up the scheduler's per-project tokio loop
+//! (that would couple this test to project / workspace seed data and
+//! a live HTTP layer); it exercises the same `translate → emit`
+//! pipeline that `tick_project` calls. That keeps the test
+//! deterministic and tightly focused on the spec's delivery: a
+//! missed webhook turns into a spine row.
+
+use std::collections::HashMap;
+
+use onsager_github::api::issues::{Issue, Label};
+use onsager_portal::reconciliation::emit::emit_routed_events;
+use onsager_portal::reconciliation::translator::{GITHUB_ADAPTER_ID, translate_issue};
+use onsager_spine::{EventStore, WorkflowMatch};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+async fn try_setup() -> Option<(PgPool, EventStore)> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPool::connect(&url).await.expect("spine connect");
+    let spine = EventStore::connect(&url).await.expect("spine open");
+    Some((pool, spine))
+}
+
+#[tokio::test]
+async fn poller_emit_lands_with_dedup_key() {
+    let Some((pool, spine)) = try_setup().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let project_id = format!("proj-{}", Uuid::new_v4());
+    let issue_number: u64 = 4242;
+
+    let issue = Issue {
+        number: issue_number,
+        title: "fix the missed delivery".into(),
+        state: "open".into(),
+        body: None,
+        labels: vec![Label {
+            name: "spec".into(),
+        }],
+        pull_request: None,
+        updated_at: None,
+    };
+
+    let mut by_label = HashMap::new();
+    by_label.insert(
+        "spec".to_string(),
+        vec![WorkflowMatch {
+            id: format!("wf-{}", Uuid::new_v4()),
+            workspace_id: workspace_id.clone(),
+            trigger_kind_tag: "github_issue_webhook".into(),
+        }],
+    );
+
+    let routed = translate_issue(&issue, "acme", "widgets", Some(&project_id), &by_label);
+    assert_eq!(routed.len(), 1, "translator must produce one TriggerFired");
+    let written = emit_routed_events(&spine, routed, &workspace_id, "test").await;
+    assert_eq!(written, 1, "emit must persist the routed event");
+
+    // Pin: the row carries the dedup key the partial unique index
+    // (adapter_id, external_ref) checks. A second emit must collapse.
+    let expected_external_ref = format!(
+        "github:project:{project_id}:issue:{issue_number}:trigger:{}",
+        by_label.get("spec").unwrap()[0].id
+    );
+    let row = sqlx::query(
+        "SELECT adapter_id, external_ref FROM events_ext \
+         WHERE workspace_id = $1 AND adapter_id = $2 AND external_ref = $3",
+    )
+    .bind(&workspace_id)
+    .bind(GITHUB_ADAPTER_ID)
+    .bind(&expected_external_ref)
+    .fetch_optional(&pool)
+    .await
+    .expect("query");
+    let row = row.expect("emitted row must exist");
+    assert_eq!(
+        row.try_get::<String, _>("external_ref").unwrap(),
+        expected_external_ref
+    );
+
+    // A second emit of the same translator output collapses on the
+    // dedup index — the load-bearing property the webhook/reconciler
+    // race relies on.
+    let routed_again = translate_issue(&issue, "acme", "widgets", Some(&project_id), &by_label);
+    let second_written = emit_routed_events(&spine, routed_again, &workspace_id, "test").await;
+    assert_eq!(
+        second_written, 0,
+        "re-emit must be deduped by the partial unique index"
+    );
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM events_ext \
+         WHERE workspace_id = $1 AND adapter_id = $2 AND external_ref = $3",
+    )
+    .bind(&workspace_id)
+    .bind(GITHUB_ADAPTER_ID)
+    .bind(&expected_external_ref)
+    .fetch_one(&pool)
+    .await
+    .expect("count");
+    assert_eq!(count, 1, "exactly one row survives the race");
+
+    // Cleanup.
+    sqlx::query("DELETE FROM events_ext WHERE workspace_id = $1")
+        .bind(&workspace_id)
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -66,6 +66,8 @@ pub use store::{
 };
 pub use trigger::{DelayAnchor, JsonFilter, TriggerKind, TriggerStorageError};
 pub use webhook_routing::{
-    IssueTriggerContext, RoutedEvent, WorkflowMatch, build_trigger_fired_events, route_check_event,
-    route_issues_labeled, route_pull_request_closed, spine_namespace, trigger_source,
+    IssueTriggerContext, RoutedEvent, WorkflowMatch, WorkflowTrigger, build_trigger_fired_events,
+    route_check_event, route_issues_labeled, route_pull_request_closed,
+    route_pull_request_closed_workflows, route_workflow_run_completed_workflows, spine_namespace,
+    trigger_source,
 };

--- a/crates/onsager-spine/src/store.rs
+++ b/crates/onsager-spine/src/store.rs
@@ -144,6 +144,55 @@ impl EventStore {
         Ok(row.0)
     }
 
+    /// Append an extension event with `(adapter_id, external_ref)`
+    /// dedup applied at the storage layer (spine migration 032 — the
+    /// partial unique index on `events_ext (adapter_id, external_ref)`).
+    /// Returns `Ok(None)` when the insert was suppressed by the
+    /// index — that's the silent no-op the webhook ↔ reconciler race
+    /// is designed to collapse to. The first writer wins; the second
+    /// is a no-op via DB constraint, not application coordination.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn append_ext_dedup(
+        &self,
+        workspace_id: &str,
+        stream_id: &str,
+        namespace: &str,
+        event_type: &str,
+        data: serde_json::Value,
+        metadata: &EventMetadata,
+        adapter_id: &str,
+        external_ref: &str,
+    ) -> Result<Option<i64>, sqlx::Error> {
+        let meta = serde_json::to_value(metadata).expect("EventMetadata must be serializable");
+        let correlation_id = parse_correlation_id(metadata.correlation_id.as_deref());
+
+        let row: Option<(i64,)> = sqlx::query_as(
+            r#"
+            INSERT INTO events_ext
+                (stream_id, namespace, event_type, data, metadata, correlation_id,
+                 workspace_id, adapter_id, external_ref)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (adapter_id, external_ref)
+                WHERE adapter_id IS NOT NULL AND external_ref IS NOT NULL
+                DO NOTHING
+            RETURNING id
+            "#,
+        )
+        .bind(stream_id)
+        .bind(namespace)
+        .bind(event_type)
+        .bind(&data)
+        .bind(&meta)
+        .bind(correlation_id)
+        .bind(workspace_id)
+        .bind(adapter_id)
+        .bind(external_ref)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| r.0))
+    }
+
     /// Resolve an artifact's workspace_id. Returns `Ok(None)` when the
     /// artifact isn't in the spine (e.g. system events that name a
     /// stream key but no row). Producers feed this into

--- a/crates/onsager-spine/src/webhook_routing.rs
+++ b/crates/onsager-spine/src/webhook_routing.rs
@@ -25,9 +25,43 @@ use crate::factory_event::FactoryEventKind;
 use crate::trigger::TriggerKind;
 
 /// A single spine event the webhook handler should emit.
+///
+/// `adapter_id` + `external_ref` are the spine-side dedup key (spine
+/// migration 032 — partial unique index on `events_ext (adapter_id,
+/// external_ref)`). The shared routing rules don't know an emitter's
+/// adapter identity, so they leave these `None`; the caller
+/// (portal webhook handler, reconciliation poller) decorates each
+/// event before emit. When both fields are `Some`, [`EventStore::
+/// append_ext_dedup`] inserts with `ON CONFLICT DO NOTHING` and a
+/// race between the webhook + reconciler paths collapses to one row.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoutedEvent {
     pub kind: FactoryEventKind,
+    pub adapter_id: Option<String>,
+    pub external_ref: Option<String>,
+}
+
+impl RoutedEvent {
+    pub fn new(kind: FactoryEventKind) -> Self {
+        Self {
+            kind,
+            adapter_id: None,
+            external_ref: None,
+        }
+    }
+
+    /// Set the dedup key. Use the same `(adapter_id, external_ref)`
+    /// the sibling path (webhook ↔ reconciler) would set so the
+    /// partial unique index collapses races.
+    pub fn with_dedup(
+        mut self,
+        adapter_id: impl Into<String>,
+        external_ref: impl Into<String>,
+    ) -> Self {
+        self.adapter_id = Some(adapter_id.into());
+        self.external_ref = Some(external_ref.into());
+        self
+    }
 }
 
 /// Source tag stamped into every `workflow.trigger_fired` payload so
@@ -87,13 +121,11 @@ pub fn build_trigger_fired_events(
             {
                 obj.insert("replayed_by".into(), Value::String(uid.to_string()));
             }
-            RoutedEvent {
-                kind: FactoryEventKind::TriggerFired {
-                    workflow_id: w.id.clone(),
-                    trigger_kind: w.trigger_kind_tag.clone(),
-                    payload,
-                },
-            }
+            RoutedEvent::new(FactoryEventKind::TriggerFired {
+                workflow_id: w.id.clone(),
+                trigger_kind: w.trigger_kind_tag.clone(),
+                payload,
+            })
         })
         .collect()
 }
@@ -209,15 +241,13 @@ pub fn route_check_event(event: &str, payload: &Value) -> Option<RoutedEvent> {
         _ => return None,
     };
 
-    Some(RoutedEvent {
-        kind: FactoryEventKind::GateCheckUpdated {
-            repo_owner,
-            repo_name,
-            pr_number,
-            check_name,
-            conclusion,
-        },
-    })
+    Some(RoutedEvent::new(FactoryEventKind::GateCheckUpdated {
+        repo_owner,
+        repo_name,
+        pr_number,
+        check_name,
+        conclusion,
+    }))
 }
 
 /// Per-workflow `pull_request.closed` routing (#240). For each matching
@@ -281,13 +311,11 @@ pub fn route_pull_request_closed_workflows(
                 "source": trigger_source::WEBHOOK,
                 "trigger_kind": "github_pull_request_closed",
             });
-            RoutedEvent {
-                kind: FactoryEventKind::TriggerFired {
-                    workflow_id: w.id.clone(),
-                    trigger_kind: "github_pull_request_closed".to_string(),
-                    payload,
-                },
-            }
+            RoutedEvent::new(FactoryEventKind::TriggerFired {
+                workflow_id: w.id.clone(),
+                trigger_kind: "github_pull_request_closed".to_string(),
+                payload,
+            })
         })
         .collect()
 }
@@ -369,13 +397,11 @@ pub fn route_workflow_run_completed_workflows(
                 "source": trigger_source::WEBHOOK,
                 "trigger_kind": "github_workflow_run_completed",
             });
-            RoutedEvent {
-                kind: FactoryEventKind::TriggerFired {
-                    workflow_id: w.id.clone(),
-                    trigger_kind: "github_workflow_run_completed".to_string(),
-                    payload,
-                },
-            }
+            RoutedEvent::new(FactoryEventKind::TriggerFired {
+                workflow_id: w.id.clone(),
+                trigger_kind: "github_workflow_run_completed".to_string(),
+                payload,
+            })
         })
         .collect()
 }
@@ -412,14 +438,14 @@ pub fn route_pull_request_closed(payload: &Value) -> Option<RoutedEvent> {
     let repo_name = repo.get("name").and_then(Value::as_str)?.to_string();
     let pr_number = pr.get("number").and_then(Value::as_u64)?;
 
-    Some(RoutedEvent {
-        kind: FactoryEventKind::GateManualApprovalSignal {
+    Some(RoutedEvent::new(
+        FactoryEventKind::GateManualApprovalSignal {
             repo_owner,
             repo_name,
             pr_number,
             source: "github.pull_request.closed".to_string(),
         },
-    })
+    ))
 }
 
 /// Namespace partition for webhook-sourced spine events. Both the live


### PR DESCRIPTION
## Summary

Closes #430. Wires the spine-emit half of the #121 reconciliation poller — PR #429 landed the foundation (migration, `Adapter::poll_since`, polling loop) but the scheduler only *logged* observed events. This commit makes the poller actually turn a missed webhook delivery into a spine event.

The shape is exactly what the spec calls out:

1. **`reconciliation/translator.rs`** — typed-shape translator (`translate_issue`, `translate_pull_request`) shared between the live webhook handler and the poller. Takes already-parsed `Issue` / `Pull` shapes from `onsager-github`, returns `Vec<RoutedEvent>`, and stamps a per-(resource, workflow) dedup key.
2. **`reconciliation/emit.rs`** — shared emit pipeline. Both webhook (`handlers/webhook.rs`) and the scheduler (`tick_project`) route through it. When `(adapter_id, external_ref)` are set it uses the new `EventStore::append_ext_dedup` (which inserts `ON CONFLICT DO NOTHING` against the spine migration 032 partial unique index) so a webhook ↔ reconciler race collapses to one row, silently.
3. **`scheduler.rs::tick_project`** — translates each `NormalizedEvent` payload back into its typed shape, calls the shared translator + emit, and advances the cursor on Ok. Failure leaves the cursor where it was so the next tick retries the same window (matches the existing `onsager-github::polling` contract).
4. **`RoutedEvent`** picks up optional `adapter_id` / `external_ref` so callers thread the dedup key end-to-end. The webhook handler resolves `(install, owner, repo) → project_id` once per delivery and decorates each routed event via `dedup_key_for`.
5. `NormalizedEvent.payload` now carries the full serialized `Issue` / `Pull` (added `Serialize` to GitHub types) so the scheduler can round-trip the typed shape through the shared translator without a re-fetch.

## Test plan

- [x] `cargo test -p onsager-portal --lib` — 204 tests pass (including 8 new translator tests + the byte-equivalent webhook/poller assertion the spec calls for).
- [x] `cargo test -p onsager-spine --lib` (80) and `cargo test -p onsager-github --lib` (15) green.
- [x] `cargo test --workspace` green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run -p xtask -- check-events`, `lint-seams`, `check-api-contract`, `check-file-budget` all clean.
- [ ] DB-gated `tests/poller_emits_to_spine.rs` — runs against the spine migrations on CI's Postgres-backed job; skipped locally (no `DATABASE_URL`). Pins exactly the spec's acceptance test: simulate a missed webhook delivery (insert via the translator path), assert one `events_ext` row with the right `(adapter_id, external_ref)`, then re-emit and assert the second insert is deduplicated to a no-op.
- [ ] Manual: `polling-only` ingestion mode + a labeled issue → `TriggerFired` on the spine within one poll interval, no public URL involved. Validated locally against `just dev` once the DB-gated CI confirms the schema path.

## Out of scope (separate narrow follow-ups, per the spec)

- ETag / `If-None-Match` round-trip in the GitHub adapter.
- Per-installation credential resolution in the scheduler (still unauth'd reads in v1).
- `check_*` polling (`gate.check_updated` stays webhook-only).

https://claude.ai/code/session_01BsQ4LReJeSQVLCAoTAEjqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsQ4LReJeSQVLCAoTAEjqW)_