### PR TITLE
ADRs 0021 + 0022 — detail page IA and SourceTag UI primitive

### DIFF
--- a/docs/adr/0021-detail-page-ia-node-as-section.md
+++ b/docs/adr/0021-detail-page-ia-node-as-section.md
@@ -1,0 +1,268 @@
+# ADR 0021 — Detail page IA: node-as-section, attribute-as-expanded-detail
+
+- **Status**: Proposed
+- **Date**: 2026-05-27
+- **Identity impact**: no
+- **Tracking issues**: pending — implementation spec to be opened on Accept.
+  Builds on ADR 0019 (which collapsed `WorkflowDetailPage`'s four tabs to
+  anchored sections) by extending the same logic to the remaining three
+  detail pages and by reframing the section split itself around substrate
+  primitives rather than v0.1 subsystem boundaries.
+- **Supersedes**: none. Refines ADR 0019 without replacing it.
+- **Superseded by**: none
+
+## Context
+
+ADR 0019 collapsed `WorkflowDetailPage`'s four tabs (Definition / Runs /
+Artifacts / Verdicts) into one anchored-section timeline. The same v0.1
+framing — node attributes promoted to top-level surfaces — survives in
+three sibling detail pages, and partially in `WorkflowDetailPage` itself.
+
+The collapse was a chrome refactor; the underlying mental model
+("Artifacts and Verdicts are surfaces") was not revisited.
+
+In code today this produces:
+
+- `pages/WorkflowDetailPage.tsx:219-256` — four anchored sections.
+  `Definition` double-renders (the linear `ArtifactFlowOverview` pill
+  strip immediately above a per-stage `<Card>` list of the same
+  stages with `gate_kind` + in/out `artifact_kind` badges). `Runs`
+  contains four sibling `<Card>`s: `ActiveRunsBanner`, `RunsList`,
+  `WorkflowEventsCard`, `WorkflowSessionsCard` — but `events` and
+  `sessions` are run-derived observers (ADR 0013 Observer surface),
+  not workflow-scoped concepts. `Verdicts` and `Artifacts` are per-run
+  attributes promoted to workflow scope as "last 5 / last 20" lists.
+- `pages/RunDetailPage.tsx:142-258` — five `<Tabs>` (Overview / Stages
+  / Artifacts / Verdicts / Events). The `Overview` tab duplicates the
+  metadata that already lives in the page header plus the stage
+  progress strip already shown in detail in the `Stages` tab. The
+  `Artifacts` tab contains a single artifact link with a hardcoded
+  `"Issue"` fallback for `artifact_kind` (a v0.1 GitHub-bound default,
+  inconsistent with the typed artifact registry per ADR 0003).
+  `Verdicts` and `Events` are stage attributes, not run-level scopes;
+  treating them as top-level tabs requires the page to invert the
+  natural per-stage grouping into per-attribute grouping and lose the
+  binding.
+- `pages/ArtifactDetailPage.tsx:329-432` — four `<Card>`s:
+  `Run Lineage` (the producing run's internal DAG), `Version History`
+  (versions table with session origin), `Vertical Lineage` (same
+  artifact across versions — overlaps with `Version History`),
+  `Horizontal Lineage` (related artifacts in the run). The three
+  lineage cards are three projections of one provenance graph
+  (ADR 0010); rendering them as parallel surfaces hides their shared
+  origin. The page renders no content — `artifact_kind` is never
+  dispatched into a body view, so an `Issue`, a `markdown`, a
+  `pull_request` and a `verdict` all look identical from the dashboard.
+- `pages/IssueDetailPage.tsx:1-376` — four `<Card>`s (Labels,
+  Assignees, Description, Onsager metadata) plus a 4-up MetaCard grid
+  (Author / Comments / Updated / Lifecycle) that mixes GitHub-fed and
+  substrate-fed fields. The page is hardcoded to
+  `artifact_kind=github_issue` with `projectId` and `number` URL
+  parameters (lines 22-25, 31-32); the "Onsager metadata" Card name is
+  the page admitting it cannot reconcile the two ontologies.
+
+The deeper pattern: each page promotes a *node attribute* (verdict,
+events, lineage axis, kind-specific fields) to *page-level section*.
+This is a v0.1 "subsystem-per-tab" mental model. ADR 0019's tab → anchored-section
+transformation changed the chrome but kept the framing.
+
+A constraint imposed by ADR 0019 narrows the design space: artifact
+and verdict have no top-level list view in main IA (only Workflows /
+Runs / Activity tabs exist). Detail pages cannot delegate "show me
+artifacts/verdicts" to a navigation surface that does not exist;
+related lists must surface inline or via filtered Activity URLs.
+
+## Decision
+
+Adopt a uniform detail-page IA shape across Workflow / Run / Artifact
+/ Issue, organized around two substrate primitives:
+
+- A *node* is the unit a detail page is organized around: a workflow
+  stage (in Definition), a run stage (in RunDetail), an artifact
+  version (in ArtifactDetail Provenance).
+- An *attribute* is anything that hangs off a node: output artifact,
+  sessions, verdict, events, source tag, kind, gate, executor.
+
+A *section* corresponds to a coarse substrate object class, not to a
+node attribute.
+
+Per-page shape:
+
+|Page           |Sections                            |Node unit                                    |Notes                                                                                                                       |
+|---------------|------------------------------------|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+|WorkflowDetail |Definition, Activity                |stage (in Definition) / run (in Activity)    |`Verdicts` and `Artifacts` sections removed. Reachable via Activity-tab filters and via run drill-down.                     |
+|RunDetail      |Stages (one section)                |stage                                        |Five tabs collapsed to zero. Header strip absorbs Overview. Artifact / sessions / verdict / events hang on each stage row.   |
+|ArtifactDetail |Content, Provenance, Consumers      |version (in Provenance Time axis)            |`Content` dispatched by `artifact_kind`. Provenance = single graph, axis switch (Time / Origin / Relations). Version History merges into Time axis. |
+|IssueDetail    |— (page retires)                    |—                                            |All renders move into `ArtifactDetail`'s Content section under `artifact_kind=github_issue` dispatch.                       |
+
+Five layout invariants:
+
+1. **One section per substrate object class.** A workflow has Definition
+   (its spec) + Activity (its history). A run has Stages (its only
+   first-class child). An artifact has Content + Provenance + Consumers.
+1. **Node attributes hang off the node, not the page.** Verdict, events,
+   sessions, output artifact all render inside the expanded detail of
+   their owning stage row, not as sibling sections.
+1. **`<Tabs>` is not primary IA.** Tabs are reserved for orthogonal
+   *views of the same data* (e.g., Provenance axis: Time / Origin /
+   Relations). Tabs are forbidden for switching between substrate object
+   classes. An xtask lint enforces this on `pages/*DetailPage.tsx`.
+1. **Header strip absorbs single-value metadata.** Status, owning
+   workflow/run link, started-at, trigger source, action buttons. No
+   "Overview" section.
+1. **Page = one document, not a stack of `<Card>`s.** Sections lead with
+   a label + horizontal rule; no `<Card>` wrapper around section
+   content. `<Card>` survives only as a contained unit for genuinely
+   self-bounded sub-content (e.g., a rendered markdown artifact body).
+
+Routing changes:
+
+- `/issues/:projectId/:number` 301-redirects to `/artifacts/:id` via
+  server-side `github_issue.external_ref` lookup (the same join
+  `IssueDetailPage` already performs at lines 49-53).
+- `WorkflowDetailPage` hash anchors: `#definition` and `#runs` preserved
+  as scroll targets. `#artifacts` and `#verdicts` 301-redirect to
+  `/workspaces/:slug/activity?workflow=<id>&source_type=artifact` and
+  `&source_type=verdict` respectively.
+
+Object-level Ask coverage (consequence for ADR 0020 ch4):
+
+`ChatAskButton` is currently mounted on `RunDetailPage` and
+`ArtifactDetailPage` but absent on `WorkflowDetailPage` and on every
+verdict / version / consumer row. This ADR makes the affordance
+load-bearing — without it, leaf objects (artifact, verdict version)
+have no horizontal-navigation primitive. See Adoption checklist.
+
+## Rejected alternatives
+
+- **Keep ADR 0019's anchored-section pattern on `WorkflowDetailPage`
+  only.** Considered as a no-op. Rejected because the other three
+  pages stay v0.1-shaped and ADR 0019's underlying principle — chrome
+  that reflects substrate — does not carry forward without this ADR.
+- **Promote Artifact and Verdict to top-level tabs (four-tab IA).**
+  Considered. Rejected by ADR 0019's own rejected alternatives section
+  (Artifact and Verdict are run-derived, not navigation-worthy). This
+  ADR accepts that constraint and addresses it by making the detail
+  page itself the surface for related-object discovery (Consumers
+  section, expandable stage rows).
+- **Keep `<Tabs>` IA, only re-organize tab contents.** Considered.
+  Rejected because the tab structure itself smuggles the "node
+  attribute = top-level surface" mental model. Re-arranging contents
+  within tabs reproduces the misframing one level down.
+- **Retain `IssueDetailPage` as a typed-kind specialization of
+  `ArtifactDetailPage`** (different code path, same parent route).
+  Considered. Rejected because parallel page paths for the same
+  underlying artifact create double-entry confusion in webhook URLs,
+  bookmarks, and Ask answers. The server-side `external_ref` lookup
+  collapses both into a single canonical artifact URL.
+- **Two ADRs (one for IA shape, one for `IssueDetailPage` retirement).**
+  Considered. Rejected because the four pages share one mental model;
+  splitting per-page would obscure the substrate principle and create
+  redundant Context sections.
+
+## Consequences
+
+### Positive
+
+- Detail pages share one IA shape. Substrate primitives map 1:1 to UI
+  primitives: node ↔ row, attribute ↔ field, axis ↔ tab (where
+  tabs are used at all).
+- Provenance source tags become legible (ADR 0010 substrate first-class)
+  because they hang on every node attribute. ADR 0022 covers their
+  visual treatment.
+- Artifact and Verdict, although not top-level surfaces, gain the
+  navigation glue they need: `Consumers` section on artifact (the
+  reverse traceability that compensates for no list view), expandable
+  stage detail on RunDetail (the verdict pin point).
+- One fewer page in the dashboard (`IssueDetailPage` retires); one
+  fewer GitHub-coupling in the substrate-facing surface.
+
+### Negative trade-offs
+
+- Expanded stage rows on RunDetail can grow tall when a stage emits
+  many events or runs multiple sessions. Mitigation: events table
+  truncates to last 20 with `[show all]`; sessions list truncates to
+  last 5.
+- `ArtifactDetail`'s Content section needs a dispatch table keyed on
+  `artifact_kind` (`github_issue`, `markdown`, `verdict`, `pull_request`,
+  future kinds). Mitigation: ship a default render (kind label + raw
+  fallback) first; per-kind branches land incrementally as needed.
+- `/issues/:projectId/:number` redirect introduces a one-step lookup
+  from `(projectId, number)` to `artifact_id`. Mitigation: the lookup
+  is the same join that `IssueDetailPage` already performs server-side;
+  no new index needed.
+
+### Neutral
+
+- WorkflowDetailPage hash anchors `#definition`, `#runs` preserved;
+  `#artifacts`, `#verdicts` 301 to Activity-filtered URLs.
+- `WorkflowEventsCard`, `WorkflowSessionsCard`, `WorkflowVerdictsTab`,
+  `WorkflowArtifactsTab` components are deleted as a side effect.
+- `components/sessions/SessionTable`, `SessionStateBadge`,
+  `SessionLogStream` were already orphaned by ADR 0019's
+  `SessionIdRedirect`; they remain dead code, cleaned up under a
+  separate dead-code follow-up, not this ADR.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog of a detail page is a spec issue.
+Spec issues already follow node-as-section: a spec has Plan (its
+stages), Implementation Notes (per-stage detail), Verdict (acceptance),
+Out of Scope (orthogonal). The detail page IA mirrors this shape —
+a page is one document organized around nodes, not a stack of cards
+organized around concerns.
+
+The "tabs = orthogonal views of same data" rule has a dev-process
+analog too: a spec's review checklist would be wrong if it used tabs
+to mean "switch between unrelated content"; in practice spec sections
+are anchored Markdown headings in one document. Detail pages adopt
+the same shape.
+
+## Adoption checklist
+
+- [ ] Open implementation spec; assign issue number; backfill into
+  this ADR's metadata
+- [ ] Remove `<Tabs>` from `RunDetailPage`; stages timeline absorbs
+  verdict, events, sessions, artifact into expanded stage detail
+- [ ] Remove `Verdicts` and `Artifacts` sections from
+  `WorkflowDetailPage`; add `Activity` section with link-out to
+  Activity tab filtered by workflow
+- [ ] Merge `ArtifactDetailPage`'s `Run Lineage`, `Version History`,
+  `Vertical Lineage`, `Horizontal Lineage` Cards into one `Provenance`
+  section with axis switch (Time / Origin / Relations)
+- [ ] Add `Content` section to `ArtifactDetailPage` with
+  `artifact_kind` dispatch; default branch + `markdown` + `github_issue`
+  branches ship first
+- [ ] Retire `IssueDetailPage`; add 301 redirect from
+  `/issues/:projectId/:number` to `/artifacts/:id` via
+  `github_issue.external_ref` server-side lookup
+- [ ] Attach `ChatAskButton` to: `WorkflowDetailPage` header; each
+  stage row in `RunDetailPage` expanded detail; each version row in
+  `ArtifactDetailPage` Provenance Time axis; each consumer row
+- [ ] Delete `WorkflowEventsCard`, `WorkflowSessionsCard`,
+  `WorkflowVerdictsTab`, `WorkflowArtifactsTab`
+- [ ] Preserve `#definition`, `#runs` hash anchors on
+  `WorkflowDetailPage`; add `#artifacts`, `#verdicts` 301 to
+  Activity-filtered URLs
+- [ ] xtask lint `check-detail-page-tabs`: `pages/*DetailPage.tsx` may
+  not import `<Tabs>` at the top level; tabs inside a section require
+  `// tabs-allow: <reason>` marker
+- [ ] Flip Status to `Accepted` once the above land
+
+## Out of scope
+
+- **Provenance source tag visual treatment.** Governed by ADR 0022.
+- **Non-linear DAG visualization in `WorkflowDetailPage` Definition.**
+  The current schema is linear stages; branching DAGs require a graph
+  layout component and ship later. This ADR does not block that work
+  but does not commit to it.
+- **Mobile-specific behaviors.** The IA shape works at mobile width
+  (stages stack vertically; expanded detail wraps). No phone-specific
+  behaviors committed here.
+- **Activity tab pre-filter URL schema.** The query-param schema for
+  `/workspaces/:slug/activity?workflow=X&source_type=verdict` is
+  governed by ADR 0019's source-type chip implementation and is not
+  re-litigated here.
+- **Per-`artifact_kind` Content render specifics.** This ADR commits
+  to a dispatch table; the visual specification per kind ships
+  incrementally as each kind earns a branch.

--- a/docs/adr/0021-detail-page-ia-node-as-section.md
+++ b/docs/adr/0021-detail-page-ia-node-as-section.md
@@ -3,11 +3,12 @@
 - **Status**: Proposed
 - **Date**: 2026-05-27
 - **Identity impact**: no
-- **Tracking issues**: pending — implementation spec to be opened on Accept.
-  Builds on ADR 0019 (which collapsed `WorkflowDetailPage`'s four tabs to
-  anchored sections) by extending the same logic to the remaining three
-  detail pages and by reframing the section split itself around substrate
-  primitives rather than v0.1 subsystem boundaries.
+- **Tracking issues**: #487 (implementation spec) and sub-issues #489,
+  #490, #491, #492. Builds on ADR 0019 (which collapsed
+  `WorkflowDetailPage`'s four tabs to anchored sections) by extending the
+  same logic to the remaining three detail pages and by reframing the
+  section split itself around substrate primitives rather than v0.1
+  subsystem boundaries.
 - **Supersedes**: none. Refines ADR 0019 without replacing it.
 - **Superseded by**: none
 

--- a/docs/adr/0022-provenance-source-tag-first-class-ui.md
+++ b/docs/adr/0022-provenance-source-tag-first-class-ui.md
@@ -1,0 +1,265 @@
+# ADR 0022 — Provenance source tag as first-class UI
+
+- **Status**: Proposed
+- **Date**: 2026-05-27
+- **Identity impact**: no. Refines how ADR 0010's substrate invariant
+  surfaces in UI; does not change the invariant itself.
+- **Tracking issues**: pending — implementation spec to be opened on
+  Accept. Depends on ADR 0021 for the detail-page surfaces this ADR
+  attaches to.
+- **Supersedes**: none
+- **Superseded by**: none
+
+## Context
+
+ADR 0010 promoted provenance to a substrate first-class concept with
+two flavors — `Deterministic` (output is verifiable from inputs
+without external state) and `Uncertain` (output depends on a
+non-deterministic executor: LLM, network, human, wall-clock) — each
+carrying a `SourceTag` payload that identifies the specific
+contributor.
+
+In the dashboard today this concept has zero UI surface. Examples
+from current code:
+
+- `pages/ArtifactDetailPage.tsx:340-395` — `Version History` table
+  columns are `Version / Session / Recorded`. No source column. An
+  operator inspecting a version cannot tell whether it came from a
+  deterministic forge step or from an agent self-report without
+  drilling into the session.
+- `pages/RunDetailPage.tsx:254-258` — verdict and event tabs render
+  status and timestamp; the verdict's `source` field is dropped on
+  the way to the row.
+- `pages/ActivityPage.tsx:23-79` — source-type chips exist (Artifact,
+  Run, Verdict, Trigger, Issue) but they reflect the *originating
+  subsystem*, not the Det/Unc flavor of each row. An operator
+  filtering for "Verdict" sees both deterministic CI verdicts and
+  agent self-reports as one flat list.
+- `pages/WorkflowDetailPage.tsx:225-244` — the Runs section shows
+  completed run status (pass/fail) without the run's terminal-verdict
+  source. Two runs that look identical in the list can have very
+  different epistemic standing.
+
+The substrate's first-class concept has no UI vocabulary. ADR 0010's
+investment in tagging every node attribute with provenance metadata
+is not reaching the operator.
+
+ADR 0021's per-detail-page IA reorganization places node attributes
+(verdict, events, sessions, output) into expanded detail rows on
+their owning node. Each of those rows is a candidate site for
+`SourceTag` rendering. Without a uniform UI vocabulary for the tag,
+the new IA shape inherits the same provenance-blindness as the old.
+
+## Decision
+
+Adopt a uniform UI vocabulary for provenance source tags. Apply it
+to every surface where Det/Unc attribution is meaningful.
+
+### Vocabulary
+
+|Flavor          |Treatment                                                              |Tight contexts |
+|----------------|-----------------------------------------------------------------------|---------------|
+|`Deterministic` |Mono small-caps, ink-tone neutral, tracked: `DETERMINISTIC`            |`DET`          |
+|`Uncertain`     |Italic serif, accent-tone, dagger superscript: *uncertain*<sup>†</sup> |*unc*<sup>†</sup>|
+
+Rationale for the typographic split:
+
+- The difference between "verifiable from inputs" and "self-reported
+  by a non-deterministic executor" is *epistemic*, not categorical.
+  Color-coded chips reduce the distinction to status (green vs amber
+  → "good vs warning"), which is wrong: an uncertain verdict can be
+  correct and a deterministic verdict can be wrong about its inputs.
+- The dagger (†) is the academic footnote convention for "this claim
+  requires verification". Readers familiar with the convention
+  recognize it; readers unfamiliar see a typographic difference and
+  reach for the tooltip.
+- Mono small-caps is the typographic equivalent of a printed
+  stamp/seal: settled, neutral, official. Italic serif is the
+  voice of editorial qualification: "as reported", "in the author's
+  view".
+- The typographic treatment uses no extra horizontal space beyond
+  the label string itself, important on row-dense surfaces.
+
+### Surfaces required to render `SourceTag`
+
+1. **`RunDetailPage` expanded stages** — each event row, each verdict,
+   each session output (per ADR 0021)
+1. **`ArtifactDetailPage` Provenance section** — every node in the
+   graph, regardless of which axis is active (Time / Origin /
+   Relations, per ADR 0021)
+1. **`ArtifactDetailPage` Consumers section** — each consumer row
+   carries the SourceTag of the run-stage that consumed it
+1. **`ActivityPage` rows** — each event row in the stream
+1. **`WorkflowDetailPage` Activity section** — each recent-run row
+   carries the source of that run's terminal verdict
+1. **Detail-page header strips** — when the page's primary object is
+   itself produced by an uncertain executor (e.g., agent-produced
+   artifact), the tag appears beside the producer link in the header
+
+### Tooltip
+
+Every `SourceTag` carries a hover/focus tooltip:
+
+- Deterministic: *"Source: Deterministic. Output is verifiable from
+  inputs without external state."*
+- Uncertain: *"Source: Uncertain. Output depends on a non-deterministic
+  executor (LLM, network, human, wall-clock). Verify before relying
+  on it."*
+
+### Filter dimension
+
+`SourceTag` becomes a filter axis parallel to existing ones:
+
+- Activity tab gains a `source` chip group (`All` / `Det` / `Unc`)
+  alongside the existing `source-type` chips
+- Workflows tab gains a `last verdict source` per-row pin; filterable
+  via a chip on the tab header
+
+### Component contract
+
+A shared `<SourceTag kind="deterministic" | "uncertain" />` component
+lands in `components/ui/source-tag.tsx`. The component:
+
+- Defaults to long-form label
+- Accepts `compact={true}` for tight contexts (table cells under
+  100px wide)
+- Renders tooltip via the existing `<Tooltip>` primitive
+- Has no `color` or `variant` prop — typography is the visual axis,
+  not theme
+
+## Rejected alternatives
+
+- **Color-coded badge chips** (e.g., emerald pill for deterministic,
+  amber pill for uncertain). Considered as the obvious option.
+  Rejected because (a) colored chips conflate Det/Unc with status
+  semantics (pass/warn), which they are not — an uncertain output can
+  be a passing verdict; a deterministic output can be a failed one;
+  (b) accessibility: colorblind operators lose the entire signal, and
+  no shape-based fallback maps cleanly onto a chip; (c) chip noise on
+  dense rows — a 20-row events list with amber chips on every row
+  reads as "everything is warning" and dilutes both status chips and
+  source chips into the same visual register.
+- **Single-icon variant** (lock for Det, question mark for Unc).
+  Considered. Rejected because icons compete with status icons
+  (check, cross, spinner) for the same visual register; two icon
+  families on each row crowds the start-of-row gutter where status
+  already lives.
+- **Render only on hover/focus** (the row shows status; source tag
+  appears on disclosure). Considered as a density-reduction option.
+  Rejected because operators scanning a verdict list need source
+  flavor at a glance — hidden-until-hover defeats the substrate's
+  first-class status. ADR 0010 made provenance first-class so it
+  could shape decisions; hiding it from default rendering reverses
+  that decision in the surface where it matters.
+- **Selective rendering** (render only on `RunDetail` and Provenance;
+  omit elsewhere). Considered. Rejected because the substrate doesn't
+  have a notion of "key" surfaces — every node carries a source tag
+  at the data level. Selective UI rendering creates the impression
+  that some events are unattributed, which is false.
+- **Inline prefix-symbol** (e.g., a small ◆ before deterministic, ◇
+  before uncertain rows). Considered as a minimal alternative.
+  Rejected because the symbols carry no semantic intuition and need
+  the same tooltip explanation as text labels — without buying any
+  density advantage over the typographic-label form.
+
+## Consequences
+
+### Positive
+
+- Operators see `SourceTag` on every surface where a substrate node
+  attribute appears. ADR 0010's first-class invariant gains UI parity.
+- A new filter axis (Det/Unc) opens for triage: "show me only
+  uncertain verdicts from this workflow" becomes a single chip
+  selection rather than a manual scan.
+- The typographic treatment costs no extra horizontal space beyond
+  the label string, important on dense surfaces (Activity stream,
+  event tables).
+- The Det/Unc distinction visibly attaches to the executor model: a
+  `claude-haiku-4.5` agent stage's verdict reads as *uncertain*<sup>†</sup>,
+  a CI verdict reads as `DETERMINISTIC` — and the operator can use
+  the distinction to calibrate trust without leaving the row.
+
+### Negative trade-offs
+
+- Surfaces with very high row counts (Activity stream paginated to
+  100+ rows) get a new visual element on every row. Mitigation: the
+  `compact={true}` form (`DET` / *unc*<sup>†</sup>) is permitted in
+  contexts under 100px column width and on the Activity stream by
+  default.
+- Operators unfamiliar with the dagger convention see an unfamiliar
+  symbol and need the tooltip on first encounter. Mitigation:
+  tooltip on every instance; one-time onboarding hint on first
+  verdict drill-in (FTUE event `ftue.source_tag.first_view`).
+- The italic serif typeface (Spectral or equivalent) must be
+  available on every surface that renders `SourceTag` — including
+  surfaces that don't currently load editorial type (e.g., embedded
+  preview thumbnails, OG-image generators). Mitigation: the
+  `<SourceTag>` component declares its own font dependency at the
+  bundle level, so any consuming surface inherits it transitively.
+
+### Neutral
+
+- ADR 0010's underlying schema is unchanged. No new substrate API,
+  no new event field. `source` is already on every event, verdict,
+  and version record.
+- The component lives in `components/ui/`, not in `components/governance/`
+  or `components/observers/`, signalling that it is a shared
+  UI primitive, not a subsystem widget.
+- The `xtask check-source-tag-coverage` lint (Adoption checklist) is
+  the dev-process enforcement counterpart of ADR 0010's substrate
+  invariant — same mechanism, different layer.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog is the spec's acceptance
+attribution. A spec's acceptance can be *verifiable* (CI pass + schema
+match) or *self-reported* (author confidence; reviewer trust).
+Treating both with the same dev-process weight is the same mistake
+the dashboard makes by rendering all provenance attributions
+identically.
+
+The corresponding spec-authoring convention: every acceptance line in
+a spec's "Done when" section is implicitly tagged. When ambiguous,
+authors annotate explicitly: *"CI passes (Deterministic)"* /
+*"reviewer judges output correct (Uncertain)"*. This matches the UI
+convention adopted here: typographic difference where the epistemic
+weight differs.
+
+## Adoption checklist
+
+- [ ] Open implementation spec; assign issue number; backfill into
+  this ADR's metadata
+- [ ] Land `components/ui/source-tag.tsx` with `kind` and `compact`
+  props, tooltip integration, no color/variant props
+- [ ] Mount `<SourceTag>` on the six surfaces enumerated in the
+  Decision section
+- [ ] Add `source` chip group (`All` / `Det` / `Unc`) to `ActivityPage`
+  alongside existing source-type chips
+- [ ] Add `last verdict source` per-row indicator + tab-header filter
+  to `WorkflowsPage`
+- [ ] Tooltip copy reviewed by ADR 0010 author for substrate-fidelity
+- [ ] FTUE event `ftue.source_tag.first_view` instrumented; one-time
+  hint shipped on first verdict drill-in
+- [ ] xtask lint `check-source-tag-coverage`: detail-page row
+  components rendering a substrate node attribute must reference
+  `<SourceTag>`; escape comments `// source-tag-omit: <reason>` allowed
+- [ ] Flip Status to `Accepted` once the above land
+
+## Out of scope
+
+- **Detail page IA shape.** Governed by ADR 0021. This ADR depends on
+  the surfaces that ADR 0021 introduces but does not specify their
+  structure.
+- **Chat (ADR 0020) integration.** Whether scope-local Ask buttons'
+  answer rendering surfaces `SourceTag` in their responses is governed
+  by chat IA + chat persona prompt design, not this ADR.
+- **Backend Det/Unc classification heuristics.** How an event is
+  labeled at write time is governed by ADR 0010 plus per-executor
+  specs. This ADR consumes the labels; it does not produce them.
+- **Dark-theme treatment.** Visual specification covers light theme
+  only. Dark-theme color and contrast targets land when dark-theme
+  support lands.
+- **Localization of dagger convention.** The dagger is a Western
+  scholarly typographic convention; locales where it carries a
+  different signal would need a per-locale override. Out of scope for
+  this ADR — revisit when localization scope opens.

--- a/docs/adr/0022-provenance-source-tag-first-class-ui.md
+++ b/docs/adr/0022-provenance-source-tag-first-class-ui.md
@@ -4,9 +4,9 @@
 - **Date**: 2026-05-27
 - **Identity impact**: no. Refines how ADR 0010's substrate invariant
   surfaces in UI; does not change the invariant itself.
-- **Tracking issues**: pending — implementation spec to be opened on
-  Accept. Depends on ADR 0021 for the detail-page surfaces this ADR
-  attaches to.
+- **Tracking issues**: #488 (implementation spec). Depends on ADR 0021's
+  implementation per #487 for the detail-page surfaces this ADR attaches
+  to.
 - **Supersedes**: none
 - **Superseded by**: none
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,9 @@ see [`../architecture.md`](../architecture.md).
 | [0017](0017-plan-compiler-three-step-algorithm.md) | Plan Compiler: three-step algorithm | Accepted (2026-05-15) — `Identity impact: yes` |
 | [0018](0018-five-kernel-invariants.md) | Five kernel invariants: static validation on workflow load | Accepted (2026-05-15) — `Identity impact: yes` |
 | [0019](0019-dashboard-ia-pipeline-centric-three-tab-surface.md) | Dashboard IA: pipeline-centric three-tab surface | Accepted (2026-05-22) — `Identity impact: no` |
-| [0020](0020-chat-as-portable-global-component-with-contextual-auto-scope.md) | Chat as portable global component with contextual auto-scope | Proposed (2026-05-22) — `Identity impact: no` |
+| [0020](0020-chat-as-portable-global-component-with-contextual-auto-scope.md) | Chat as portable global component with contextual auto-scope | Accepted (2026-05-22) — `Identity impact: no` |
+| [0021](0021-detail-page-ia-node-as-section.md) | Detail page IA: node-as-section, attribute-as-expanded-detail | Proposed (2026-05-27) — `Identity impact: no` |
+| [0022](0022-provenance-source-tag-first-class-ui.md) | Provenance source tag as first-class UI | Proposed (2026-05-27) — `Identity impact: no` |
 
 ## How to add an ADR
 


### PR DESCRIPTION
Lands two architectural decision records as decision artifacts — verified, indexed, cross-referenced, and paired with their implementation specs. This PR does **not** implement the IA refactor or the SourceTag component; that work is tracked by the spec issues below.

## What each ADR commits to

- **ADR 0021 — detail page IA: node-as-section.** Reshapes the four detail pages (`WorkflowDetailPage`, `RunDetailPage`, `ArtifactDetailPage`, `IssueDetailPage`) around two substrate primitives — a *node* (workflow stage / run stage / artifact version) and the *attributes* that hang off it. Node attributes (verdict, events, sessions, output) render inside their owning node's expanded detail rather than being promoted to page-level sections or tabs; `<Tabs>` is barred as primary IA; `IssueDetailPage` retires into an `artifact_kind=github_issue` dispatch on `ArtifactDetailPage`. It refines ADR 0019's anchored-section decision by extending the same logic to the remaining three pages.
- **ADR 0022 — provenance source tag as first-class UI.** Gives ADR 0010's Deterministic/Uncertain provenance flavors a uniform typographic UI vocabulary (`DETERMINISTIC` mono small-caps vs. *uncertain*† italic serif, no color/variant prop), a shared `<SourceTag>` primitive, tooltips, and a Det/Unc filter axis — rendered on every surface that displays a substrate node attribute.

## 0022 depends on 0021

Four of the six surfaces ADR 0022 mounts `<SourceTag>` on (RunDetail expanded stages, ArtifactDetail Provenance, ArtifactDetail Consumers, WorkflowDetail Activity) only exist after ADR 0021's IA reshape lands. The dependency is declared in 0022's metadata and in its implementation spec.

## Status

Both ADRs remain **Proposed**. Their Status flips to `Accepted` under their implementation specs on completion, not in this PR:

- ADR 0021 → Part of #487 (implementation spec) and sub-issues #489, #490, #491, #492
- ADR 0022 → Part of #488 (implementation spec); depends on #487

## No prior specs retired

ADR 0021 refines ADR 0019 without retiring it; ADR 0022 depends on ADR 0010 without amending it. No earlier spec is retired or superseded, so no `closed-by` follow-up comments were filed.

## Refines

- [ADR 0019](docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md) — pipeline-centric three-tab IA (0021 extends its anchored-section move)
- [ADR 0010](docs/adr/0010-provenance-as-substrate-first-class.md) — provenance as substrate first-class (0022 surfaces its invariant in UI)

## Changes

- `docs/adr/0021-detail-page-ia-node-as-section.md` (new)
- `docs/adr/0022-provenance-source-tag-first-class-ui.md` (new)
- `docs/adr/README.md` — index rows for 0021 + 0022; corrected the 0020 row to `Accepted (2026-05-22)` to match the file (flipped in 1d6ca3b)

All file:line citations in both ADRs' Context sections were re-grepped against the current tree and confirmed accurate; no citations required updating.

---
_Generated by [Claude Code](https://claude.ai/code/session_0179NjkRWtnxcAoQHce3Az5z)_