### PR TITLE
adr: 0020 chat mount/invocation split (one responsive mount + 5 channels)

### DIFF
--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -51,15 +51,17 @@ they imply that chat inside the dashboard:
 - Should be aware of what the user is currently looking at, without
   forcing them to restate it
 
-A second concern is form. Power-user preferences genuinely diverge.
-Some want chat permanently visible (Cursor-style right sidebar). Some
-want it on-demand and out of the way when idle (Linear-style slide-
-over drawer). Some want minimum chrome and keyboard-only entry
-(Raycast-style palette mode). Some want a low-commitment touchpoint
-that never blocks the main view (Intercom-style floating button).
-Forcing one form across all users is arbitrary, and the underlying
-conversation state is mount-agnostic — the same `ChatContainer` can
-render inside any of them.
+A second concern is form and entry. The earlier framing of this ADR
+listed four "mount forms" (FAB, Sidebar, Drawer, Palette) as user-
+selectable shells. A mobile-first design review found this conflated
+two orthogonal axes: where the chat surface lives in the viewport
+(mount form) and how the user opens it (invocation channel). FAB
+and ⌘K are invocation channels, not viewport forms; Drawer and
+Sidebar are the same surface positioned differently across mobile
+and desktop. One responsive mount with several invocation channels
+fits the P1 ICP (Staff/Principal Engineer working across mobile and
+desktop) without forcing a "pick your shell" choice users should
+not have to think about.
 
 The third concern is scope. The current
 `chatStorageKey(user.id, workspace.id)` at
@@ -71,29 +73,67 @@ finer scoping is needed.
 
 ## Decision
 
-Chat becomes a portable global component, mountable in four user-
-selectable forms with one shared state and storage layer.
+Chat becomes a portable global component: one responsive mount, five
+invocation channels, one shared state and storage layer.
 
-### Mount forms
+### Mount: one responsive component
 
-|Form       |Position                                           |Default trigger         |Typical user               |
-|-----------|---------------------------------------------------|------------------------|---------------------------|
-|**FAB**    |Floating bottom-right button + expanding panel     |Click FAB               |Low-commitment touchpoint  |
-|**Sidebar**|Persistent right column (desktop) / drawer (mobile)|Always-on               |Cursor-style power user    |
-|**Drawer** |Slide-over panel from the right edge               |Top-chrome button + `⌘J`|Default; “open when needed”|
-|**Palette**|Embedded inside ⌘K as a chat mode                  |`⌘K` then `tab`         |Keyboard-only              |
+A single `ChatContainer` adapts to the viewport — no user-selectable
+mount form.
 
-**Drawer is the default** for new accounts. The choice is conservative:
-it does not pre-occupy main-area width and adapts cleanly from
-desktop to mobile. Users change it via account-level settings or a
-dock-mode toggle in the top chrome that cycles between forms at
-runtime. The toggle does not lose conversation state — switching the
-mount only changes the shell.
+|Platform|Position               |Size                            |Dismiss                  |
+|--------|-----------------------|--------------------------------|-------------------------|
+|Mobile  |Bottom-anchored overlay|~70% viewport height, full width|Drag-down or close button|
+|Desktop |Right-anchored sidebar |420px fixed width, full height  |`⌘J` or close button     |
 
-The four mounts share a single `ChatContainer` component (state +
-storage + conversation feed + HITL card layout + DAG preview). Mount
-wrappers are thin adapters that handle position, sizing, and dismissal
-behaviour.
+Both render the same Hybrid surface — a segmented control with two
+tabs, `Queue` (HITL aggregator for the current scope) and `Thread`
+(rolling conversation). Default tab is `Queue` when scope has
+pending HITL, `Thread` otherwise.
+
+### Invocation channels
+
+Five channels open the same mount. Guiding rule: **more prominent
+entry → more specific scope** — the loud FAB lands in the current
+route; the quieter top-chrome bell lands in the workspace-wide
+Inbox. The inversion would surprise users.
+
+|#|Channel                 |Default scope                           |Default tab                  |Platform                            |
+|-|------------------------|----------------------------------------|-----------------------------|------------------------------------|
+|1|Push notification       |HITL's scope                            |Queue + card highlighted     |Mobile + desktop notification center|
+|2|FAB (scope-aware)       |Current route                           |Queue if pending, else Thread|Mobile                              |
+|3|Top chrome bell         |`workspace` (Inbox)                     |Queue                        |Mobile + desktop                    |
+|4|Scope-local "Ask" button|Object-level (step / verdict / artifact)|Thread                       |Mobile + desktop                    |
+|5|⌘K palette              |Current route                           |Thread                       |Desktop                             |
+
+Only push notification is a deep link, carrying an HITL id; the
+other four land in the mount's default state for the resolved
+scope. Push originates on the portal MCP control plane (ADR 0008);
+the dashboard consumes it as one MCP client among many (ADR 0007).
+
+### FAB three-state behavior (mobile)
+
+States are driven by scope HITL state and viewport conditions, not
+user toggle. Long-press jumps to the Inbox (`scope=workspace`); a
+first-time hint surfaces on the third FAB use.
+
+|State |Trigger                             |Visual                                                                                               |
+|------|------------------------------------|-----------------------------------------------------------------------------------------------------|
+|Active|Current scope has pending HITL      |52px filled circle, foreground icon, accent badge with count, 3-second pulse ring on new HITL arrival|
+|Muted |Current scope has no pending HITL   |40px outlined circle, secondary icon color, no badge, opacity 0.75                                   |
+|Hidden|Scroll-down velocity, or keyboard up|Fade-out + 8px downward translate; restore on scroll-up or keyboard dismiss                          |
+
+### Notification action buttons
+
+- **Approval-kind HITL** ships `Approve` / `Reject` buttons, handled
+  in the notification surface without opening the app. The handler
+  relays the choice to the portal MCP control plane (ADR 0008).
+- **Selection-kind and Clarify-kind HITL** ship only `Open`. These
+  kinds need additional input the notification surface cannot
+  capture; `Open` lands on the highlighted Queue card.
+
+The callback → MCP elicitation response binding is a follow-up ADR
+(see Out of scope).
 
 ### Contextual auto-scope
 
@@ -150,9 +190,9 @@ backend under the new schema. No automated data migration ships.
 
 After ADR 0019 + this ADR land, signed-in users with zero workflows
 land on the Workflows tab and see an empty state. The empty state
-displays a “Start in chat →” card that opens the chat surface in
-whichever mount the user has chosen, scoped to the workspace. The
-chat empty state itself shows the template gallery from
+displays a “Start in chat →” card that opens the chat surface,
+scoped to the workspace. The chat empty state itself shows the
+template gallery from
 `apps/dashboard/src/lib/templates/v0.json` (per spec #406, content
 unchanged). The DraftStrip from `apps/dashboard/src/components/chat/ DraftStrip.tsx` is removed; its function (switching between in-flight
 drafts) is absorbed into the Workflows tab’s state-filter chips when
@@ -165,12 +205,19 @@ filtered to `Drafted`.
   because it would re-create the spec #289 mode-split that pipeline-
   centric IA explicitly retires, and it would contradict ADR 0007’s
   framing of the chat UI as one MCP client among many.
-- **Single mount form (Sidebar only, or Drawer only).** Considered
-  for each of the four. Rejected because user preferences genuinely
-  diverge across the four established patterns (Cursor / Linear /
-  Raycast / Intercom), and the conversation state is mount-agnostic.
-  Supporting all four costs four thin wrappers around one container,
-  not four implementations.
+- **Keep four user-selectable mount forms (FAB / Sidebar / Drawer /
+  Palette).** The previous draft. Two of the four are invocation
+  channels, not viewport forms; the other two are the same surface
+  positioned differently. Conflating the axes forces a shell choice
+  the user should not have to make.
+- **Drawer as the unified desktop+mobile mount.** Rejected because a
+  right-edge slide-over fits mobile poorly — the natural mobile
+  gesture is bottom-anchored with drag-down dismiss. Costs the
+  one-thumb HITL workflow for code reuse.
+- **Cursor-style persistent sidebar as the only desktop mount.**
+  Rejected because it pre-occupies main-area width even when idle,
+  conflicting with ADR 0019's three-tab surface. A "pin sidebar
+  open" preference can layer on the responsive mount later.
 - **One chat thread per workspace, no auto-scope.** The simplest
   extension of the current shape. Rejected because users working
   across multiple workflows in the same workspace lose continuity;
@@ -207,8 +254,10 @@ filtered to `Drafted`.
 - Contextual auto-scope removes the cost of restating “which workflow
   am I asking about” — chat already knows. Finer scope means cleaner
   per-object conversation history.
-- Mount-form preference becomes a personal choice. The “one form for
-  everyone” UX debate goes away; users opt into their style.
+- One responsive mount sidesteps the "one form for everyone" debate
+  without forcing a shell choice on the user; the five invocation
+  channels cover the patterns different users want (push, ambient
+  FAB, Inbox bell, scope-local Ask, keyboard).
 - Server-side storage enables cross-device continuity and aligns
   chat state with the MCP control plane’s existing authority. Other
   intent frontends (Claude, Cursor) can consult the same scoped
@@ -218,11 +267,11 @@ filtered to `Drafted`.
 
 ### Negative trade-offs
 
-- Implementation cost is non-trivial: four mount wrappers + scope
-  state machine + storage backend + migration of the storage call
-  sites. Mitigation: phase 0 ships Drawer + Sidebar only; phase 1
-  adds FAB; phase 2 adds Palette. The internal `ChatContainer`
-  component is shared across phases.
+- Implementation cost is non-trivial: responsive mount + four
+  invocation channels + scope state machine + storage backend +
+  migration of the storage call sites. Mitigation: phase 0 ships
+  the mount plus push, FAB, bell, and scope-local Ask; phase 1
+  adds ⌘K. The internal `ChatContainer` is shared across phases.
 - Auto-scope-on-tab-switch is subtle: scope preserves at the current
   level rather than resetting on every tab change. Users may not
   predict this. Mitigation: the chat header always shows the scope
@@ -231,10 +280,9 @@ filtered to `Drafted`.
   chat history. Mitigation: a one-time “previous conversations” link
   surfaces the legacy localStorage reads for one release window;
   users can copy text out manually if they need to retain it.
-- The default mount (Drawer) is a judgment call, not a measured
-  decision. Some users will dislike it. Mitigation: the dock-mode
-  toggle is in the top chrome, one click away, and settings carry
-  the preference across sessions.
+- "More prominent entry → more specific scope" is a learned rule;
+  the reverse would feel more natural. Mitigation: long-press on
+  FAB jumps to Inbox, with a first-time hint on third use.
 - Cross-scope history search is a new product surface (the search
   results UI inside chat). The first version is unlikely to be ideal.
   Mitigation: scoped (default) search remains the primary path;
@@ -243,10 +291,11 @@ filtered to `Drafted`.
 ### Neutral
 
 - The chat empty-state template gallery (per spec #406) is unaffected;
-  it renders inside whichever mount the user picks.
+  it renders inside the responsive mount, scoped to the workspace.
 - HITL cards continue to render inline in the conversation. They
-  must fit in the narrowest mount (FAB panel, ~360px wide). The
-  current card layout is already this narrow.
+  must fit the narrowest viewport (mobile full-width minus 16px
+  padding) and the desktop 420px sidebar. The current card layout
+  is already this narrow.
 - The DAG preview moves from a separate right pane (the old ChatPage
   split) into the chat surface itself, rendered inline as a
   message-attached card. The visual real estate per draft is
@@ -269,9 +318,11 @@ either as a view onto the same thread; the storage schema’s
 
 ## Adoption checklist
 
-- [ ] Land the `ChatContainer` component with state machine, storage
-  interface, and conversation feed — mount-form-agnostic
-- [ ] Land Drawer mount (default) and Sidebar mount as phase 0
+Phase 0 (responsive mount + push + FAB + bell + scope-local Ask):
+
+- [ ] Land the `ChatContainer` with state machine, storage interface,
+  conversation feed, and the Queue / Thread segmented control —
+  one responsive shell across mobile and desktop
 - [ ] Land the contextual auto-scope hook that observes route changes
   and computes scope; surface the breadcrumb in the chat header
 - [ ] Land the pin affordance + pinned-scope persistence
@@ -279,22 +330,30 @@ either as a view onto the same thread; the storage schema’s
   `(user_id, scope_type, scope_id)` key shape; keep the old
   `localStorage` reads available behind a one-release “previous
   conversations” surface
+- [ ] Land the scope-aware FAB (mobile): Active / Muted / Hidden
+  states, long-press → Inbox, first-time hint on third use
+- [ ] Land the top-chrome bell (mobile + desktop) → Queue at
+  `scope=workspace`
+- [ ] Land the scope-local "Ask" on step / verdict / artifact surfaces
+- [ ] Land push notifications with Approve / Reject for approval-kind
+  HITL and Open-only for selection / clarify kinds; deep link
+  scrolls Queue to the matching card
 - [ ] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in
   `App.tsx` with the global container; remove the `/chat` and
   `/workspaces/:slug/chat` page routes (the 301 redirects land
   in ADR 0019’s adoption checklist)
-- [ ] Add the dock-mode toggle to top chrome and the form selector
-  to account settings
 - [ ] Migrate the DraftStrip’s function into the Workflows tab’s
   `Drafted` filter chip; delete `components/chat/DraftStrip.tsx`
-- [ ] Land FAB mount (phase 1)
-- [ ] Land Palette mount (phase 2)
+
+Phase 1 (⌘K invocation) and closeout:
+
+- [ ] Land the ⌘K palette invocation on desktop, opening Thread at
+  the current route's scope
 - [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager
   root) Timeline with an entry for this ADR
 - [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and
   #400
-- [ ] Flip Status to `Accepted` once phase 0 (Drawer + Sidebar +
-  storage + auto-scope) ships
+- [ ] Flip Status to `Accepted` once phase 0 ships
 
 ## Out of scope
 
@@ -307,6 +366,14 @@ either as a view onto the same thread; the storage schema’s
   case emerges; this ADR commits to single rolling thread per scope.
   The storage schema’s reserved-not-required `thread_id` axis keeps
   the door open.
+- **Notification action button → MCP elicitation response binding.**
+  This ADR fixes the *shape* of action buttons (Approve / Reject
+  for approval-kind HITL; Open-only otherwise). The wire-level
+  binding to the MCP elicitation response on the portal control
+  plane (ADR 0008) — signing, replay protection, response shape
+  when the app is closed, iOS/Android-specific affordances — is a
+  follow-up ADR. Phase 0 may ship Open-only on all kinds if that
+  ADR has not landed in time.
 - **Chat-as-MCP-App rendering.** Whether the dashboard chat surface
   itself becomes an MCP App (SEP-1865), rather than a native
   dashboard surface that consumes MCP, is a downstream decision.


### PR DESCRIPTION
## Summary

Revises ADR 0020 in place to replace the four user-selectable mount forms (FAB / Sidebar / Drawer / Palette) with one responsive `ChatContainer` plus five invocation channels (push, FAB, top-chrome bell, scope-local Ask, ⌘K). A mobile-first design review found that the previous four-form model conflated mount form (where the surface lives in the viewport) with invocation channel (how it's opened), and overspent on shells that don't serve the P1 ICP.

What changes in the ADR:

- Mount: one responsive component — bottom-anchored overlay on mobile, right-anchored 420px sidebar on desktop, shared Hybrid Queue/Thread surface
- Invocation channels: 5-entry table with default scope, default tab, platform per channel; guiding rule **more prominent entry → more specific scope**
- FAB three-state behavior (Active / Muted / Hidden) with visual specs
- Notification action buttons: Approve/Reject for approval-kind HITL; Open-only for selection/clarify kinds. Wire-level binding to the MCP elicitation response (ADR 0008) flagged for follow-up ADR (named in Out of scope).
- Adoption checklist: phase 0 = responsive mount + push + FAB + bell + scope-local Ask; phase 1 = ⌘K palette
- New Rejected alternatives: keep all four mount forms; Drawer as the unified mount; Cursor-style persistent sidebar as the only desktop mount

What's preserved (unchanged): contextual auto-scope rules, single rolling thread per scope, server-side storage schema, pin affordance, fresh-start migration, empty-state behaviour.

Diff stats: 127 insertions, 60 deletions (319 → 386 lines, +21%). Focused revision — sections that don't change aren't reformatted.

Closes #461. Implementation work (still tracked by #451) is a separate follow-up — #451's body describes the prior four-mount-form decision and will need to be amended once this lands.

## Test plan

- [ ] Doc-only change; no runtime behavior. CI runs the link/format checks.
- [ ] Visual review: mount + invocation tables, FAB three-state table, Notification action buttons section, adoption checklist phasing, new Rejected alternatives, Out of scope addition.
- [ ] Cross-reference check: ADR 0007 and ADR 0008 cited in Invocation channels (push deep link), Notification action buttons (Approve/Reject relay), and Out of scope (follow-up ADR).


---
_Generated by [Claude Code](https://claude.ai/code/session_0187T4tzV7BQnbCA4hAaW19Z)_