### PR TITLE
refactor(dashboard): retire in-app /chat navigations for global mount (#468)

### DIFF
--- a/apps/dashboard/src/components/workflows/LocalDraftsCard.tsx
+++ b/apps/dashboard/src/components/workflows/LocalDraftsCard.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react"
-import { Link, useNavigate } from "react-router-dom"
 import { ArrowRight, FileText, Plus, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAuth } from "@/lib/auth"
 import { useWorkflowDraft } from "@/lib/drafts"
 import { useOSSFlag } from "@/hooks/useOSSFlag"
+import { useChatUi } from "@/lib/chat/use-chat-ui"
 import type { WorkflowDraft } from "@/components/workflows/workflow-draft"
 
 // Drafted-chip view (#467, ADR 0019 + 0020). Replaces the chat-page
@@ -15,21 +15,20 @@ import type { WorkflowDraft } from "@/components/workflows/workflow-draft"
 // — newest first, quick "Continue" entry per draft, "+ New draft"
 // affordance, OSS "drafts on this device" footer.
 //
-// "Continue in chat" routes to `/chat?draft=<id>`. The route bounces
-// to the workspace overview today (chat is mid-migration to a global
-// component per ADR 0020 / spec #451) but the URL is the forward-
-// compatible target — once ChatContainer lands, the param wakes the
-// global surface on the right draft.
+// "Continue in chat" opens the global chat mount (ADR 0020 / #471)
+// — the `/chat` page route was retired (#468), so the action wakes
+// the portable surface instead of navigating. Draft binding to the
+// chat thread is a separate concern (a follow-up under #451).
 export function LocalDraftsCard() {
   const { user } = useAuth()
   const isOss = useOSSFlag()
-  const navigate = useNavigate()
+  const { open: openChat } = useChatUi()
   const { drafts, newDraft, deleteById } = useWorkflowDraft(user?.id ?? null)
 
   const handleNew = useCallback(() => {
-    const fresh = newDraft()
-    navigate(`/chat?draft=${encodeURIComponent(fresh.id)}`)
-  }, [newDraft, navigate])
+    newDraft()
+    openChat()
+  }, [newDraft, openChat])
 
   return (
     <Card>
@@ -78,35 +77,39 @@ interface DraftRowProps {
 }
 
 function DraftRow({ draft, canDelete, onDelete }: DraftRowProps) {
+  const { open: openChat } = useChatUi()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const stageCount = draft.workflow.stages.length
   const trigger = draft.workflow.trigger
   const hasRepo =
     trigger.repo_owner.trim() !== "" && trigger.repo_name.trim() !== ""
-  const continueHref = `/chat?draft=${encodeURIComponent(draft.id)}`
   return (
     <li className="group flex items-center gap-3 rounded-md border bg-background px-3 py-2 hover:border-primary/40">
-      <Link
-        to={continueHref}
-        className="min-w-0 flex-1 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => openChat()}
         aria-label={`Continue draft ${draft.name || "Untitled draft"} in chat`}
+        className="h-auto min-w-0 flex-1 justify-start whitespace-normal px-2 py-1 text-left font-normal hover:bg-transparent"
       >
-        <div className="truncate text-sm font-medium">
-          {draft.name || "Untitled draft"}
-        </div>
-        <div className="truncate text-xs text-muted-foreground">
-          {hasRepo
-            ? `${trigger.repo_owner}/${trigger.repo_name}${trigger.label ? ` · ${trigger.label}` : ""}`
-            : "No trigger yet"}
-          {" · "}
-          {stageCount === 0
-            ? "0 stages"
-            : `${stageCount} stage${stageCount === 1 ? "" : "s"}`}
-          {" · "}
-          {formatRelative(draft.updated_at)}
-        </div>
-      </Link>
-      <Button size="sm" variant="ghost" render={<Link to={continueHref} />}>
+        <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+          <span className="w-full truncate text-sm font-medium">
+            {draft.name || "Untitled draft"}
+          </span>
+          <span className="w-full truncate text-xs text-muted-foreground">
+            {hasRepo
+              ? `${trigger.repo_owner}/${trigger.repo_name}${trigger.label ? ` · ${trigger.label}` : ""}`
+              : "No trigger yet"}
+            {" · "}
+            {stageCount === 0
+              ? "0 stages"
+              : `${stageCount} stage${stageCount === 1 ? "" : "s"}`}
+            {" · "}
+            {formatRelative(draft.updated_at)}
+          </span>
+        </span>
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => openChat()}>
         Continue
         <ArrowRight className="h-3.5 w-3.5" />
       </Button>

--- a/apps/dashboard/src/components/workspaces/WorkspaceSwitcher.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceSwitcher.tsx
@@ -88,9 +88,10 @@ export function WorkspaceSwitcher() {
   )
 
   if (workspaces.length === 0) {
-    // Zero memberships: the FTUE flow lives at /chat and binding lifts
-    // workspace creation into a single dialog. Rendering a no-op switcher
-    // here would be confusing chrome.
+    // Zero memberships: the FTUE flow lives at the workspace picker
+    // (`/workspaces`) and binding lifts workspace creation into a
+    // single dialog. Rendering a no-op switcher here would be
+    // confusing chrome.
     return null
   }
 

--- a/apps/dashboard/src/lib/build-info.ts
+++ b/apps/dashboard/src/lib/build-info.ts
@@ -1,9 +1,10 @@
 // Build-info descriptor (`GET /api/build-info`, spec #398).
 //
-// The FTUE OSS banner on the workspace-less `/chat` entry only renders
-// when `is_oss` is true. Fetched once per session (no auth required) and
-// cached at module scope; failures default to `is_oss: false` so a
-// down portal doesn't accidentally flash the OSS banner on Cloud.
+// FTUE OSS-only affordances (e.g. the "drafts on this device" footer
+// on the local drafts card) only render when `is_oss` is true. Fetched
+// once per session (no auth required) and cached at module scope;
+// failures default to `is_oss: false` so a down portal doesn't
+// accidentally flash OSS-only chrome on Cloud.
 
 import { useEffect, useState } from "react"
 

--- a/apps/dashboard/src/lib/drafts.ts
+++ b/apps/dashboard/src/lib/drafts.ts
@@ -1,11 +1,11 @@
 // Client-side workflow-draft storage (spec #401).
 //
 // Drafts are a first-class user object the FTUE leans on: a P1 engineer
-// who lands on `/chat` without a workspace must be able to design a
-// workflow over multiple sessions, close the tab, reopen, and resume —
-// all before the binding flow (axis 5) promotes the draft into a real
-// spine workflow. The substrate stays untouched in v1; server-side draft
-// sync is a v1.5 follow-up.
+// without a workspace must be able to design a workflow over multiple
+// sessions, close the tab, reopen, and resume — all before the binding
+// flow (axis 5) promotes the draft into a real spine workflow. The
+// substrate stays untouched in v1; server-side draft sync is a v1.5
+// follow-up.
 
 import { useCallback, useMemo, useState } from "react"
 

--- a/apps/dashboard/src/lib/workspace.tsx
+++ b/apps/dashboard/src/lib/workspace.tsx
@@ -89,9 +89,11 @@ export function WorkspaceScope({ children }: WorkspaceLayoutProps) {
 
   if (workspaces.length === 0) {
     // Deep-link to a scoped path with zero memberships — send them to
-    // `/chat`, the FTUE entry. The picker still lives at `/workspaces`
-    // for users who want to create one explicitly.
-    return <Navigate to="/chat" replace />
+    // the workspace picker / FTUE surface. Matches `BarePathRedirect`
+    // in App.tsx (#453 / ADR 0019); the legacy `/chat` FTUE entry is
+    // retired (#468 / ADR 0019, ADR 0020) and the global chat mount
+    // (ADR 0020 / #471) is reachable from any signed-in surface.
+    return <Navigate to="/workspaces" replace />
   }
 
   if (!active) {

--- a/apps/dashboard/src/pages/WorkspacesPage.tsx
+++ b/apps/dashboard/src/pages/WorkspacesPage.tsx
@@ -10,8 +10,10 @@ import { usePageHeader } from "@/components/layout/PageHeader"
 
 /**
  * Top-level Workspaces page. Lists the user's workspaces and exposes the
- * explicit create flow. The FTUE entry is `/chat`; binding lifts workspace
- * creation into a single dialog, so this page is admin-mode only.
+ * explicit create flow. Also serves as the zero-memberships FTUE landing
+ * surface (`BarePathRedirect` / `WorkspaceScope` send users here when
+ * they have no workspaces); binding lifts workspace creation into a
+ * single dialog, so this page is admin-mode for established users.
  */
 export function WorkspacesPage() {
   usePageHeader({ title: "Workspaces" })

--- a/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
+++ b/apps/dashboard/tests/smoke/ftue-oss-boundary.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Routes, Route } from "react-router-dom"
 
 import { WorkflowDetailPage } from "@/pages/WorkflowDetailPage"
 import { LocalDraftsCard } from "@/components/workflows/LocalDraftsCard"
+import { ChatUiProvider } from "@/lib/chat/use-chat-ui"
 
 // Spec #405: Cloud-vs-OSS capability boundary surfacing. Three inline
 // lines surface only when `is_oss === true`, exactly where the user is
@@ -267,7 +268,9 @@ describe("Spec #467 — LocalDraftsCard OSS footer", () => {
   function renderCard() {
     return render(
       <MemoryRouter>
-        <LocalDraftsCard />
+        <ChatUiProvider>
+          <LocalDraftsCard />
+        </ChatUiProvider>
       </MemoryRouter>,
     )
   }

--- a/apps/dashboard/tests/smoke/local-drafts-card-chat-mount.test.tsx
+++ b/apps/dashboard/tests/smoke/local-drafts-card-chat-mount.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+
+import { LocalDraftsCard } from "@/components/workflows/LocalDraftsCard"
+import { ChatUiProvider, useChatUi } from "@/lib/chat/use-chat-ui"
+
+// `/chat` and `/workspaces/:slug/chat` were retired as page routes
+// (#468 / ADR 0019). The local-drafts card's "Continue" and "New draft"
+// affordances used to navigate to `/chat?draft=<id>`; the ADR 0020
+// global chat mount means they now invoke `useChatUi().open()` instead.
+// This pins that contract so a future regression to `navigate('/chat')`
+// fails loudly rather than silently bouncing through a redirect.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: null, authEnabled: false }),
+}))
+
+const ossMock = vi.hoisted(() => ({ useOSSFlag: vi.fn() }))
+vi.mock("@/hooks/useOSSFlag", () => ossMock)
+
+function seedDrafts(items: { id: string; name: string }[]) {
+  const drafts = items.map((it) => ({
+    id: it.id,
+    user_id: "anon",
+    name: it.name,
+    source: "blank" as const,
+    workflow: {
+      name: "",
+      trigger: { install_id: "", repo_owner: "", repo_name: "", label: "" },
+      stages: [],
+    },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }))
+  window.localStorage.setItem(
+    "onsager.drafts.anon",
+    JSON.stringify({ drafts }),
+  )
+}
+
+// Probe component reads `useChatUi().isOpen` and renders it as text so
+// the test can assert the open/closed transition without depending on
+// ChatContainer (which has its own provider needs for auth/workspaces).
+function ChatOpenProbe() {
+  const { isOpen } = useChatUi()
+  return <div data-testid="chat-open">{isOpen ? "open" : "closed"}</div>
+}
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <ChatUiProvider>
+        <LocalDraftsCard />
+        <ChatOpenProbe />
+      </ChatUiProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  ossMock.useOSSFlag.mockReturnValue(false)
+})
+
+describe("LocalDraftsCard — chat-mount invocation (#468)", () => {
+  it("clicking `Continue` on a draft row opens the global chat mount", async () => {
+    seedDrafts([{ id: "d_1", name: "My draft" }])
+    const user = userEvent.setup()
+    renderCard()
+    expect(screen.getByTestId("chat-open").textContent).toBe("closed")
+    // The row has two clickable elements — the row tile and the
+    // explicit "Continue" button. Both should open the chat mount;
+    // we click the explicit button as the user-visible affordance.
+    const continueBtn = await screen.findByRole("button", { name: /^Continue$/ })
+    await user.click(continueBtn)
+    expect(screen.getByTestId("chat-open").textContent).toBe("open")
+  })
+
+  it("clicking the row tile also opens the global chat mount", async () => {
+    seedDrafts([{ id: "d_1", name: "My draft" }])
+    const user = userEvent.setup()
+    renderCard()
+    expect(screen.getByTestId("chat-open").textContent).toBe("closed")
+    const tile = await screen.findByRole("button", {
+      name: /Continue draft My draft in chat/i,
+    })
+    await user.click(tile)
+    expect(screen.getByTestId("chat-open").textContent).toBe("open")
+  })
+
+  it("clicking `New draft` opens the chat mount on a fresh draft", async () => {
+    const user = userEvent.setup()
+    renderCard()
+    expect(screen.getByTestId("chat-open").textContent).toBe("closed")
+    const newBtn = await screen.findByRole("button", { name: /New draft/i })
+    await user.click(newBtn)
+    expect(screen.getByTestId("chat-open").textContent).toBe("open")
+  })
+})

--- a/apps/dashboard/tests/smoke/workflows-page-state-chips.test.tsx
+++ b/apps/dashboard/tests/smoke/workflows-page-state-chips.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter, Routes, Route } from "react-router-dom"
 
 import { WorkflowsPage } from "@/pages/WorkflowsPage"
+import { ChatUiProvider } from "@/lib/chat/use-chat-ui"
 
 // Workflows-tab state filter chips + Drafted view (#467 / ADR 0019).
 // Pins the chip row's count rendering, the URL `?state=` round-trip,
@@ -48,19 +49,21 @@ function renderPage(initialPath: string) {
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={[initialPath]}>
-        <Routes>
-          <Route
-            path="/workspaces/:workspace/*"
-            element={
-              <WorkspaceScope>
-                <Routes>
-                  <Route index element={<WorkflowsPage />} />
-                  <Route path="workflows" element={<WorkflowsPage />} />
-                </Routes>
-              </WorkspaceScope>
-            }
-          />
-        </Routes>
+        <ChatUiProvider>
+          <Routes>
+            <Route
+              path="/workspaces/:workspace/*"
+              element={
+                <WorkspaceScope>
+                  <Routes>
+                    <Route index element={<WorkflowsPage />} />
+                    <Route path="workflows" element={<WorkflowsPage />} />
+                  </Routes>
+                </WorkspaceScope>
+              }
+            />
+          </Routes>
+        </ChatUiProvider>
       </MemoryRouter>
     </QueryClientProvider>,
   )


### PR DESCRIPTION
## Summary

Spec #468 / ADR 0019 + ADR 0020. The `/chat` and `/workspaces/:slug/chat` page routes were retired and replaced with redirects in PR #460; this finishes the audit by replacing the remaining in-app navigations to `/chat` with the ADR 0020 global chat mount invocation (`useChatUi().open()` from the `ChatContainer` that landed in #480).

## Plan vs. current state

The first three Plan items from #468 were absorbed by PR #460 (the broader ADR 0019 top-chrome IA PR), which already wired the redirects into `App.tsx` and extended the spec #306 smoke-test:

- [x] Add `/chat` and `/workspaces/:slug/chat` to the spec #306 redirect map — done in #460 (`apps/dashboard/src/App.tsx:225` + `:261`).
- [x] Remove the two `<Route>` mounts for `ChatPage` — done in #460 (lazy-import removed; ChatPage stays as orphan source per #457 design, #451 cleans it up).
- [x] Extend the redirect smoke-test — done in #460 (`apps/dashboard/tests/smoke/workspace-routing.test.tsx` covers both new redirects).
- [x] Grep + replace remaining in-app navigations to `/chat` with chat-mount invocations — **this PR**.

## What this PR changes

- `LocalDraftsCard` (`Continue` row + "New draft" button) — was `navigate('/chat?draft=<id>')` and `<Link to="/chat?draft=…">`; now calls `useChatUi().open()` so the global chat surface wakes in place. Draft binding to the chat thread is a follow-up under #451.
- `WorkspaceScope` zero-memberships fallback — was `<Navigate to="/chat" />` (which was itself bouncing through the redirect); now goes straight to `/workspaces` (the picker / FTUE surface), matching `BarePathRedirect`.
- Stale `/chat` references in surrounding comments (`WorkspaceSwitcher`, `build-info`, `drafts`, `WorkspacesPage`) updated to reflect the new global-mount reality.

## Test plan

- [x] `pnpm test` green (218 tests in 34 files).
- [x] Existing redirect smoke-test still passes — `/chat` and `/workspaces/:slug/chat` redirects unchanged.
- [x] New smoke test `local-drafts-card-chat-mount.test.tsx` pins the chat-mount-invocation contract on Continue / New draft / row tile.
- [x] Two existing tests (`workflows-page-state-chips.test.tsx`, `ftue-oss-boundary.test.tsx`) updated to wrap `LocalDraftsCard` in `ChatUiProvider`.
- [x] `pnpm exec tsc -b` clean, `pnpm lint` clean.
- [x] `xtask check-file-budget` clean.

Closes #468

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCGoJy4FhycrPjLak7sHbJ)_