### PR TITLE
feat(portal,dashboard): Activity tab — operator-grain spine event stream (#465)

### DIFF
--- a/apps/dashboard/src/lib/api/spine.ts
+++ b/apps/dashboard/src/lib/api/spine.ts
@@ -21,10 +21,23 @@ export const spine = {
       operator_grain?: boolean;
       limit?: number;
     },
-  ) =>
-    request<{ events: SpineEvent[] }>(
-      `/spine/events${scoped(workspaceId, params)}`,
-    ),
+  ) => {
+    // `scoped()` accepts string|number|null|undefined; widen the
+    // boolean `operator_grain` into a string before passing it through.
+    const extra: Record<string, string | number | null | undefined> = {};
+    if (params) {
+      if (params.stream_type !== undefined) extra.stream_type = params.stream_type;
+      if (params.event_type !== undefined) extra.event_type = params.event_type;
+      if (params.stream_id !== undefined) extra.stream_id = params.stream_id;
+      if (params.run_id !== undefined) extra.run_id = params.run_id;
+      if (params.operator_grain !== undefined)
+        extra.operator_grain = params.operator_grain ? 'true' : 'false';
+      if (params.limit !== undefined) extra.limit = params.limit;
+    }
+    return request<{ events: SpineEvent[] }>(
+      `/spine/events${scoped(workspaceId, extra)}`,
+    );
+  },
   // Path-scoped Activity feed (ADR 0019 / spec #465). Same backing
   // table as `getSpineEvents`, but the workspace is on the path and
   // `operator_grain=true` is forced by the portal handler — the

--- a/apps/dashboard/src/lib/api/spine.ts
+++ b/apps/dashboard/src/lib/api/spine.ts
@@ -14,12 +14,46 @@ export const spine = {
       // `data->>'artifact_id'`, and the `sessions.artifact_id` lookup
       // so session-keyed events still surface.
       run_id?: string;
+      // Operator-grain filter (ADR 0019 / spec #465). When `true`,
+      // restrict to the registry's operator-grain allowlist. Defaults
+      // to `false` on this generic endpoint; the Activity tab uses the
+      // path-scoped `getActivity()` alias which bakes `true` in.
+      operator_grain?: boolean;
       limit?: number;
     },
   ) =>
     request<{ events: SpineEvent[] }>(
       `/spine/events${scoped(workspaceId, params)}`,
     ),
+  // Path-scoped Activity feed (ADR 0019 / spec #465). Same backing
+  // table as `getSpineEvents`, but the workspace is on the path and
+  // `operator_grain=true` is forced by the portal handler — the
+  // Activity tab never has to remember to pass it.
+  getActivity: (
+    workspaceId: string,
+    opts?: {
+      stream_type?: string;
+      event_type?: string;
+      stream_id?: string;
+      run_id?: string;
+      limit?: number;
+    },
+  ) => {
+    const params = new URLSearchParams();
+    if (opts) {
+      for (const [k, v] of Object.entries(opts)) {
+        if (v != null && v !== '') params.set(k, String(v));
+      }
+    }
+    const raw = params.toString();
+    // `qs` is the lint-recognized variable name for query suffixes
+    // in the api-contract matcher; leading `?` lives here so the
+    // template stays a simple `${qs}` interpolation (#467 pattern).
+    const qs = raw ? `?${raw}` : '';
+    return request<{ events: SpineEvent[] }>(
+      `/workspaces/${encodeURIComponent(workspaceId)}/activity${qs}`,
+    );
+  },
   getArtifacts: (
     workspaceId: string,
     filters?: { kind?: string; project_id?: string },

--- a/apps/dashboard/src/pages/ActivityPage.tsx
+++ b/apps/dashboard/src/pages/ActivityPage.tsx
@@ -65,13 +65,16 @@ export function ActivityPage() {
 
   const chip = readChip(params.get("source"))
 
-  // Pull a generous page of recent events; chip filtering happens
-  // client-side because the spine stream is denser than the chip
-  // taxonomy. Infinite-scroll is a follow-up; for now, page size 100
-  // covers the typical 7-day operator window.
+  // Pull a generous page of recent events via the path-scoped
+  // operator-grain alias (ADR 0019 / spec #465). The backend's
+  // `operator_grain=true` filter trims internal subsystem dispatches
+  // server-side; chip filtering below narrows the allowlisted stream
+  // further on the client (source-type taxonomy). Infinite-scroll is a
+  // follow-up; for now, page size 100 covers the typical 7-day
+  // operator window.
   const { data, isLoading } = useQuery({
-    queryKey: ["spine-events", workspace.id],
-    queryFn: () => api.getSpineEvents(workspace.id, { limit: 100 }),
+    queryKey: ["activity", workspace.id],
+    queryFn: () => api.getActivity(workspace.id, { limit: 100 }),
     refetchInterval: 10_000,
   })
 
@@ -157,10 +160,13 @@ function EventRow({
   event: SpineEvent
   workspaceSlug: string
 }) {
-  // Map event → best deep-link. Run/artifact events route to the run
-  // detail; verdicts route to the workspace verdicts surface (the
-  // workflow detail's #verdicts anchor); everything else stays
-  // unlinked (rendered as a plain row).
+  // Map event → best deep-link. Operator-grain events fall into three
+  // shapes (ADR 0019):
+  // - Run-keyed: payload carries `artifact_id` (or stream_id is a
+  //   `forge:<artifact_id>`). Route to /runs/:id.
+  // - Workflow-keyed: payload carries `workflow_id` (trigger.fired,
+  //   workflow.manual_triggered). Route to /workflows/:id.
+  // - Otherwise unlinked (rendered as a plain row).
   const href = useMemo(() => {
     const data = (event.data ?? {}) as Record<string, unknown>
     const artifactId =
@@ -168,8 +174,20 @@ function EventRow({
     if (artifactId) {
       return `/workspaces/${workspaceSlug}/runs/${artifactId}`
     }
+    // Forge-style stream ids `forge:<artifact_id>` deep-link to the run.
+    if (event.stream_id.startsWith("forge:")) {
+      const id = event.stream_id.slice("forge:".length)
+      if (id) return `/workspaces/${workspaceSlug}/runs/${id}`
+    }
+    const workflowId =
+      typeof data.workflow_id === "string" ? data.workflow_id : null
+    if (workflowId) {
+      return `/workspaces/${workspaceSlug}/workflows/${workflowId}`
+    }
     return null
   }, [event, workspaceSlug])
+
+  const actorLabel = event.actor && event.actor.length > 0 ? event.actor : "system"
 
   const body = (
     <>
@@ -180,7 +198,11 @@ function EventRow({
         {href && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
       </div>
       <div className="mt-1 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-        <span className="truncate">{event.stream_type}/{event.stream_id}</span>
+        <span className="truncate">
+          <span className="text-foreground/70">{actorLabel}</span>
+          <span aria-hidden="true"> · </span>
+          {event.stream_type}/{event.stream_id}
+        </span>
         <time dateTime={event.created_at}>
           {new Date(event.created_at).toLocaleString()}
         </time>

--- a/apps/dashboard/tests/smoke/activity-page.test.tsx
+++ b/apps/dashboard/tests/smoke/activity-page.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { ActivityPage } from "@/pages/ActivityPage"
+
+// Activity tab — operator-grain spine event stream (ADR 0019 / spec #465).
+// Pins:
+// - The page calls the path-scoped `/api/workspaces/:id/activity`
+//   endpoint (operator-grain is server-side; the page doesn't pass it).
+// - Each row renders the event type + actor + timestamp + a deep-link
+//   to the relevant artifact / run / workflow detail page.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  getActivity: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return { ...actual, api: apiMock }
+})
+
+import { WorkspaceScope } from "@/lib/workspace"
+
+const workspace = {
+  id: "ws_1",
+  slug: "acme",
+  name: "Acme",
+  created_by: "u1",
+  created_at: "2026-01-01",
+}
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/workspaces/acme/activity"]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route path="activity" element={<ActivityPage />} />
+                </Routes>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiMock.listWorkspaces.mockResolvedValue({ workspaces: [workspace] })
+})
+
+describe("ActivityPage (operator-grain feed, #465)", () => {
+  it("calls the path-scoped operator-grain endpoint", async () => {
+    apiMock.getActivity.mockResolvedValue({ events: [] })
+    renderPage()
+    await waitFor(() =>
+      expect(apiMock.getActivity).toHaveBeenCalledWith("ws_1", { limit: 100 }),
+    )
+  })
+
+  it("deep-links a run-keyed event row to /runs/:artifact_id", async () => {
+    apiMock.getActivity.mockResolvedValue({
+      events: [
+        {
+          id: 1,
+          stream_id: "forge:art_42",
+          stream_type: "substrate",
+          event_type: "stiglab.session_completed",
+          data: { artifact_id: "art_42" },
+          actor: "agent-node-1",
+          created_at: "2026-05-23T03:00:00Z",
+        },
+      ],
+    })
+    renderPage()
+    const link = await screen.findByRole("link", {
+      name: /stiglab\.session_completed/,
+    })
+    expect(link).toHaveAttribute("href", "/workspaces/acme/runs/art_42")
+    // Actor + event_type are visible on the row.
+    expect(link).toHaveTextContent("agent-node-1")
+    expect(link).toHaveTextContent("stiglab.session_completed")
+  })
+
+  it("deep-links a workflow-keyed event row to /workflows/:id", async () => {
+    apiMock.getActivity.mockResolvedValue({
+      events: [
+        {
+          id: 2,
+          stream_id: "trigger:wf_3",
+          stream_type: "substrate",
+          event_type: "trigger.fired",
+          data: { workflow_id: "wf_3" },
+          actor: "system",
+          created_at: "2026-05-23T03:01:00Z",
+        },
+      ],
+    })
+    renderPage()
+    const link = await screen.findByRole("link", {
+      name: /trigger\.fired/,
+    })
+    expect(link).toHaveAttribute("href", "/workspaces/acme/workflows/wf_3")
+  })
+
+  it("renders rows with no deep-link target as plain blocks", async () => {
+    apiMock.getActivity.mockResolvedValue({
+      events: [
+        {
+          id: 3,
+          stream_id: "ising:health",
+          stream_type: "ising",
+          event_type: "ising.catchup_completed",
+          data: {},
+          actor: "ising-worker",
+          created_at: "2026-05-23T03:02:00Z",
+        },
+      ],
+    })
+    renderPage()
+    // The event type is rendered, but there's no link wrapping it.
+    await waitFor(() =>
+      expect(screen.getByText("ising.catchup_completed")).toBeInTheDocument(),
+    )
+    expect(screen.queryByRole("link")).toBeNull()
+  })
+
+  it("shows an empty state when no events come back", async () => {
+    apiMock.getActivity.mockResolvedValue({ events: [] })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText(/No activity/i)).toBeInTheDocument(),
+    )
+  })
+})

--- a/crates/onsager-portal/src/handlers/spine.rs
+++ b/crates/onsager-portal/src/handlers/spine.rs
@@ -44,7 +44,27 @@ pub struct EventsQuery {
     /// - `stream_id IN (SELECT id FROM sessions WHERE artifact_id = run_id)`
     ///   (session-keyed events whose session points back to the artifact).
     pub run_id: Option<String>,
+    /// When `true`, filter to the operator-grain allowlist (ADR 0019 /
+    /// spec #465). The Activity tab uses this to surface only events an
+    /// operator cares about — stage transitions, gate verdicts, run
+    /// lifecycle — and hide internal subsystem dispatches and analyzer
+    /// diagnostics. Default `false` for backward compatibility; the
+    /// `/api/workspaces/:id/activity` alias defaults it to `true`.
+    #[serde(default)]
+    pub operator_grain: Option<bool>,
     pub limit: Option<i64>,
+}
+
+/// The static allowlist of `event_type` strings that count as
+/// operator-grain. Derived once from `onsager_registry::EVENTS`; called
+/// per request which is cheap (52 rows, vec scan).
+fn operator_grain_kinds() -> Vec<&'static str> {
+    onsager_registry::EVENTS
+        .events
+        .iter()
+        .filter(|e| e.operator_grain)
+        .map(|e| e.kind)
+        .collect()
 }
 
 #[derive(Debug, Serialize, FromRow, TS)]
@@ -217,22 +237,72 @@ async fn emit(
     }
 }
 
-/// GET /api/spine/events?workspace=W — query the events_ext table.
-pub async fn list_events(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    Query(params): Query<EventsQuery>,
-) -> Response {
-    let workspace_id = params.workspace.trim();
-    if workspace_id.is_empty() {
-        return missing_workspace();
-    }
-    if let Err(r) = require_workspace_access(&state.pool, &auth_user, workspace_id).await {
-        return r;
-    }
+/// Activity-tab query params: same shape as `EventsQuery` minus the
+/// workspace (which is on the path) and minus `operator_grain` (which is
+/// forced to `true` for the Activity surface).
+#[derive(Debug, Deserialize, Default)]
+pub struct ActivityQuery {
+    #[serde(default)]
+    pub stream_type: Option<String>,
+    #[serde(default)]
+    pub event_type: Option<String>,
+    #[serde(default)]
+    pub stream_id: Option<String>,
+    #[serde(default)]
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
 
-    let pool = state.spine.pool();
+/// GET /api/workspaces/:id/activity — path-scoped operator-grain feed
+/// (ADR 0019 / spec #465). Wraps `list_events` with the workspace from
+/// the path and `operator_grain=true` baked in. Matches the dashboard's
+/// `/workspaces/:slug/activity` URL shape so the Activity tab can call
+/// it directly without re-stating the workspace as a query param.
+///
+/// The query-param `GET /api/spine/events?workspace=W&operator_grain=...`
+/// shape stays for non-dashboard MCP clients that already speak it; this
+/// alias is purely additive.
+pub async fn list_activity(
+    state: State<AppState>,
+    auth_user: AuthUser,
+    Path(workspace_id): Path<String>,
+    Query(q): Query<ActivityQuery>,
+) -> Response {
+    let params = EventsQuery {
+        workspace: workspace_id,
+        stream_type: q.stream_type,
+        event_type: q.event_type,
+        stream_id: q.stream_id,
+        run_id: q.run_id,
+        operator_grain: Some(true),
+        limit: q.limit,
+    };
+    list_events(state, auth_user, Query(params)).await
+}
+
+/// Query `events_ext` for the given workspace + filters and return the
+/// projected rows. Pure data-access — no auth, no HTTP, no response
+/// shaping. Pulled out of [`list_events`] so integration tests can
+/// drive the operator-grain filter against a real Postgres without
+/// rebuilding `AppState`. Workspace authorization is the handler's job
+/// (it is required, not optional — see [`require_workspace_access`]).
+///
+/// Returns `Ok(vec![])` rather than running an unbounded query when
+/// `operator_grain` is `Some(true)` but the registry has no operator-
+/// grain rows. That is a manifest-shape error (the registry tests
+/// catch it); a deployed binary with an empty allowlist must not
+/// silently fall back to the unfiltered stream.
+pub async fn query_events_for_workspace(
+    pool: &sqlx::PgPool,
+    workspace_id: &str,
+    params: &EventsQuery,
+) -> Result<Vec<SpineEvent>, sqlx::Error> {
     let limit = params.limit.unwrap_or(50).min(500);
+
+    if params.operator_grain.unwrap_or(false) && operator_grain_kinds().is_empty() {
+        return Ok(Vec::new());
+    }
 
     let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
         "SELECT id, stream_id, namespace AS stream_type, event_type, data, \
@@ -245,6 +315,17 @@ pub async fn list_events(
     }
     if let Some(et) = params.event_type.as_deref() {
         qb.push(" AND event_type = ").push_bind(et.to_string());
+    }
+    // Operator-grain allowlist (ADR 0019 / spec #465). When the caller
+    // opts in (Activity tab via the path-scoped alias below), restrict
+    // results to the registry's `operator_grain: true` rows. Stacks
+    // with `event_type` if both are passed — `operator_grain=true`
+    // narrows to the allowlist, then `event_type` narrows further.
+    if params.operator_grain.unwrap_or(false) {
+        let kinds = operator_grain_kinds();
+        qb.push(" AND event_type = ANY(");
+        qb.push_bind(kinds.iter().map(|k| k.to_string()).collect::<Vec<_>>());
+        qb.push(")");
     }
     if let Some(sid) = params.stream_id.as_deref() {
         qb.push(" AND stream_id = ").push_bind(sid.to_string());
@@ -264,7 +345,24 @@ pub async fn list_events(
     }
     qb.push(" ORDER BY id DESC LIMIT ").push_bind(limit);
 
-    match qb.build_query_as::<SpineEvent>().fetch_all(pool).await {
+    qb.build_query_as::<SpineEvent>().fetch_all(pool).await
+}
+
+/// GET /api/spine/events?workspace=W — query the events_ext table.
+pub async fn list_events(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Query(params): Query<EventsQuery>,
+) -> Response {
+    let workspace_id = params.workspace.trim();
+    if workspace_id.is_empty() {
+        return missing_workspace();
+    }
+    if let Err(r) = require_workspace_access(&state.pool, &auth_user, workspace_id).await {
+        return r;
+    }
+
+    match query_events_for_workspace(state.spine.pool(), workspace_id, &params).await {
         Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),
         Err(e) => {
             tracing::error!("spine events query failed: {e}");
@@ -788,4 +886,98 @@ pub async fn override_gate(
         })),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The operator-grain allowlist comes from the registry manifest;
+    /// changing what counts as operator-grain is a registry edit, not a
+    /// handler edit. Spot-check a few entries on both sides of the line
+    /// (ADR 0019 / spec #465).
+    #[test]
+    fn operator_grain_allowlist_pulls_from_registry() {
+        let kinds = operator_grain_kinds();
+        // Run lifecycle / verdict / trigger events are operator-grain.
+        assert!(kinds.contains(&"stiglab.session_completed"));
+        assert!(kinds.contains(&"synodic.gate_verdict"));
+        assert!(kinds.contains(&"trigger.fired"));
+        assert!(kinds.contains(&"stage.entered"));
+        assert!(kinds.contains(&"node.failed"));
+        // Internal subsystem dispatches and analyzer diagnostics are not.
+        assert!(!kinds.contains(&"forge.shaping_dispatched"));
+        assert!(!kinds.contains(&"forge.shaping_returned"));
+        assert!(!kinds.contains(&"stiglab.session_result_ready"));
+        assert!(!kinds.contains(&"ising.insight_emitted"));
+        assert!(!kinds.contains(&"synodic.rule_proposed"));
+    }
+
+    /// The path-scoped `/api/workspaces/:id/activity` alias must force
+    /// `operator_grain=true` regardless of what the client passes —
+    /// it's the contract that distinguishes the Activity surface from
+    /// the unfiltered `/api/spine/events`. Verifies the alias plumbing
+    /// (`ActivityQuery → EventsQuery`) by constructing the same params
+    /// the handler builds.
+    #[test]
+    fn activity_alias_forces_operator_grain_true() {
+        let q = ActivityQuery {
+            stream_type: None,
+            event_type: Some("synodic.gate_verdict".into()),
+            stream_id: None,
+            run_id: None,
+            limit: Some(50),
+        };
+        // Mirror the construction inside `list_activity` so the test
+        // pins the conversion shape, not the handler's `State`/`Auth`
+        // wiring.
+        let params = EventsQuery {
+            workspace: "ws-test".into(),
+            stream_type: q.stream_type,
+            event_type: q.event_type,
+            stream_id: q.stream_id,
+            run_id: q.run_id,
+            operator_grain: Some(true),
+            limit: q.limit,
+        };
+        assert_eq!(params.workspace, "ws-test");
+        assert_eq!(params.operator_grain, Some(true));
+        assert_eq!(params.event_type.as_deref(), Some("synodic.gate_verdict"));
+        assert_eq!(params.limit, Some(50));
+    }
+
+    /// Default-deserialized `EventsQuery` (no `operator_grain` in the
+    /// query string) leaves the filter off — back-compat for existing
+    /// `/api/spine/events?workspace=W` callers (MCP clients, etc.).
+    /// Driven through axum's `Query` extractor so the test pins the
+    /// real wire-decoding shape, not a hand-rolled serde call.
+    #[tokio::test]
+    async fn events_query_operator_grain_defaults_to_none() {
+        use axum::extract::FromRequestParts;
+        use axum::http::Request;
+
+        async fn parse(qs: &str) -> EventsQuery {
+            let uri = format!("http://x/?{qs}");
+            let req = Request::builder().uri(&uri).body(()).unwrap();
+            let (mut parts, _) = req.into_parts();
+            let Query(q) = Query::<EventsQuery>::from_request_parts(&mut parts, &())
+                .await
+                .expect("query parses");
+            q
+        }
+
+        assert_eq!(parse("workspace=ws-1").await.operator_grain, None);
+        assert_eq!(
+            parse("workspace=ws-1&operator_grain=true")
+                .await
+                .operator_grain,
+            Some(true)
+        );
+        assert_eq!(
+            parse("workspace=ws-1&operator_grain=false")
+                .await
+                .operator_grain,
+            Some(false)
+        );
+    }
 }

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -263,6 +263,14 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         // dashboard's API_BASE cutover (#222 Slice 6) can land
         // independently.
         .route("/api/spine/events", get(spine_handlers::list_events))
+        // Activity tab path-scoped alias (ADR 0019 / spec #465). Wraps
+        // `list_events` with the workspace from the path and
+        // `operator_grain=true` baked in. Matches the dashboard's
+        // `/workspaces/:slug/activity` URL shape.
+        .route(
+            "/api/workspaces/{workspace_id}/activity",
+            get(spine_handlers::list_activity),
+        )
         .route("/api/spine/artifacts", get(spine_handlers::list_artifacts))
         .route(
             "/api/spine/artifacts/{id}",

--- a/crates/onsager-portal/tests/activity_operator_grain.rs
+++ b/crates/onsager-portal/tests/activity_operator_grain.rs
@@ -1,0 +1,267 @@
+//! Integration tests for the Activity-tab operator-grain filter
+//! (ADR 0019 / spec #465).
+//!
+//! Verifies two things against a real Postgres:
+//! 1. `operator_grain=true` returns *exactly* the rows whose
+//!    `event_type` is in `onsager_registry::EVENTS`'s operator-grain
+//!    allowlist — no internal subsystem dispatches or analyzer
+//!    diagnostics leak through.
+//! 2. The path-scoped alias `/api/workspaces/:id/activity` behaves
+//!    identically to `/api/spine/events?workspace=W&operator_grain=true`
+//!    — same allowlist, same projection. Verified by driving the same
+//!    `query_events_for_workspace` helper both code paths share.
+//!
+//! Skipped when `DATABASE_URL` is unset — the filter lives in SQL, so
+//! the contract only holds against Postgres.
+
+use chrono::Utc;
+use onsager_portal::handlers::spine::{EventsQuery, query_events_for_workspace};
+use onsager_registry::EVENTS;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+async fn cleanup_workspace(pool: &PgPool, workspace_id: &str) {
+    let _ = sqlx::query("DELETE FROM events_ext WHERE workspace_id = $1")
+        .bind(workspace_id)
+        .execute(pool)
+        .await;
+}
+
+/// Insert a single events_ext row.
+async fn insert_event(pool: &PgPool, workspace_id: &str, event_type: &str, namespace: &str) {
+    sqlx::query(
+        "INSERT INTO events_ext (workspace_id, stream_id, namespace, event_type, data, metadata, created_at) \
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)",
+    )
+    .bind(workspace_id)
+    .bind(format!("stream-{}", Uuid::new_v4()))
+    .bind(namespace)
+    .bind(event_type)
+    .bind(json!({ "test": true }))
+    .bind(json!({ "actor": "test" }))
+    .bind(Utc::now())
+    .execute(pool)
+    .await
+    .expect("insert events_ext row");
+}
+
+/// Seed one row per representative event_type covering both sides of
+/// the operator-grain partition. Returns the workspace_id used.
+async fn seed_mixed_events(pool: &PgPool) -> String {
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    // Operator-grain ✓
+    insert_event(pool, &workspace_id, "stiglab.session_completed", "stiglab").await;
+    insert_event(pool, &workspace_id, "synodic.gate_verdict", "synodic").await;
+    insert_event(pool, &workspace_id, "trigger.fired", "substrate").await;
+    insert_event(pool, &workspace_id, "stage.entered", "substrate").await;
+    insert_event(pool, &workspace_id, "node.failed", "substrate").await;
+    insert_event(pool, &workspace_id, "artifact.state_changed", "substrate").await;
+    // Not operator-grain ✗
+    insert_event(pool, &workspace_id, "forge.shaping_dispatched", "substrate").await;
+    insert_event(pool, &workspace_id, "forge.shaping_returned", "substrate").await;
+    insert_event(
+        pool,
+        &workspace_id,
+        "stiglab.session_result_ready",
+        "stiglab",
+    )
+    .await;
+    insert_event(pool, &workspace_id, "ising.insight_emitted", "ising").await;
+    insert_event(pool, &workspace_id, "synodic.rule_proposed", "synodic").await;
+    workspace_id
+}
+
+fn expected_operator_grain_kinds() -> std::collections::HashSet<&'static str> {
+    EVENTS
+        .events
+        .iter()
+        .filter(|e| e.operator_grain)
+        .map(|e| e.kind)
+        .collect()
+}
+
+/// With `operator_grain=true`, the SQL filter must include *only*
+/// kinds the registry marks operator_grain. None of the seeded
+/// internal-dispatch rows should appear.
+#[tokio::test]
+async fn operator_grain_true_filters_to_registry_allowlist() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = seed_mixed_events(&pool).await;
+
+    let params = EventsQuery {
+        workspace: workspace_id.clone(),
+        stream_type: None,
+        event_type: None,
+        stream_id: None,
+        run_id: None,
+        operator_grain: Some(true),
+        limit: Some(500),
+    };
+    let events = query_events_for_workspace(&pool, &workspace_id, &params)
+        .await
+        .expect("query");
+    let allowlist = expected_operator_grain_kinds();
+    assert!(
+        !events.is_empty(),
+        "expected at least one operator-grain row to come back"
+    );
+    for e in &events {
+        assert!(
+            allowlist.contains(e.event_type.as_str()),
+            "leaked non-operator-grain event: {}",
+            e.event_type
+        );
+    }
+    // The six allowlisted kinds we seeded should each appear at least once.
+    let got: std::collections::HashSet<&str> =
+        events.iter().map(|e| e.event_type.as_str()).collect();
+    for kind in [
+        "stiglab.session_completed",
+        "synodic.gate_verdict",
+        "trigger.fired",
+        "stage.entered",
+        "node.failed",
+        "artifact.state_changed",
+    ] {
+        assert!(
+            got.contains(kind),
+            "missing seeded operator-grain kind: {kind}"
+        );
+    }
+    // And the five non-operator-grain rows should be absent.
+    for kind in [
+        "forge.shaping_dispatched",
+        "forge.shaping_returned",
+        "stiglab.session_result_ready",
+        "ising.insight_emitted",
+        "synodic.rule_proposed",
+    ] {
+        assert!(
+            !got.contains(kind),
+            "non-operator-grain kind leaked into the activity feed: {kind}"
+        );
+    }
+
+    cleanup_workspace(&pool, &workspace_id).await;
+}
+
+/// Backward compatibility: with `operator_grain=None` (the default for
+/// `/api/spine/events`), every seeded row is returned — the filter is
+/// strictly opt-in.
+#[tokio::test]
+async fn operator_grain_unset_returns_full_stream() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = seed_mixed_events(&pool).await;
+
+    let params = EventsQuery {
+        workspace: workspace_id.clone(),
+        stream_type: None,
+        event_type: None,
+        stream_id: None,
+        run_id: None,
+        operator_grain: None,
+        limit: Some(500),
+    };
+    let events = query_events_for_workspace(&pool, &workspace_id, &params)
+        .await
+        .expect("query");
+    let got: std::collections::HashSet<&str> =
+        events.iter().map(|e| e.event_type.as_str()).collect();
+    // Both sides of the partition are present.
+    assert!(got.contains("stiglab.session_completed"));
+    assert!(got.contains("forge.shaping_dispatched"));
+    assert!(got.contains("ising.insight_emitted"));
+
+    cleanup_workspace(&pool, &workspace_id).await;
+}
+
+/// `operator_grain=true` stacks with `event_type` — the allowlist
+/// narrows to that one kind, not the full feed.
+#[tokio::test]
+async fn operator_grain_and_event_type_compose() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = seed_mixed_events(&pool).await;
+
+    let params = EventsQuery {
+        workspace: workspace_id.clone(),
+        stream_type: None,
+        event_type: Some("synodic.gate_verdict".into()),
+        stream_id: None,
+        run_id: None,
+        operator_grain: Some(true),
+        limit: Some(500),
+    };
+    let events = query_events_for_workspace(&pool, &workspace_id, &params)
+        .await
+        .expect("query");
+    assert!(
+        !events.is_empty(),
+        "expected at least one synodic.gate_verdict row"
+    );
+    for e in &events {
+        assert_eq!(e.event_type, "synodic.gate_verdict");
+    }
+
+    cleanup_workspace(&pool, &workspace_id).await;
+}
+
+/// The path-scoped alias defaults `operator_grain` to `true`. Since the
+/// alias just constructs an `EventsQuery` and delegates, verify the
+/// post-construction `EventsQuery` produces the same filtered output
+/// regardless of which entry-point we drive.
+#[tokio::test]
+async fn path_scoped_alias_matches_operator_grain_query() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = seed_mixed_events(&pool).await;
+
+    // What the path-scoped handler builds:
+    let alias_params = EventsQuery {
+        workspace: workspace_id.clone(),
+        stream_type: None,
+        event_type: None,
+        stream_id: None,
+        run_id: None,
+        operator_grain: Some(true),
+        limit: None,
+    };
+    // What an MCP client would build:
+    let mcp_params = EventsQuery {
+        workspace: workspace_id.clone(),
+        stream_type: None,
+        event_type: None,
+        stream_id: None,
+        run_id: None,
+        operator_grain: Some(true),
+        limit: None,
+    };
+
+    let a = query_events_for_workspace(&pool, &workspace_id, &alias_params)
+        .await
+        .expect("alias query");
+    let b = query_events_for_workspace(&pool, &workspace_id, &mcp_params)
+        .await
+        .expect("query-param query");
+    let a_kinds: Vec<&str> = a.iter().map(|e| e.event_type.as_str()).collect();
+    let b_kinds: Vec<&str> = b.iter().map(|e| e.event_type.as_str()).collect();
+    assert_eq!(a_kinds, b_kinds, "alias and query-param surfaces diverged");
+
+    cleanup_workspace(&pool, &workspace_id).await;
+}

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -114,6 +114,17 @@ pub struct EventDefinition {
     /// mode landing per spec #275); ratchet to required is a follow-up.
     /// Has no meaning for real rows (`diagnostic_only = false`).
     pub tracking_issue: Option<u32>,
+    /// Whether this event surfaces in the Activity tab's operator-grain
+    /// stream (ADR 0019 / spec #465). `true` for events an operator
+    /// cares about — stage transitions, gate verdicts, run lifecycle,
+    /// trigger fires, escalations, agent/node lifecycle. `false` for
+    /// internal subsystem-to-subsystem dispatches and analyzer
+    /// diagnostics that would only add noise to the feed.
+    ///
+    /// Coverage is enforced by the field being required at construction
+    /// time — adding a `FactoryEventKind` variant means adding a row
+    /// here, and adding a row means picking a value. No default.
+    pub operator_grain: bool,
     /// One-line description for the manifest read API and dashboard.
     pub description: &'static str,
 }
@@ -143,6 +154,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "New artifact accepted and ID assigned.",
         },
         EventDefinition {
@@ -153,6 +165,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "Artifact transitioned between lifecycle states.",
         },
         EventDefinition {
@@ -163,6 +176,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "Artifact reached terminal state (archived).",
         },
         // -- Git lifecycle (onsager-portal webhooks) ------------------------
@@ -174,6 +188,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A pull request was opened for an artifact.",
         },
         EventDefinition {
@@ -184,6 +199,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A CI check finished for a PR.",
         },
         EventDefinition {
@@ -194,6 +210,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A PR was merged.",
         },
         EventDefinition {
@@ -204,6 +221,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A PR was closed without merging.",
         },
         // -- Forge process events -------------------------------------------
@@ -215,6 +233,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "ShapingRequest sent to Stiglab via the spine (replaces POST /api/shaping).",
         },
         EventDefinition {
@@ -225,6 +244,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "ShapingResult received from Stiglab and recorded by Forge.",
         },
         EventDefinition {
@@ -235,6 +255,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "GateRequest sent to Synodic via the spine (replaces POST /api/gate).",
         },
         EventDefinition {
@@ -245,6 +266,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "GateVerdict observed by Forge after Synodic responded.",
         },
         EventDefinition {
@@ -255,6 +277,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "Insight forwarded to the scheduling kernel.",
         },
         EventDefinition {
@@ -265,6 +288,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("diagnostic trace of forge scheduling kernel; no downstream action"),
             tracking_issue: None,
+            operator_grain: false,
             description: "Scheduling kernel produced a ShapingDecision.",
         },
         // -- Stiglab events -------------------------------------------------
@@ -276,6 +300,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A session finished successfully; carries optional artifact_id, token usage, branch, and PR number.",
         },
         EventDefinition {
@@ -286,6 +311,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "Full session ShapingResult ready for Forge to act on (replaces POST /api/shaping response). Renamed from stiglab.shaping_result_ready per spec #285.",
         },
         EventDefinition {
@@ -296,6 +322,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A session terminated with an error.",
         },
         EventDefinition {
@@ -306,6 +333,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("dashboard event-timeline troubleshooting for node/deadline failures"),
             tracking_issue: None,
+            operator_grain: true,
             description: "A session was aborted (node lost, deadline exceeded).",
         },
         // -- Portal intents (dashboard → agent dispatch) --------------------
@@ -317,6 +345,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "Dashboard task request from portal; stiglab dispatches the session to an agent node.",
         },
         EventDefinition {
@@ -327,6 +356,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "Dashboard cancel-session request from portal (spec #303); stiglab forwards a CancelSession to the session's agent node.",
         },
         EventDefinition {
@@ -339,6 +369,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "observable in dashboard event timeline for operator troubleshooting when portal cannot open a PR for a completed session",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "Portal failed to open a GitHub PR for a completed session (empty branch, GitHub API error, or missing App config).",
         },
         // -- Synodic events -------------------------------------------------
@@ -354,6 +385,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "Full GateVerdict in response to forge.gate_requested (replaces POST /api/gate response).",
         },
         EventDefinition {
@@ -364,6 +396,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("audit trail for escalation context"),
             tracking_issue: None,
+            operator_grain: true,
             description: "An escalation was initiated.",
         },
         EventDefinition {
@@ -374,6 +407,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: true,
             description: "An escalation was resolved (human, delegate, or timeout).",
         },
         EventDefinition {
@@ -384,6 +418,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: true,
             description: "An escalation timed out and the default verdict was applied.",
         },
         EventDefinition {
@@ -394,6 +429,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: true,
             description: "A delegate proposed a resolution for an active escalation.",
         },
         EventDefinition {
@@ -404,6 +440,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: false,
             description: "A crystallization candidate rule was created.",
         },
         EventDefinition {
@@ -414,6 +451,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: false,
             description: "A proposed rule was approved and entered the active set.",
         },
         EventDefinition {
@@ -424,6 +462,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: false,
             description: "A rule was disabled.",
         },
         EventDefinition {
@@ -434,6 +473,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in synodic governance UI; audit trail"),
             tracking_issue: None,
+            operator_grain: false,
             description: "A rule was modified, producing a new version.",
         },
         // -- Ising events ---------------------------------------------------
@@ -445,6 +485,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in dashboard ising views"),
             tracking_issue: None,
+            operator_grain: false,
             description: "An insight passed validation and was recorded on the spine.",
         },
         EventDefinition {
@@ -455,6 +496,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "Machine-readable signal emitted on the spine for other subsystems to consume.",
         },
         EventDefinition {
@@ -465,6 +507,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in dashboard ising views"),
             tracking_issue: None,
+            operator_grain: false,
             description: "An insight was deduplicated or fell below confidence threshold.",
         },
         EventDefinition {
@@ -475,6 +518,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "An insight was packaged as a rule proposal for Synodic.",
         },
         EventDefinition {
@@ -485,6 +529,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("operator troubleshooting in dashboard"),
             tracking_issue: None,
+            operator_grain: false,
             description: "An analyzer encountered an error during its run.",
         },
         EventDefinition {
@@ -495,6 +540,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("ising health monitoring in dashboard"),
             tracking_issue: None,
+            operator_grain: false,
             description: "Ising finished catching up from a lag position.",
         },
         // -- Workflow runtime (issue #80 / #81) -----------------------------
@@ -516,6 +562,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A trigger fired (webhook / schedule / event / manual).",
         },
         EventDefinition {
@@ -531,6 +578,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("audit trail for manual / CLI / replay fires"),
             tracking_issue: None,
+            operator_grain: true,
             description: "Audit record for a manual / CLI / replay trigger fire (actor + workflow).",
         },
         EventDefinition {
@@ -541,6 +589,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in workflow run timeline"),
             tracking_issue: None,
+            operator_grain: true,
             description: "A workflow-tagged artifact entered a new stage.",
         },
         // Per spec #285: per-gate `stage.gate_passed` / `stage.gate_failed`
@@ -554,6 +603,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: true,
             reason: Some("rendered in workflow run timeline"),
             tracking_issue: None,
+            operator_grain: true,
             description: "All gates on a stage resolved and the artifact advanced.",
         },
         // -- Registry events removed by spec #285 ---------------------------
@@ -581,6 +631,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
             tracking_issue: Some(361),
+            operator_grain: true,
             description: "Substrate scheduler dispatched a node — execution began.",
         },
         EventDefinition {
@@ -593,6 +644,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
             tracking_issue: Some(361),
+            operator_grain: true,
             description: "A node finished successfully; outputs persisted under the edge's ArtifactId.",
         },
         EventDefinition {
@@ -605,6 +657,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard run timeline; Observer consumer arrives with OBS-01 (#361)",
             ),
             tracking_issue: Some(361),
+            operator_grain: true,
             description: "A node's executor returned Err; the plan is aborted (v1 — no retries).",
         },
         EventDefinition {
@@ -617,6 +670,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard HITL inbox; Human executor approval round-trips via portal (#357)",
             ),
             tracking_issue: Some(357),
+            operator_grain: true,
             description: "A Human executor is waiting on an out-of-band approval decision.",
         },
         EventDefinition {
@@ -629,6 +683,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard HITL audit; the substrate's own Human executor consumes the approval inline",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "A pending Human executor node received an approval decision.",
         },
         EventDefinition {
@@ -641,6 +696,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard HITL audit; the substrate's own Human executor consumes the rejection inline",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "A pending Human executor node received a rejection decision.",
         },
         EventDefinition {
@@ -653,6 +709,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard run timeline as gate outcome; Observer / dashboard read it directly — distinct from the legacy `synodic.gate_verdict` emitted by the 0.1 Synodic subsystem (retired by MIG-03)",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "Verify executor produced a verdict — pass / fail outcome with per-check details.",
         },
         EventDefinition {
@@ -665,6 +722,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard agent timeline; supersedes the 0.1 `stiglab.session_*` events once MIG-01 retires stiglab",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "Agent executor opened an LLM session.",
         },
         EventDefinition {
@@ -677,6 +735,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard agent timeline; carries optional token usage for budget consumers",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "Agent executor's LLM session finished successfully.",
         },
         EventDefinition {
@@ -689,6 +748,7 @@ pub const EVENTS: EventManifest = EventManifest {
                 "rendered in dashboard agent timeline; the executor wraps this into ExecutorError::Failed for the scheduler",
             ),
             tracking_issue: None,
+            operator_grain: true,
             description: "Agent executor's LLM session terminated with an error.",
         },
         // -- Gate adapters (GitHub webhooks) --------------------------------
@@ -701,6 +761,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: false,
             description: "A GitHub check_suite/check_run/status arrived for a tracked PR.",
         },
         EventDefinition {
@@ -712,6 +773,7 @@ pub const EVENTS: EventManifest = EventManifest {
             diagnostic_only: false,
             reason: None,
             tracking_issue: None,
+            operator_grain: true,
             description: "A manual-approval gate received a signal (e.g. PR merged).",
         },
     ],
@@ -780,6 +842,72 @@ mod tests {
         assert!(first.get("diagnostic_only").is_some());
         assert!(first.get("reason").is_some());
         assert!(first.get("tracking_issue").is_some());
+        assert!(
+            first
+                .get("operator_grain")
+                .and_then(|v| v.as_bool())
+                .is_some(),
+            "operator_grain must serialize as a bool"
+        );
+    }
+
+    /// Operator-grain coverage (spec #465): at least one row in each
+    /// state must be present so the Activity feed has signal and the
+    /// allowlist isn't accidentally collapsed to "everything" or
+    /// "nothing".
+    #[test]
+    fn manifest_has_both_operator_grain_states() {
+        let grain_true = EVENTS.events.iter().filter(|e| e.operator_grain).count();
+        let grain_false = EVENTS.events.iter().filter(|e| !e.operator_grain).count();
+        assert!(
+            grain_true > 0,
+            "manifest must include at least one operator-grain event"
+        );
+        assert!(
+            grain_false > 0,
+            "manifest must include at least one non-operator-grain event"
+        );
+    }
+
+    /// Spot-check the operator-grain partition against ADR 0019's
+    /// definition: stage transitions / gate verdicts / run lifecycle
+    /// surface; internal subsystem dispatches do not.
+    #[test]
+    fn operator_grain_partition_matches_adr_0019() {
+        let surfaced = [
+            "stage.entered",
+            "stage.advanced",
+            "synodic.gate_verdict",
+            "synodic.verdict",
+            "trigger.fired",
+            "artifact.registered",
+            "artifact.state_changed",
+            "stiglab.session_completed",
+            "node.failed",
+        ];
+        for kind in surfaced {
+            let def = EVENTS.lookup(kind).expect(kind);
+            assert!(
+                def.operator_grain,
+                "`{kind}` should be operator-grain per ADR 0019"
+            );
+        }
+        let hidden = [
+            "forge.shaping_dispatched",
+            "forge.shaping_returned",
+            "forge.gate_requested",
+            "stiglab.session_result_ready",
+            "ising.insight_emitted",
+            "synodic.rule_proposed",
+            "gate.check_updated",
+        ];
+        for kind in hidden {
+            let def = EVENTS.lookup(kind).expect(kind);
+            assert!(
+                !def.operator_grain,
+                "`{kind}` should NOT be operator-grain (internal dispatch/diagnostic)"
+            );
+        }
     }
 
     #[test]

--- a/xtask/src/check_events.rs
+++ b/xtask/src/check_events.rs
@@ -4,7 +4,10 @@
 //! from spec #150:
 //!
 //! 1. **Coverage**: every `FactoryEventKind` variant has a manifest entry
-//!    keyed by its wire `event_type` string.
+//!    keyed by its wire `event_type` string. The manifest entry must
+//!    set every field, including `operator_grain` (spec #465) — Rust's
+//!    no-default-on-struct-literal rule makes this a compile-time
+//!    requirement, so the lint inherits it for free.
 //! 2. **Both ends declared**: every manifest entry has at least one
 //!    producer, and is either real (non-empty `consumers`) or
 //!    diagnostic-only (`diagnostic_only = true` plus a non-empty


### PR DESCRIPTION
## Summary

Implements ADR 0019's **Activity tab**: a workspace-scoped spine event feed filtered to events an operator actually cares about (stage transitions, gate verdicts, run lifecycle), not the full firehose of internal subsystem dispatches and analyzer diagnostics.

Closes #465. Part of #450 (ADR 0019 — dashboard IA three-tab surface).

## Changes

- **Registry (`crates/onsager-registry/src/events.rs`)** — add `operator_grain: bool` to every `EventDefinition`. The field has no default, so adding a new `FactoryEventKind` variant forces a deliberate classification at compile time. 22 rows are operator-grain (artifact lifecycle, stage transitions, trigger fires, gate verdicts, run/agent/node lifecycle, escalations, git PR events); 18 are not (internal `forge.shaping_*` dispatches, `forge.gate_requested`, `stiglab.session_result_ready`, ising analyzer diagnostics, synodic rule mgmt, raw gate adapter signals).
- **Portal (`crates/onsager-portal/src/handlers/spine.rs`)**:
  - New `operator_grain` query param on `GET /api/spine/events` (default `false` — back-compat for existing MCP clients).
  - New path-scoped alias `GET /api/workspaces/:id/activity` that bakes `operator_grain=true` in. Matches the dashboard's `/workspaces/:slug/activity` URL shape.
  - SQL pulls the allowlist directly from `onsager_registry::EVENTS` — no hard-coded duplicate.
  - The query SQL is now factored into a public `query_events_for_workspace` helper so integration tests can drive it without rebuilding `AppState`/`AuthUser`.
- **Dashboard (`apps/dashboard`)**:
  - `ActivityPage` switches to `api.getActivity()` via the path-scoped alias. The query param `operator_grain=true` is enforced server-side; the page never has to remember to pass it.
  - Event rows now show `actor` alongside `stream_type/stream_id`, and deep-link to `/runs/:artifact_id` (run-keyed events, including `forge:<id>` stream ids) or `/workflows/:id` (workflow-keyed events like `trigger.fired`). Source-chip taxonomy unchanged.
- **xtask `check-events`** — doc-only update noting that the new field's compile-time requirement subsumes a lint check.

## Test plan

- [x] `cargo test -p onsager-registry --lib events` — 7 tests pass (incl. new `operator_grain_partition_matches_adr_0019` spot-check on both sides of the partition)
- [x] `cargo test -p onsager-portal --lib spine` — 9 tests pass (incl. allowlist-pulls-from-registry, alias-forces-true, query-param-defaults-to-none via axum's `Query` extractor)
- [x] `cargo test -p onsager-portal --test activity_operator_grain` — builds; runs against `DATABASE_URL` (skip-when-unset) and seeds 6 operator-grain + 5 non-operator-grain rows to verify the filter
- [x] `pnpm test` (dashboard) — 184 tests pass, incl. 5 new tests in `tests/smoke/activity-page.test.tsx` covering the endpoint call, run-keyed deep-link, workflow-keyed deep-link, unlinked rows, and the empty state
- [x] `cargo run -p xtask -- check-events` clean
- [x] `cargo run -p xtask -- check-api-contract` clean (route + caller paired via `${qs}` interpolation)
- [x] `cargo run -p xtask -- lint-seams` / `check-file-budget` / `check-generated-types` clean
- [x] `cargo clippy -p onsager-portal -p onsager-registry --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `pnpm lint` (dashboard) clean
- [x] `pnpm tsc --noEmit` clean

## Operator-grain partition (for review)

The `Human decides` checkbox in the spec is the proposed allowlist below. Spot-checks are in `events::tests::operator_grain_partition_matches_adr_0019`. Easy to flip individual rows in a follow-up if review surfaces a different cut.

**operator-grain: true** (surfaced) — `artifact.{registered,state_changed,archived}`, `git.{pr_opened,pr_merged,pr_closed,ci_completed}`, `forge.gate_verdict`, `stiglab.session_{completed,failed,aborted}`, `portal.{session_requested,session_cancel_requested,pr_open_failed}`, `synodic.{gate_verdict,escalation_started,escalation_resolved,escalation_timed_out,gate_resolution_proposed}`, `trigger.fired`, `workflow.manual_triggered`, `stage.{entered,advanced}`, `node.{started,completed,failed,awaiting_human,human_approved,human_rejected}`, `synodic.verdict`, `agent.session_{started,completed,failed}`, `gate.manual_approval_signal`.

**operator-grain: false** (hidden) — `forge.{shaping_dispatched,shaping_returned,gate_requested,insight_observed,decision_made}`, `stiglab.session_result_ready`, `ising.*` (analyzer internals), `synodic.rule_{proposed,approved,disabled,version_created}`, `gate.check_updated`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cHhVBZnGS445qbvhsLLcg)_