### PR TITLE
feat(dashboard): lazy-load + last-N for workflow timeline (#466)

### DIFF
--- a/apps/dashboard/src/components/workflows/WorkflowArtifactsTab.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowArtifactsTab.tsx
@@ -3,15 +3,27 @@ import { useQuery } from "@tanstack/react-query"
 import { Package } from "lucide-react"
 import { api } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArtifactBadge } from "./ArtifactBadge"
+import { useLazyReveal } from "@/hooks/useLazyReveal"
 import { useActiveWorkspace } from "@/lib/workspace"
 
 // Workflow-scoped artifact list from the dedicated backend route (#302).
 // Replaces the per-run artifact fan-out we used to do client-side; one
 // request, server-side filter, and we can poll without scaling the
 // request count with the number of runs.
-export function WorkflowArtifactsTab({ workflowId }: { workflowId: string }) {
+//
+// `limit` truncates the inline render to "last N" with an in-place
+// `[show all]` control plus IntersectionObserver-based lazy reveal on
+// scroll (#466). Omit for the legacy "render everything" behaviour.
+export function WorkflowArtifactsTab({
+  workflowId,
+  limit,
+}: {
+  workflowId: string
+  limit?: number
+}) {
   const workspace = useActiveWorkspace()
   const { data, isLoading } = useQuery({
     queryKey: ["workflow-artifacts", workflowId],
@@ -21,10 +33,19 @@ export function WorkflowArtifactsTab({ workflowId }: { workflowId: string }) {
   })
 
   const artifacts = data?.artifacts ?? []
+  const initial = limit ?? artifacts.length
+  const { visibleCount, sentinelRef, hasMore, revealAll } = useLazyReveal({
+    initial,
+    step: limit ?? 20,
+    total: artifacts.length,
+  })
+  const visibleArtifacts = limit ? artifacts.slice(0, visibleCount) : artifacts
 
   if (!isLoading && artifacts.length === 0) {
     return <EmptyState />
   }
+
+  const remaining = artifacts.length - visibleCount
 
   return (
     <Card>
@@ -37,27 +58,40 @@ export function WorkflowArtifactsTab({ workflowId }: { workflowId: string }) {
             Loading…
           </p>
         ) : (
-          artifacts.map((artifact) => (
-            <Link
-              key={artifact.id}
-              to={`/workspaces/${workspace.slug}/artifacts/${artifact.id}`}
-              className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
-            >
-              <ArtifactBadge kind={artifact.kind} />
-              <span className="min-w-0 flex-1 truncate text-sm">
-                {artifact.name ?? artifact.id}
-              </span>
-              <Badge
-                variant={artifact.state === "released" ? "default" : "outline"}
-                className="shrink-0"
+          <>
+            {visibleArtifacts.map((artifact) => (
+              <Link
+                key={artifact.id}
+                to={`/workspaces/${workspace.slug}/artifacts/${artifact.id}`}
+                className="flex items-center gap-2 rounded-md border px-3 py-2 hover:bg-muted/50"
               >
-                {artifact.state}
-              </Badge>
-              <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
-                v{artifact.current_version}
-              </span>
-            </Link>
-          ))
+                <ArtifactBadge kind={artifact.kind} />
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {artifact.name ?? artifact.id}
+                </span>
+                <Badge
+                  variant={artifact.state === "released" ? "default" : "outline"}
+                  className="shrink-0"
+                >
+                  {artifact.state}
+                </Badge>
+                <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                  v{artifact.current_version}
+                </span>
+              </Link>
+            ))}
+            {limit && hasMore && (
+              <div ref={sentinelRef} className="flex justify-center pt-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={revealAll}
+                >
+                  Show all ({remaining} more)
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </CardContent>
     </Card>

--- a/apps/dashboard/src/components/workflows/WorkflowArtifactsTab.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowArtifactsTab.tsx
@@ -81,15 +81,23 @@ export function WorkflowArtifactsTab({
               </Link>
             ))}
             {limit && hasMore && (
-              <div ref={sentinelRef} className="flex justify-center pt-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={revealAll}
-                >
-                  Show all ({remaining} more)
-                </Button>
-              </div>
+              <>
+                {/* 1px sentinel sits above the explicit button so the
+                    observer fires on scroll-end without consuming the
+                    button's hit area — otherwise the auto-reveal would
+                    fire as soon as the button entered the viewport and
+                    the user could never click it. */}
+                <div ref={sentinelRef} aria-hidden="true" className="h-px" />
+                <div className="flex justify-center pt-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={revealAll}
+                  >
+                    Show all ({remaining} more)
+                  </Button>
+                </div>
+              </>
             )}
           </>
         )}

--- a/apps/dashboard/src/hooks/useLazyReveal.ts
+++ b/apps/dashboard/src/hooks/useLazyReveal.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+// Progressive in-page reveal for long anchored sections on
+// `WorkflowDetailPage` (#466). Holds a `visibleCount` that starts at
+// `initial`, grows by `step` whenever the returned sentinel ref enters
+// the viewport, and snaps to `total` when `revealAll` is called.
+//
+// Returning the sentinel ref instead of accepting one lets the caller
+// drop it next to a "Show all" button without threading observer wiring
+// through props.
+export function useLazyReveal({
+  initial,
+  step,
+  total,
+}: {
+  initial: number
+  step: number
+  total: number
+}) {
+  const [rawVisibleCount, setVisibleCount] = useState(initial)
+  // Clamp at render time so consumers passing a shrinking `total`
+  // (e.g. filter change) never see `visibleCount > total`.
+  const visibleCount = useMemo(
+    () => Math.min(Math.max(rawVisibleCount, initial), total || initial),
+    [rawVisibleCount, initial, total],
+  )
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) return
+    if (visibleCount >= total) return
+    if (typeof IntersectionObserver === "undefined") return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisibleCount((c) => Math.min(c + step, total))
+          }
+        }
+      },
+      { rootMargin: "200px 0px" },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [visibleCount, step, total])
+
+  const revealAll = useCallback(() => {
+    setVisibleCount(total)
+  }, [total])
+
+  return {
+    visibleCount,
+    sentinelRef,
+    hasMore: visibleCount < total,
+    revealAll,
+  }
+}

--- a/apps/dashboard/src/hooks/useLazyReveal.ts
+++ b/apps/dashboard/src/hooks/useLazyReveal.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 // Progressive in-page reveal for long anchored sections on
 // `WorkflowDetailPage` (#466). Holds a `visibleCount` that starts at
@@ -18,12 +18,11 @@ export function useLazyReveal({
   total: number
 }) {
   const [rawVisibleCount, setVisibleCount] = useState(initial)
-  // Clamp at render time so consumers passing a shrinking `total`
-  // (e.g. filter change) never see `visibleCount > total`.
-  const visibleCount = useMemo(
-    () => Math.min(Math.max(rawVisibleCount, initial), total || initial),
-    [rawVisibleCount, initial, total],
-  )
+  // Clamp at render time so the invariant `visibleCount <= total`
+  // holds even when consumers pass a shrinking `total` (e.g. filter
+  // change). When `total = 0` this correctly yields `visibleCount = 0`
+  // — empty list, no Show-all button.
+  const visibleCount = Math.min(rawVisibleCount, total)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from "react"
+import { useLazyReveal } from "@/hooks/useLazyReveal"
 import { Link, useParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import {
@@ -74,7 +75,10 @@ type SectionId = (typeof SECTION_IDS)[number]
 
 // Per-section last_n truncation. Verdicts are denser; show fewer
 // inline and link out to the cross-workflow list for the rest (#455).
+// Artifacts and Runs lazy-load additional rows on scroll (#466) — these
+// constants seed the initial render and the per-step chunk size.
 const LAST_N_RUNS = 10
+const LAST_N_ARTIFACTS = 20
 const LAST_N_VERDICTS = 5
 
 export function WorkflowDetailPage() {
@@ -98,8 +102,23 @@ export function WorkflowDetailPage() {
     const all = runsData?.runs ?? []
     return isOss ? filterRunsToLastSevenDays(all) : all
   }, [runsData, isOss])
-  const visibleRuns = useMemo(() => runs.slice(0, LAST_N_RUNS), [runs])
-  const runsOverflow = runs.length > LAST_N_RUNS
+  // Lazy reveal for the Runs section (#466). `visibleCount` starts at
+  // `LAST_N_RUNS`, grows by the same step as the sentinel enters the
+  // viewport, and snaps to `runs.length` via the section header's
+  // "Show all" button. Cross-workflow runs page link stays separate.
+  const {
+    visibleCount: visibleRunCount,
+    sentinelRef: runsSentinelRef,
+    hasMore: runsHasMore,
+  } = useLazyReveal({
+    initial: LAST_N_RUNS,
+    step: LAST_N_RUNS,
+    total: runs.length,
+  })
+  const visibleRuns = useMemo(
+    () => runs.slice(0, visibleRunCount),
+    [runs, visibleRunCount],
+  )
 
   // Spec #120 item 3 — webhook delivery health for this workflow's
   // installation.
@@ -156,6 +175,7 @@ export function WorkflowDetailPage() {
   }
 
   const runsListHref = `/workspaces/${workspace.slug}/runs?workflow_id=${encodeURIComponent(workflow.id)}`
+  const totalRunCount = runs.length
 
   return (
     <div ref={scrollRoot} className="space-y-6 md:space-y-8">
@@ -203,7 +223,7 @@ export function WorkflowDetailPage() {
       <section id="runs" className="scroll-mt-20 space-y-4">
         <SectionHeader
           title="Runs"
-          actionHref={runsOverflow ? runsListHref : undefined}
+          actionHref={totalRunCount > LAST_N_RUNS ? runsListHref : undefined}
           actionLabel="Show all"
         />
         <ActiveRunsBanner
@@ -216,6 +236,7 @@ export function WorkflowDetailPage() {
           stageIds={workflow.stages.map((s) => s.id)}
           workspaceSlug={workspace.slug}
           isOss={isOss}
+          sentinelRef={runsHasMore ? runsSentinelRef : undefined}
         />
         <WorkflowEventsCard workflowId={workflow.id} runs={visibleRuns} />
         <WorkflowSessionsCard runs={visibleRuns} />
@@ -223,7 +244,10 @@ export function WorkflowDetailPage() {
 
       <section id="artifacts" className="scroll-mt-20 space-y-4">
         <SectionHeader title="Artifacts" />
-        <WorkflowArtifactsTab workflowId={workflow.id} />
+        <WorkflowArtifactsTab
+          workflowId={workflow.id}
+          limit={LAST_N_ARTIFACTS}
+        />
       </section>
 
       <section id="verdicts" className="scroll-mt-20 space-y-4">
@@ -345,11 +369,17 @@ function RunsList({
   stageIds,
   workspaceSlug,
   isOss,
+  sentinelRef,
 }: {
   runs: WorkflowRun[]
   stageIds: string[]
   workspaceSlug: string
   isOss: boolean
+  // When provided, rendered as a 1px sentinel below the run rows so
+  // `useLazyReveal`'s IntersectionObserver can extend the visible
+  // window as the user scrolls (#466). `undefined` when all runs are
+  // already on screen.
+  sentinelRef?: React.RefObject<HTMLDivElement | null>
 }) {
   return (
     <Card>
@@ -375,6 +405,9 @@ function RunsList({
               workspaceSlug={workspaceSlug}
             />
           ))
+        )}
+        {sentinelRef && (
+          <div ref={sentinelRef} aria-hidden="true" className="h-px" />
         )}
       </CardContent>
     </Card>

--- a/apps/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -103,9 +103,10 @@ export function WorkflowDetailPage() {
     return isOss ? filterRunsToLastSevenDays(all) : all
   }, [runsData, isOss])
   // Lazy reveal for the Runs section (#466). `visibleCount` starts at
-  // `LAST_N_RUNS`, grows by the same step as the sentinel enters the
-  // viewport, and snaps to `runs.length` via the section header's
-  // "Show all" button. Cross-workflow runs page link stays separate.
+  // `LAST_N_RUNS` and grows by the same step as the sentinel below the
+  // run rows enters the viewport. The section header's "Show all" link
+  // is a separate affordance — it deep-links to the cross-workflow runs
+  // page, not an in-page expansion.
   const {
     visibleCount: visibleRunCount,
     sentinelRef: runsSentinelRef,

--- a/apps/dashboard/tests/setup.ts
+++ b/apps/dashboard/tests/setup.ts
@@ -32,3 +32,26 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = function scrollIntoView() {};
 }
+
+// jsdom does not ship IntersectionObserver. The anchored-timeline lazy-load
+// (#466) uses it as a scroll-end sentinel. Stub it so component tests can
+// mount; tests that exercise the lazy-load path call the captured callback
+// manually via the global mock.
+if (typeof globalThis.IntersectionObserver === "undefined") {
+  class IntersectionObserverStub {
+    constructor(cb: IntersectionObserverCallback) {
+      void cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds: ReadonlyArray<number> = [];
+  }
+  // @ts-expect-error assigning to globalThis
+  globalThis.IntersectionObserver = IntersectionObserverStub;
+}

--- a/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
@@ -164,6 +164,7 @@ describe("WorkflowDetailPage lazy reveal (#466)", () => {
     cb: IntersectionObserverCallback
     targets: Element[]
   }> = []
+  let originalIO: typeof IntersectionObserver | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -189,6 +190,7 @@ describe("WorkflowDetailPage lazy reveal (#466)", () => {
       readonly rootMargin = ""
       readonly thresholds: ReadonlyArray<number> = []
     }
+    originalIO = globalThis.IntersectionObserver
     // @ts-expect-error replacing the stub installed by setup.ts
     globalThis.IntersectionObserver = CaptureObserver
 
@@ -207,6 +209,9 @@ describe("WorkflowDetailPage lazy reveal (#466)", () => {
 
   afterEach(() => {
     window.location.hash = ""
+    if (originalIO) {
+      globalThis.IntersectionObserver = originalIO
+    }
   })
 
   function makeRuns(n: number) {

--- a/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-detail-tabs.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter, Routes, Route } from "react-router-dom"
 
@@ -152,5 +152,162 @@ describe("WorkflowDetailPage anchored timeline (#455)", () => {
     expect(screen.queryByRole("tab", { name: "Runs" })).toBeNull()
     expect(screen.queryByRole("tab", { name: "Artifacts" })).toBeNull()
     expect(screen.queryByRole("tab", { name: "Verdicts" })).toBeNull()
+  })
+})
+
+// Lazy reveal + truncation contract (#466). The anchored sections
+// truncate to "last N" with a `[show all]` control. Runs and
+// Artifacts also lazy-load additional rows on scroll, modelled here
+// by capturing the IntersectionObserver callback and firing it.
+describe("WorkflowDetailPage lazy reveal (#466)", () => {
+  const observers: Array<{
+    cb: IntersectionObserverCallback
+    targets: Element[]
+  }> = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    observers.length = 0
+    window.history.replaceState(null, "", "/workspaces/acme/workflows/wf_1")
+
+    class CaptureObserver {
+      cb: IntersectionObserverCallback
+      targets: Element[] = []
+      constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb
+        observers.push(this)
+      }
+      observe(el: Element) {
+        this.targets.push(el)
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return []
+      }
+      readonly root = null
+      readonly rootMargin = ""
+      readonly thresholds: ReadonlyArray<number> = []
+    }
+    // @ts-expect-error replacing the stub installed by setup.ts
+    globalThis.IntersectionObserver = CaptureObserver
+
+    apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+    apiMock.getWorkflow.mockResolvedValue(workflow)
+    apiMock.getWorkspaceWebhookDeliveriesHealth.mockResolvedValue({
+      installations: [],
+    })
+    apiMock.getSpineEvents.mockResolvedValue({ events: [] })
+    apiMock.listWorkflows.mockResolvedValue({
+      workflows: [],
+      counts: { drafted: 0, bound: 0, active: 0, paused: 0, all: 0 },
+    })
+    apiMock.getWorkflowVerdicts.mockResolvedValue({ verdicts: [] })
+  })
+
+  afterEach(() => {
+    window.location.hash = ""
+  })
+
+  function makeRuns(n: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `run_${i}`,
+      workflow_id: "wf_1",
+      artifact_id: `art_${i}`,
+      status: "passed" as const,
+      stages: [{ stage_id: "s_1", status: "passed" as const }],
+      started_at: new Date(2026, 4, 22, 12, 0, i).toISOString(),
+      updated_at: new Date(2026, 4, 22, 12, 0, i).toISOString(),
+    }))
+  }
+
+  function makeArtifacts(n: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `art_${i}`,
+      kind: "Issue",
+      name: `Artifact ${i}`,
+      state: "drafted",
+      owner: null,
+      current_version: 0,
+      consumers: {},
+      external_ref: null,
+      created_at: "2026-04-22T00:00:00Z",
+      updated_at: "2026-04-22T00:00:00Z",
+      last_observed_at: null,
+    }))
+  }
+
+  it("Runs section truncates to last 10 and reveals more when the sentinel intersects", async () => {
+    apiMock.getWorkflowRuns.mockResolvedValue({ runs: makeRuns(25) })
+    apiMock.getWorkflowArtifacts.mockResolvedValue({ artifacts: [] })
+
+    renderPage("/workspaces/acme/workflows/wf_1")
+
+    await waitFor(() => {
+      expect(screen.getByText("art_0")).toBeInTheDocument()
+    })
+
+    // First 10 visible, 11th not yet rendered.
+    expect(screen.getByText("art_9")).toBeInTheDocument()
+    expect(screen.queryByText("art_10")).toBeNull()
+
+    // Header "Show all" link goes to the cross-workflow runs page.
+    expect(
+      screen.getByRole("link", { name: "Show all" }),
+    ).toHaveAttribute(
+      "href",
+      "/workspaces/acme/runs?workflow_id=wf_1",
+    )
+
+    // Fire the sentinel observer → next chunk of 10 reveals.
+    const obs = observers[0]
+    expect(obs).toBeDefined()
+    act(() => {
+      obs.cb(
+        obs.targets.map(
+          (t) =>
+            ({ isIntersecting: true, target: t }) as unknown as IntersectionObserverEntry,
+        ),
+        obs as unknown as IntersectionObserver,
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("art_19")).toBeInTheDocument()
+    })
+    expect(screen.queryByText("art_20")).toBeNull()
+  })
+
+  it("Artifacts section truncates to last 20 and expands on [Show all]", async () => {
+    apiMock.getWorkflowRuns.mockResolvedValue({ runs: [] })
+    apiMock.getWorkflowArtifacts.mockResolvedValue({
+      artifacts: makeArtifacts(25),
+    })
+
+    renderPage("/workspaces/acme/workflows/wf_1")
+
+    await waitFor(() => {
+      expect(screen.getByText("Artifact 0")).toBeInTheDocument()
+    })
+
+    // First 20 rendered, 21st not yet.
+    expect(screen.getByText("Artifact 19")).toBeInTheDocument()
+    expect(screen.queryByText("Artifact 20")).toBeNull()
+
+    const artifactsSection = document.getElementById("artifacts")!
+    const showAll = within(artifactsSection).getByRole("button", {
+      name: /Show all/,
+    })
+    expect(showAll).toHaveTextContent("Show all (5 more)")
+
+    fireEvent.click(showAll)
+
+    await waitFor(() => {
+      expect(screen.getByText("Artifact 24")).toBeInTheDocument()
+    })
+    // Once everything is visible the trigger is gone.
+    expect(
+      within(artifactsSection).queryByRole("button", { name: /Show all/ }),
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Adds the lazy-reveal piece of the anchored-timeline collapse from ADR 0019. The page was already a single scroll surface with four anchored sections (#455); this PR adds the long-section mitigation called out under "Negative trade-offs":

- **Artifacts** section now truncates to 20 with an inline `Show all (N more)` button that expands in place. There is no separate artifacts list page to deep-link to, so the toggle lives at the bottom of the section.
- **Runs** section now grows in chunks of 10 as a 1px sentinel below the run rows enters the viewport. The header `Show all` deep-link to the cross-workflow runs page is unchanged.
- New shared `useLazyReveal` hook owns the `visibleCount` state and the `IntersectionObserver` wiring so the page-level Runs section and the `WorkflowArtifactsTab` component share one shape.
- Test setup ships an `IntersectionObserver` stub for jsdom; the lazy-reveal tests swap in a capturing implementation and drive the sentinel callback deterministically.

## Delivers

- [x] Plan item: Add "last N" truncation + `[show all]` to Runs and Artifacts sections (artifacts side — runs already truncated under #455)
- [x] Plan item: Add lazy-load on scroll for Runs and Artifacts
- [x] Plan item: Verify bookmarks resolving to `#runs`, `#artifacts`, `#verdicts` land on the right section (covered by the existing hash-anchor effect + the four-section render test)
- [x] Test: each anchored section renders standalone
- [x] Test: truncated → expanded state for Runs (intersection-driven) and Artifacts ("Show all" button)

Closes #466. Part of #450 (ADR 0019).

## Test plan

- [x] `pnpm --filter dashboard exec tsc -b --noEmit` clean
- [x] `pnpm --filter dashboard lint` clean
- [x] `pnpm --filter dashboard test` — 169/169 green (4 in `workflow-detail-tabs.test.tsx`)
- [x] `pnpm --filter dashboard build` clean
- [x] `cargo run -p xtask -- check-file-budget` clean
- [x] `cargo run -p xtask -- lint-seams` clean
- [x] `cargo run -p xtask -- check-api-contract` clean

https://claude.ai/code/session_01RZ1SjBt4NZoYsxaiBRjKPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ1SjBt4NZoYsxaiBRjKPq)_