### PR TITLE
adr: 0020 chat as portable global component (Proposed → Accepted)

### DIFF
--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -1,6 +1,6 @@
 # ADR 0020 — Chat as portable global component with contextual auto-scope
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-05-22
 - **Identity impact**: no
 - **Tracking issues**: #451 (implementation spec). Sibling to


### PR DESCRIPTION
## Summary

- Flip ADR 0020 status from `Proposed` → `Accepted` now that all four phase-0 sub-issues (#470 storage backend, #471 ChatContainer + scope state, #472 invocation channels, #473 ⌘K palette) have landed on `main` 2026-05-23.
- Closes out the final item on #451's adoption checklist; the other two meta-tasks (Notion root-page Timeline entry, `closed by` comments on #398 / #400) were discharged in the same session and #451 itself is now closed as completed.

## Test plan

- [x] `grep "Status:" docs/adr/0020-*.md` shows `Accepted`
- [ ] CI doc lints pass

Part of #451.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtH45BUVQnb5Ko4Uy4xoYw)_