### PR TITLE
fix(portal): fail-fast when GitHub OAuth is configured without PORTAL_PUBLIC_URL

### DIFF
--- a/crates/onsager-portal/src/config.rs
+++ b/crates/onsager-portal/src/config.rs
@@ -139,6 +139,26 @@ impl Config {
                  not — the relying party cannot authenticate to the owner"
             );
         }
+
+        self.assert_public_url_for_release(cfg!(debug_assertions));
+    }
+
+    // Release builds must have PORTAL_PUBLIC_URL set when GitHub OAuth is
+    // configured. Without it, build_callback_url() falls back to
+    // http://localhost:<port>/... and silently emits that into the
+    // redirect_uri sent to GitHub — which GitHub rejects with
+    // "The redirect_uri is not associated with this application."
+    // Debug builds keep the localhost fallback so local OAuth testing
+    // against an app whose callback is registered as
+    // http://localhost:3002/api/auth/github/callback still works.
+    fn assert_public_url_for_release(&self, is_debug_build: bool) {
+        if !is_debug_build && self.github_client_id.is_some() && self.public_url.is_none() {
+            panic!(
+                "invalid SSO config: GITHUB_CLIENT_ID is set but PORTAL_PUBLIC_URL is \
+                 not — release builds would otherwise leak http://localhost into the \
+                 OAuth redirect_uri and GitHub would reject the sign-in flow"
+            );
+        }
     }
 }
 
@@ -275,5 +295,39 @@ mod tests {
             ..base_config()
         };
         c.assert_sso_consistent();
+    }
+
+    #[test]
+    #[should_panic(expected = "PORTAL_PUBLIC_URL")]
+    fn release_panics_when_github_oauth_set_without_public_url() {
+        let c = Config {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            public_url: None,
+            ..base_config()
+        };
+        c.assert_public_url_for_release(false);
+    }
+
+    #[test]
+    fn release_accepts_github_oauth_with_public_url() {
+        let c = Config {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            public_url: Some("https://app.onsager.ai".into()),
+            ..base_config()
+        };
+        c.assert_public_url_for_release(false);
+    }
+
+    #[test]
+    fn debug_build_keeps_localhost_fallback() {
+        let c = Config {
+            github_client_id: Some("id".into()),
+            github_client_secret: Some("secret".into()),
+            public_url: None,
+            ..base_config()
+        };
+        c.assert_public_url_for_release(true);
     }
 }


### PR DESCRIPTION
## Summary

Production at `app.onsager.ai` was 307-redirecting users to GitHub with `redirect_uri=http://localhost:3002/api/auth/github/callback` — GitHub rejected it with **"The redirect_uri is not associated with this application."** Root cause: `PORTAL_PUBLIC_URL` is unset on the production Railway service, so `build_callback_url()` in `handlers/auth.rs:600-614` silently fell through to its dev-only localhost fallback in a release build.

This PR adds a release-mode startup invariant: if `github_client_id` is set then `public_url` must also be set, otherwise `Config::assert_sso_consistent` panics at boot. Same shape as the existing `assert_sso_consistent` panics — fail-fast on ambiguous SSO configuration so misconfigured deploys never begin serving traffic. Debug builds keep the localhost fallback so local OAuth testing still works against an app whose callback is registered to `localhost:3002`.

## Delivers

- [x] Release-mode check in `Config::assert_sso_consistent` extension (factored as `assert_public_url_for_release` so the test suite can exercise both branches deterministically without a `should_panic` test that's a no-op under `cargo test`'s debug profile).
- [x] Unit tests covering the release panic, the release accept case, and the debug-build fallthrough.

## Operational follow-up (not in this PR)

**Before merging this PR, set `PORTAL_PUBLIC_URL=https://app.onsager.ai` on the production Railway service** — otherwise the next deploy with this code will panic-loop on boot. The variable was missing before this PR; the assertion just makes the misconfiguration loud instead of silent.

After deploy, verify with:

```bash
curl -sI https://app.onsager.ai/api/auth/github | grep -i ^location
# Expect: redirect_uri=https%3A%2F%2Fapp.onsager.ai%2Fapi%2Fauth%2Fgithub%2Fcallback
# Not:    redirect_uri=http%3A%2F%2Flocalhost%3A3002%2F...
```

## Test plan

- [x] `cargo test -p onsager-portal --lib config::tests` — 11 passed (3 new).
- [x] `RUSTFLAGS="-D warnings" cargo build -p onsager-portal` — clean.
- [x] `RUSTFLAGS="-D warnings" cargo clippy -p onsager-portal --all-targets -- -D warnings` — clean.
- [x] `cargo run -p xtask --quiet -- lint-seams` — clean.
- [x] `cargo run -p xtask --quiet -- check-api-contract` — clean.
- [ ] Manual post-deploy: GitHub sign-in on `app.onsager.ai` round-trips successfully.

Closes #443

https://claude.ai/code/session_01QG7geTDLic7crn6yMAwpQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QG7geTDLic7crn6yMAwpQ5)_