### PR TITLE
feat(dashboard): ⌘K palette invocation for chat (#473)

### DIFF
--- a/apps/dashboard/src/components/chat/ChatContainer.tsx
+++ b/apps/dashboard/src/components/chat/ChatContainer.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils"
 // scope/tab state.
 
 export function ChatContainer() {
-  const { isOpen, close, tab, setTab, scopeOverride, highlightHitlId } = useChatUi()
+  const { isOpen, close, tab, setTab, scopeOverride, highlightHitlId, prefill } = useChatUi()
   const { user } = useAuth()
   const workspace = useOptionalActiveWorkspace()
   const userId = user?.id ?? null
@@ -150,6 +150,7 @@ export function ChatContainer() {
                   workspace={workspace}
                   scope={effectiveScope}
                   userId={userId}
+                  initialPrompt={prefill}
                 />
               ) : (
                 <NoWorkspaceState />

--- a/apps/dashboard/src/components/chat/ChatThreadView.tsx
+++ b/apps/dashboard/src/components/chat/ChatThreadView.tsx
@@ -33,6 +33,8 @@ interface ChatThreadViewProps {
   workspace: Workspace
   scope: ChatScope
   userId: string | null
+  /** One-shot composer pre-fill from `useChatUi.open({ prefill })` (#473). */
+  initialPrompt?: string | null
 }
 
 function toWireScope(scope: ChatScope): ChatScopeWire {
@@ -50,6 +52,7 @@ export function ChatThreadView({
   workspace,
   scope,
   userId,
+  initialPrompt,
 }: ChatThreadViewProps) {
   const qc = useQueryClient()
   const threadKey = ["chat", "thread", workspace.id, scopeKey(scope)]
@@ -61,13 +64,32 @@ export function ChatThreadView({
     staleTime: 60_000,
   })
 
-  const [prompt, setPrompt] = useState("")
+  const [prompt, setPrompt] = useState(initialPrompt ?? "")
   const [sendError, setSendError] = useState<string | null>(null)
   const feedEndRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     feedEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [threadQuery.data?.messages])
+
+  // When the chat opens with a pre-fill (⌘K → `ask: …`, #473), drop
+  // the caret at the end of the seeded text so Enter sends immediately
+  // or the user can keep typing. Mount-only: the parent (ChatContainer)
+  // unmounts on close, so each open() with a fresh prefill remounts
+  // this view — re-running on every initialPrompt change would steal
+  // focus if the prop pointer ever flipped mid-session.
+  useEffect(() => {
+    if (initialPrompt) {
+      const el = textareaRef.current
+      if (el) {
+        el.focus()
+        const len = initialPrompt.length
+        el.setSelectionRange(len, len)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const sendMutation = useMutation({
     mutationFn: async (text: string) => {
@@ -179,6 +201,7 @@ export function ChatThreadView({
         className="flex shrink-0 items-end gap-2 border-t bg-background/95 p-2 backdrop-blur supports-[backdrop-filter]:bg-background/80"
       >
         <Textarea
+          ref={textareaRef}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={onKeyDown}
@@ -229,9 +252,26 @@ function ErrorState({ message }: { message: string }) {
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-muted-foreground">
+    <div
+      data-slot="chat-thread-empty"
+      className="flex flex-col items-center gap-2 py-8 text-center text-sm text-muted-foreground"
+    >
       <MessageSquare className="h-8 w-8 text-muted-foreground/50" />
       <div>Start the conversation for this scope.</div>
+      <div
+        data-slot="chat-thread-empty-hint"
+        className="hidden text-xs text-muted-foreground/80 md:block"
+      >
+        Tip — press{" "}
+        <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          ⌘K
+        </kbd>{" "}
+        then type{" "}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+          ask:
+        </code>{" "}
+        followed by your question.
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -41,13 +41,17 @@ const TOP_TABS: TopTab[] = [
 ]
 
 export function AppLayout({ children }: { children: ReactNode }) {
+  // ChatUi is mounted *above* CommandPalette so the palette's chat
+  // command (⌘K → `ask: …`, spec #473) can call `useChatUi.open()`.
+  // CommandPalette's chat command uses `useOptionalChatUi` so other
+  // mounts (tests, isolated stories) still render without throwing.
   return (
     <PageHeaderProvider>
-      <CommandPaletteProvider>
-        <ChatUiProvider>
+      <ChatUiProvider>
+        <CommandPaletteProvider>
           <AppLayoutInner>{children}</AppLayoutInner>
-        </ChatUiProvider>
-      </CommandPaletteProvider>
+        </CommandPaletteProvider>
+      </ChatUiProvider>
     </PageHeaderProvider>
   )
 }

--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
   Activity,
   Building2,
   GitBranch,
+  MessageSquare,
   Search,
   Settings as SettingsIcon,
   Terminal,
@@ -30,6 +31,7 @@ import {
 import { CreateSessionSheet } from "@/components/sessions/CreateSessionSheet"
 import { NewWorkspaceDialog } from "@/components/workspaces/NewWorkspaceDialog"
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
+import { useOptionalChatUi } from "@/lib/chat/use-chat-ui"
 
 // Single global "do something" surface — create a primitive or jump to
 // a section. Replaces the old chrome `+` dropdown: that pattern doesn't
@@ -97,16 +99,47 @@ export function CommandPaletteTrigger() {
   )
 }
 
+// Parses the palette input for the chat-invocation grammar (ADR 0020
+// channel 5, spec #473). Returns the inline message after `ask:` /
+// `ask ` (empty string when the user typed only the keyword), or null
+// when the input is not an ask command. Matches case-insensitively so
+// `Ask:` and `ASK ` work the same. The `\b` anchor keeps `askbar`
+// from triggering — only the word `ask` followed by end-of-input,
+// `:`, or whitespace counts.
+// eslint-disable-next-line react-refresh/only-export-components
+export function parseAskCommand(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const m = trimmed.match(/^ask\b\s*:?\s*(.*)$/i)
+  if (!m) return null
+  return m[1].trim()
+}
+
 function CommandPaletteDialog() {
   const { open, setOpen } = usePalette()
   const navigate = useNavigate()
   const activeWorkspace = useOptionalActiveWorkspace()
+  const chatUi = useOptionalChatUi()
 
   const [sessionOpen, setSessionOpen] = useState(false)
   const [workspaceOpen, setWorkspaceOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  // Detected "ask…" grammar in the input (ADR 0020 channel 5):
+  //   "ask"          → empty prefill (just opens the chat)
+  //   "ask:"         → empty prefill
+  //   "ask: <msg>"   → seed the composer with <msg>
+  //   "ask <msg>"    → seed the composer with <msg>
+  // When non-null we force-mount the chat command so cmdk's fuzzy
+  // filter doesn't drop it for inputs the score wouldn't otherwise
+  // match (e.g. "ask: why did run #42 fail?").
+  const askPrefill = useMemo(() => parseAskCommand(search), [search])
+  const hasAskGrammar = askPrefill !== null
+  const showInlineLabel = hasAskGrammar && (askPrefill ?? "").length > 0
 
   const run = (action: () => void) => {
     setOpen(false)
+    setSearch("")
     action()
   }
   const go = (path: string) => run(() => navigate(path))
@@ -119,6 +152,17 @@ function CommandPaletteDialog() {
       ? `/workspaces/${activeWorkspace.slug}/${suffix}`
       : "/workspaces"
 
+  // Open the global chat (ADR 0020 / spec #473). Routes the prefill
+  // through `useChatUi.open({ prefill })` — the chat lands on Thread
+  // at the route's auto-scope (we deliberately don't pass `scope` so
+  // the auto-scope hook follows the current view). When the chat
+  // provider isn't mounted (unlikely outside tests), this no-ops so
+  // the palette doesn't throw.
+  const openChat = (prefill?: string) =>
+    run(() => {
+      chatUi?.open({ tab: "thread", prefill: prefill || undefined })
+    })
+
   return (
     <>
       <CommandDialog open={open} onOpenChange={setOpen}>
@@ -127,9 +171,42 @@ function CommandPaletteDialog() {
             for context, otherwise CommandInput throws and the dialog
             tears down the tree (blank screen). */}
         <Command>
-          <CommandInput placeholder="Type a command or search…" />
+          <CommandInput
+            placeholder="Type a command or search…"
+            value={search}
+            onValueChange={setSearch}
+          />
           <CommandList>
           <CommandEmpty>No results.</CommandEmpty>
+
+            {chatUi && (
+              <CommandGroup heading="Chat">
+                <CommandItem
+                  value="ask"
+                  keywords={["chat", "question", "talk", "assistant"]}
+                  // forceMount when the user is typing an inline message
+                  // — cmdk's default fuzzy filter would otherwise drop
+                  // this item for queries like "ask: why did run #42
+                  // fail?" that don't score against just "ask".
+                  forceMount={hasAskGrammar ? true : undefined}
+                  onSelect={() => openChat(askPrefill ?? undefined)}
+                >
+                  <MessageSquare className="mr-2 h-4 w-4" />
+                  {showInlineLabel ? (
+                    <span>
+                      Ask:{" "}
+                      <span className="font-medium text-foreground">
+                        {askPrefill}
+                      </span>
+                    </span>
+                  ) : (
+                    "Ask the assistant"
+                  )}
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {chatUi && <CommandSeparator />}
 
             <CommandGroup heading="Create">
               <CommandItem

--- a/apps/dashboard/src/lib/chat/use-chat-ui.tsx
+++ b/apps/dashboard/src/lib/chat/use-chat-ui.tsx
@@ -30,6 +30,8 @@ export interface ChatOpenOptions {
   tab?: ChatTab
   /** When set, the Queue tab scrolls to / highlights this HITL card. */
   highlightHitlId?: string
+  /** One-shot pre-fill for the Thread composer (⌘K → `ask: …`, #473). */
+  prefill?: string
 }
 
 export interface ChatUi {
@@ -39,6 +41,8 @@ export interface ChatUi {
   scopeOverride: ChatScope | null
   /** Set by `open({ highlightHitlId })`; cleared on close. */
   highlightHitlId: string | null
+  /** Set by `open({ prefill })`; cleared on close. */
+  prefill: string | null
   open(options?: ChatOpenOptions): void
   close(): void
   toggle(): void
@@ -52,23 +56,27 @@ export function ChatUiProvider({ children }: { children: ReactNode }) {
   const [tab, setTab] = useState<ChatTab>("thread")
   const [scopeOverride, setScopeOverride] = useState<ChatScope | null>(null)
   const [highlightHitlId, setHighlightHitlId] = useState<string | null>(null)
+  const [prefill, setPrefill] = useState<string | null>(null)
 
   const open = useCallback((options?: ChatOpenOptions) => {
     if (options?.tab) setTab(options.tab)
     setScopeOverride(options?.scope ?? null)
     setHighlightHitlId(options?.highlightHitlId ?? null)
+    setPrefill(options?.prefill ?? null)
     setIsOpen(true)
   }, [])
   const close = useCallback(() => {
     setIsOpen(false)
     setScopeOverride(null)
     setHighlightHitlId(null)
+    setPrefill(null)
   }, [])
   const toggle = useCallback(() => {
     setIsOpen((v) => {
       if (v) {
         setScopeOverride(null)
         setHighlightHitlId(null)
+        setPrefill(null)
       }
       return !v
     })
@@ -93,12 +101,13 @@ export function ChatUiProvider({ children }: { children: ReactNode }) {
       tab,
       scopeOverride,
       highlightHitlId,
+      prefill,
       open,
       close,
       toggle,
       setTab,
     }),
-    [isOpen, tab, scopeOverride, highlightHitlId, open, close, toggle],
+    [isOpen, tab, scopeOverride, highlightHitlId, prefill, open, close, toggle],
   )
   return <ChatUiContext.Provider value={value}>{children}</ChatUiContext.Provider>
 }

--- a/apps/dashboard/tests/smoke/command-palette.test.tsx
+++ b/apps/dashboard/tests/smoke/command-palette.test.tsx
@@ -1,25 +1,31 @@
-import { describe, it, expect } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, act } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom"
 import {
   CommandPaletteProvider,
   CommandPaletteTrigger,
+  parseAskCommand,
 } from "@/components/layout/CommandPalette"
+import { ChatUiProvider, useChatUi } from "@/lib/chat/use-chat-ui"
 
 // Regression: clicking the search trigger used to render a blank
 // browser because shadcn's CommandDialog does not auto-wrap children
 // in <Command>, so cmdk primitives threw on missing context. This
 // test mounts the trigger, clicks it, and asserts the palette renders
 // real content (groups + items) rather than crashing the tree.
-function mount() {
+function mount(children?: ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <CommandPaletteProvider>
-          <CommandPaletteTrigger />
-        </CommandPaletteProvider>
+        <ChatUiProvider>
+          <CommandPaletteProvider>
+            <CommandPaletteTrigger />
+            {children}
+          </CommandPaletteProvider>
+        </ChatUiProvider>
       </MemoryRouter>
     </QueryClientProvider>,
   )
@@ -49,5 +55,98 @@ describe("CommandPalette", () => {
     expect(screen.getByText(/^workflows$/i)).toBeInTheDocument()
     expect(screen.getByText(/^runs$/i)).toBeInTheDocument()
     expect(screen.getByText(/^activity$/i)).toBeInTheDocument()
+    // Chat invocation (ADR 0020 channel 5, spec #473).
+    expect(screen.getByText(/ask the assistant/i)).toBeInTheDocument()
+  })
+})
+
+describe("parseAskCommand", () => {
+  it("returns null for non-ask input", () => {
+    expect(parseAskCommand("")).toBeNull()
+    expect(parseAskCommand("workflows")).toBeNull()
+    expect(parseAskCommand("askbar")).toBeNull()
+  })
+
+  it("returns empty string for the bare keyword", () => {
+    expect(parseAskCommand("ask")).toBe("")
+    expect(parseAskCommand("ASK")).toBe("")
+    expect(parseAskCommand("  ask  ")).toBe("")
+    expect(parseAskCommand("ask:")).toBe("")
+  })
+
+  it("extracts the inline message after the separator", () => {
+    expect(parseAskCommand("ask: why did run #42 fail?")).toBe(
+      "why did run #42 fail?",
+    )
+    expect(parseAskCommand("ask why did run #42 fail?")).toBe(
+      "why did run #42 fail?",
+    )
+    expect(parseAskCommand("Ask: hello")).toBe("hello")
+  })
+})
+
+// Spec #473 — the ⌘K palette opens the global chat at the current
+// route's scope, default tab `Thread`, with the inline message
+// (when present) routed through `useChatUi.open({ prefill })`.
+describe("CommandPalette → chat invocation", () => {
+  function ChatUiProbe({
+    onState,
+  }: {
+    onState: (s: {
+      isOpen: boolean
+      tab: string
+      prefill: string | null
+      scopeOverride: unknown
+    }) => void
+  }) {
+    const { isOpen, tab, prefill, scopeOverride } = useChatUi()
+    onState({ isOpen, tab, prefill, scopeOverride })
+    return null
+  }
+
+  it("ask + Enter opens the chat with no prefill on the Thread tab", async () => {
+    const onState = vi.fn()
+    mount(<ChatUiProbe onState={onState} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /command palette/i }))
+    const input = screen.getByPlaceholderText(/type a command or search/i)
+    fireEvent.change(input, { target: { value: "ask" } })
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" })
+    })
+
+    const last = onState.mock.calls.at(-1)?.[0]
+    expect(last.isOpen).toBe(true)
+    expect(last.tab).toBe("thread")
+    expect(last.prefill).toBeNull()
+    // No scope override — auto-scope follows the current route.
+    expect(last.scopeOverride).toBeNull()
+  })
+
+  it("`ask: <msg>` + Enter opens the chat with the message pre-filled", async () => {
+    const onState = vi.fn()
+    mount(<ChatUiProbe onState={onState} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /command palette/i }))
+    const input = screen.getByPlaceholderText(/type a command or search/i)
+    fireEvent.change(input, {
+      target: { value: "ask: why did run #42 fail?" },
+    })
+
+    // The inline label confirms cmdk surfaces the chat item even
+    // though the query wouldn't naturally score against "ask".
+    expect(screen.getByText(/^Ask:$/)).toBeInTheDocument()
+    expect(screen.getByText(/why did run #42 fail\?/)).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" })
+    })
+
+    const last = onState.mock.calls.at(-1)?.[0]
+    expect(last.isOpen).toBe(true)
+    expect(last.tab).toBe("thread")
+    expect(last.prefill).toBe("why did run #42 fail?")
+    expect(last.scopeOverride).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

ADR 0020's fifth invocation channel for the global chat (spec #473). Typing `ask` (or `ask: <question>`) into the ⌘K command palette and pressing Enter opens the chat at the current route's auto-scope on the Thread tab. The inline-message form seeds the composer with the question and drops the caret at the end so Enter sends immediately.

## Delivers

- [x] Register a chat-invocation command in `CommandPaletteProvider`
- [x] Support inline-message pre-fill (`ask: ` → opens chat with the message pre-filled)
- [x] Wire to the auto-scope hook so the opened chat lands at the current route's scope
- [x] Add a discoverability hint to the empty `Thread` tab pointing at ⌘K → ask

## Design notes

- **forceMount on the chat command** — when the input matches the `ask` grammar (`ask`, `ask:`, `ask: <msg>`, `ask <msg>`), the command item is force-mounted so cmdk's fuzzy filter doesn't drop it for queries like `ask: why did run #42 fail?` that wouldn't score against the bare keyword.
- **No scope override** — `useChatUi.open({ tab: "thread", prefill })` deliberately omits `scope`. The auto-scope hook (`useAutoScope`) therefore follows the current route, honoring any active pin — matching the spec ("at the current route's scope, per the auto-scope hook").
- **`useOptionalChatUi`** — the palette dialog reads the chat context optionally so isolated mounts (tests, stories) without a `ChatUiProvider` parent still render. The chat command is hidden in that case rather than crashing the dialog.
- **Provider order in `AppLayout`** — swapped so `ChatUiProvider` wraps `CommandPaletteProvider`; the palette dialog renders inside the chat provider now.
- **`prefill` plumbing** — added a one-shot `prefill: string | null` field to `useChatUi`, cleared on close/toggle. `ChatThreadView` reads it as `initialPrompt`, seeds the composer state, focuses the textarea, and parks the caret at the end.
- **Discoverability hint** — desktop-only on the empty Thread state, since ⌘K is a desktop primitive (mobile keeps using the FAB / bell / palette opener for entry).

## Test plan

- [x] `tests/smoke/command-palette.test.tsx` — three new cases:
  - `parseAskCommand` unit tests (bare keyword, separator forms, case-insensitivity, false positives)
  - ⌘K → `ask` + Enter → chat opens, Thread tab, no prefill, no scope override
  - ⌘K → `ask: <msg>` + Enter → chat opens, Thread tab, prefill = `<msg>`, no scope override
- [x] All 234 existing dashboard tests still pass
- [x] `pnpm lint` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `cargo run -p xtask -- lint-seams check-api-contract check-events check-hitl-coverage check-file-budget` clean

Closes #473

https://claude.ai/code/session_01233vwchwNFh2CLtaY71iww

---
_Generated by [Claude Code](https://claude.ai/code/session_01233vwchwNFh2CLtaY71iww)_