### PR TITLE
ADR 0019 + 0020: pipeline-centric IA + portable chat (Proposed)

### DIFF
--- a/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
+++ b/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
@@ -1,6 +1,6 @@
 # ADR 0019 — Dashboard IA: pipeline-centric three-tab surface
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-05-22
 - **Identity impact**: no
 - **Tracking issues**: #450 (implementation spec). Refines the

--- a/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
+++ b/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
@@ -1,0 +1,306 @@
+# ADR 0019 — Dashboard IA: pipeline-centric three-tab surface
+
+- **Status**: Proposed
+- **Date**: 2026-05-22
+- **Identity impact**: no
+- **Tracking issues**: #450 (implementation spec). Refines the
+  IA frame set by spec #289 (closed 2026-05-13 as completed, sub-PRs
+  2a–6 unshipped) and the FTUE umbrella spec #397 (closed 2026-05-19).
+  Retires spec #398 (universal-chat-entry, closed 2026-05-18) as a
+  side effect. The chat surface restructuring it implies is named in
+  the sibling ADR 0020.
+- **Supersedes**: none. The predecessor specs (#289, #397, #398) are
+  the prior dashboard-IA frame in prose; the repo convention reserves
+  the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
+- **Superseded by**: none
+
+## Context
+
+The dashboard IA has accreted in layers. Spec #289 set a two-surface
+frame (sidebar = Chat + Workflows; everything else under ⌘K). Spec
+#398 routed `/` to `/chat` so first-time users would see chat on
+landing. Spec #306 added redirect-preserving fallbacks for older
+top-level routes (`/sessions`, `/spine`, `/governance`, `/issues`,
+`/nodes`). The FTUE umbrella spec #397 (and its children #404, #406,
+#408) layered on activation instrumentation, template gallery, and a
+factory metaphor for user-facing copy.
+
+In code today this produces:
+
+- Two route entries pointing at the same `ChatPage` component (`/chat`
+  unscoped, `/workspaces/:slug/chat` scoped) with subtly different
+  storage-key behaviour (`apps/dashboard/src/pages/ChatPage.tsx:293-297`)
+- A two-item sidebar carrying a workspace switcher + user menu around
+  two nav items, occupying ~260px of chrome to serve two destinations
+- A 4-tab `WorkflowDetailPage` where every tab is a stack of cards
+  (`apps/dashboard/src/pages/WorkflowDetailPage.tsx:218-256`)
+- Six redirect entries for previously top-level surfaces; the
+  redirect graveyard signals the IA has been shuffled at least once
+- Multiple banners (OSS notice, draft chip strip, MetaphorBanner,
+  webhook warnings) stacking at the top of the chat surface
+
+First-paint screen density does not differ visibly from a generic
+SaaS dashboard with two nav items. The sidebar is mostly chrome around
+empty space, and `ChatPage`’s default 2fr/3fr split renders an empty
+DAG preview as 60% of the viewport before the user has typed anything.
+Complexity hides in the second layer rather than the first: top-level
+looks light, drill-in looks dense.
+
+The deeper mismatch is between the domain hierarchy and the
+navigation hierarchy:
+
+|Object  |Domain position                     |URL position                               |
+|--------|------------------------------------|-------------------------------------------|
+|Run     |Child of Workflow                   |Flat `/runs/:id`                           |
+|Artifact|Child of Run (or Stage)             |Flat `/artifacts/:id`                      |
+|Verdict |Child of Run                        |No route; a tab inside Workflow detail     |
+|Draft   |Pre-bound Workflow                  |No route; a chip strip inside ChatPage     |
+|Issue   |Trigger source, not a product object|Top-level detail route `/issues/:proj/:num`|
+|Project |Implicit (repo+install binding)     |No UI at all                               |
+
+Spec #289’s two-surface framing also splits a single linear pipeline
+(Chat → Draft → Bind → Workflow → Run → Artifact + Verdict) into two
+parallel modes (R&D vs production). The end-to-end view is hidden by
+the navigation shape.
+
+## Decision
+
+Adopt a pipeline-centric three-tab top-level IA. The sidebar is
+removed; workspace switcher and user menu move into the top chrome.
+
+|Tab      |Surface role                                                                               |URL                          |
+|---------|-------------------------------------------------------------------------------------------|-----------------------------|
+|Workflows|All workflows in current workspace, filtered by state. Default landing for signed-in users.|`/workspaces/:slug/workflows`|
+|Runs     |Cross-workflow execution history, filterable by workflow / status / time.                  |`/workspaces/:slug/runs`     |
+|Activity |Spine event stream at operator grain.                                                      |`/workspaces/:slug/activity` |
+
+The Workflows tab carries filter chips for the four workflow lifecycle
+states — Drafted, Bound, Active, Paused. These chips expose the
+activation ladder (per spec #404 instrumentation, with `Drafted` as
+the new key metric per KB position
+`364d79199ca681b4953be66481634f97`) as filter dimensions, not as
+separate navigational surfaces. A workflow with `status='draft'` is
+the same object as one with `status='bound'`; only its state pin
+differs.
+
+Routing changes:
+
+- `/` redirects to `/workspaces/:slug/workflows` for signed-in users
+  with at least one workspace, otherwise to `/workspaces` (picker)
+- `/chat` and `/workspaces/:slug/chat` are retired; existing bookmarks
+  301 to `/workspaces/:slug/workflows`. The chat surface itself
+  remains reachable as a global component per ADR 0020
+- `WorkflowDetailPage`’s four tabs (Definition / Runs / Artifacts /
+  Verdicts) collapse into one timeline page with anchored sections.
+  Existing hash anchors (`#definition`, `#runs`, `#artifacts`,
+  `#verdicts`) are preserved as scroll targets for bookmark
+  compatibility
+- Issues are not a top-level surface. The existing
+  `/issues/:projectId/:number` route remains as a deep-link target
+  for webhook notifications, with no in-dashboard entry point. Issue
+  records render as Activity source-type rows and as embedded
+  trigger-instance rows inside Workflow detail
+- The redirect map from spec #306 is extended with the chat retirements
+  but otherwise unchanged
+
+The AI factory metaphor is removed from the dashboard’s
+substrate-facing surfaces. A grep of `apps/dashboard/src/` finds the
+metaphor at six distinct locations, not the five originally tallied
+under spec #408 (only one of which carries an inline comment marker):
+
+1. `pages/ChatPage.tsx:838-843` — chat empty-state “inspection
+   reports / QC checkpoint” copy (spec #408 location 1, explicitly
+   commented in code)
+1. `pages/WorkflowsPage.tsx:69` — empty-state “factory starts
+   responding to GitHub events” copy
+1. `pages/WorkflowStartPage.tsx:23,99,255` — page title “Start the
+   factory” and “Run factory” button label
+1. `components/factory/workflows/MetaphorBanner.tsx` — workflow
+   detail banner; the file is deleted, not just its copy
+1. `components/chat/BindDraftDialog.tsx:186` — bind-draft dialog
+   prompt “First, name your factory floor.”
+1. `lib/chat/llm-client.ts:48,67` — chat assistant system prompt
+   persona (“AI factory operator”, “QC checkpoints” vocabulary). This
+   surface was missed by the original spec #408 enumeration. It
+   matters because it implicitly propagates the metaphor through every
+   assistant response.
+
+The following metaphor surfaces are explicitly **kept**, per KB
+position (Notion `364d79199ca681b4953be66481634f97`: metaphor is
+permitted on marketing and template-content surfaces):
+
+- `pages/LandingPage.tsx` (marketing landing)
+- `pages/ShowcaseDogfoodPage.tsx` (public showcase)
+- `apps/marketing/*` (marketing app)
+- `apps/dashboard/src/lib/templates/v0.json` — the `factory_framing`
+  string on each template, locked as user-facing template copy by
+  the FTUE umbrella spec #406. These describe each template to the
+  user before they pick one and are content, not chrome.
+- `components/layout/CommandPalette.tsx:136` — `factory` retained as
+  a keyword alias on the “New workflow” command, so users who knew
+  the old vocabulary can still find the action
+
+The directory name `components/factory/` is an internal identifier
+that KB explicitly excludes from the metaphor-permitted list. Renaming
+it is a mechanical refactor (50+ import sites) and lands as a
+follow-up issue, not under this ADR.
+
+The metaphor tightening therefore goes by *location*, not just by
+*surface type*. KB’s existing rule (no IA / routes / identifiers /
+DB schema) is preserved; this ADR enumerates the six dashboard
+locations that fall under the rule but had been missed in practice.
+
+## Rejected alternatives
+
+- **Keep spec #289’s two-surface IA, only fix the UI density.**
+  Considered as the lowest-risk option. Rejected because the
+  underlying problem is structural — chat and workflows are adjacent
+  stages of one pipeline, not parallel surfaces — and UI-only fixes
+  leave the mental-model mismatch in place.
+- **Object-centric three-tab IA (Workflows / Issues / Activity).**
+  Considered. Rejected because Issues are a passthrough view of
+  GitHub’s data model, not a first-class Onsager object. Promoting
+  them dilutes the workflow-first framing. The `/issues/:proj/:num`
+  route stays as a deep-link target only.
+- **Single-object IA (workflow-as-only-object), landing on the last
+  workflow visited.** Considered. Rejected because OSS users with
+  zero workflows have no surface to enter; the “where do I start”
+  question has no answer in this shape.
+- **Workspace-as-canvas single-page dashboard.** Considered. Rejected
+  because the canvas grid does not scale past ~10 workflows, and
+  cross-workflow runs and activity have no obvious place to land.
+- **Promote Drafted / Bound / Active / Paused to separate top-level
+  tabs.** Considered briefly. Rejected because these are workflow
+  lifecycle *states*, not separate surfaces. A workflow does not
+  change identity when its state pin moves from Drafted to Bound;
+  filter chips on the Workflows tab express the same axis without
+  fragmenting the object model. This also keeps the activation ladder
+  (per ADR 0009-adjacent instrumentation spec #404) on its metric
+  axis rather than promoting it to IA, in line with the KB framing.
+- **Retain the factory metaphor inside the dashboard as teaching
+  copy.** KB’s current rule would technically permit it (the rule
+  excludes IA / routes / identifiers / schema but not in-app copy).
+  Rejected because (a) the metaphor has spread to six unrelated
+  surfaces with no coordinated voice, (b) the product positioning
+  has shifted from “AI factory” to “AI-augmented work executor” per
+  the 2026-05-14 KB amendment, and (c) once a user produces their
+  first draft, substrate-native vocabulary should take over — also a
+  KB-explicit transition.
+
+## Consequences
+
+### Positive
+
+- First-paint screen density drops sharply. The chrome is one row
+  (logo + workspace switcher + three tabs + ⌘K + avatar); the main
+  area is full-width.
+- Cross-workflow visibility becomes a first-class affordance. Runs
+  and Activity answer “what happened in this workspace lately”
+  without drilling into a specific workflow.
+- Workflow lifecycle becomes legible via state filter chips. The
+  activation ladder surfaces as filter counts (`Drafted · 2`,
+  `Active · 3`), keeping it visible as a metric without making it a
+  navigational axis.
+- Chat has a single, consistent role across the dashboard as a
+  global component (per ADR 0020), not a separate mode.
+- In-app vocabulary becomes consistent: factory metaphor confined to
+  marketing and template content; dashboard chrome and copy speak
+  substrate-native terms.
+
+### Negative trade-offs
+
+- Existing OSS users will find their muscle memory broken on first
+  deploy. Mitigation: changelog entry plus a one-release “what’s new”
+  banner pointing at the new chrome.
+- The Workflow detail page becomes long when a workflow has many
+  runs, artifacts, and verdicts. Mitigation: each anchored section
+  truncates to “last N” with `[show all]` controls and lazy-loads on
+  scroll.
+- The `factory_framing` strings inside `templates/v0.json` now exist
+  under a different governance regime than the surrounding UI (kept,
+  not removed). Mitigation: a comment block at the top of the JSON
+  file cites this ADR and the FTUE umbrella spec #406.
+- The Issue detail route survives as an entry-point-less deep link.
+  Mitigation: webhook notification links still resolve; the route is
+  documented as “deep-link target only” in the route table.
+- The `components/factory/` directory name is technically a
+  KB-violating identifier that this ADR does not resolve. Mitigation:
+  a follow-up refactor issue is filed; until renamed, the directory
+  remains internal-only and never surfaces to users.
+
+### Neutral
+
+- The redirect map from spec #306 grows by two entries (`/chat`,
+  `/workspaces/:slug/chat`). The existing redirect plumbing handles
+  it.
+- Settings remains accessible under the user menu and ⌘K, with no
+  top-level tab. Unchanged from prior IA.
+- Hash anchors inside the collapsed `WorkflowDetailPage` stay
+  bookmark-stable.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog of a top-level dashboard tab is
+the issue label that gates work entering each lane. Workflows tab
+maps to issues labelled `area:workflow`; Runs tab maps to runs
+surfaced through spec issues with run logs; Activity tab maps to the
+spine event log used by maintainers to debug cross-spec behaviour.
+
+The lifecycle state filter chips parallel issue states: Drafted ↔
+issue `draft`, Bound ↔ `in-progress`, Active ↔ `in-flight`, Paused ↔
+`on-hold`.
+
+The “metaphor only in marketing and template content” rule maps to
+the spec authoring convention: an issue’s title and body use substrate
+terms; only fields whose contents are surfaced to users (such as a
+template’s `factory_framing`) may carry metaphor copy.
+
+## Adoption checklist
+
+- [ ] Land the new top chrome (workspace switcher + three tabs +
+  tools cluster); delete `AppSidebar.tsx` and remove its imports
+- [ ] Add list routes for `/workspaces/:slug/runs` and
+  `/workspaces/:slug/activity`; the existing flat `/runs/:id` and
+  `/artifacts/:id` detail routes are preserved
+- [ ] Collapse `WorkflowDetailPage.tsx` from four tabs to one timeline
+  page; preserve `#definition`, `#runs`, `#artifacts`,
+  `#verdicts` hash anchors as scroll targets
+- [ ] Add state filter chips (`All`, `Drafted · N`, `Bound · N`,
+  `Active · N`, `Paused · N`) to the Workflows list
+- [ ] Add 301 redirects for `/chat` and `/workspaces/:slug/chat` in
+  the spec #306 redirect map; extend the smoke-test for redirect
+  coverage
+- [ ] Remove the metaphor from the six locations enumerated in the
+  Decision section; delete `MetaphorBanner.tsx`; update the
+  `llm-client.ts` system prompt to substrate-native vocabulary
+- [ ] Add a comment block to `apps/dashboard/src/lib/templates/v0.json`
+  citing ADR 0019 and spec #406 (templates’ `factory_framing`
+  stays as user-facing copy)
+- [ ] File a follow-up issue to rename `components/factory/` to a
+  substrate-native name; mark as blocked until ADR 0019 ships
+- [ ] Add `closed by ADR 0019` follow-up comments to specs #289,
+  #397, #398
+- [ ] Update KB page `364d79199ca681b4953be66481634f97` (“Onsager 产
+  品定位 v0.1”) to point at ADR 0019 as the current IA reference
+- [ ] Flip Status to `Accepted` once the above land
+
+## Out of scope
+
+- **Chat surface mount form.** Where chat renders (FAB / Sidebar /
+  Drawer / Palette) is governed by ADR 0020, not this ADR. This ADR
+  fixes the tab structure only.
+- **Workflow detail content model.** Which artifacts and verdicts
+  appear under each anchored section is governed by ADR 0009 +
+  ADR 0016. This ADR changes the page’s chrome from tabs to anchored
+  sections, not the content shape.
+- **Cross-workspace surfaces.** All three tabs are workspace-scoped.
+  A global “all workspaces” overview is not part of this ADR.
+- **Mobile-specific IA.** The three-tab pattern fits desktop and
+  tablet. On phone-narrow viewports the chrome compresses (workspace
+  switcher + logo on row 1, tabs on row 2), and the long workflow
+  detail page benefits from anchored sections, but no phone-specific
+  IA changes are committed here.
+- **The `components/factory/` directory rename.** Filed as a
+  follow-up. This ADR removes the metaphor from user-visible copy
+  and from the assistant persona, but does not refactor the internal
+  module name.

--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -1,0 +1,319 @@
+# ADR 0020 — Chat as portable global component with contextual auto-scope
+
+- **Status**: Proposed
+- **Date**: 2026-05-22
+- **Identity impact**: no
+- **Tracking issues**: #451 (implementation spec). Sibling to
+  ADR 0019, which removes the top-level Chat tab. This ADR governs
+  what chat *becomes* once it is no longer a tab. Builds on ADR 0007
+  (tools and skills as the public contract) and ADR 0008 (portal
+  owns the agent control plane).
+- **Supersedes**: none. Predecessor specs (#398 universal-chat-entry,
+  #400 chat empty-state chips, #401 DraftStrip + chat surface) are
+  the prior frame in prose; the repo convention reserves the
+  `Supersedes` field for ADR-to-ADR replacement, so no entry here.
+- **Superseded by**: none
+
+## Context
+
+The dashboard’s chat surface is a page today — `ChatPage.tsx` (1005
+lines), reachable via two routes (`/chat` and
+`/workspaces/:slug/chat`). It hosts a conversation feed with HITL
+cards, a draft chip strip, a right-pane DAG preview, an empty-state
+template gallery, and a stack of banners (OSS notice, webhook health
+warning). The right-pane DAG preview is rendered as a 60% viewport
+strip even when no draft is active.
+
+This commits the chat to one of the four top-level dashboard surfaces
+that spec #289’s two-surface IA recognized. With ADR 0019 collapsing
+the IA to three tabs (Workflows / Runs / Activity) and removing Chat
+from top-level, the question becomes: how does a user reach chat, and
+in what form?
+
+KB position (Notion `35cd79199ca68131b4f6efac9ed8c3d6`, Onsager root
+note) frames the substrate as UI-portable via the MCP control plane:
+
+> Onsager substrate UI-portable via MCP control plane (intent /
+> spec_plan / compile / run / status / artifacts / verdicts); Claude
+> / Cursor / Onsager UI 互换 intent frontends
+
+ADR 0007 names the same point at the protocol layer: tools and skills
+are the public contract; the dashboard chat UI is one of N consumers
+of that contract, not a privileged one. ADR 0008 then carves portal
+as the owner of the public surface those consumers reach. Together
+they imply that chat inside the dashboard:
+
+- Is one MCP client among Claude, Cursor, and any other intent
+  frontend
+- Should not occupy a privileged top-level position relative to other
+  user activities
+- Should be reachable from anywhere a user might form an intent
+- Should be aware of what the user is currently looking at, without
+  forcing them to restate it
+
+A second concern is form. Power-user preferences genuinely diverge.
+Some want chat permanently visible (Cursor-style right sidebar). Some
+want it on-demand and out of the way when idle (Linear-style slide-
+over drawer). Some want minimum chrome and keyboard-only entry
+(Raycast-style palette mode). Some want a low-commitment touchpoint
+that never blocks the main view (Intercom-style floating button).
+Forcing one form across all users is arbitrary, and the underlying
+conversation state is mount-agnostic — the same `ChatContainer` can
+render inside any of them.
+
+The third concern is scope. The current
+`chatStorageKey(user.id, workspace.id)` at
+`apps/dashboard/src/pages/ChatPage.tsx:293-297` ties one thread per
+workspace. Users investigating multiple workflows in the same
+workspace lose continuity: every conversation about workflow A is
+mixed into the same thread as conversations about workflow B. A
+finer scoping is needed.
+
+## Decision
+
+Chat becomes a portable global component, mountable in four user-
+selectable forms with one shared state and storage layer.
+
+### Mount forms
+
+|Form       |Position                                           |Default trigger         |Typical user               |
+|-----------|---------------------------------------------------|------------------------|---------------------------|
+|**FAB**    |Floating bottom-right button + expanding panel     |Click FAB               |Low-commitment touchpoint  |
+|**Sidebar**|Persistent right column (desktop) / drawer (mobile)|Always-on               |Cursor-style power user    |
+|**Drawer** |Slide-over panel from the right edge               |Top-chrome button + `⌘J`|Default; “open when needed”|
+|**Palette**|Embedded inside ⌘K as a chat mode                  |`⌘K` then `tab`         |Keyboard-only              |
+
+**Drawer is the default** for new accounts. The choice is conservative:
+it does not pre-occupy main-area width and adapts cleanly from
+desktop to mobile. Users change it via account-level settings or a
+dock-mode toggle in the top chrome that cycles between forms at
+runtime. The toggle does not lose conversation state — switching the
+mount only changes the shell.
+
+The four mounts share a single `ChatContainer` component (state +
+storage + conversation feed + HITL card layout + DAG preview). Mount
+wrappers are thin adapters that handle position, sizing, and dismissal
+behaviour.
+
+### Contextual auto-scope
+
+The chat scope follows the user’s current view:
+
+|Current view                            |Default chat scope              |
+|----------------------------------------|--------------------------------|
+|Workflows tab list                      |`workspace`                     |
+|Workflow detail                         |`workflow:{id}`                 |
+|Run detail                              |`run:{id}`                      |
+|Verdict detail (within run)             |`verdict:{id}`                  |
+|Workspace switch                        |scope reset to new workspace    |
+|Tab switch (Workflows ↔ Runs ↔ Activity)|scope preserved at current level|
+
+Each scope holds **one rolling thread**. Returning to a previously
+visited scope resumes the same conversation; no implicit thread
+creation. A pin control in the chat header locks the scope against
+navigation changes, supporting cross-context inquiry — “looking at
+workflow A while asking a question about workflow B” — without
+forking the conversation model.
+
+Cross-scope history is fully indexed on the backend. The scope filter
+is a default view, not a wall: when the user asks “what did we
+decide about release notes last week?” inside a workflow A scope, the
+assistant searches across all the user’s scopes in the current
+workspace and cites the source scope alongside the answer.
+
+The chat header renders the scope path as a breadcrumb:
+`acme-corp / Auto-merge on green / Run #42`. Pin state shows as a
+filled-icon affordance next to the breadcrumb.
+
+### Storage schema change
+
+```
+old: chatStorageKey(user_id, workspace_id) → localStorage entry
+new: chatStorageKey(user_id, scope_type, scope_id) → backend (server-side)
+```
+
+The old single-thread-per-workspace key collapses to
+`scope_type='workspace'`; new finer scopes (`workflow`, `run`,
+`verdict`) get their own keys. The storage backend moves from
+client-side `localStorage` to server-side persistence; the engine
+choice (Postgres, spine, dedicated chat store) is delegated to the
+implementation spec.
+
+**Migration strategy: fresh start.** Onsager is pre-launch; existing
+chat-storage entries belong to OSS dogfood users only. Their
+`localStorage` entries are read once at first login after this ADR
+ships and surfaced as a one-time “previous conversations” link
+inside the workspace-scoped thread. Subsequent writes go to the
+backend under the new schema. No automated data migration ships.
+
+### Empty-state behaviour
+
+After ADR 0019 + this ADR land, signed-in users with zero workflows
+land on the Workflows tab and see an empty state. The empty state
+displays a “Start in chat →” card that opens the chat surface in
+whichever mount the user has chosen, scoped to the workspace. The
+chat empty state itself shows the template gallery from
+`apps/dashboard/src/lib/templates/v0.json` (per spec #406, content
+unchanged). The DraftStrip from `apps/dashboard/src/components/chat/ DraftStrip.tsx` is removed; its function (switching between in-flight
+drafts) is absorbed into the Workflows tab’s state-filter chips when
+filtered to `Drafted`.
+
+## Rejected alternatives
+
+- **Keep chat as a page (one of the three top-level tabs).**
+  Considered as a “Chat / Workflows / Runs” tab trio. Rejected
+  because it would re-create the spec #289 mode-split that pipeline-
+  centric IA explicitly retires, and it would contradict ADR 0007’s
+  framing of the chat UI as one MCP client among many.
+- **Single mount form (Sidebar only, or Drawer only).** Considered
+  for each of the four. Rejected because user preferences genuinely
+  diverge across the four established patterns (Cursor / Linear /
+  Raycast / Intercom), and the conversation state is mount-agnostic.
+  Supporting all four costs four thin wrappers around one container,
+  not four implementations.
+- **One chat thread per workspace, no auto-scope.** The simplest
+  extension of the current shape. Rejected because users working
+  across multiple workflows in the same workspace lose continuity;
+  every conversation about workflow A mixes into the same thread as
+  conversations about workflow B.
+- **Multiple threads per scope (GitHub-issue-with-comments shape).**
+  Considered. Rejected for now because single rolling thread per
+  scope is simpler to ship, simpler to teach, and matches the Cursor
+  model users already recognise. The storage schema reserves room to
+  add a `thread_id` axis later if the multi-thread case emerges; the
+  reserve costs nothing now.
+- **Scope follows navigation strictly, no pin.** Considered for
+  simplicity. Rejected because power users investigating workflow A
+  while consulting workflow B’s conversation history would lose
+  context on every click. Pin is a low-cost escape hatch (one
+  icon, one boolean in scope state).
+- **Store chat client-side (localStorage only).** Considered because
+  it preserves the current shape. Rejected because cross-device
+  continuity is part of the value once chat scopes get finer than
+  workspace, and the substrate’s MCP control plane already owns
+  conversation state authoritatively. Client-side caching can be a
+  perf layer; authoritative state lives on the server.
+- **Store chat client-side per scope, with sync-on-demand.**
+  Considered as a hybrid. Rejected because the sync-conflict
+  resolution adds complexity disproportionate to the value;
+  pre-launch is the cheapest moment to fix the schema.
+
+## Consequences
+
+### Positive
+
+- Chat reaches every view in the dashboard without consuming a tab
+  slot.
+- Contextual auto-scope removes the cost of restating “which workflow
+  am I asking about” — chat already knows. Finer scope means cleaner
+  per-object conversation history.
+- Mount-form preference becomes a personal choice. The “one form for
+  everyone” UX debate goes away; users opt into their style.
+- Server-side storage enables cross-device continuity and aligns
+  chat state with the MCP control plane’s existing authority. Other
+  intent frontends (Claude, Cursor) can consult the same scoped
+  threads via the same MCP endpoints.
+- Pin affordance handles the “look at A, ask about B” case without
+  forking the conversation model.
+
+### Negative trade-offs
+
+- Implementation cost is non-trivial: four mount wrappers + scope
+  state machine + storage backend + migration of the storage call
+  sites. Mitigation: phase 0 ships Drawer + Sidebar only; phase 1
+  adds FAB; phase 2 adds Palette. The internal `ChatContainer`
+  component is shared across phases.
+- Auto-scope-on-tab-switch is subtle: scope preserves at the current
+  level rather than resetting on every tab change. Users may not
+  predict this. Mitigation: the chat header always shows the scope
+  path as a breadcrumb, making the current scope unambiguous.
+- Fresh-start migration discards the few existing OSS dogfood users’
+  chat history. Mitigation: a one-time “previous conversations” link
+  surfaces the legacy localStorage reads for one release window;
+  users can copy text out manually if they need to retain it.
+- The default mount (Drawer) is a judgment call, not a measured
+  decision. Some users will dislike it. Mitigation: the dock-mode
+  toggle is in the top chrome, one click away, and settings carry
+  the preference across sessions.
+- Cross-scope history search is a new product surface (the search
+  results UI inside chat). The first version is unlikely to be ideal.
+  Mitigation: scoped (default) search remains the primary path;
+  cross-scope is opt-in via an explicit search command in chat.
+
+### Neutral
+
+- The chat empty-state template gallery (per spec #406) is unaffected;
+  it renders inside whichever mount the user picks.
+- HITL cards continue to render inline in the conversation. They
+  must fit in the narrowest mount (FAB panel, ~360px wide). The
+  current card layout is already this narrow.
+- The DAG preview moves from a separate right pane (the old ChatPage
+  split) into the chat surface itself, rendered inline as a
+  message-attached card. The visual real estate per draft is
+  smaller; only the active draft’s DAG renders, not a permanently
+  open preview pane.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog: the issue body and the PR
+description are the dev-process equivalents of mounted chat surfaces.
+The same conversation about a workflow happens both inside the
+dashboard chat (during build) and inside the issue or PR thread
+(during review). Both crystallise into the workflow’s spec.
+
+The contextual auto-scope rule maps to: a dashboard chat scoped to
+`workflow:{id}` is the same conversation that lives in the spec
+issue’s thread for that workflow. The MCP control plane can surface
+either as a view onto the same thread; the storage schema’s
+`(user_id, scope_type='workflow', scope_id={id})` is the join key.
+
+## Adoption checklist
+
+- [ ] Land the `ChatContainer` component with state machine, storage
+  interface, and conversation feed — mount-form-agnostic
+- [ ] Land Drawer mount (default) and Sidebar mount as phase 0
+- [ ] Land the contextual auto-scope hook that observes route changes
+  and computes scope; surface the breadcrumb in the chat header
+- [ ] Land the pin affordance + pinned-scope persistence
+- [ ] Land the storage backend with the new
+  `(user_id, scope_type, scope_id)` key shape; keep the old
+  `localStorage` reads available behind a one-release “previous
+  conversations” surface
+- [ ] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in
+  `App.tsx` with the global container; remove the `/chat` and
+  `/workspaces/:slug/chat` page routes (the 301 redirects land
+  in ADR 0019’s adoption checklist)
+- [ ] Add the dock-mode toggle to top chrome and the form selector
+  to account settings
+- [ ] Migrate the DraftStrip’s function into the Workflows tab’s
+  `Drafted` filter chip; delete `components/chat/DraftStrip.tsx`
+- [ ] Land FAB mount (phase 1)
+- [ ] Land Palette mount (phase 2)
+- [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager
+  root) Timeline with an entry for this ADR
+- [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and
+  #400
+- [ ] Flip Status to `Accepted` once phase 0 (Drawer + Sidebar +
+  storage + auto-scope) ships
+
+## Out of scope
+
+- **Server-side storage backend choice.** Whether the new chat state
+  lives in Postgres, in the spine, or in a dedicated chat store is
+  governed by the implementation spec, not this ADR. The schema
+  shape `(user_id, scope_type, scope_id)` is fixed by this ADR; the
+  storage engine is not.
+- **Multi-thread per scope.** Reserved for a follow-up if the use
+  case emerges; this ADR commits to single rolling thread per scope.
+  The storage schema’s reserved-not-required `thread_id` axis keeps
+  the door open.
+- **Chat-as-MCP-App rendering.** Whether the dashboard chat surface
+  itself becomes an MCP App (SEP-1865), rather than a native
+  dashboard surface that consumes MCP, is a downstream decision.
+  KB page `361d79199ca6815d8398cc509d7fe01b` carries the open
+  question. Not resolved here.
+- **Voice or multi-modal chat input.** Out of scope.
+- **Chat session sharing across users.** All conversations are
+  user-private. Multi-user shared chat is not part of this ADR.
+- **Cross-workspace chat scope.** A scope above `workspace` is not
+  defined; chat does not span workspaces.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,8 @@ see [`../architecture.md`](../architecture.md).
 | [0016](0016-workflow-library-n-isomorphic-islands.md) | Workflow Library: N isomorphic islands | Accepted (2026-05-15) — `Identity impact: no` |
 | [0017](0017-plan-compiler-three-step-algorithm.md) | Plan Compiler: three-step algorithm | Accepted (2026-05-15) — `Identity impact: yes` |
 | [0018](0018-five-kernel-invariants.md) | Five kernel invariants: static validation on workflow load | Accepted (2026-05-15) — `Identity impact: yes` |
+| [0019](0019-dashboard-ia-pipeline-centric-three-tab-surface.md) | Dashboard IA: pipeline-centric three-tab surface | Proposed (2026-05-22) — `Identity impact: no` |
+| [0020](0020-chat-as-portable-global-component-with-contextual-auto-scope.md) | Chat as portable global component with contextual auto-scope | Proposed (2026-05-22) — `Identity impact: no` |
 
 ## How to add an ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,7 +29,7 @@ see [`../architecture.md`](../architecture.md).
 | [0016](0016-workflow-library-n-isomorphic-islands.md) | Workflow Library: N isomorphic islands | Accepted (2026-05-15) — `Identity impact: no` |
 | [0017](0017-plan-compiler-three-step-algorithm.md) | Plan Compiler: three-step algorithm | Accepted (2026-05-15) — `Identity impact: yes` |
 | [0018](0018-five-kernel-invariants.md) | Five kernel invariants: static validation on workflow load | Accepted (2026-05-15) — `Identity impact: yes` |
-| [0019](0019-dashboard-ia-pipeline-centric-three-tab-surface.md) | Dashboard IA: pipeline-centric three-tab surface | Proposed (2026-05-22) — `Identity impact: no` |
+| [0019](0019-dashboard-ia-pipeline-centric-three-tab-surface.md) | Dashboard IA: pipeline-centric three-tab surface | Accepted (2026-05-22) — `Identity impact: no` |
 | [0020](0020-chat-as-portable-global-component-with-contextual-auto-scope.md) | Chat as portable global component with contextual auto-scope | Proposed (2026-05-22) — `Identity impact: no` |
 
 ## How to add an ADR


### PR DESCRIPTION
## Summary

Files two ADRs: **ADR 0019** lands as `Status: Accepted` (pipeline-centric three-tab dashboard IA, retiring the spec #289 two-surface frame). **ADR 0020** lands as `Status: Proposed` for further discussion (chat as portable global component with four mount forms, contextual auto-scope, and a fresh-start storage schema). This is the decision PR — no code under `apps/` is modified.

Part of #450, Part of #451.

## Decisions

- **ADR 0019 (Accepted)** — Top-level tabs collapse to Workflows / Runs / Activity; workflow lifecycle (Drafted / Bound / Active / Paused) surfaces as filter chips on the Workflows tab, not as separate navigational surfaces; the sidebar is removed; six factory-metaphor surfaces inside the dashboard are removed (marketing pages and `templates/v0.json`'s `factory_framing` strings are kept).
- **ADR 0020 (Proposed)** — Chat becomes a portable global component mountable in four forms (FAB / Sidebar / Drawer / Palette; Drawer is the default), sharing one `ChatContainer`. Scope auto-tracks the current view (`workspace` / `workflow:{id}` / `run:{id}` / `verdict:{id}`) with a pin to lock against navigation; single rolling thread per scope; storage moves to `(user_id, scope_type, scope_id)` server-side with a fresh-start migration. **Reviewer left this one open for further discussion** — the mount-form set, default choice, and storage migration are the open points.

## Linked implementation issues

Part of #450 (ADR 0019 implementation), Part of #451 (ADR 0020 implementation). This is the decision-only PR; the spec issues stay open to track the actual `apps/dashboard/` code changes. ADR 0019's implementation can proceed under #450; ADR 0020's implementation under #451 is gated on ADR 0020 acceptance.

## Predecessor lineage

Four predecessor specs frame the prior dashboard IA in prose. The repo convention reserves the ADR `Supersedes` field for ADR-to-ADR replacement, so this PR uses prose linkage (and `closed by ADR …` comments on each predecessor) rather than the `Closes` keyword (which would also be a no-op against already-closed issues):

- **#289** (two-surface IA, closed 2026-05-13) — supersedes by ADR 0019. Sub-PRs 2a–6 were never shipped; the IA frame itself moves to ADR 0019.
- **#397** (FTUE umbrella, closed 2026-05-19) — supersedes by ADR 0019. Children #404 / #406 / #408 are absorbed: #404 activation instrumentation becomes the lifecycle filter chips; #406 template gallery survives unchanged inside the new chat surface; #408 metaphor removal is expanded to the six locations enumerated in ADR 0019.
- **#398** (universal-chat-entry, closed 2026-05-18) — supersedes by ADR 0019 (IA restructuring removes the `/chat` top-level routing) and ADR 0020 (the chat surface itself becomes a portable global component, reachable everywhere).
- **#400** (chat empty-state chips, closed) — supersedes by ADR 0020. The template gallery survives but renders inside the new mount-form-agnostic `ChatContainer`.

## Open discussion on ADR 0020

ADR 0019 is accepted; ADR 0020 stays in `Proposed` for review of:

1. **The four mount forms with Drawer as default.** Drawer is a judgment call, not a measured decision. Confirm both the four-form set (FAB / Sidebar / Drawer / Palette) and Drawer-as-default — or narrow the set.
2. **The ChatStorageKey fresh-start migration.** No automated data move; existing OSS dogfood `localStorage` entries are read once and surfaced as a one-time "previous conversations" link inside the workspace-scoped thread. Confirm this matches the pre-launch operating posture.
3. **Contextual auto-scope behaviour.** Scope auto-tracks the current view; a pin locks against navigation. Cross-scope history search is opt-in via an explicit search command. Confirm the breadcrumb-as-disambiguation pattern is enough.
4. **Single rolling thread per scope.** Reserves room for `thread_id` later but commits to one thread now. Confirm.

The other ratification items from the original PR (the six factory-metaphor locations and the `templates/v0.json` decision) carried with ADR 0019 and are settled by its acceptance.

## Out of scope

This is the **decision** PR. No code under `apps/` is modified — only `docs/adr/` files (the two new ADRs and the README index). Implementation work lands under the two tracking issues (#450 for ADR 0019, #451 for ADR 0020).