### PR TITLE
test(dashboard): cover #463 top-chrome regions + tab scope

### DIFF
--- a/apps/dashboard/src/lib/workspace.tsx
+++ b/apps/dashboard/src/lib/workspace.tsx
@@ -126,12 +126,12 @@ export function useActiveWorkspace(): Workspace {
   return ctx.workspace
 }
 
-/** Optional: callers outside scoped routes (sidebar switcher, AppSidebar
- * nav links) read this. The sidebar lives in `AppLayout`, which mounts
+/** Optional: callers outside scoped routes (the top-chrome workspace
+ * switcher) read this. The top chrome lives in `AppLayout`, which mounts
  * above the `/workspaces/:workspace/*` route, so `WorkspaceContext` is
  * not in scope there. Fall back to the URL pathname + memberships query
- * so the sidebar can resolve `/workspaces/<active>/...` links and the
- * switcher's trigger button shows the active workspace's name.
+ * so the chrome can resolve `/workspaces/<active>/...` tab links and
+ * the switcher's trigger button shows the active workspace's name.
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useOptionalActiveWorkspace(): Workspace | null {

--- a/apps/dashboard/tests/smoke/top-chrome.test.tsx
+++ b/apps/dashboard/tests/smoke/top-chrome.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+
+import { AppLayout } from "@/components/layout/AppLayout"
+
+// Top chrome shell from #463 / ADR 0019. Two Test items the spec
+// pins are covered here:
+//
+//  - Component test: the top chrome renders all regions at desktop AND
+//    mobile widths. jsdom doesn't apply media queries, so both the
+//    desktop chrome (`<nav aria-label="Workspace sections">`) and the
+//    mobile tabs row (`<nav aria-label="Workspace sections (mobile)">`)
+//    are present in the DOM; we assert each region exposes the same
+//    three tabs and that the desktop chrome carries the logo, workspace
+//    switcher, ⌘K trigger, and user-menu button.
+//  - Tab switching preserves workspace scope across the three tabs:
+//    clicking each tab inside either nav navigates to
+//    `/workspaces/<slug>/<tab>`, never bare `/<tab>`.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      github_login: "alice",
+      github_name: "Alice",
+      github_avatar_url: null,
+    },
+    logout: vi.fn(),
+    authEnabled: true,
+  }),
+}))
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [
+        {
+          id: "w1",
+          slug: "acme",
+          name: "Acme",
+          created_by: "u1",
+          created_at: "2026-01-01",
+        },
+      ],
+    }),
+    createWorkspace: vi.fn(),
+  },
+}))
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location">{loc.pathname}</div>
+}
+
+function renderChrome(initialPath = "/workspaces/acme/workflows") {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <AppLayout>
+                <LocationProbe />
+              </AppLayout>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("top chrome (#463 / ADR 0019)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders the desktop chrome with logo, switcher, three tabs, ⌘K, and avatar", async () => {
+    renderChrome()
+    // Wait for the memberships query to resolve so the chrome's
+    // workspace-scoped hrefs are populated; before then the fallback
+    // target is `/workspaces`.
+    expect(await screen.findByText("Acme")).toBeInTheDocument()
+    // Logo points at the active workspace's Workflows tab.
+    const home = screen.getByRole("link", { name: /onsager home/i })
+    expect(home).toHaveAttribute("href", "/workspaces/acme/workflows")
+    // Desktop nav region exists and lists all three tabs as links.
+    const desktopNav = screen.getByRole("navigation", {
+      name: /workspace sections$/i,
+    })
+    for (const tab of ["Workflows", "Runs", "Activity"]) {
+      const link = within(desktopNav).getByRole("link", { name: tab })
+      expect(link).toHaveAttribute("href", `/workspaces/acme/${tab.toLowerCase()}`)
+    }
+    // ⌘K and avatar/user-menu triggers live in the right cluster.
+    expect(
+      screen.getAllByRole("button", { name: /open command palette/i }).length,
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByRole("button", { name: /open user menu/i }).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it("renders the mobile chrome with a second tabs row carrying all three tabs", async () => {
+    renderChrome()
+    expect(await screen.findByText("Acme")).toBeInTheDocument()
+    const mobileNav = screen.getByRole("navigation", {
+      name: /workspace sections \(mobile\)/i,
+    })
+    for (const tab of ["Workflows", "Runs", "Activity"]) {
+      const link = within(mobileNav).getByRole("link", { name: tab })
+      expect(link).toHaveAttribute("href", `/workspaces/acme/${tab.toLowerCase()}`)
+    }
+  })
+
+  it("tab switching preserves workspace scope across all three tabs", async () => {
+    renderChrome("/workspaces/acme/workflows")
+    // Wait for the active workspace to resolve so tab hrefs are scoped
+    // (without it the fallback target is `/workspaces`).
+    await screen.findByText("Acme")
+    const desktopNav = screen.getByRole("navigation", {
+      name: /workspace sections$/i,
+    })
+
+    fireEvent.click(within(desktopNav).getByRole("link", { name: "Runs" }))
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/acme/runs",
+      ),
+    )
+
+    fireEvent.click(within(desktopNav).getByRole("link", { name: "Activity" }))
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/acme/activity",
+      ),
+    )
+
+    fireEvent.click(within(desktopNav).getByRole("link", { name: "Workflows" }))
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/acme/workflows",
+      ),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Spec #463 ("three-tab top chrome + sidebar removal") had every Plan item shipped by PR #460, but the spec's Test section pins two checks that weren't yet covered:

- **Component test — top chrome renders all regions at desktop and mobile widths.** jsdom doesn't apply media queries, so both the desktop chrome and the mobile tabs row render in the DOM at once. The test pins down each region by `aria-label` and asserts the desktop row exposes the logo, workspace switcher, three tabs, ⌘K trigger, and avatar; the mobile tabs row exposes the three tabs as workspace-scoped links.
- **E2E-equivalent — tab switching preserves workspace scope.** Clicks each of the three tabs in turn and asserts location stays under `/workspaces/<slug>/<tab>`, never bare `/<tab>`.

The new `tests/smoke/top-chrome.test.tsx` carries both. Mutation-checked locally (mutate one line of `TopTabs`' path → all three tests fail).

Also tidies a stale `AppSidebar` reference in `useOptionalActiveWorkspace`'s doc comment — the sidebar was deleted in PR #460; the comment now names the top chrome as the caller.

## Delivers

Spec #463 Test section:
- [x] Component test: top chrome renders all regions at desktop and mobile widths
- [x] E2E: signed-in user with a workspace lands on `/workspaces/:slug/workflows` (already covered by `workspace-routing.test.tsx`)
- [x] E2E: signed-in user with no workspace lands on `/workspaces` (already covered by `workspace-routing.test.tsx`)
- [x] E2E: tab switching preserves workspace scope across the three tabs

All Plan items were delivered by PR #460 (`AppLayout.tsx`, route table in `App.tsx`, `RunsPage.tsx`, `ActivityPage.tsx`, `BarePathRedirect`).

## Test plan

- [x] `pnpm test tests/smoke/top-chrome.test.tsx` — 3 passed
- [x] `pnpm test` — 170/170 passed
- [x] `pnpm lint`
- [x] `pnpm tsc --noEmit`
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`
- [x] `cargo run -p xtask -- check-file-budget`
- [x] `cargo run -p xtask -- lint-seams`
- [x] `cargo run -p xtask -- check-api-contract`

Closes #463.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEnoofcGs8qtn27rG31vhy)_