### PR TITLE
fix(spine): migration 025 skips workflows with NULL created_by

### DIFF
--- a/crates/onsager-spine/migrations/025_workflow_version_pin.sql
+++ b/crates/onsager-spine/migrations/025_workflow_version_pin.sql
@@ -47,6 +47,16 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_workflow_version
 --    insert a published `workflow_versions` row, and point the workflow
 --    at it. Idempotent — `ON CONFLICT DO NOTHING` covers re-runs and the
 --    UPDATE skips workflows that already have an active version.
+--
+--    Skip workflows with NULL `created_by`. Migration 009 added that
+--    column as nullable and explicitly committed pre-#156 rows to a
+--    "broken until re-activated" state (sessions fail loudly on next
+--    dispatch via `stiglab.session_failed`). `workflow_versions.created_by`
+--    (migration 022) and `workflow_changes.actor` (migration 023) are
+--    NOT NULL, so threading a NULL through here would abort the whole
+--    DO block. Leaving these orphans with `active_version_id = NULL`
+--    matches their existing semantics; re-activation through the
+--    application layer mints a fresh v1 then.
 DO $$
 DECLARE
     w           RECORD;
@@ -58,6 +68,7 @@ BEGIN
                created_at, workspace_id, install_id
           FROM workflows
          WHERE active_version_id IS NULL
+           AND created_by IS NOT NULL
     LOOP
         new_version := 'wfv_' || w.workflow_id;
 


### PR DESCRIPTION
## Summary

Production is crashlooping because spine migration 025 fails on every container start:

```
ERROR:  null value in column "created_by" of relation "workflow_versions" violates not-null constraint
DETAIL:  row wfv_wf_bb7ec751… ... null, published, null, ...
CONTEXT: PL/pgSQL function inline_code_block line 41 at SQL statement
```

The `DO $$` block backfills v1 `workflow_versions` rows from `workflows`, threading `workflows.created_by` through to `workflow_versions.created_by` (NOT NULL per migration 022) and `workflow_changes.actor` (NOT NULL per migration 023). But `workflows.created_by` is nullable by design — migration 009 added it nullable and explicitly committed pre-#156 rows to a "broken until re-activated" state (sessions fail loudly on next dispatch). One orphan row in `workflows` aborts the entire DO block, container exits non-zero, Railway restart loop.

## Fix

One-line filter on the cursor: `AND created_by IS NOT NULL`. Orphan workflows keep `active_version_id = NULL`, matching migration 009's existing "broken until re-activated" semantics. Re-activation through the application layer mints a fresh v1 then.

No schema change. No data loss — orphan workflows already do nothing.

Migration 025 has never successfully applied in prod (crashing on first run), so editing it in place is the right call per pre-launch posture.

## Test plan

- [x] Static review of the SQL diff (no Docker in this sandbox for a live Postgres run).
- [ ] Manual post-deploy: container reaches steady state, `curl https://app.onsager.ai/api/health` returns 200, Railway deployment shows `SUCCESS` instead of restart loop.

## Deploy ordering note

This PR is independent of #444 (the GitHub OAuth fail-fast guard) and should be merged **first** to unblock production. #444 is currently blocked by this crashloop anyway — its assertion can't even be reached because the container never finishes migrations.

Closes #445

https://claude.ai/code/session_01QG7geTDLic7crn6yMAwpQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QG7geTDLic7crn6yMAwpQ5)_