### PR TITLE
feat(portal,dashboard): Runs tab status + time-range filters (#464)

### DIFF
--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -12,6 +12,7 @@ import type {
   RunLinkedSession,
 } from './types';
 import type { WorkflowRun } from './generated/WorkflowRun';
+import type { StageRunStatus } from './generated/StageRunStatus';
 // Generated wire shapes (spec #434 cascaded ts-rs into `onsager-spine` so
 // `TriggerKind` and `Workflow` are emitted from Rust). The dashboard
 // keeps a richer nested UI-side `Workflow` (with `status`, flattened
@@ -227,15 +228,26 @@ export const workflows = {
     return { workflows: lists.flat() };
   },
   // Workspace-scoped cross-workflow runs list (#454 / ADR 0019). Backs
-  // the dashboard's Runs tab; optional `workflowId` narrows to a single
-  // workflow's history (mirrors the chip filter on RunsPage).
+  // the dashboard's Runs tab. Optional filters mirror the portal's
+  // `WorkspaceRunsQuery` (#464): `workflowId` narrows to a single
+  // workflow, `status` filters at the SQL layer, `since` / `until` are
+  // ISO-8601 bounds on `updated_at`.
   listWorkspaceRuns: (
     workspaceId: string,
-    opts?: { workflowId?: string; limit?: number },
+    opts?: {
+      workflowId?: string;
+      status?: StageRunStatus;
+      since?: string;
+      until?: string;
+      limit?: number;
+    },
   ): Promise<{ runs: WorkflowRun[] }> => {
     if (!workspaceId) throw new ApiError('workspaceId is required', 400);
     const params = new URLSearchParams();
     if (opts?.workflowId) params.set('workflow_id', opts.workflowId);
+    if (opts?.status) params.set('status', opts.status);
+    if (opts?.since) params.set('since', opts.since);
+    if (opts?.until) params.set('until', opts.until);
     if (opts?.limit) params.set('limit', String(opts.limit));
     const raw = params.toString();
     // `qs` is the lint-recognized variable name for query suffixes

--- a/apps/dashboard/src/pages/RunsPage.tsx
+++ b/apps/dashboard/src/pages/RunsPage.tsx
@@ -12,8 +12,10 @@ import { cn } from "@/lib/utils"
 
 // Cross-workflow runs list (#454 / ADR 0019). Each row links to the
 // existing flat `/workspaces/:slug/runs/:runId` detail route.
-// Filterable by status + workflow id; both are URL-persisted so deep
-// links and refreshes preserve the filter.
+// Filterable by status, workflow id, and time range; all three are
+// URL-persisted so deep links and refreshes preserve the filter.
+// Status + time range are sent to the portal as query params (#464)
+// rather than post-filtered client-side.
 
 const STATUS_FILTERS = [
   { key: "all", label: "All" },
@@ -24,6 +26,18 @@ const STATUS_FILTERS = [
 ] as const
 
 type StatusFilter = (typeof STATUS_FILTERS)[number]["key"]
+
+const RANGE_FILTERS = [
+  { key: "24h", label: "Last 24h", hours: 24 },
+  { key: "7d", label: "Last 7d", hours: 24 * 7 },
+  { key: "30d", label: "Last 30d", hours: 24 * 30 },
+  { key: "all", label: "All", hours: null },
+] as const
+
+type RangeFilter = (typeof RANGE_FILTERS)[number]["key"]
+
+// Proposed default (alignment item on #464): runs from the last 7 days.
+const DEFAULT_RANGE: RangeFilter = "7d"
 
 const STATUS_VARIANT: Record<
   StageRunStatus,
@@ -42,6 +56,19 @@ function readStatusFilter(raw: string | null): StatusFilter {
     : "all"
 }
 
+function readRangeFilter(raw: string | null): RangeFilter {
+  if (raw === null) return DEFAULT_RANGE
+  return (RANGE_FILTERS.map((f) => f.key) as readonly string[]).includes(raw)
+    ? (raw as RangeFilter)
+    : DEFAULT_RANGE
+}
+
+function rangeSinceISO(range: RangeFilter, now: Date): string | undefined {
+  const meta = RANGE_FILTERS.find((r) => r.key === range)
+  if (!meta || meta.hours === null) return undefined
+  return new Date(now.getTime() - meta.hours * 60 * 60 * 1000).toISOString()
+}
+
 export function RunsPage() {
   usePageHeader({ title: "Runs" })
   const workspace = useActiveWorkspace()
@@ -49,16 +76,28 @@ export function RunsPage() {
 
   const statusFilter = readStatusFilter(params.get("status"))
   const workflowFilter = params.get("workflow_id") ?? ""
+  const rangeFilter = readRangeFilter(params.get("range"))
+
+  // Pin `since` for the lifetime of this render so React Query's key
+  // doesn't churn every tick. Refreshing the page reseeds the window.
+  const since = useMemo(
+    () => rangeSinceISO(rangeFilter, new Date()),
+    [rangeFilter],
+  )
 
   const { data: runsData, isLoading } = useQuery({
     queryKey: [
       "workspace-runs",
       workspace.id,
       workflowFilter || "*",
+      statusFilter,
+      rangeFilter,
     ],
     queryFn: () =>
       api.listWorkspaceRuns(workspace.id, {
         workflowId: workflowFilter || undefined,
+        status: statusFilter === "all" ? undefined : statusFilter,
+        since,
         limit: 100,
       }),
   })
@@ -76,16 +115,18 @@ export function RunsPage() {
     )
   }, [workflowFilter, workflowsData])
 
-  const runs = useMemo(() => {
-    const all = runsData?.runs ?? []
-    if (statusFilter === "all") return all
-    return all.filter((r) => r.status === statusFilter)
-  }, [runsData, statusFilter])
+  const runs: WorkflowRun[] = runsData?.runs ?? []
 
   const setStatusFilter = (next: StatusFilter) => {
     const updated = new URLSearchParams(params)
     if (next === "all") updated.delete("status")
     else updated.set("status", next)
+    setParams(updated, { replace: true })
+  }
+  const setRangeFilter = (next: RangeFilter) => {
+    const updated = new URLSearchParams(params)
+    if (next === DEFAULT_RANGE) updated.delete("range")
+    else updated.set("range", next)
     setParams(updated, { replace: true })
   }
   const clearWorkflow = () => {
@@ -107,34 +148,63 @@ export function RunsPage() {
         </div>
       </div>
 
-      <div className="-mx-1 flex flex-wrap items-center gap-2 px-1">
-        {STATUS_FILTERS.map((f) => {
-          const active = statusFilter === f.key
-          return (
+      <div className="space-y-2">
+        <div
+          className="-mx-1 flex flex-wrap items-center gap-2 px-1"
+          role="group"
+          aria-label="Status filter"
+        >
+          {STATUS_FILTERS.map((f) => {
+            const active = statusFilter === f.key
+            return (
+              <Button
+                key={f.key}
+                type="button"
+                size="sm"
+                variant={active ? "default" : "outline"}
+                className="h-7 rounded-full px-3 text-xs font-medium"
+                aria-pressed={active}
+                onClick={() => setStatusFilter(f.key)}
+              >
+                {f.label}
+              </Button>
+            )
+          })}
+          {workflowFilter && (
             <Button
-              key={f.key}
               type="button"
               size="sm"
-              variant={active ? "default" : "outline"}
+              variant="secondary"
               className="h-7 rounded-full px-3 text-xs font-medium"
-              onClick={() => setStatusFilter(f.key)}
+              onClick={clearWorkflow}
+              aria-label="Clear workflow filter"
             >
-              {f.label}
+              Workflow: {workflowName ?? workflowFilter.slice(0, 8)} ×
             </Button>
-          )
-        })}
-        {workflowFilter && (
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="h-7 rounded-full px-3 text-xs font-medium"
-            onClick={clearWorkflow}
-            aria-label="Clear workflow filter"
-          >
-            Workflow: {workflowName ?? workflowFilter.slice(0, 8)} ×
-          </Button>
-        )}
+          )}
+        </div>
+        <div
+          className="-mx-1 flex flex-wrap items-center gap-2 px-1"
+          role="group"
+          aria-label="Time range filter"
+        >
+          {RANGE_FILTERS.map((f) => {
+            const active = rangeFilter === f.key
+            return (
+              <Button
+                key={f.key}
+                type="button"
+                size="sm"
+                variant={active ? "default" : "outline"}
+                className="h-7 rounded-full px-3 text-xs font-medium"
+                aria-pressed={active}
+                onClick={() => setRangeFilter(f.key)}
+              >
+                {f.label}
+              </Button>
+            )
+          })}
+        </div>
       </div>
 
       {isLoading ? (
@@ -148,7 +218,9 @@ export function RunsPage() {
             <div>
               <p className="text-base font-medium">No runs match</p>
               <p className="text-sm text-muted-foreground">
-                {statusFilter === "all" && !workflowFilter
+                {statusFilter === "all" &&
+                !workflowFilter &&
+                rangeFilter === "all"
                   ? "No artifacts have flowed through a workflow in this workspace yet."
                   : "Try a different filter, or clear it to see all runs."}
               </p>

--- a/apps/dashboard/tests/smoke/runs-page-filters.test.tsx
+++ b/apps/dashboard/tests/smoke/runs-page-filters.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom"
+
+import { RunsPage } from "@/pages/RunsPage"
+import { WorkspaceScope } from "@/lib/workspace"
+
+// Runs-tab filter chips (#464 / ADR 0019). Pins:
+// - the status + range chip rows render and round-trip through the URL,
+// - the default time range is the last 7 days,
+// - chip selections push status/since query params to the API client,
+// - the workflow_id chip is read from the URL and clearable.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  listWorkspaceRuns: vi.fn(),
+  listWorkflows: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return { ...actual, api: apiMock }
+})
+
+const workspace = {
+  id: "ws_1",
+  slug: "acme",
+  name: "Acme",
+  created_by: "u1",
+  created_at: "2026-01-01",
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  return (
+    <div data-testid="probe-search">{loc.search}</div>
+  )
+}
+
+function renderPage(initialPath: string) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <>
+                  <LocationProbe />
+                  <Routes>
+                    <Route index element={<RunsPage />} />
+                    <Route path="runs" element={<RunsPage />} />
+                  </Routes>
+                </>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+  apiMock.listWorkflows.mockResolvedValue({ workflows: [] })
+  apiMock.listWorkspaceRuns.mockResolvedValue({ runs: [] })
+})
+
+describe("RunsPage filters (#464)", () => {
+  it("defaults to 7-day range and sends `since` to the API", async () => {
+    renderPage("/workspaces/acme/runs")
+    await waitFor(() =>
+      expect(apiMock.listWorkspaceRuns).toHaveBeenCalled(),
+    )
+    const lastCall = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+    expect(lastCall[0]).toBe("ws_1")
+    expect(lastCall[1].status).toBeUndefined()
+    expect(typeof lastCall[1].since).toBe("string")
+    const since = new Date(lastCall[1].since)
+    // 7 days ± a 30s skew for test wall-clock drift.
+    const ageMs = Date.now() - since.getTime()
+    expect(ageMs).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 30_000)
+    expect(ageMs).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 30_000)
+    // Range chip row defaults to "Last 7d" pressed.
+    const sevenDay = await screen.findByRole("button", { name: /Last 7d/ })
+    expect(sevenDay.getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("clicking a status chip re-queries with status + updates URL", async () => {
+    const user = userEvent.setup()
+    renderPage("/workspaces/acme/runs")
+    await waitFor(() =>
+      expect(apiMock.listWorkspaceRuns).toHaveBeenCalled(),
+    )
+    const failedChip = await screen.findByRole("button", { name: "Failed" })
+    await user.click(failedChip)
+    await waitFor(() => {
+      const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+      expect(last[1].status).toBe("failed")
+    })
+    expect(screen.getByTestId("probe-search").textContent).toContain(
+      "status=failed",
+    )
+  })
+
+  it("clicking a range chip re-queries with the new `since` + updates URL", async () => {
+    const user = userEvent.setup()
+    renderPage("/workspaces/acme/runs")
+    await waitFor(() =>
+      expect(apiMock.listWorkspaceRuns).toHaveBeenCalled(),
+    )
+    const dayChip = await screen.findByRole("button", { name: /Last 24h/ })
+    await user.click(dayChip)
+    await waitFor(() => {
+      const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+      const since = new Date(last[1].since)
+      const ageMs = Date.now() - since.getTime()
+      expect(ageMs).toBeGreaterThan(24 * 60 * 60 * 1000 - 30_000)
+      expect(ageMs).toBeLessThan(24 * 60 * 60 * 1000 + 30_000)
+    })
+    expect(screen.getByTestId("probe-search").textContent).toContain(
+      "range=24h",
+    )
+  })
+
+  it("range=all clears `since` and sends no time bound", async () => {
+    const user = userEvent.setup()
+    renderPage("/workspaces/acme/runs")
+    await waitFor(() =>
+      expect(apiMock.listWorkspaceRuns).toHaveBeenCalled(),
+    )
+    const allChips = await screen.findAllByRole("button", { name: "All" })
+    // The status chip row also has an "All" — pick the one in the range row.
+    const rangeAll = allChips.find((b) =>
+      b.closest('[aria-label="Time range filter"]'),
+    )
+    expect(rangeAll).toBeTruthy()
+    await user.click(rangeAll!)
+    await waitFor(() => {
+      const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+      expect(last[1].since).toBeUndefined()
+    })
+    expect(screen.getByTestId("probe-search").textContent).toContain(
+      "range=all",
+    )
+  })
+
+  it("reads initial chip values from the URL", async () => {
+    renderPage("/workspaces/acme/runs?status=passed&range=30d")
+    await waitFor(() =>
+      expect(apiMock.listWorkspaceRuns).toHaveBeenCalled(),
+    )
+    const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+    expect(last[1].status).toBe("passed")
+    const since = new Date(last[1].since)
+    const ageMs = Date.now() - since.getTime()
+    expect(ageMs).toBeGreaterThan(30 * 24 * 60 * 60 * 1000 - 30_000)
+    expect(ageMs).toBeLessThan(30 * 24 * 60 * 60 * 1000 + 30_000)
+    const passed = await screen.findByRole("button", { name: "Passed" })
+    expect(passed.getAttribute("aria-pressed")).toBe("true")
+    const thirtyDay = await screen.findByRole("button", { name: /Last 30d/ })
+    expect(thirtyDay.getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("forwards workflow_id from the URL and shows a clearable chip", async () => {
+    apiMock.listWorkflows.mockResolvedValue({
+      workflows: [
+        {
+          id: "wf_abc",
+          workspace_id: "ws_1",
+          name: "My workflow",
+          stages: [],
+          active: false,
+          status: "drafted",
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage("/workspaces/acme/runs?workflow_id=wf_abc")
+    await waitFor(() => {
+      const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+      expect(last[1].workflowId).toBe("wf_abc")
+    })
+    const chip = await screen.findByRole("button", {
+      name: /Clear workflow filter/i,
+    })
+    await user.click(chip)
+    await waitFor(() => {
+      const last = apiMock.listWorkspaceRuns.mock.calls.at(-1)!
+      expect(last[1].workflowId).toBeUndefined()
+    })
+  })
+})

--- a/crates/onsager-portal/src/handlers/runs.rs
+++ b/crates/onsager-portal/src/handlers/runs.rs
@@ -242,29 +242,106 @@ pub async fn get_run(
     .into_response()
 }
 
+/// Status filter for `GET /api/workspaces/:id/runs`. Mirrors
+/// `StageRunStatus` — the projection above is total, so each variant
+/// has a complementary SQL predicate against `state` +
+/// `workflow_parked_reason`.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunStatusFilter {
+    Pending,
+    Blocked,
+    Passed,
+    Failed,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct WorkspaceRunsQuery {
     #[serde(default)]
     pub workflow_id: Option<String>,
     #[serde(default)]
+    pub status: Option<RunStatusFilter>,
+    /// Inclusive lower bound on `updated_at` (ISO-8601). Filters at the
+    /// SQL layer alongside `until`; ordering still uses `updated_at`.
+    #[serde(default)]
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
+    /// Inclusive upper bound on `updated_at` (ISO-8601).
+    #[serde(default)]
+    pub until: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
     pub limit: Option<i64>,
 }
 
 #[derive(Debug, sqlx::FromRow)]
-struct WorkspaceRunRow {
-    artifact_id: String,
-    workflow_id: String,
-    state: String,
-    current_stage_index: Option<i32>,
-    workflow_parked_reason: Option<String>,
-    created_at: chrono::DateTime<chrono::Utc>,
-    updated_at: chrono::DateTime<chrono::Utc>,
+pub struct WorkspaceRunRow {
+    pub artifact_id: String,
+    pub workflow_id: String,
+    pub state: String,
+    pub current_stage_index: Option<i32>,
+    pub workflow_parked_reason: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// SQL half of `list_workspace_runs`. Pulled out so integration tests
+/// can exercise the `status` / `since` / `until` filter combinations
+/// without spinning up the Axum app — the projection layer above is
+/// already covered by the per-stage status table elsewhere.
+pub async fn fetch_workspace_run_rows(
+    spine: &sqlx::PgPool,
+    workspace_id: &str,
+    q: &WorkspaceRunsQuery,
+) -> Result<Vec<WorkspaceRunRow>, sqlx::Error> {
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT artifact_id, workflow_id, state, current_stage_index, \
+                workflow_parked_reason, created_at, updated_at \
+         FROM artifacts WHERE workflow_id IS NOT NULL AND workspace_id = ",
+    );
+    qb.push_bind(workspace_id);
+    if let Some(wf_id) = q.workflow_id.as_deref() {
+        qb.push(" AND workflow_id = ").push_bind(wf_id);
+    }
+    match q.status {
+        Some(RunStatusFilter::Passed) => {
+            qb.push(" AND state = 'released'");
+        }
+        Some(RunStatusFilter::Failed) => {
+            qb.push(" AND state = 'archived'");
+        }
+        Some(RunStatusFilter::Blocked) => {
+            qb.push(
+                " AND state NOT IN ('released', 'archived') \
+                  AND workflow_parked_reason IS NOT NULL",
+            );
+        }
+        Some(RunStatusFilter::Pending) => {
+            qb.push(
+                " AND state NOT IN ('released', 'archived') \
+                  AND workflow_parked_reason IS NULL",
+            );
+        }
+        None => {}
+    }
+    if let Some(since) = q.since {
+        qb.push(" AND updated_at >= ").push_bind(since);
+    }
+    if let Some(until) = q.until {
+        qb.push(" AND updated_at <= ").push_bind(until);
+    }
+    qb.push(" ORDER BY updated_at DESC LIMIT ").push_bind(limit);
+    qb.build_query_as::<WorkspaceRunRow>()
+        .fetch_all(spine)
+        .await
 }
 
 /// GET /api/workspaces/:id/runs — workspace-scoped cross-workflow runs
 /// list. Each row is one artifact flowing through a workflow, projected
-/// the same way as `GET /api/workflows/:id/runs`. Optionally filterable
-/// by `workflow_id` to scope to a single workflow's history.
+/// the same way as `GET /api/workflows/:id/runs`. Optional query params:
+/// `workflow_id` (scope to a single workflow), `status`
+/// (pending | blocked | passed | failed — filtered at the SQL layer
+/// rather than post-projection), `since` / `until` (ISO-8601 bounds on
+/// `updated_at`).
 pub async fn list_workspace_runs(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -275,38 +352,8 @@ pub async fn list_workspace_runs(
         return r;
     }
     let spine = state.spine.pool();
-    let limit = q.limit.unwrap_or(50).clamp(1, 500);
 
-    let rows = if let Some(wf_id) = q.workflow_id.as_deref() {
-        sqlx::query_as::<_, WorkspaceRunRow>(
-            "SELECT artifact_id, workflow_id, state, current_stage_index, \
-                    workflow_parked_reason, created_at, updated_at \
-             FROM artifacts \
-             WHERE workspace_id = $1 AND workflow_id = $2 \
-             ORDER BY updated_at DESC \
-             LIMIT $3",
-        )
-        .bind(&workspace_id)
-        .bind(wf_id)
-        .bind(limit)
-        .fetch_all(spine)
-        .await
-    } else {
-        sqlx::query_as::<_, WorkspaceRunRow>(
-            "SELECT artifact_id, workflow_id, state, current_stage_index, \
-                    workflow_parked_reason, created_at, updated_at \
-             FROM artifacts \
-             WHERE workspace_id = $1 AND workflow_id IS NOT NULL \
-             ORDER BY updated_at DESC \
-             LIMIT $2",
-        )
-        .bind(&workspace_id)
-        .bind(limit)
-        .fetch_all(spine)
-        .await
-    };
-
-    let rows = match rows {
+    let rows = match fetch_workspace_run_rows(spine, &workspace_id, &q).await {
         Ok(r) => r,
         Err(e) => {
             tracing::error!("failed to list workspace runs: {e}");

--- a/crates/onsager-portal/tests/workspace_runs_filter.rs
+++ b/crates/onsager-portal/tests/workspace_runs_filter.rs
@@ -1,0 +1,290 @@
+//! Integration test for spec #464 — `GET /api/workspaces/:id/runs`
+//! status + time-range filters at the SQL layer.
+//!
+//! The handler's HTTP plumbing is the same shape the run-detail and
+//! workflow-runs routes already cover; what's new and worth pinning is
+//! the SQL the four optional query params (`status`, `since`, `until`,
+//! plus the existing `workflow_id`) compose into. The test calls
+//! `fetch_workspace_run_rows` directly so the assertions are on row
+//! identity, not on serialization order.
+//!
+//! Skipped when `DATABASE_URL` is unset — the artifact ↔ workflow rows
+//! live on the spine, which only the Postgres-backed harness exercises.
+
+use chrono::{Duration, Utc};
+use onsager_portal::handlers::runs::{
+    RunStatusFilter, WorkspaceRunsQuery, fetch_workspace_run_rows,
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+/// Insert one workflow-bound artifact with the given state /
+/// parked-reason / `updated_at`. Returns the artifact id.
+async fn seed_run(
+    spine: &PgPool,
+    workspace_id: &str,
+    workflow_id: &str,
+    state: &str,
+    parked_reason: Option<&str>,
+    updated_at: chrono::DateTime<Utc>,
+) -> String {
+    let artifact_id = format!("art_{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO artifacts \
+            (artifact_id, kind, name, owner, created_by, state, workspace_id, \
+             workflow_id, current_stage_index, workflow_parked_reason, \
+             created_at, updated_at) \
+         VALUES ($1, 'code', 'runs-filter-test', 'tester', 'tester', \
+                 $2, $3, $4, 0, $5, $6, $6)",
+    )
+    .bind(&artifact_id)
+    .bind(state)
+    .bind(workspace_id)
+    .bind(workflow_id)
+    .bind(parked_reason)
+    .bind(updated_at)
+    .execute(spine)
+    .await
+    .unwrap();
+    artifact_id
+}
+
+async fn cleanup(spine: &PgPool, workspace_id: &str) {
+    let _ = sqlx::query("DELETE FROM artifacts WHERE workspace_id = $1")
+        .bind(workspace_id)
+        .execute(spine)
+        .await;
+}
+
+/// Common fixture: 4 runs covering every status × 3 timestamps (now,
+/// -2d, -10d). Returns `(workspace_id, ids_by_status)`.
+async fn seed_status_fixture(
+    spine: &PgPool,
+) -> (String, std::collections::HashMap<&'static str, String>) {
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let workflow_id = format!("wf_{}", Uuid::new_v4());
+    let now = Utc::now();
+    let mut ids = std::collections::HashMap::new();
+    ids.insert(
+        "passed",
+        seed_run(spine, &workspace_id, &workflow_id, "released", None, now).await,
+    );
+    ids.insert(
+        "failed",
+        seed_run(
+            spine,
+            &workspace_id,
+            &workflow_id,
+            "archived",
+            None,
+            now - Duration::days(2),
+        )
+        .await,
+    );
+    ids.insert(
+        "blocked",
+        seed_run(
+            spine,
+            &workspace_id,
+            &workflow_id,
+            "under_review",
+            Some("agent_session: stuck"),
+            now - Duration::days(2),
+        )
+        .await,
+    );
+    ids.insert(
+        "pending",
+        seed_run(
+            spine,
+            &workspace_id,
+            &workflow_id,
+            "under_review",
+            None,
+            now - Duration::days(10),
+        )
+        .await,
+    );
+    (workspace_id, ids)
+}
+
+fn empty_query() -> WorkspaceRunsQuery {
+    WorkspaceRunsQuery {
+        workflow_id: None,
+        status: None,
+        since: None,
+        until: None,
+        limit: None,
+    }
+}
+
+#[tokio::test]
+async fn status_filter_returns_only_matching_state() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let (workspace_id, ids) = seed_status_fixture(&spine).await;
+
+    for (status_str, filter) in [
+        ("passed", RunStatusFilter::Passed),
+        ("failed", RunStatusFilter::Failed),
+        ("blocked", RunStatusFilter::Blocked),
+        ("pending", RunStatusFilter::Pending),
+    ] {
+        let q = WorkspaceRunsQuery {
+            status: Some(filter),
+            ..empty_query()
+        };
+        let rows = fetch_workspace_run_rows(&spine, &workspace_id, &q)
+            .await
+            .expect("fetch rows");
+        assert_eq!(
+            rows.len(),
+            1,
+            "status={status_str} should return exactly one row"
+        );
+        assert_eq!(
+            rows[0].artifact_id, ids[status_str],
+            "status={status_str} returned the wrong row"
+        );
+    }
+
+    cleanup(&spine, &workspace_id).await;
+}
+
+#[tokio::test]
+async fn unfiltered_returns_all_workflow_bound_runs() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let (workspace_id, ids) = seed_status_fixture(&spine).await;
+
+    let rows = fetch_workspace_run_rows(&spine, &workspace_id, &empty_query())
+        .await
+        .expect("fetch rows");
+    assert_eq!(rows.len(), 4, "no filter should return all 4 seeded rows");
+    let returned: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.artifact_id.clone()).collect();
+    for id in ids.values() {
+        assert!(returned.contains(id), "expected {id} in result set");
+    }
+
+    cleanup(&spine, &workspace_id).await;
+}
+
+#[tokio::test]
+async fn since_filter_clips_old_rows() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let (workspace_id, ids) = seed_status_fixture(&spine).await;
+
+    // since = now - 5 days → excludes the -10d "pending" row.
+    let q = WorkspaceRunsQuery {
+        since: Some(Utc::now() - Duration::days(5)),
+        ..empty_query()
+    };
+    let rows = fetch_workspace_run_rows(&spine, &workspace_id, &q)
+        .await
+        .expect("fetch rows");
+    let returned: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.artifact_id.clone()).collect();
+    assert_eq!(rows.len(), 3, "since=-5d should exclude the -10d row");
+    assert!(!returned.contains(&ids["pending"]));
+    assert!(returned.contains(&ids["passed"]));
+    assert!(returned.contains(&ids["failed"]));
+    assert!(returned.contains(&ids["blocked"]));
+
+    cleanup(&spine, &workspace_id).await;
+}
+
+#[tokio::test]
+async fn until_filter_clips_new_rows() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let (workspace_id, ids) = seed_status_fixture(&spine).await;
+
+    // until = now - 1 day → excludes the "passed" row at "now".
+    let q = WorkspaceRunsQuery {
+        until: Some(Utc::now() - Duration::days(1)),
+        ..empty_query()
+    };
+    let rows = fetch_workspace_run_rows(&spine, &workspace_id, &q)
+        .await
+        .expect("fetch rows");
+    let returned: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.artifact_id.clone()).collect();
+    assert!(!returned.contains(&ids["passed"]));
+    assert!(returned.contains(&ids["failed"]));
+    assert!(returned.contains(&ids["blocked"]));
+    assert!(returned.contains(&ids["pending"]));
+
+    cleanup(&spine, &workspace_id).await;
+}
+
+#[tokio::test]
+async fn combined_workflow_id_status_and_time_range() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let wf_a = format!("wf_{}", Uuid::new_v4());
+    let wf_b = format!("wf_{}", Uuid::new_v4());
+    let now = Utc::now();
+
+    // wf_a — one passed in window, one passed too old.
+    let in_window = seed_run(&spine, &workspace_id, &wf_a, "released", None, now).await;
+    let _old = seed_run(
+        &spine,
+        &workspace_id,
+        &wf_a,
+        "released",
+        None,
+        now - Duration::days(10),
+    )
+    .await;
+    // wf_a — passed in window but wrong workflow (should still appear when
+    // we filter by wf_a; included to keep the noise representative).
+    let _failed_in_window = seed_run(
+        &spine,
+        &workspace_id,
+        &wf_a,
+        "archived",
+        None,
+        now - Duration::hours(2),
+    )
+    .await;
+    // wf_b — passed in window; excluded because workflow_id filter is wf_a.
+    let _other_workflow = seed_run(&spine, &workspace_id, &wf_b, "released", None, now).await;
+
+    let q = WorkspaceRunsQuery {
+        workflow_id: Some(wf_a.clone()),
+        status: Some(RunStatusFilter::Passed),
+        since: Some(now - Duration::days(5)),
+        until: Some(now + Duration::hours(1)),
+        limit: None,
+    };
+    let rows = fetch_workspace_run_rows(&spine, &workspace_id, &q)
+        .await
+        .expect("fetch rows");
+    assert_eq!(
+        rows.len(),
+        1,
+        "combined filter should narrow to one row, got {rows:?}",
+    );
+    assert_eq!(rows[0].artifact_id, in_window);
+    assert_eq!(rows[0].workflow_id, wf_a);
+
+    cleanup(&spine, &workspace_id).await;
+}


### PR DESCRIPTION
## Summary

- Portal `GET /api/workspaces/:id/runs` learns `status` (pending | blocked | passed | failed) and `since` / `until` (ISO-8601) query params; existing `workflow_id` + `limit` preserved. Status is filtered at the SQL layer rather than after stage projection — the projection rules in `project_run_stages` are total over `state` + `workflow_parked_reason`, so each variant has a complementary SQL predicate. `since` / `until` are inclusive bounds on `updated_at` (the existing sort key).
- Dashboard RunsPage gains a time-range chip row (Last 24h / 7d / 30d / All) alongside the existing status + workflow chips; selections persist to the URL as `?range=` and round-trip on refresh. Default range is the last 7 days per the alignment note on the spec. Status filtering moves from client-side post-filter to a backend query param so the row count matches the chip count exactly.
- `fetch_workspace_run_rows` is the new pub helper that holds the SQL-builder logic so integration tests can exercise the four-param filter matrix without spinning up the Axum app.

## Test plan

- [x] Portal `cargo build --workspace`, `cargo clippy --workspace --all-targets`, `cargo test --workspace --lib` (all green under `RUSTFLAGS="-D warnings"`).
- [x] `xtask lint-seams`, `xtask check-api-contract`, `xtask check-events`, `xtask check-file-budget` clean.
- [x] Dashboard `pnpm tsc -p tsconfig.app.json --noEmit` + `pnpm vitest run` (185 tests pass; 6 new in `runs-page-filters.test.tsx`).
- [x] New `crates/onsager-portal/tests/workspace_runs_filter.rs` compiles; covers each status variant, `since` / `until` boundaries, and combined `workflow_id` + `status` + time range. Will run against Postgres in CI (skips locally without `DATABASE_URL`).
- [ ] E2E (workflow detail → Runs tab with workflow preselected) — Plan item is open; deferring to a follow-up since this PR ships the chip + URL contract that the E2E would exercise.

Closes #464

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZyUVDThCweWQGUXN44mXM)_