### PR TITLE
adr: reflow 0019-0022 to one line per paragraph

### DIFF
--- a/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
+++ b/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
@@ -3,51 +3,25 @@
 - **Status**: Accepted
 - **Date**: 2026-05-22
 - **Identity impact**: no
-- **Tracking issues**: #450 (implementation spec). Refines the
-  IA frame set by spec #289 (closed 2026-05-13 as completed, sub-PRs
-  2a–6 unshipped) and the FTUE umbrella spec #397 (closed 2026-05-19).
-  Retires spec #398 (universal-chat-entry, closed 2026-05-18) as a
-  side effect. The chat surface restructuring it implies is named in
-  the sibling ADR 0020.
-- **Supersedes**: none. The predecessor specs (#289, #397, #398) are
-  the prior dashboard-IA frame in prose; the repo convention reserves
-  the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
+- **Tracking issues**: #450 (implementation spec). Refines the IA frame set by spec #289 (closed 2026-05-13 as completed, sub-PRs 2a–6 unshipped) and the FTUE umbrella spec #397 (closed 2026-05-19). Retires spec #398 (universal-chat-entry, closed 2026-05-18) as a side effect. The chat surface restructuring it implies is named in the sibling ADR 0020.
+- **Supersedes**: none. The predecessor specs (#289, #397, #398) are the prior dashboard-IA frame in prose; the repo convention reserves the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
 - **Superseded by**: none
 
 ## Context
 
-The dashboard IA has accreted in layers. Spec #289 set a two-surface
-frame (sidebar = Chat + Workflows; everything else under ⌘K). Spec
-#398 routed `/` to `/chat` so first-time users would see chat on
-landing. Spec #306 added redirect-preserving fallbacks for older
-top-level routes (`/sessions`, `/spine`, `/governance`, `/issues`,
-`/nodes`). The FTUE umbrella spec #397 (and its children #404, #406,
-#408) layered on activation instrumentation, template gallery, and a
-factory metaphor for user-facing copy.
+The dashboard IA has accreted in layers. Spec #289 set a two-surface frame (sidebar = Chat + Workflows; everything else under ⌘K). Spec #398 routed `/` to `/chat` so first-time users would see chat on landing. Spec #306 added redirect-preserving fallbacks for older top-level routes (`/sessions`, `/spine`, `/governance`, `/issues`, `/nodes`). The FTUE umbrella spec #397 (and its children #404, #406, #408) layered on activation instrumentation, template gallery, and a factory metaphor for user-facing copy.
 
 In code today this produces:
 
-- Two route entries pointing at the same `ChatPage` component (`/chat`
-  unscoped, `/workspaces/:slug/chat` scoped) with subtly different
-  storage-key behaviour (`apps/dashboard/src/pages/ChatPage.tsx:293-297`)
-- A two-item sidebar carrying a workspace switcher + user menu around
-  two nav items, occupying ~260px of chrome to serve two destinations
-- A 4-tab `WorkflowDetailPage` where every tab is a stack of cards
-  (`apps/dashboard/src/pages/WorkflowDetailPage.tsx:218-256`)
-- Six redirect entries for previously top-level surfaces; the
-  redirect graveyard signals the IA has been shuffled at least once
-- Multiple banners (OSS notice, draft chip strip, MetaphorBanner,
-  webhook warnings) stacking at the top of the chat surface
+- Two route entries pointing at the same `ChatPage` component (`/chat` unscoped, `/workspaces/:slug/chat` scoped) with subtly different storage-key behaviour (`apps/dashboard/src/pages/ChatPage.tsx:293-297`)
+- A two-item sidebar carrying a workspace switcher + user menu around two nav items, occupying ~260px of chrome to serve two destinations
+- A 4-tab `WorkflowDetailPage` where every tab is a stack of cards (`apps/dashboard/src/pages/WorkflowDetailPage.tsx:218-256`)
+- Six redirect entries for previously top-level surfaces; the redirect graveyard signals the IA has been shuffled at least once
+- Multiple banners (OSS notice, draft chip strip, MetaphorBanner, webhook warnings) stacking at the top of the chat surface
 
-First-paint screen density does not differ visibly from a generic
-SaaS dashboard with two nav items. The sidebar is mostly chrome around
-empty space, and `ChatPage`’s default 2fr/3fr split renders an empty
-DAG preview as 60% of the viewport before the user has typed anything.
-Complexity hides in the second layer rather than the first: top-level
-looks light, drill-in looks dense.
+First-paint screen density does not differ visibly from a generic SaaS dashboard with two nav items. The sidebar is mostly chrome around empty space, and `ChatPage`’s default 2fr/3fr split renders an empty DAG preview as 60% of the viewport before the user has typed anything. Complexity hides in the second layer rather than the first: top-level looks light, drill-in looks dense.
 
-The deeper mismatch is between the domain hierarchy and the
-navigation hierarchy:
+The deeper mismatch is between the domain hierarchy and the navigation hierarchy:
 
 |Object  |Domain position                     |URL position                               |
 |--------|------------------------------------|-------------------------------------------|
@@ -58,15 +32,11 @@ navigation hierarchy:
 |Issue   |Trigger source, not a product object|Top-level detail route `/issues/:proj/:num`|
 |Project |Implicit (repo+install binding)     |No UI at all                               |
 
-Spec #289’s two-surface framing also splits a single linear pipeline
-(Chat → Draft → Bind → Workflow → Run → Artifact + Verdict) into two
-parallel modes (R&D vs production). The end-to-end view is hidden by
-the navigation shape.
+Spec #289’s two-surface framing also splits a single linear pipeline (Chat → Draft → Bind → Workflow → Run → Artifact + Verdict) into two parallel modes (R&D vs production). The end-to-end view is hidden by the navigation shape.
 
 ## Decision
 
-Adopt a pipeline-centric three-tab top-level IA. The sidebar is
-removed; workspace switcher and user menu move into the top chrome.
+Adopt a pipeline-centric three-tab top-level IA. The sidebar is removed; workspace switcher and user menu move into the top chrome.
 
 |Tab      |Surface role                                                                               |URL                          |
 |---------|-------------------------------------------------------------------------------------------|-----------------------------|
@@ -74,233 +44,96 @@ removed; workspace switcher and user menu move into the top chrome.
 |Runs     |Cross-workflow execution history, filterable by workflow / status / time.                  |`/workspaces/:slug/runs`     |
 |Activity |Spine event stream at operator grain.                                                      |`/workspaces/:slug/activity` |
 
-The Workflows tab carries filter chips for the four workflow lifecycle
-states — Drafted, Bound, Active, Paused. These chips expose the
-activation ladder (per spec #404 instrumentation, with `Drafted` as
-the new key metric per KB position
-`364d79199ca681b4953be66481634f97`) as filter dimensions, not as
-separate navigational surfaces. A workflow with `status='draft'` is
-the same object as one with `status='bound'`; only its state pin
-differs.
+The Workflows tab carries filter chips for the four workflow lifecycle states — Drafted, Bound, Active, Paused. These chips expose the activation ladder (per spec #404 instrumentation, with `Drafted` as the new key metric per KB position `364d79199ca681b4953be66481634f97`) as filter dimensions, not as separate navigational surfaces. A workflow with `status='draft'` is the same object as one with `status='bound'`; only its state pin differs.
 
 Routing changes:
 
-- `/` redirects to `/workspaces/:slug/workflows` for signed-in users
-  with at least one workspace, otherwise to `/workspaces` (picker)
-- `/chat` and `/workspaces/:slug/chat` are retired; existing bookmarks
-  301 to `/workspaces/:slug/workflows`. The chat surface itself
-  remains reachable as a global component per ADR 0020
-- `WorkflowDetailPage`’s four tabs (Definition / Runs / Artifacts /
-  Verdicts) collapse into one timeline page with anchored sections.
-  Existing hash anchors (`#definition`, `#runs`, `#artifacts`,
-  `#verdicts`) are preserved as scroll targets for bookmark
-  compatibility
-- Issues are not a top-level surface. The existing
-  `/issues/:projectId/:number` route remains as a deep-link target
-  for webhook notifications, with no in-dashboard entry point. Issue
-  records render as Activity source-type rows and as embedded
-  trigger-instance rows inside Workflow detail
-- The redirect map from spec #306 is extended with the chat retirements
-  but otherwise unchanged
+- `/` redirects to `/workspaces/:slug/workflows` for signed-in users with at least one workspace, otherwise to `/workspaces` (picker)
+- `/chat` and `/workspaces/:slug/chat` are retired; existing bookmarks 301 to `/workspaces/:slug/workflows`. The chat surface itself remains reachable as a global component per ADR 0020
+- `WorkflowDetailPage`’s four tabs (Definition / Runs / Artifacts / Verdicts) collapse into one timeline page with anchored sections. Existing hash anchors (`#definition`, `#runs`, `#artifacts`, `#verdicts`) are preserved as scroll targets for bookmark compatibility
+- Issues are not a top-level surface. The existing `/issues/:projectId/:number` route remains as a deep-link target for webhook notifications, with no in-dashboard entry point. Issue records render as Activity source-type rows and as embedded trigger-instance rows inside Workflow detail
+- The redirect map from spec #306 is extended with the chat retirements but otherwise unchanged
 
-The AI factory metaphor is removed from the dashboard’s
-substrate-facing surfaces. A grep of `apps/dashboard/src/` finds the
-metaphor at six distinct locations, not the five originally tallied
-under spec #408 (only one of which carries an inline comment marker):
+The AI factory metaphor is removed from the dashboard’s substrate-facing surfaces. A grep of `apps/dashboard/src/` finds the metaphor at six distinct locations, not the five originally tallied under spec #408 (only one of which carries an inline comment marker):
 
-1. `pages/ChatPage.tsx:838-843` — chat empty-state “inspection
-   reports / QC checkpoint” copy (spec #408 location 1, explicitly
-   commented in code)
-1. `pages/WorkflowsPage.tsx:69` — empty-state “factory starts
-   responding to GitHub events” copy
-1. `pages/WorkflowStartPage.tsx:23,99,255` — page title “Start the
-   factory” and “Run factory” button label
-1. `components/factory/workflows/MetaphorBanner.tsx` — workflow
-   detail banner; the file is deleted, not just its copy
-1. `components/chat/BindDraftDialog.tsx:186` — bind-draft dialog
-   prompt “First, name your factory floor.”
-1. `lib/chat/llm-client.ts:48,67` — chat assistant system prompt
-   persona (“AI factory operator”, “QC checkpoints” vocabulary). This
-   surface was missed by the original spec #408 enumeration. It
-   matters because it implicitly propagates the metaphor through every
-   assistant response.
+1. `pages/ChatPage.tsx:838-843` — chat empty-state “inspection reports / QC checkpoint” copy (spec #408 location 1, explicitly commented in code)
+1. `pages/WorkflowsPage.tsx:69` — empty-state “factory starts responding to GitHub events” copy
+1. `pages/WorkflowStartPage.tsx:23,99,255` — page title “Start the factory” and “Run factory” button label
+1. `components/factory/workflows/MetaphorBanner.tsx` — workflow detail banner; the file is deleted, not just its copy
+1. `components/chat/BindDraftDialog.tsx:186` — bind-draft dialog prompt “First, name your factory floor.”
+1. `lib/chat/llm-client.ts:48,67` — chat assistant system prompt persona (“AI factory operator”, “QC checkpoints” vocabulary). This surface was missed by the original spec #408 enumeration. It matters because it implicitly propagates the metaphor through every assistant response.
 
-The following metaphor surfaces are explicitly **kept**, per KB
-position (Notion `364d79199ca681b4953be66481634f97`: metaphor is
-permitted on marketing and template-content surfaces):
+The following metaphor surfaces are explicitly **kept**, per KB position (Notion `364d79199ca681b4953be66481634f97`: metaphor is permitted on marketing and template-content surfaces):
 
 - `pages/LandingPage.tsx` (marketing landing)
 - `pages/ShowcaseDogfoodPage.tsx` (public showcase)
 - `apps/marketing/*` (marketing app)
-- `apps/dashboard/src/lib/templates/v0.json` — the `factory_framing`
-  string on each template, locked as user-facing template copy by
-  the FTUE umbrella spec #406. These describe each template to the
-  user before they pick one and are content, not chrome.
-- `components/layout/CommandPalette.tsx:136` — `factory` retained as
-  a keyword alias on the “New workflow” command, so users who knew
-  the old vocabulary can still find the action
+- `apps/dashboard/src/lib/templates/v0.json` — the `factory_framing` string on each template, locked as user-facing template copy by the FTUE umbrella spec #406. These describe each template to the user before they pick one and are content, not chrome.
+- `components/layout/CommandPalette.tsx:136` — `factory` retained as a keyword alias on the “New workflow” command, so users who knew the old vocabulary can still find the action
 
-The directory name `components/factory/` is an internal identifier
-that KB explicitly excludes from the metaphor-permitted list. Renaming
-it is a mechanical refactor (50+ import sites) and lands as a
-follow-up issue, not under this ADR.
+The directory name `components/factory/` is an internal identifier that KB explicitly excludes from the metaphor-permitted list. Renaming it is a mechanical refactor (50+ import sites) and lands as a follow-up issue, not under this ADR.
 
-The metaphor tightening therefore goes by *location*, not just by
-*surface type*. KB’s existing rule (no IA / routes / identifiers /
-DB schema) is preserved; this ADR enumerates the six dashboard
-locations that fall under the rule but had been missed in practice.
+The metaphor tightening therefore goes by *location*, not just by *surface type*. KB’s existing rule (no IA / routes / identifiers / DB schema) is preserved; this ADR enumerates the six dashboard locations that fall under the rule but had been missed in practice.
 
 ## Rejected alternatives
 
-- **Keep spec #289’s two-surface IA, only fix the UI density.**
-  Considered as the lowest-risk option. Rejected because the
-  underlying problem is structural — chat and workflows are adjacent
-  stages of one pipeline, not parallel surfaces — and UI-only fixes
-  leave the mental-model mismatch in place.
-- **Object-centric three-tab IA (Workflows / Issues / Activity).**
-  Considered. Rejected because Issues are a passthrough view of
-  GitHub’s data model, not a first-class Onsager object. Promoting
-  them dilutes the workflow-first framing. The `/issues/:proj/:num`
-  route stays as a deep-link target only.
-- **Single-object IA (workflow-as-only-object), landing on the last
-  workflow visited.** Considered. Rejected because OSS users with
-  zero workflows have no surface to enter; the “where do I start”
-  question has no answer in this shape.
-- **Workspace-as-canvas single-page dashboard.** Considered. Rejected
-  because the canvas grid does not scale past ~10 workflows, and
-  cross-workflow runs and activity have no obvious place to land.
-- **Promote Drafted / Bound / Active / Paused to separate top-level
-  tabs.** Considered briefly. Rejected because these are workflow
-  lifecycle *states*, not separate surfaces. A workflow does not
-  change identity when its state pin moves from Drafted to Bound;
-  filter chips on the Workflows tab express the same axis without
-  fragmenting the object model. This also keeps the activation ladder
-  (per ADR 0009-adjacent instrumentation spec #404) on its metric
-  axis rather than promoting it to IA, in line with the KB framing.
-- **Retain the factory metaphor inside the dashboard as teaching
-  copy.** KB’s current rule would technically permit it (the rule
-  excludes IA / routes / identifiers / schema but not in-app copy).
-  Rejected because (a) the metaphor has spread to six unrelated
-  surfaces with no coordinated voice, (b) the product positioning
-  has shifted from “AI factory” to “AI-augmented work executor” per
-  the 2026-05-14 KB amendment, and (c) once a user produces their
-  first draft, substrate-native vocabulary should take over — also a
-  KB-explicit transition.
+- **Keep spec #289’s two-surface IA, only fix the UI density.** Considered as the lowest-risk option. Rejected because the underlying problem is structural — chat and workflows are adjacent stages of one pipeline, not parallel surfaces — and UI-only fixes leave the mental-model mismatch in place.
+- **Object-centric three-tab IA (Workflows / Issues / Activity).** Considered. Rejected because Issues are a passthrough view of GitHub’s data model, not a first-class Onsager object. Promoting them dilutes the workflow-first framing. The `/issues/:proj/:num` route stays as a deep-link target only.
+- **Single-object IA (workflow-as-only-object), landing on the last workflow visited.** Considered. Rejected because OSS users with zero workflows have no surface to enter; the “where do I start” question has no answer in this shape.
+- **Workspace-as-canvas single-page dashboard.** Considered. Rejected because the canvas grid does not scale past ~10 workflows, and cross-workflow runs and activity have no obvious place to land.
+- **Promote Drafted / Bound / Active / Paused to separate top-level tabs.** Considered briefly. Rejected because these are workflow lifecycle *states*, not separate surfaces. A workflow does not change identity when its state pin moves from Drafted to Bound; filter chips on the Workflows tab express the same axis without fragmenting the object model. This also keeps the activation ladder (per ADR 0009-adjacent instrumentation spec #404) on its metric axis rather than promoting it to IA, in line with the KB framing.
+- **Retain the factory metaphor inside the dashboard as teaching copy.** KB’s current rule would technically permit it (the rule excludes IA / routes / identifiers / schema but not in-app copy). Rejected because (a) the metaphor has spread to six unrelated surfaces with no coordinated voice, (b) the product positioning has shifted from “AI factory” to “AI-augmented work executor” per the 2026-05-14 KB amendment, and (c) once a user produces their first draft, substrate-native vocabulary should take over — also a KB-explicit transition.
 
 ## Consequences
 
 ### Positive
 
-- First-paint screen density drops sharply. The chrome is one row
-  (logo + workspace switcher + three tabs + ⌘K + avatar); the main
-  area is full-width.
-- Cross-workflow visibility becomes a first-class affordance. Runs
-  and Activity answer “what happened in this workspace lately”
-  without drilling into a specific workflow.
-- Workflow lifecycle becomes legible via state filter chips. The
-  activation ladder surfaces as filter counts (`Drafted · 2`,
-  `Active · 3`), keeping it visible as a metric without making it a
-  navigational axis.
-- Chat has a single, consistent role across the dashboard as a
-  global component (per ADR 0020), not a separate mode.
-- In-app vocabulary becomes consistent: factory metaphor confined to
-  marketing and template content; dashboard chrome and copy speak
-  substrate-native terms.
+- First-paint screen density drops sharply. The chrome is one row (logo + workspace switcher + three tabs + ⌘K + avatar); the main area is full-width.
+- Cross-workflow visibility becomes a first-class affordance. Runs and Activity answer “what happened in this workspace lately” without drilling into a specific workflow.
+- Workflow lifecycle becomes legible via state filter chips. The activation ladder surfaces as filter counts (`Drafted · 2`, `Active · 3`), keeping it visible as a metric without making it a navigational axis.
+- Chat has a single, consistent role across the dashboard as a global component (per ADR 0020), not a separate mode.
+- In-app vocabulary becomes consistent: factory metaphor confined to marketing and template content; dashboard chrome and copy speak substrate-native terms.
 
 ### Negative trade-offs
 
-- Existing OSS users will find their muscle memory broken on first
-  deploy. Mitigation: changelog entry plus a one-release “what’s new”
-  banner pointing at the new chrome.
-- The Workflow detail page becomes long when a workflow has many
-  runs, artifacts, and verdicts. Mitigation: each anchored section
-  truncates to “last N” with `[show all]` controls and lazy-loads on
-  scroll.
-- The `factory_framing` strings inside `templates/v0.json` now exist
-  under a different governance regime than the surrounding UI (kept,
-  not removed). Mitigation: a comment block at the top of the JSON
-  file cites this ADR and the FTUE umbrella spec #406.
-- The Issue detail route survives as an entry-point-less deep link.
-  Mitigation: webhook notification links still resolve; the route is
-  documented as “deep-link target only” in the route table.
-- The `components/factory/` directory name is technically a
-  KB-violating identifier that this ADR does not resolve. Mitigation:
-  a follow-up refactor issue is filed; until renamed, the directory
-  remains internal-only and never surfaces to users.
+- Existing OSS users will find their muscle memory broken on first deploy. Mitigation: changelog entry plus a one-release “what’s new” banner pointing at the new chrome.
+- The Workflow detail page becomes long when a workflow has many runs, artifacts, and verdicts. Mitigation: each anchored section truncates to “last N” with `[show all]` controls and lazy-loads on scroll.
+- The `factory_framing` strings inside `templates/v0.json` now exist under a different governance regime than the surrounding UI (kept, not removed). Mitigation: a comment block at the top of the JSON file cites this ADR and the FTUE umbrella spec #406.
+- The Issue detail route survives as an entry-point-less deep link. Mitigation: webhook notification links still resolve; the route is documented as “deep-link target only” in the route table.
+- The `components/factory/` directory name is technically a KB-violating identifier that this ADR does not resolve. Mitigation: a follow-up refactor issue is filed; until renamed, the directory remains internal-only and never surfaces to users.
 
 ### Neutral
 
-- The redirect map from spec #306 grows by two entries (`/chat`,
-  `/workspaces/:slug/chat`). The existing redirect plumbing handles
-  it.
-- Settings remains accessible under the user menu and ⌘K, with no
-  top-level tab. Unchanged from prior IA.
-- Hash anchors inside the collapsed `WorkflowDetailPage` stay
-  bookmark-stable.
+- The redirect map from spec #306 grows by two entries (`/chat`, `/workspaces/:slug/chat`). The existing redirect plumbing handles it.
+- Settings remains accessible under the user menu and ⌘K, with no top-level tab. Unchanged from prior IA.
+- Hash anchors inside the collapsed `WorkflowDetailPage` stay bookmark-stable.
 
 ## Dev-process counterpart
 
-Per ADR 0002, the dev-process analog of a top-level dashboard tab is
-the issue label that gates work entering each lane. Workflows tab
-maps to issues labelled `area:workflow`; Runs tab maps to runs
-surfaced through spec issues with run logs; Activity tab maps to the
-spine event log used by maintainers to debug cross-spec behaviour.
+Per ADR 0002, the dev-process analog of a top-level dashboard tab is the issue label that gates work entering each lane. Workflows tab maps to issues labelled `area:workflow`; Runs tab maps to runs surfaced through spec issues with run logs; Activity tab maps to the spine event log used by maintainers to debug cross-spec behaviour.
 
-The lifecycle state filter chips parallel issue states: Drafted ↔
-issue `draft`, Bound ↔ `in-progress`, Active ↔ `in-flight`, Paused ↔
-`on-hold`.
+The lifecycle state filter chips parallel issue states: Drafted ↔ issue `draft`, Bound ↔ `in-progress`, Active ↔ `in-flight`, Paused ↔ `on-hold`.
 
-The “metaphor only in marketing and template content” rule maps to
-the spec authoring convention: an issue’s title and body use substrate
-terms; only fields whose contents are surfaced to users (such as a
-template’s `factory_framing`) may carry metaphor copy.
+The “metaphor only in marketing and template content” rule maps to the spec authoring convention: an issue’s title and body use substrate terms; only fields whose contents are surfaced to users (such as a template’s `factory_framing`) may carry metaphor copy.
 
 ## Adoption checklist
 
-- [ ] Land the new top chrome (workspace switcher + three tabs +
-  tools cluster); delete `AppSidebar.tsx` and remove its imports
-- [ ] Add list routes for `/workspaces/:slug/runs` and
-  `/workspaces/:slug/activity`; the existing flat `/runs/:id` and
-  `/artifacts/:id` detail routes are preserved
-- [ ] Collapse `WorkflowDetailPage.tsx` from four tabs to one timeline
-  page; preserve `#definition`, `#runs`, `#artifacts`,
-  `#verdicts` hash anchors as scroll targets
-- [ ] Add state filter chips (`All`, `Drafted · N`, `Bound · N`,
-  `Active · N`, `Paused · N`) to the Workflows list
-- [ ] Add 301 redirects for `/chat` and `/workspaces/:slug/chat` in
-  the spec #306 redirect map; extend the smoke-test for redirect
-  coverage
-- [ ] Remove the metaphor from the six locations enumerated in the
-  Decision section; delete `MetaphorBanner.tsx`; update the
-  `llm-client.ts` system prompt to substrate-native vocabulary
-- [ ] Add a comment block to `apps/dashboard/src/lib/templates/v0.json`
-  citing ADR 0019 and spec #406 (templates’ `factory_framing`
-  stays as user-facing copy)
-- [ ] File a follow-up issue to rename `components/factory/` to a
-  substrate-native name; mark as blocked until ADR 0019 ships
-- [ ] Add `closed by ADR 0019` follow-up comments to specs #289,
-  #397, #398
-- [ ] Update KB page `364d79199ca681b4953be66481634f97` (“Onsager 产
-  品定位 v0.1”) to point at ADR 0019 as the current IA reference
+- [ ] Land the new top chrome (workspace switcher + three tabs + tools cluster); delete `AppSidebar.tsx` and remove its imports
+- [ ] Add list routes for `/workspaces/:slug/runs` and `/workspaces/:slug/activity`; the existing flat `/runs/:id` and `/artifacts/:id` detail routes are preserved
+- [ ] Collapse `WorkflowDetailPage.tsx` from four tabs to one timeline page; preserve `#definition`, `#runs`, `#artifacts`, `#verdicts` hash anchors as scroll targets
+- [ ] Add state filter chips (`All`, `Drafted · N`, `Bound · N`, `Active · N`, `Paused · N`) to the Workflows list
+- [ ] Add 301 redirects for `/chat` and `/workspaces/:slug/chat` in the spec #306 redirect map; extend the smoke-test for redirect coverage
+- [ ] Remove the metaphor from the six locations enumerated in the Decision section; delete `MetaphorBanner.tsx`; update the `llm-client.ts` system prompt to substrate-native vocabulary
+- [ ] Add a comment block to `apps/dashboard/src/lib/templates/v0.json` citing ADR 0019 and spec #406 (templates’ `factory_framing` stays as user-facing copy)
+- [ ] File a follow-up issue to rename `components/factory/` to a substrate-native name; mark as blocked until ADR 0019 ships
+- [ ] Add `closed by ADR 0019` follow-up comments to specs #289, #397, #398
+- [ ] Update KB page `364d79199ca681b4953be66481634f97` (“Onsager 产 品定位 v0.1”) to point at ADR 0019 as the current IA reference
 - [ ] Flip Status to `Accepted` once the above land
 
 ## Out of scope
 
-- **Chat surface mount form.** Where chat renders (FAB / Sidebar /
-  Drawer / Palette) is governed by ADR 0020, not this ADR. This ADR
-  fixes the tab structure only.
-- **Workflow detail content model.** Which artifacts and verdicts
-  appear under each anchored section is governed by ADR 0009 +
-  ADR 0016. This ADR changes the page’s chrome from tabs to anchored
-  sections, not the content shape.
-- **Cross-workspace surfaces.** All three tabs are workspace-scoped.
-  A global “all workspaces” overview is not part of this ADR.
-- **Mobile-specific IA.** The three-tab pattern fits desktop and
-  tablet. On phone-narrow viewports the chrome compresses (workspace
-  switcher + logo on row 1, tabs on row 2), and the long workflow
-  detail page benefits from anchored sections, but no phone-specific
-  IA changes are committed here.
-- **The `components/factory/` directory rename.** Filed as a
-  follow-up. This ADR removes the metaphor from user-visible copy
-  and from the assistant persona, but does not refactor the internal
-  module name.
+- **Chat surface mount form.** Where chat renders (FAB / Sidebar / Drawer / Palette) is governed by ADR 0020, not this ADR. This ADR fixes the tab structure only.
+- **Workflow detail content model.** Which artifacts and verdicts appear under each anchored section is governed by ADR 0009 + ADR 0016. This ADR changes the page’s chrome from tabs to anchored sections, not the content shape.
+- **Cross-workspace surfaces.** All three tabs are workspace-scoped. A global “all workspaces” overview is not part of this ADR.
+- **Mobile-specific IA.** The three-tab pattern fits desktop and tablet. On phone-narrow viewports the chrome compresses (workspace switcher + logo on row 1, tabs on row 2), and the long workflow detail page benefits from anchored sections, but no phone-specific IA changes are committed here.
+- **The `components/factory/` directory rename.** Filed as a follow-up. This ADR removes the metaphor from user-visible copy and from the assistant persona, but does not refactor the internal module name.

--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -3,100 +3,49 @@
 - **Status**: Accepted
 - **Date**: 2026-05-22
 - **Identity impact**: no
-- **Tracking issues**: #451 (implementation spec). Sibling to
-  ADR 0019, which removes the top-level Chat tab. This ADR governs
-  what chat *becomes* once it is no longer a tab. Builds on ADR 0007
-  (tools and skills as the public contract) and ADR 0008 (portal
-  owns the agent control plane).
-- **Supersedes**: none. Predecessor specs (#398 universal-chat-entry,
-  #400 chat empty-state chips, #401 DraftStrip + chat surface) are
-  the prior frame in prose; the repo convention reserves the
-  `Supersedes` field for ADR-to-ADR replacement, so no entry here.
+- **Tracking issues**: #451 (implementation spec). Sibling to ADR 0019, which removes the top-level Chat tab. This ADR governs what chat *becomes* once it is no longer a tab. Builds on ADR 0007 (tools and skills as the public contract) and ADR 0008 (portal owns the agent control plane).
+- **Supersedes**: none. Predecessor specs (#398 universal-chat-entry, #400 chat empty-state chips, #401 DraftStrip + chat surface) are the prior frame in prose; the repo convention reserves the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
 - **Superseded by**: none
 
 ## Context
 
-The dashboard’s chat surface is a page today — `ChatPage.tsx` (1005
-lines), reachable via two routes (`/chat` and
-`/workspaces/:slug/chat`). It hosts a conversation feed with HITL
-cards, a draft chip strip, a right-pane DAG preview, an empty-state
-template gallery, and a stack of banners (OSS notice, webhook health
-warning). The right-pane DAG preview is rendered as a 60% viewport
-strip even when no draft is active.
+The dashboard’s chat surface is a page today — `ChatPage.tsx` (1005 lines), reachable via two routes (`/chat` and `/workspaces/:slug/chat`). It hosts a conversation feed with HITL cards, a draft chip strip, a right-pane DAG preview, an empty-state template gallery, and a stack of banners (OSS notice, webhook health warning). The right-pane DAG preview is rendered as a 60% viewport strip even when no draft is active.
 
-This commits the chat to one of the four top-level dashboard surfaces
-that spec #289’s two-surface IA recognized. With ADR 0019 collapsing
-the IA to three tabs (Workflows / Runs / Activity) and removing Chat
-from top-level, the question becomes: how does a user reach chat, and
-in what form?
+This commits the chat to one of the four top-level dashboard surfaces that spec #289’s two-surface IA recognized. With ADR 0019 collapsing the IA to three tabs (Workflows / Runs / Activity) and removing Chat from top-level, the question becomes: how does a user reach chat, and in what form?
 
-KB position (Notion `35cd79199ca68131b4f6efac9ed8c3d6`, Onsager root
-note) frames the substrate as UI-portable via the MCP control plane:
+KB position (Notion `35cd79199ca68131b4f6efac9ed8c3d6`, Onsager root note) frames the substrate as UI-portable via the MCP control plane:
 
-> Onsager substrate UI-portable via MCP control plane (intent /
-> spec_plan / compile / run / status / artifacts / verdicts); Claude
-> / Cursor / Onsager UI 互换 intent frontends
+> Onsager substrate UI-portable via MCP control plane (intent / spec_plan / compile / run / status / artifacts / verdicts); Claude / Cursor / Onsager UI 互换 intent frontends
 
-ADR 0007 names the same point at the protocol layer: tools and skills
-are the public contract; the dashboard chat UI is one of N consumers
-of that contract, not a privileged one. ADR 0008 then carves portal
-as the owner of the public surface those consumers reach. Together
-they imply that chat inside the dashboard:
+ADR 0007 names the same point at the protocol layer: tools and skills are the public contract; the dashboard chat UI is one of N consumers of that contract, not a privileged one. ADR 0008 then carves portal as the owner of the public surface those consumers reach. Together they imply that chat inside the dashboard:
 
-- Is one MCP client among Claude, Cursor, and any other intent
-  frontend
-- Should not occupy a privileged top-level position relative to other
-  user activities
+- Is one MCP client among Claude, Cursor, and any other intent frontend
+- Should not occupy a privileged top-level position relative to other user activities
 - Should be reachable from anywhere a user might form an intent
-- Should be aware of what the user is currently looking at, without
-  forcing them to restate it
+- Should be aware of what the user is currently looking at, without forcing them to restate it
 
-A second concern is form and entry. The earlier framing of this ADR
-listed four "mount forms" (FAB, Sidebar, Drawer, Palette) as user-
-selectable shells. A mobile-first design review found this conflated
-two orthogonal axes: where the chat surface lives in the viewport
-(mount form) and how the user opens it (invocation channel). FAB
-and ⌘K are invocation channels, not viewport forms; Drawer and
-Sidebar are the same surface positioned differently across mobile
-and desktop. One responsive mount with several invocation channels
-fits the P1 ICP (Staff/Principal Engineer working across mobile and
-desktop) without forcing a "pick your shell" choice users should
-not have to think about.
+A second concern is form and entry. The earlier framing of this ADR listed four "mount forms" (FAB, Sidebar, Drawer, Palette) as user- selectable shells. A mobile-first design review found this conflated two orthogonal axes: where the chat surface lives in the viewport (mount form) and how the user opens it (invocation channel). FAB and ⌘K are invocation channels, not viewport forms; Drawer and Sidebar are the same surface positioned differently across mobile and desktop. One responsive mount with several invocation channels fits the P1 ICP (Staff/Principal Engineer working across mobile and desktop) without forcing a "pick your shell" choice users should not have to think about.
 
-The third concern is scope. The current
-`chatStorageKey(user.id, workspace.id)` at
-`apps/dashboard/src/pages/ChatPage.tsx:293-297` ties one thread per
-workspace. Users investigating multiple workflows in the same
-workspace lose continuity: every conversation about workflow A is
-mixed into the same thread as conversations about workflow B. A
-finer scoping is needed.
+The third concern is scope. The current `chatStorageKey(user.id, workspace.id)` at `apps/dashboard/src/pages/ChatPage.tsx:293-297` ties one thread per workspace. Users investigating multiple workflows in the same workspace lose continuity: every conversation about workflow A is mixed into the same thread as conversations about workflow B. A finer scoping is needed.
 
 ## Decision
 
-Chat becomes a portable global component: one responsive mount, five
-invocation channels, one shared state and storage layer.
+Chat becomes a portable global component: one responsive mount, five invocation channels, one shared state and storage layer.
 
 ### Mount: one responsive component
 
-A single `ChatContainer` adapts to the viewport — no user-selectable
-mount form.
+A single `ChatContainer` adapts to the viewport — no user-selectable mount form.
 
 |Platform|Position               |Size                            |Dismiss                  |
 |--------|-----------------------|--------------------------------|-------------------------|
 |Mobile  |Bottom-anchored overlay|~70% viewport height, full width|Drag-down or close button|
 |Desktop |Right-anchored sidebar |420px fixed width, full height  |`⌘J` or close button     |
 
-Both render the same Hybrid surface — a segmented control with two
-tabs, `Queue` (HITL aggregator for the current scope) and `Thread`
-(rolling conversation). Default tab is `Queue` when scope has
-pending HITL, `Thread` otherwise.
+Both render the same Hybrid surface — a segmented control with two tabs, `Queue` (HITL aggregator for the current scope) and `Thread` (rolling conversation). Default tab is `Queue` when scope has pending HITL, `Thread` otherwise.
 
 ### Invocation channels
 
-Five channels open the same mount. Guiding rule: **more prominent
-entry → more specific scope** — the loud FAB lands in the current
-route; the quieter top-chrome bell lands in the workspace-wide
-Inbox. The inversion would surprise users.
+Five channels open the same mount. Guiding rule: **more prominent entry → more specific scope** — the loud FAB lands in the current route; the quieter top-chrome bell lands in the workspace-wide Inbox. The inversion would surprise users.
 
 |#|Channel                 |Default scope                           |Default tab                  |Platform                            |
 |-|------------------------|----------------------------------------|-----------------------------|------------------------------------|
@@ -106,16 +55,11 @@ Inbox. The inversion would surprise users.
 |4|Scope-local "Ask" button|Object-level (step / verdict / artifact)|Thread                       |Mobile + desktop                    |
 |5|⌘K palette              |Current route                           |Thread                       |Desktop                             |
 
-Only push notification is a deep link, carrying an HITL id; the
-other four land in the mount's default state for the resolved
-scope. Push originates on the portal MCP control plane (ADR 0008);
-the dashboard consumes it as one MCP client among many (ADR 0007).
+Only push notification is a deep link, carrying an HITL id; the other four land in the mount's default state for the resolved scope. Push originates on the portal MCP control plane (ADR 0008); the dashboard consumes it as one MCP client among many (ADR 0007).
 
 ### FAB three-state behavior (mobile)
 
-States are driven by scope HITL state and viewport conditions, not
-user toggle. Long-press jumps to the Inbox (`scope=workspace`); a
-first-time hint surfaces on the third FAB use.
+States are driven by scope HITL state and viewport conditions, not user toggle. Long-press jumps to the Inbox (`scope=workspace`); a first-time hint surfaces on the third FAB use.
 
 |State |Trigger                             |Visual                                                                                               |
 |------|------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -125,15 +69,10 @@ first-time hint surfaces on the third FAB use.
 
 ### Notification action buttons
 
-- **Approval-kind HITL** ships `Approve` / `Reject` buttons, handled
-  in the notification surface without opening the app. The handler
-  relays the choice to the portal MCP control plane (ADR 0008).
-- **Selection-kind and Clarify-kind HITL** ship only `Open`. These
-  kinds need additional input the notification surface cannot
-  capture; `Open` lands on the highlighted Queue card.
+- **Approval-kind HITL** ships `Approve` / `Reject` buttons, handled in the notification surface without opening the app. The handler relays the choice to the portal MCP control plane (ADR 0008).
+- **Selection-kind and Clarify-kind HITL** ship only `Open`. These kinds need additional input the notification surface cannot capture; `Open` lands on the highlighted Queue card.
 
-The callback → MCP elicitation response binding is a follow-up ADR
-(see Out of scope).
+The callback → MCP elicitation response binding is a follow-up ADR (see Out of scope).
 
 ### Contextual auto-scope
 
@@ -148,22 +87,11 @@ The chat scope follows the user’s current view:
 |Workspace switch                        |scope reset to new workspace    |
 |Tab switch (Workflows ↔ Runs ↔ Activity)|scope preserved at current level|
 
-Each scope holds **one rolling thread**. Returning to a previously
-visited scope resumes the same conversation; no implicit thread
-creation. A pin control in the chat header locks the scope against
-navigation changes, supporting cross-context inquiry — “looking at
-workflow A while asking a question about workflow B” — without
-forking the conversation model.
+Each scope holds **one rolling thread**. Returning to a previously visited scope resumes the same conversation; no implicit thread creation. A pin control in the chat header locks the scope against navigation changes, supporting cross-context inquiry — “looking at workflow A while asking a question about workflow B” — without forking the conversation model.
 
-Cross-scope history is fully indexed on the backend. The scope filter
-is a default view, not a wall: when the user asks “what did we
-decide about release notes last week?” inside a workflow A scope, the
-assistant searches across all the user’s scopes in the current
-workspace and cites the source scope alongside the answer.
+Cross-scope history is fully indexed on the backend. The scope filter is a default view, not a wall: when the user asks “what did we decide about release notes last week?” inside a workflow A scope, the assistant searches across all the user’s scopes in the current workspace and cites the source scope alongside the answer.
 
-The chat header renders the scope path as a breadcrumb:
-`acme-corp / Auto-merge on green / Run #42`. Pin state shows as a
-filled-icon affordance next to the breadcrumb.
+The chat header renders the scope path as a breadcrumb: `acme-corp / Auto-merge on green / Run #42`. Pin state shows as a filled-icon affordance next to the breadcrumb.
 
 ### Storage schema change
 
@@ -172,215 +100,84 @@ old: chatStorageKey(user_id, workspace_id) → localStorage entry
 new: chatStorageKey(user_id, scope_type, scope_id) → backend (server-side)
 ```
 
-The old single-thread-per-workspace key collapses to
-`scope_type='workspace'`; new finer scopes (`workflow`, `run`,
-`verdict`) get their own keys. The storage backend moves from
-client-side `localStorage` to server-side persistence; the engine
-choice (Postgres, spine, dedicated chat store) is delegated to the
-implementation spec.
+The old single-thread-per-workspace key collapses to `scope_type='workspace'`; new finer scopes (`workflow`, `run`, `verdict`) get their own keys. The storage backend moves from client-side `localStorage` to server-side persistence; the engine choice (Postgres, spine, dedicated chat store) is delegated to the implementation spec.
 
-**Migration strategy: fresh start.** Onsager is pre-launch; existing
-chat-storage entries belong to OSS dogfood users only. Their
-`localStorage` entries are read once at first login after this ADR
-ships and surfaced as a one-time “previous conversations” link
-inside the workspace-scoped thread. Subsequent writes go to the
-backend under the new schema. No automated data migration ships.
+**Migration strategy: fresh start.** Onsager is pre-launch; existing chat-storage entries belong to OSS dogfood users only. Their `localStorage` entries are read once at first login after this ADR ships and surfaced as a one-time “previous conversations” link inside the workspace-scoped thread. Subsequent writes go to the backend under the new schema. No automated data migration ships.
 
 ### Empty-state behaviour
 
-After ADR 0019 + this ADR land, signed-in users with zero workflows
-land on the Workflows tab and see an empty state. The empty state
-displays a “Start in chat →” card that opens the chat surface,
-scoped to the workspace. The chat empty state itself shows the
-template gallery from
-`apps/dashboard/src/lib/templates/v0.json` (per spec #406, content
-unchanged). The DraftStrip from `apps/dashboard/src/components/chat/ DraftStrip.tsx` is removed; its function (switching between in-flight
-drafts) is absorbed into the Workflows tab’s state-filter chips when
-filtered to `Drafted`.
+After ADR 0019 + this ADR land, signed-in users with zero workflows land on the Workflows tab and see an empty state. The empty state displays a “Start in chat →” card that opens the chat surface, scoped to the workspace. The chat empty state itself shows the template gallery from `apps/dashboard/src/lib/templates/v0.json` (per spec #406, content unchanged). The DraftStrip from `apps/dashboard/src/components/chat/ DraftStrip.tsx` is removed; its function (switching between in-flight drafts) is absorbed into the Workflows tab’s state-filter chips when filtered to `Drafted`.
 
 ## Rejected alternatives
 
-- **Keep chat as a page (one of the three top-level tabs).**
-  Considered as a “Chat / Workflows / Runs” tab trio. Rejected
-  because it would re-create the spec #289 mode-split that pipeline-
-  centric IA explicitly retires, and it would contradict ADR 0007’s
-  framing of the chat UI as one MCP client among many.
-- **Keep four user-selectable mount forms (FAB / Sidebar / Drawer /
-  Palette).** The previous draft. Two of the four are invocation
-  channels, not viewport forms; the other two are the same surface
-  positioned differently. Conflating the axes forces a shell choice
-  the user should not have to make.
-- **Drawer as the unified desktop+mobile mount.** Rejected because a
-  right-edge slide-over fits mobile poorly — the natural mobile
-  gesture is bottom-anchored with drag-down dismiss. Costs the
-  one-thumb HITL workflow for code reuse.
-- **Cursor-style persistent sidebar as the only desktop mount.**
-  Rejected because it pre-occupies main-area width even when idle,
-  conflicting with ADR 0019's three-tab surface. A "pin sidebar
-  open" preference can layer on the responsive mount later.
-- **One chat thread per workspace, no auto-scope.** The simplest
-  extension of the current shape. Rejected because users working
-  across multiple workflows in the same workspace lose continuity;
-  every conversation about workflow A mixes into the same thread as
-  conversations about workflow B.
-- **Multiple threads per scope (GitHub-issue-with-comments shape).**
-  Considered. Rejected for now because single rolling thread per
-  scope is simpler to ship, simpler to teach, and matches the Cursor
-  model users already recognise. The storage schema reserves room to
-  add a `thread_id` axis later if the multi-thread case emerges; the
-  reserve costs nothing now.
-- **Scope follows navigation strictly, no pin.** Considered for
-  simplicity. Rejected because power users investigating workflow A
-  while consulting workflow B’s conversation history would lose
-  context on every click. Pin is a low-cost escape hatch (one
-  icon, one boolean in scope state).
-- **Store chat client-side (localStorage only).** Considered because
-  it preserves the current shape. Rejected because cross-device
-  continuity is part of the value once chat scopes get finer than
-  workspace, and the substrate’s MCP control plane already owns
-  conversation state authoritatively. Client-side caching can be a
-  perf layer; authoritative state lives on the server.
-- **Store chat client-side per scope, with sync-on-demand.**
-  Considered as a hybrid. Rejected because the sync-conflict
-  resolution adds complexity disproportionate to the value;
-  pre-launch is the cheapest moment to fix the schema.
+- **Keep chat as a page (one of the three top-level tabs).** Considered as a “Chat / Workflows / Runs” tab trio. Rejected because it would re-create the spec #289 mode-split that pipeline- centric IA explicitly retires, and it would contradict ADR 0007’s framing of the chat UI as one MCP client among many.
+- **Keep four user-selectable mount forms (FAB / Sidebar / Drawer / Palette).** The previous draft. Two of the four are invocation channels, not viewport forms; the other two are the same surface positioned differently. Conflating the axes forces a shell choice the user should not have to make.
+- **Drawer as the unified desktop+mobile mount.** Rejected because a right-edge slide-over fits mobile poorly — the natural mobile gesture is bottom-anchored with drag-down dismiss. Costs the one-thumb HITL workflow for code reuse.
+- **Cursor-style persistent sidebar as the only desktop mount.** Rejected because it pre-occupies main-area width even when idle, conflicting with ADR 0019's three-tab surface. A "pin sidebar open" preference can layer on the responsive mount later.
+- **One chat thread per workspace, no auto-scope.** The simplest extension of the current shape. Rejected because users working across multiple workflows in the same workspace lose continuity; every conversation about workflow A mixes into the same thread as conversations about workflow B.
+- **Multiple threads per scope (GitHub-issue-with-comments shape).** Considered. Rejected for now because single rolling thread per scope is simpler to ship, simpler to teach, and matches the Cursor model users already recognise. The storage schema reserves room to add a `thread_id` axis later if the multi-thread case emerges; the reserve costs nothing now.
+- **Scope follows navigation strictly, no pin.** Considered for simplicity. Rejected because power users investigating workflow A while consulting workflow B’s conversation history would lose context on every click. Pin is a low-cost escape hatch (one icon, one boolean in scope state).
+- **Store chat client-side (localStorage only).** Considered because it preserves the current shape. Rejected because cross-device continuity is part of the value once chat scopes get finer than workspace, and the substrate’s MCP control plane already owns conversation state authoritatively. Client-side caching can be a perf layer; authoritative state lives on the server.
+- **Store chat client-side per scope, with sync-on-demand.** Considered as a hybrid. Rejected because the sync-conflict resolution adds complexity disproportionate to the value; pre-launch is the cheapest moment to fix the schema.
 
 ## Consequences
 
 ### Positive
 
-- Chat reaches every view in the dashboard without consuming a tab
-  slot.
-- Contextual auto-scope removes the cost of restating “which workflow
-  am I asking about” — chat already knows. Finer scope means cleaner
-  per-object conversation history.
-- One responsive mount sidesteps the "one form for everyone" debate
-  without forcing a shell choice on the user; the five invocation
-  channels cover the patterns different users want (push, ambient
-  FAB, Inbox bell, scope-local Ask, keyboard).
-- Server-side storage enables cross-device continuity and aligns
-  chat state with the MCP control plane’s existing authority. Other
-  intent frontends (Claude, Cursor) can consult the same scoped
-  threads via the same MCP endpoints.
-- Pin affordance handles the “look at A, ask about B” case without
-  forking the conversation model.
+- Chat reaches every view in the dashboard without consuming a tab slot.
+- Contextual auto-scope removes the cost of restating “which workflow am I asking about” — chat already knows. Finer scope means cleaner per-object conversation history.
+- One responsive mount sidesteps the "one form for everyone" debate without forcing a shell choice on the user; the five invocation channels cover the patterns different users want (push, ambient FAB, Inbox bell, scope-local Ask, keyboard).
+- Server-side storage enables cross-device continuity and aligns chat state with the MCP control plane’s existing authority. Other intent frontends (Claude, Cursor) can consult the same scoped threads via the same MCP endpoints.
+- Pin affordance handles the “look at A, ask about B” case without forking the conversation model.
 
 ### Negative trade-offs
 
-- Implementation cost is non-trivial: responsive mount + four
-  invocation channels + scope state machine + storage backend +
-  migration of the storage call sites. Mitigation: phase 0 ships
-  the mount plus push, FAB, bell, and scope-local Ask; phase 1
-  adds ⌘K. The internal `ChatContainer` is shared across phases.
-- Auto-scope-on-tab-switch is subtle: scope preserves at the current
-  level rather than resetting on every tab change. Users may not
-  predict this. Mitigation: the chat header always shows the scope
-  path as a breadcrumb, making the current scope unambiguous.
-- Fresh-start migration discards the few existing OSS dogfood users’
-  chat history. Mitigation: a one-time “previous conversations” link
-  surfaces the legacy localStorage reads for one release window;
-  users can copy text out manually if they need to retain it.
-- "More prominent entry → more specific scope" is a learned rule;
-  the reverse would feel more natural. Mitigation: long-press on
-  FAB jumps to Inbox, with a first-time hint on third use.
-- Cross-scope history search is a new product surface (the search
-  results UI inside chat). The first version is unlikely to be ideal.
-  Mitigation: scoped (default) search remains the primary path;
-  cross-scope is opt-in via an explicit search command in chat.
+- Implementation cost is non-trivial: responsive mount + four invocation channels + scope state machine + storage backend + migration of the storage call sites. Mitigation: phase 0 ships the mount plus push, FAB, bell, and scope-local Ask; phase 1 adds ⌘K. The internal `ChatContainer` is shared across phases.
+- Auto-scope-on-tab-switch is subtle: scope preserves at the current level rather than resetting on every tab change. Users may not predict this. Mitigation: the chat header always shows the scope path as a breadcrumb, making the current scope unambiguous.
+- Fresh-start migration discards the few existing OSS dogfood users’ chat history. Mitigation: a one-time “previous conversations” link surfaces the legacy localStorage reads for one release window; users can copy text out manually if they need to retain it.
+- "More prominent entry → more specific scope" is a learned rule; the reverse would feel more natural. Mitigation: long-press on FAB jumps to Inbox, with a first-time hint on third use.
+- Cross-scope history search is a new product surface (the search results UI inside chat). The first version is unlikely to be ideal. Mitigation: scoped (default) search remains the primary path; cross-scope is opt-in via an explicit search command in chat.
 
 ### Neutral
 
-- The chat empty-state template gallery (per spec #406) is unaffected;
-  it renders inside the responsive mount, scoped to the workspace.
-- HITL cards continue to render inline in the conversation. They
-  must fit the narrowest viewport (mobile full-width minus 16px
-  padding) and the desktop 420px sidebar. The current card layout
-  is already this narrow.
-- The DAG preview moves from a separate right pane (the old ChatPage
-  split) into the chat surface itself, rendered inline as a
-  message-attached card. The visual real estate per draft is
-  smaller; only the active draft’s DAG renders, not a permanently
-  open preview pane.
+- The chat empty-state template gallery (per spec #406) is unaffected; it renders inside the responsive mount, scoped to the workspace.
+- HITL cards continue to render inline in the conversation. They must fit the narrowest viewport (mobile full-width minus 16px padding) and the desktop 420px sidebar. The current card layout is already this narrow.
+- The DAG preview moves from a separate right pane (the old ChatPage split) into the chat surface itself, rendered inline as a message-attached card. The visual real estate per draft is smaller; only the active draft’s DAG renders, not a permanently open preview pane.
 
 ## Dev-process counterpart
 
-Per ADR 0002, the dev-process analog: the issue body and the PR
-description are the dev-process equivalents of mounted chat surfaces.
-The same conversation about a workflow happens both inside the
-dashboard chat (during build) and inside the issue or PR thread
-(during review). Both crystallise into the workflow’s spec.
+Per ADR 0002, the dev-process analog: the issue body and the PR description are the dev-process equivalents of mounted chat surfaces. The same conversation about a workflow happens both inside the dashboard chat (during build) and inside the issue or PR thread (during review). Both crystallise into the workflow’s spec.
 
-The contextual auto-scope rule maps to: a dashboard chat scoped to
-`workflow:{id}` is the same conversation that lives in the spec
-issue’s thread for that workflow. The MCP control plane can surface
-either as a view onto the same thread; the storage schema’s
-`(user_id, scope_type='workflow', scope_id={id})` is the join key.
+The contextual auto-scope rule maps to: a dashboard chat scoped to `workflow:{id}` is the same conversation that lives in the spec issue’s thread for that workflow. The MCP control plane can surface either as a view onto the same thread; the storage schema’s `(user_id, scope_type='workflow', scope_id={id})` is the join key.
 
 ## Adoption checklist
 
 Phase 0 (responsive mount + push + FAB + bell + scope-local Ask):
 
-- [ ] Land the `ChatContainer` with state machine, storage interface,
-  conversation feed, and the Queue / Thread segmented control —
-  one responsive shell across mobile and desktop
-- [ ] Land the contextual auto-scope hook that observes route changes
-  and computes scope; surface the breadcrumb in the chat header
+- [ ] Land the `ChatContainer` with state machine, storage interface, conversation feed, and the Queue / Thread segmented control — one responsive shell across mobile and desktop
+- [ ] Land the contextual auto-scope hook that observes route changes and computes scope; surface the breadcrumb in the chat header
 - [ ] Land the pin affordance + pinned-scope persistence
-- [ ] Land the storage backend with the new
-  `(user_id, scope_type, scope_id)` key shape; keep the old
-  `localStorage` reads available behind a one-release “previous
-  conversations” surface
-- [ ] Land the scope-aware FAB (mobile): Active / Muted / Hidden
-  states, long-press → Inbox, first-time hint on third use
-- [ ] Land the top-chrome bell (mobile + desktop) → Queue at
-  `scope=workspace`
+- [ ] Land the storage backend with the new `(user_id, scope_type, scope_id)` key shape; keep the old `localStorage` reads available behind a one-release “previous conversations” surface
+- [ ] Land the scope-aware FAB (mobile): Active / Muted / Hidden states, long-press → Inbox, first-time hint on third use
+- [ ] Land the top-chrome bell (mobile + desktop) → Queue at `scope=workspace`
 - [ ] Land the scope-local "Ask" on step / verdict / artifact surfaces
-- [ ] Land push notifications with Approve / Reject for approval-kind
-  HITL and Open-only for selection / clarify kinds; deep link
-  scrolls Queue to the matching card
-- [ ] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in
-  `App.tsx` with the global container; remove the `/chat` and
-  `/workspaces/:slug/chat` page routes (the 301 redirects land
-  in ADR 0019’s adoption checklist)
-- [ ] Migrate the DraftStrip’s function into the Workflows tab’s
-  `Drafted` filter chip; delete `components/chat/DraftStrip.tsx`
+- [ ] Land push notifications with Approve / Reject for approval-kind HITL and Open-only for selection / clarify kinds; deep link scrolls Queue to the matching card
+- [ ] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in `App.tsx` with the global container; remove the `/chat` and `/workspaces/:slug/chat` page routes (the 301 redirects land in ADR 0019’s adoption checklist)
+- [ ] Migrate the DraftStrip’s function into the Workflows tab’s `Drafted` filter chip; delete `components/chat/DraftStrip.tsx`
 
 Phase 1 (⌘K invocation) and closeout:
 
-- [ ] Land the ⌘K palette invocation on desktop, opening Thread at
-  the current route's scope
-- [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager
-  root) Timeline with an entry for this ADR
-- [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and
-  #400
+- [ ] Land the ⌘K palette invocation on desktop, opening Thread at the current route's scope
+- [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager root) Timeline with an entry for this ADR
+- [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and #400
 - [ ] Flip Status to `Accepted` once phase 0 ships
 
 ## Out of scope
 
-- **Server-side storage backend choice.** Whether the new chat state
-  lives in Postgres, in the spine, or in a dedicated chat store is
-  governed by the implementation spec, not this ADR. The schema
-  shape `(user_id, scope_type, scope_id)` is fixed by this ADR; the
-  storage engine is not.
-- **Multi-thread per scope.** Reserved for a follow-up if the use
-  case emerges; this ADR commits to single rolling thread per scope.
-  The storage schema’s reserved-not-required `thread_id` axis keeps
-  the door open.
-- **Notification action button → MCP elicitation response binding.**
-  This ADR fixes the *shape* of action buttons (Approve / Reject
-  for approval-kind HITL; Open-only otherwise). The wire-level
-  binding to the MCP elicitation response on the portal control
-  plane (ADR 0008) — signing, replay protection, response shape
-  when the app is closed, iOS/Android-specific affordances — is a
-  follow-up ADR. Phase 0 may ship Open-only on all kinds if that
-  ADR has not landed in time.
-- **Chat-as-MCP-App rendering.** Whether the dashboard chat surface
-  itself becomes an MCP App (SEP-1865), rather than a native
-  dashboard surface that consumes MCP, is a downstream decision.
-  KB page `361d79199ca6815d8398cc509d7fe01b` carries the open
-  question. Not resolved here.
+- **Server-side storage backend choice.** Whether the new chat state lives in Postgres, in the spine, or in a dedicated chat store is governed by the implementation spec, not this ADR. The schema shape `(user_id, scope_type, scope_id)` is fixed by this ADR; the storage engine is not.
+- **Multi-thread per scope.** Reserved for a follow-up if the use case emerges; this ADR commits to single rolling thread per scope. The storage schema’s reserved-not-required `thread_id` axis keeps the door open.
+- **Notification action button → MCP elicitation response binding.** This ADR fixes the *shape* of action buttons (Approve / Reject for approval-kind HITL; Open-only otherwise). The wire-level binding to the MCP elicitation response on the portal control plane (ADR 0008) — signing, replay protection, response shape when the app is closed, iOS/Android-specific affordances — is a follow-up ADR. Phase 0 may ship Open-only on all kinds if that ADR has not landed in time.
+- **Chat-as-MCP-App rendering.** Whether the dashboard chat surface itself becomes an MCP App (SEP-1865), rather than a native dashboard surface that consumes MCP, is a downstream decision. KB page `361d79199ca6815d8398cc509d7fe01b` carries the open question. Not resolved here.
 - **Voice or multi-modal chat input.** Out of scope.
-- **Chat session sharing across users.** All conversations are
-  user-private. Multi-user shared chat is not part of this ADR.
-- **Cross-workspace chat scope.** A scope above `workspace` is not
-  defined; chat does not span workspaces.
+- **Chat session sharing across users.** All conversations are user-private. Multi-user shared chat is not part of this ADR.
+- **Cross-workspace chat scope.** A scope above `workspace` is not defined; chat does not span workspaces.

--- a/docs/adr/0021-detail-page-ia-node-as-section.md
+++ b/docs/adr/0021-detail-page-ia-node-as-section.md
@@ -3,89 +3,35 @@
 - **Status**: Proposed
 - **Date**: 2026-05-27
 - **Identity impact**: no
-- **Tracking issues**: #487 (implementation spec) and sub-issues #489,
-  #490, #491, #492. Builds on ADR 0019 (which collapsed
-  `WorkflowDetailPage`'s four tabs to anchored sections) by extending the
-  same logic to the remaining three detail pages and by reframing the
-  section split itself around substrate primitives rather than v0.1
-  subsystem boundaries.
+- **Tracking issues**: #487 (implementation spec) and sub-issues #489, #490, #491, #492. Builds on ADR 0019 (which collapsed `WorkflowDetailPage`'s four tabs to anchored sections) by extending the same logic to the remaining three detail pages and by reframing the section split itself around substrate primitives rather than v0.1 subsystem boundaries.
 - **Supersedes**: none. Refines ADR 0019 without replacing it.
 - **Superseded by**: none
 
 ## Context
 
-ADR 0019 collapsed `WorkflowDetailPage`'s four tabs (Definition / Runs /
-Artifacts / Verdicts) into one anchored-section timeline. The same v0.1
-framing — node attributes promoted to top-level surfaces — survives in
-three sibling detail pages, and partially in `WorkflowDetailPage` itself.
+ADR 0019 collapsed `WorkflowDetailPage`'s four tabs (Definition / Runs / Artifacts / Verdicts) into one anchored-section timeline. The same v0.1 framing — node attributes promoted to top-level surfaces — survives in three sibling detail pages, and partially in `WorkflowDetailPage` itself.
 
-The collapse was a chrome refactor; the underlying mental model
-("Artifacts and Verdicts are surfaces") was not revisited.
+The collapse was a chrome refactor; the underlying mental model ("Artifacts and Verdicts are surfaces") was not revisited.
 
 In code today this produces:
 
-- `pages/WorkflowDetailPage.tsx:219-256` — four anchored sections.
-  `Definition` double-renders (the linear `ArtifactFlowOverview` pill
-  strip immediately above a per-stage `<Card>` list of the same
-  stages with `gate_kind` + in/out `artifact_kind` badges). `Runs`
-  contains four sibling `<Card>`s: `ActiveRunsBanner`, `RunsList`,
-  `WorkflowEventsCard`, `WorkflowSessionsCard` — but `events` and
-  `sessions` are run-derived observers (ADR 0013 Observer surface),
-  not workflow-scoped concepts. `Verdicts` and `Artifacts` are per-run
-  attributes promoted to workflow scope as "last 5 / last 20" lists.
-- `pages/RunDetailPage.tsx:142-258` — five `<Tabs>` (Overview / Stages
-  / Artifacts / Verdicts / Events). The `Overview` tab duplicates the
-  metadata that already lives in the page header plus the stage
-  progress strip already shown in detail in the `Stages` tab. The
-  `Artifacts` tab contains a single artifact link with a hardcoded
-  `"Issue"` fallback for `artifact_kind` (a v0.1 GitHub-bound default,
-  inconsistent with the typed artifact registry per ADR 0003).
-  `Verdicts` and `Events` are stage attributes, not run-level scopes;
-  treating them as top-level tabs requires the page to invert the
-  natural per-stage grouping into per-attribute grouping and lose the
-  binding.
-- `pages/ArtifactDetailPage.tsx:329-432` — four `<Card>`s:
-  `Run Lineage` (the producing run's internal DAG), `Version History`
-  (versions table with session origin), `Vertical Lineage` (same
-  artifact across versions — overlaps with `Version History`),
-  `Horizontal Lineage` (related artifacts in the run). The three
-  lineage cards are three projections of one provenance graph
-  (ADR 0010); rendering them as parallel surfaces hides their shared
-  origin. The page renders no content — `artifact_kind` is never
-  dispatched into a body view, so an `Issue`, a `markdown`, a
-  `pull_request` and a `verdict` all look identical from the dashboard.
-- `pages/IssueDetailPage.tsx:1-376` — four `<Card>`s (Labels,
-  Assignees, Description, Onsager metadata) plus a 4-up MetaCard grid
-  (Author / Comments / Updated / Lifecycle) that mixes GitHub-fed and
-  substrate-fed fields. The page is hardcoded to
-  `artifact_kind=github_issue` with `projectId` and `number` URL
-  parameters (lines 22-25, 31-32); the "Onsager metadata" Card name is
-  the page admitting it cannot reconcile the two ontologies.
+- `pages/WorkflowDetailPage.tsx:219-256` — four anchored sections. `Definition` double-renders (the linear `ArtifactFlowOverview` pill strip immediately above a per-stage `<Card>` list of the same stages with `gate_kind` + in/out `artifact_kind` badges). `Runs` contains four sibling `<Card>`s: `ActiveRunsBanner`, `RunsList`, `WorkflowEventsCard`, `WorkflowSessionsCard` — but `events` and `sessions` are run-derived observers (ADR 0013 Observer surface), not workflow-scoped concepts. `Verdicts` and `Artifacts` are per-run attributes promoted to workflow scope as "last 5 / last 20" lists.
+- `pages/RunDetailPage.tsx:142-258` — five `<Tabs>` (Overview / Stages / Artifacts / Verdicts / Events). The `Overview` tab duplicates the metadata that already lives in the page header plus the stage progress strip already shown in detail in the `Stages` tab. The `Artifacts` tab contains a single artifact link with a hardcoded `"Issue"` fallback for `artifact_kind` (a v0.1 GitHub-bound default, inconsistent with the typed artifact registry per ADR 0003). `Verdicts` and `Events` are stage attributes, not run-level scopes; treating them as top-level tabs requires the page to invert the natural per-stage grouping into per-attribute grouping and lose the binding.
+- `pages/ArtifactDetailPage.tsx:329-432` — four `<Card>`s: `Run Lineage` (the producing run's internal DAG), `Version History` (versions table with session origin), `Vertical Lineage` (same artifact across versions — overlaps with `Version History`), `Horizontal Lineage` (related artifacts in the run). The three lineage cards are three projections of one provenance graph (ADR 0010); rendering them as parallel surfaces hides their shared origin. The page renders no content — `artifact_kind` is never dispatched into a body view, so an `Issue`, a `markdown`, a `pull_request` and a `verdict` all look identical from the dashboard.
+- `pages/IssueDetailPage.tsx:1-376` — four `<Card>`s (Labels, Assignees, Description, Onsager metadata) plus a 4-up MetaCard grid (Author / Comments / Updated / Lifecycle) that mixes GitHub-fed and substrate-fed fields. The page is hardcoded to `artifact_kind=github_issue` with `projectId` and `number` URL parameters (lines 22-25, 31-32); the "Onsager metadata" Card name is the page admitting it cannot reconcile the two ontologies.
 
-The deeper pattern: each page promotes a *node attribute* (verdict,
-events, lineage axis, kind-specific fields) to *page-level section*.
-This is a v0.1 "subsystem-per-tab" mental model. ADR 0019's tab → anchored-section
-transformation changed the chrome but kept the framing.
+The deeper pattern: each page promotes a *node attribute* (verdict, events, lineage axis, kind-specific fields) to *page-level section*. This is a v0.1 "subsystem-per-tab" mental model. ADR 0019's tab → anchored-section transformation changed the chrome but kept the framing.
 
-A constraint imposed by ADR 0019 narrows the design space: artifact
-and verdict have no top-level list view in main IA (only Workflows /
-Runs / Activity tabs exist). Detail pages cannot delegate "show me
-artifacts/verdicts" to a navigation surface that does not exist;
-related lists must surface inline or via filtered Activity URLs.
+A constraint imposed by ADR 0019 narrows the design space: artifact and verdict have no top-level list view in main IA (only Workflows / Runs / Activity tabs exist). Detail pages cannot delegate "show me artifacts/verdicts" to a navigation surface that does not exist; related lists must surface inline or via filtered Activity URLs.
 
 ## Decision
 
-Adopt a uniform detail-page IA shape across Workflow / Run / Artifact
-/ Issue, organized around two substrate primitives:
+Adopt a uniform detail-page IA shape across Workflow / Run / Artifact / Issue, organized around two substrate primitives:
 
-- A *node* is the unit a detail page is organized around: a workflow
-  stage (in Definition), a run stage (in RunDetail), an artifact
-  version (in ArtifactDetail Provenance).
-- An *attribute* is anything that hangs off a node: output artifact,
-  sessions, verdict, events, source tag, kind, gate, executor.
+- A *node* is the unit a detail page is organized around: a workflow stage (in Definition), a run stage (in RunDetail), an artifact version (in ArtifactDetail Provenance).
+- An *attribute* is anything that hangs off a node: output artifact, sessions, verdict, events, source tag, kind, gate, executor.
 
-A *section* corresponds to a coarse substrate object class, not to a
-node attribute.
+A *section* corresponds to a coarse substrate object class, not to a node attribute.
 
 Per-page shape:
 
@@ -98,172 +44,74 @@ Per-page shape:
 
 Five layout invariants:
 
-1. **One section per substrate object class.** A workflow has Definition
-   (its spec) + Activity (its history). A run has Stages (its only
-   first-class child). An artifact has Content + Provenance + Consumers.
-1. **Node attributes hang off the node, not the page.** Verdict, events,
-   sessions, output artifact all render inside the expanded detail of
-   their owning stage row, not as sibling sections.
-1. **`<Tabs>` is not primary IA.** Tabs are reserved for orthogonal
-   *views of the same data* (e.g., Provenance axis: Time / Origin /
-   Relations). Tabs are forbidden for switching between substrate object
-   classes. An xtask lint enforces this on `pages/*DetailPage.tsx`.
-1. **Header strip absorbs single-value metadata.** Status, owning
-   workflow/run link, started-at, trigger source, action buttons. No
-   "Overview" section.
-1. **Page = one document, not a stack of `<Card>`s.** Sections lead with
-   a label + horizontal rule; no `<Card>` wrapper around section
-   content. `<Card>` survives only as a contained unit for genuinely
-   self-bounded sub-content (e.g., a rendered markdown artifact body).
+1. **One section per substrate object class.** A workflow has Definition (its spec) + Activity (its history). A run has Stages (its only first-class child). An artifact has Content + Provenance + Consumers.
+1. **Node attributes hang off the node, not the page.** Verdict, events, sessions, output artifact all render inside the expanded detail of their owning stage row, not as sibling sections.
+1. **`<Tabs>` is not primary IA.** Tabs are reserved for orthogonal *views of the same data* (e.g., Provenance axis: Time / Origin / Relations). Tabs are forbidden for switching between substrate object classes. An xtask lint enforces this on `pages/*DetailPage.tsx`.
+1. **Header strip absorbs single-value metadata.** Status, owning workflow/run link, started-at, trigger source, action buttons. No "Overview" section.
+1. **Page = one document, not a stack of `<Card>`s.** Sections lead with a label + horizontal rule; no `<Card>` wrapper around section content. `<Card>` survives only as a contained unit for genuinely self-bounded sub-content (e.g., a rendered markdown artifact body).
 
 Routing changes:
 
-- `/issues/:projectId/:number` 301-redirects to `/artifacts/:id` via
-  server-side `github_issue.external_ref` lookup (the same join
-  `IssueDetailPage` already performs at lines 49-53).
-- `WorkflowDetailPage` hash anchors: `#definition` and `#runs` preserved
-  as scroll targets. `#artifacts` and `#verdicts` 301-redirect to
-  `/workspaces/:slug/activity?workflow=<id>&source_type=artifact` and
-  `&source_type=verdict` respectively.
+- `/issues/:projectId/:number` 301-redirects to `/artifacts/:id` via server-side `github_issue.external_ref` lookup (the same join `IssueDetailPage` already performs at lines 49-53).
+- `WorkflowDetailPage` hash anchors: `#definition` and `#runs` preserved as scroll targets. `#artifacts` and `#verdicts` 301-redirect to `/workspaces/:slug/activity?workflow=<id>&source_type=artifact` and `&source_type=verdict` respectively.
 
 Object-level Ask coverage (consequence for ADR 0020 ch4):
 
-`ChatAskButton` is currently mounted on `RunDetailPage` and
-`ArtifactDetailPage` but absent on `WorkflowDetailPage` and on every
-verdict / version / consumer row. This ADR makes the affordance
-load-bearing — without it, leaf objects (artifact, verdict version)
-have no horizontal-navigation primitive. See Adoption checklist.
+`ChatAskButton` is currently mounted on `RunDetailPage` and `ArtifactDetailPage` but absent on `WorkflowDetailPage` and on every verdict / version / consumer row. This ADR makes the affordance load-bearing — without it, leaf objects (artifact, verdict version) have no horizontal-navigation primitive. See Adoption checklist.
 
 ## Rejected alternatives
 
-- **Keep ADR 0019's anchored-section pattern on `WorkflowDetailPage`
-  only.** Considered as a no-op. Rejected because the other three
-  pages stay v0.1-shaped and ADR 0019's underlying principle — chrome
-  that reflects substrate — does not carry forward without this ADR.
-- **Promote Artifact and Verdict to top-level tabs (four-tab IA).**
-  Considered. Rejected by ADR 0019's own rejected alternatives section
-  (Artifact and Verdict are run-derived, not navigation-worthy). This
-  ADR accepts that constraint and addresses it by making the detail
-  page itself the surface for related-object discovery (Consumers
-  section, expandable stage rows).
-- **Keep `<Tabs>` IA, only re-organize tab contents.** Considered.
-  Rejected because the tab structure itself smuggles the "node
-  attribute = top-level surface" mental model. Re-arranging contents
-  within tabs reproduces the misframing one level down.
-- **Retain `IssueDetailPage` as a typed-kind specialization of
-  `ArtifactDetailPage`** (different code path, same parent route).
-  Considered. Rejected because parallel page paths for the same
-  underlying artifact create double-entry confusion in webhook URLs,
-  bookmarks, and Ask answers. The server-side `external_ref` lookup
-  collapses both into a single canonical artifact URL.
-- **Two ADRs (one for IA shape, one for `IssueDetailPage` retirement).**
-  Considered. Rejected because the four pages share one mental model;
-  splitting per-page would obscure the substrate principle and create
-  redundant Context sections.
+- **Keep ADR 0019's anchored-section pattern on `WorkflowDetailPage` only.** Considered as a no-op. Rejected because the other three pages stay v0.1-shaped and ADR 0019's underlying principle — chrome that reflects substrate — does not carry forward without this ADR.
+- **Promote Artifact and Verdict to top-level tabs (four-tab IA).** Considered. Rejected by ADR 0019's own rejected alternatives section (Artifact and Verdict are run-derived, not navigation-worthy). This ADR accepts that constraint and addresses it by making the detail page itself the surface for related-object discovery (Consumers section, expandable stage rows).
+- **Keep `<Tabs>` IA, only re-organize tab contents.** Considered. Rejected because the tab structure itself smuggles the "node attribute = top-level surface" mental model. Re-arranging contents within tabs reproduces the misframing one level down.
+- **Retain `IssueDetailPage` as a typed-kind specialization of `ArtifactDetailPage`** (different code path, same parent route). Considered. Rejected because parallel page paths for the same underlying artifact create double-entry confusion in webhook URLs, bookmarks, and Ask answers. The server-side `external_ref` lookup collapses both into a single canonical artifact URL.
+- **Two ADRs (one for IA shape, one for `IssueDetailPage` retirement).** Considered. Rejected because the four pages share one mental model; splitting per-page would obscure the substrate principle and create redundant Context sections.
 
 ## Consequences
 
 ### Positive
 
-- Detail pages share one IA shape. Substrate primitives map 1:1 to UI
-  primitives: node ↔ row, attribute ↔ field, axis ↔ tab (where
-  tabs are used at all).
-- Provenance source tags become legible (ADR 0010 substrate first-class)
-  because they hang on every node attribute. ADR 0022 covers their
-  visual treatment.
-- Artifact and Verdict, although not top-level surfaces, gain the
-  navigation glue they need: `Consumers` section on artifact (the
-  reverse traceability that compensates for no list view), expandable
-  stage detail on RunDetail (the verdict pin point).
-- One fewer page in the dashboard (`IssueDetailPage` retires); one
-  fewer GitHub-coupling in the substrate-facing surface.
+- Detail pages share one IA shape. Substrate primitives map 1:1 to UI primitives: node ↔ row, attribute ↔ field, axis ↔ tab (where tabs are used at all).
+- Provenance source tags become legible (ADR 0010 substrate first-class) because they hang on every node attribute. ADR 0022 covers their visual treatment.
+- Artifact and Verdict, although not top-level surfaces, gain the navigation glue they need: `Consumers` section on artifact (the reverse traceability that compensates for no list view), expandable stage detail on RunDetail (the verdict pin point).
+- One fewer page in the dashboard (`IssueDetailPage` retires); one fewer GitHub-coupling in the substrate-facing surface.
 
 ### Negative trade-offs
 
-- Expanded stage rows on RunDetail can grow tall when a stage emits
-  many events or runs multiple sessions. Mitigation: events table
-  truncates to last 20 with `[show all]`; sessions list truncates to
-  last 5.
-- `ArtifactDetail`'s Content section needs a dispatch table keyed on
-  `artifact_kind` (`github_issue`, `markdown`, `verdict`, `pull_request`,
-  future kinds). Mitigation: ship a default render (kind label + raw
-  fallback) first; per-kind branches land incrementally as needed.
-- `/issues/:projectId/:number` redirect introduces a one-step lookup
-  from `(projectId, number)` to `artifact_id`. Mitigation: the lookup
-  is the same join that `IssueDetailPage` already performs server-side;
-  no new index needed.
+- Expanded stage rows on RunDetail can grow tall when a stage emits many events or runs multiple sessions. Mitigation: events table truncates to last 20 with `[show all]`; sessions list truncates to last 5.
+- `ArtifactDetail`'s Content section needs a dispatch table keyed on `artifact_kind` (`github_issue`, `markdown`, `verdict`, `pull_request`, future kinds). Mitigation: ship a default render (kind label + raw fallback) first; per-kind branches land incrementally as needed.
+- `/issues/:projectId/:number` redirect introduces a one-step lookup from `(projectId, number)` to `artifact_id`. Mitigation: the lookup is the same join that `IssueDetailPage` already performs server-side; no new index needed.
 
 ### Neutral
 
-- WorkflowDetailPage hash anchors `#definition`, `#runs` preserved;
-  `#artifacts`, `#verdicts` 301 to Activity-filtered URLs.
-- `WorkflowEventsCard`, `WorkflowSessionsCard`, `WorkflowVerdictsTab`,
-  `WorkflowArtifactsTab` components are deleted as a side effect.
-- `components/sessions/SessionTable`, `SessionStateBadge`,
-  `SessionLogStream` were already orphaned by ADR 0019's
-  `SessionIdRedirect`; they remain dead code, cleaned up under a
-  separate dead-code follow-up, not this ADR.
+- WorkflowDetailPage hash anchors `#definition`, `#runs` preserved; `#artifacts`, `#verdicts` 301 to Activity-filtered URLs.
+- `WorkflowEventsCard`, `WorkflowSessionsCard`, `WorkflowVerdictsTab`, `WorkflowArtifactsTab` components are deleted as a side effect.
+- `components/sessions/SessionTable`, `SessionStateBadge`, `SessionLogStream` were already orphaned by ADR 0019's `SessionIdRedirect`; they remain dead code, cleaned up under a separate dead-code follow-up, not this ADR.
 
 ## Dev-process counterpart
 
-Per ADR 0002, the dev-process analog of a detail page is a spec issue.
-Spec issues already follow node-as-section: a spec has Plan (its
-stages), Implementation Notes (per-stage detail), Verdict (acceptance),
-Out of Scope (orthogonal). The detail page IA mirrors this shape —
-a page is one document organized around nodes, not a stack of cards
-organized around concerns.
+Per ADR 0002, the dev-process analog of a detail page is a spec issue. Spec issues already follow node-as-section: a spec has Plan (its stages), Implementation Notes (per-stage detail), Verdict (acceptance), Out of Scope (orthogonal). The detail page IA mirrors this shape — a page is one document organized around nodes, not a stack of cards organized around concerns.
 
-The "tabs = orthogonal views of same data" rule has a dev-process
-analog too: a spec's review checklist would be wrong if it used tabs
-to mean "switch between unrelated content"; in practice spec sections
-are anchored Markdown headings in one document. Detail pages adopt
-the same shape.
+The "tabs = orthogonal views of same data" rule has a dev-process analog too: a spec's review checklist would be wrong if it used tabs to mean "switch between unrelated content"; in practice spec sections are anchored Markdown headings in one document. Detail pages adopt the same shape.
 
 ## Adoption checklist
 
-- [ ] Open implementation spec; assign issue number; backfill into
-  this ADR's metadata
-- [ ] Remove `<Tabs>` from `RunDetailPage`; stages timeline absorbs
-  verdict, events, sessions, artifact into expanded stage detail
-- [ ] Remove `Verdicts` and `Artifacts` sections from
-  `WorkflowDetailPage`; add `Activity` section with link-out to
-  Activity tab filtered by workflow
-- [ ] Merge `ArtifactDetailPage`'s `Run Lineage`, `Version History`,
-  `Vertical Lineage`, `Horizontal Lineage` Cards into one `Provenance`
-  section with axis switch (Time / Origin / Relations)
-- [ ] Add `Content` section to `ArtifactDetailPage` with
-  `artifact_kind` dispatch; default branch + `markdown` + `github_issue`
-  branches ship first
-- [ ] Retire `IssueDetailPage`; add 301 redirect from
-  `/issues/:projectId/:number` to `/artifacts/:id` via
-  `github_issue.external_ref` server-side lookup
-- [ ] Attach `ChatAskButton` to: `WorkflowDetailPage` header; each
-  stage row in `RunDetailPage` expanded detail; each version row in
-  `ArtifactDetailPage` Provenance Time axis; each consumer row
-- [ ] Delete `WorkflowEventsCard`, `WorkflowSessionsCard`,
-  `WorkflowVerdictsTab`, `WorkflowArtifactsTab`
-- [ ] Preserve `#definition`, `#runs` hash anchors on
-  `WorkflowDetailPage`; add `#artifacts`, `#verdicts` 301 to
-  Activity-filtered URLs
-- [ ] xtask lint `check-detail-page-tabs`: `pages/*DetailPage.tsx` may
-  not import `<Tabs>` at the top level; tabs inside a section require
-  `// tabs-allow: <reason>` marker
+- [ ] Open implementation spec; assign issue number; backfill into this ADR's metadata
+- [ ] Remove `<Tabs>` from `RunDetailPage`; stages timeline absorbs verdict, events, sessions, artifact into expanded stage detail
+- [ ] Remove `Verdicts` and `Artifacts` sections from `WorkflowDetailPage`; add `Activity` section with link-out to Activity tab filtered by workflow
+- [ ] Merge `ArtifactDetailPage`'s `Run Lineage`, `Version History`, `Vertical Lineage`, `Horizontal Lineage` Cards into one `Provenance` section with axis switch (Time / Origin / Relations)
+- [ ] Add `Content` section to `ArtifactDetailPage` with `artifact_kind` dispatch; default branch + `markdown` + `github_issue` branches ship first
+- [ ] Retire `IssueDetailPage`; add 301 redirect from `/issues/:projectId/:number` to `/artifacts/:id` via `github_issue.external_ref` server-side lookup
+- [ ] Attach `ChatAskButton` to: `WorkflowDetailPage` header; each stage row in `RunDetailPage` expanded detail; each version row in `ArtifactDetailPage` Provenance Time axis; each consumer row
+- [ ] Delete `WorkflowEventsCard`, `WorkflowSessionsCard`, `WorkflowVerdictsTab`, `WorkflowArtifactsTab`
+- [ ] Preserve `#definition`, `#runs` hash anchors on `WorkflowDetailPage`; add `#artifacts`, `#verdicts` 301 to Activity-filtered URLs
+- [ ] xtask lint `check-detail-page-tabs`: `pages/*DetailPage.tsx` may not import `<Tabs>` at the top level; tabs inside a section require `// tabs-allow: <reason>` marker
 - [ ] Flip Status to `Accepted` once the above land
 
 ## Out of scope
 
 - **Provenance source tag visual treatment.** Governed by ADR 0022.
-- **Non-linear DAG visualization in `WorkflowDetailPage` Definition.**
-  The current schema is linear stages; branching DAGs require a graph
-  layout component and ship later. This ADR does not block that work
-  but does not commit to it.
-- **Mobile-specific behaviors.** The IA shape works at mobile width
-  (stages stack vertically; expanded detail wraps). No phone-specific
-  behaviors committed here.
-- **Activity tab pre-filter URL schema.** The query-param schema for
-  `/workspaces/:slug/activity?workflow=X&source_type=verdict` is
-  governed by ADR 0019's source-type chip implementation and is not
-  re-litigated here.
-- **Per-`artifact_kind` Content render specifics.** This ADR commits
-  to a dispatch table; the visual specification per kind ships
-  incrementally as each kind earns a branch.
+- **Non-linear DAG visualization in `WorkflowDetailPage` Definition.** The current schema is linear stages; branching DAGs require a graph layout component and ship later. This ADR does not block that work but does not commit to it.
+- **Mobile-specific behaviors.** The IA shape works at mobile width (stages stack vertically; expanded detail wraps). No phone-specific behaviors committed here.
+- **Activity tab pre-filter URL schema.** The query-param schema for `/workspaces/:slug/activity?workflow=X&source_type=verdict` is governed by ADR 0019's source-type chip implementation and is not re-litigated here.
+- **Per-`artifact_kind` Content render specifics.** This ADR commits to a dispatch table; the visual specification per kind ships incrementally as each kind earns a branch.

--- a/docs/adr/0022-provenance-source-tag-first-class-ui.md
+++ b/docs/adr/0022-provenance-source-tag-first-class-ui.md
@@ -2,58 +2,29 @@
 
 - **Status**: Proposed
 - **Date**: 2026-05-27
-- **Identity impact**: no. Refines how ADR 0010's substrate invariant
-  surfaces in UI; does not change the invariant itself.
-- **Tracking issues**: #488 (implementation spec). Depends on ADR 0021's
-  implementation per #487 for the detail-page surfaces this ADR attaches
-  to.
+- **Identity impact**: no. Refines how ADR 0010's substrate invariant surfaces in UI; does not change the invariant itself.
+- **Tracking issues**: #488 (implementation spec). Depends on ADR 0021's implementation per #487 for the detail-page surfaces this ADR attaches to.
 - **Supersedes**: none
 - **Superseded by**: none
 
 ## Context
 
-ADR 0010 promoted provenance to a substrate first-class concept with
-two flavors — `Deterministic` (output is verifiable from inputs
-without external state) and `Uncertain` (output depends on a
-non-deterministic executor: LLM, network, human, wall-clock) — each
-carrying a `SourceTag` payload that identifies the specific
-contributor.
+ADR 0010 promoted provenance to a substrate first-class concept with two flavors — `Deterministic` (output is verifiable from inputs without external state) and `Uncertain` (output depends on a non-deterministic executor: LLM, network, human, wall-clock) — each carrying a `SourceTag` payload that identifies the specific contributor.
 
-In the dashboard today this concept has zero UI surface. Examples
-from current code:
+In the dashboard today this concept has zero UI surface. Examples from current code:
 
-- `pages/ArtifactDetailPage.tsx:340-395` — `Version History` table
-  columns are `Version / Session / Recorded`. No source column. An
-  operator inspecting a version cannot tell whether it came from a
-  deterministic forge step or from an agent self-report without
-  drilling into the session.
-- `pages/RunDetailPage.tsx:254-258` — verdict and event tabs render
-  status and timestamp; the verdict's `source` field is dropped on
-  the way to the row.
-- `pages/ActivityPage.tsx:23-79` — source-type chips exist (Artifact,
-  Run, Verdict, Trigger, Issue) but they reflect the *originating
-  subsystem*, not the Det/Unc flavor of each row. An operator
-  filtering for "Verdict" sees both deterministic CI verdicts and
-  agent self-reports as one flat list.
-- `pages/WorkflowDetailPage.tsx:225-244` — the Runs section shows
-  completed run status (pass/fail) without the run's terminal-verdict
-  source. Two runs that look identical in the list can have very
-  different epistemic standing.
+- `pages/ArtifactDetailPage.tsx:340-395` — `Version History` table columns are `Version / Session / Recorded`. No source column. An operator inspecting a version cannot tell whether it came from a deterministic forge step or from an agent self-report without drilling into the session.
+- `pages/RunDetailPage.tsx:254-258` — verdict and event tabs render status and timestamp; the verdict's `source` field is dropped on the way to the row.
+- `pages/ActivityPage.tsx:23-79` — source-type chips exist (Artifact, Run, Verdict, Trigger, Issue) but they reflect the *originating subsystem*, not the Det/Unc flavor of each row. An operator filtering for "Verdict" sees both deterministic CI verdicts and agent self-reports as one flat list.
+- `pages/WorkflowDetailPage.tsx:225-244` — the Runs section shows completed run status (pass/fail) without the run's terminal-verdict source. Two runs that look identical in the list can have very different epistemic standing.
 
-The substrate's first-class concept has no UI vocabulary. ADR 0010's
-investment in tagging every node attribute with provenance metadata
-is not reaching the operator.
+The substrate's first-class concept has no UI vocabulary. ADR 0010's investment in tagging every node attribute with provenance metadata is not reaching the operator.
 
-ADR 0021's per-detail-page IA reorganization places node attributes
-(verdict, events, sessions, output) into expanded detail rows on
-their owning node. Each of those rows is a candidate site for
-`SourceTag` rendering. Without a uniform UI vocabulary for the tag,
-the new IA shape inherits the same provenance-blindness as the old.
+ADR 0021's per-detail-page IA reorganization places node attributes (verdict, events, sessions, output) into expanded detail rows on their owning node. Each of those rows is a candidate site for `SourceTag` rendering. Without a uniform UI vocabulary for the tag, the new IA shape inherits the same provenance-blindness as the old.
 
 ## Decision
 
-Adopt a uniform UI vocabulary for provenance source tags. Apply it
-to every surface where Det/Unc attribution is meaningful.
+Adopt a uniform UI vocabulary for provenance source tags. Apply it to every surface where Det/Unc attribution is meaningful.
 
 ### Vocabulary
 
@@ -64,202 +35,94 @@ to every surface where Det/Unc attribution is meaningful.
 
 Rationale for the typographic split:
 
-- The difference between "verifiable from inputs" and "self-reported
-  by a non-deterministic executor" is *epistemic*, not categorical.
-  Color-coded chips reduce the distinction to status (green vs amber
-  → "good vs warning"), which is wrong: an uncertain verdict can be
-  correct and a deterministic verdict can be wrong about its inputs.
-- The dagger (†) is the academic footnote convention for "this claim
-  requires verification". Readers familiar with the convention
-  recognize it; readers unfamiliar see a typographic difference and
-  reach for the tooltip.
-- Mono small-caps is the typographic equivalent of a printed
-  stamp/seal: settled, neutral, official. Italic serif is the
-  voice of editorial qualification: "as reported", "in the author's
-  view".
-- The typographic treatment uses no extra horizontal space beyond
-  the label string itself, important on row-dense surfaces.
+- The difference between "verifiable from inputs" and "self-reported by a non-deterministic executor" is *epistemic*, not categorical. Color-coded chips reduce the distinction to status (green vs amber → "good vs warning"), which is wrong: an uncertain verdict can be correct and a deterministic verdict can be wrong about its inputs.
+- The dagger (†) is the academic footnote convention for "this claim requires verification". Readers familiar with the convention recognize it; readers unfamiliar see a typographic difference and reach for the tooltip.
+- Mono small-caps is the typographic equivalent of a printed stamp/seal: settled, neutral, official. Italic serif is the voice of editorial qualification: "as reported", "in the author's view".
+- The typographic treatment uses no extra horizontal space beyond the label string itself, important on row-dense surfaces.
 
 ### Surfaces required to render `SourceTag`
 
-1. **`RunDetailPage` expanded stages** — each event row, each verdict,
-   each session output (per ADR 0021)
-1. **`ArtifactDetailPage` Provenance section** — every node in the
-   graph, regardless of which axis is active (Time / Origin /
-   Relations, per ADR 0021)
-1. **`ArtifactDetailPage` Consumers section** — each consumer row
-   carries the SourceTag of the run-stage that consumed it
+1. **`RunDetailPage` expanded stages** — each event row, each verdict, each session output (per ADR 0021)
+1. **`ArtifactDetailPage` Provenance section** — every node in the graph, regardless of which axis is active (Time / Origin / Relations, per ADR 0021)
+1. **`ArtifactDetailPage` Consumers section** — each consumer row carries the SourceTag of the run-stage that consumed it
 1. **`ActivityPage` rows** — each event row in the stream
-1. **`WorkflowDetailPage` Activity section** — each recent-run row
-   carries the source of that run's terminal verdict
-1. **Detail-page header strips** — when the page's primary object is
-   itself produced by an uncertain executor (e.g., agent-produced
-   artifact), the tag appears beside the producer link in the header
+1. **`WorkflowDetailPage` Activity section** — each recent-run row carries the source of that run's terminal verdict
+1. **Detail-page header strips** — when the page's primary object is itself produced by an uncertain executor (e.g., agent-produced artifact), the tag appears beside the producer link in the header
 
 ### Tooltip
 
 Every `SourceTag` carries a hover/focus tooltip:
 
-- Deterministic: *"Source: Deterministic. Output is verifiable from
-  inputs without external state."*
-- Uncertain: *"Source: Uncertain. Output depends on a non-deterministic
-  executor (LLM, network, human, wall-clock). Verify before relying
-  on it."*
+- Deterministic: *"Source: Deterministic. Output is verifiable from inputs without external state."*
+- Uncertain: *"Source: Uncertain. Output depends on a non-deterministic executor (LLM, network, human, wall-clock). Verify before relying on it."*
 
 ### Filter dimension
 
 `SourceTag` becomes a filter axis parallel to existing ones:
 
-- Activity tab gains a `source` chip group (`All` / `Det` / `Unc`)
-  alongside the existing `source-type` chips
-- Workflows tab gains a `last verdict source` per-row pin; filterable
-  via a chip on the tab header
+- Activity tab gains a `source` chip group (`All` / `Det` / `Unc`) alongside the existing `source-type` chips
+- Workflows tab gains a `last verdict source` per-row pin; filterable via a chip on the tab header
 
 ### Component contract
 
-A shared `<SourceTag kind="deterministic" | "uncertain" />` component
-lands in `components/ui/source-tag.tsx`. The component:
+A shared `<SourceTag kind="deterministic" | "uncertain" />` component lands in `components/ui/source-tag.tsx`. The component:
 
 - Defaults to long-form label
-- Accepts `compact={true}` for tight contexts (table cells under
-  100px wide)
+- Accepts `compact={true}` for tight contexts (table cells under 100px wide)
 - Renders tooltip via the existing `<Tooltip>` primitive
-- Has no `color` or `variant` prop — typography is the visual axis,
-  not theme
+- Has no `color` or `variant` prop — typography is the visual axis, not theme
 
 ## Rejected alternatives
 
-- **Color-coded badge chips** (e.g., emerald pill for deterministic,
-  amber pill for uncertain). Considered as the obvious option.
-  Rejected because (a) colored chips conflate Det/Unc with status
-  semantics (pass/warn), which they are not — an uncertain output can
-  be a passing verdict; a deterministic output can be a failed one;
-  (b) accessibility: colorblind operators lose the entire signal, and
-  no shape-based fallback maps cleanly onto a chip; (c) chip noise on
-  dense rows — a 20-row events list with amber chips on every row
-  reads as "everything is warning" and dilutes both status chips and
-  source chips into the same visual register.
-- **Single-icon variant** (lock for Det, question mark for Unc).
-  Considered. Rejected because icons compete with status icons
-  (check, cross, spinner) for the same visual register; two icon
-  families on each row crowds the start-of-row gutter where status
-  already lives.
-- **Render only on hover/focus** (the row shows status; source tag
-  appears on disclosure). Considered as a density-reduction option.
-  Rejected because operators scanning a verdict list need source
-  flavor at a glance — hidden-until-hover defeats the substrate's
-  first-class status. ADR 0010 made provenance first-class so it
-  could shape decisions; hiding it from default rendering reverses
-  that decision in the surface where it matters.
-- **Selective rendering** (render only on `RunDetail` and Provenance;
-  omit elsewhere). Considered. Rejected because the substrate doesn't
-  have a notion of "key" surfaces — every node carries a source tag
-  at the data level. Selective UI rendering creates the impression
-  that some events are unattributed, which is false.
-- **Inline prefix-symbol** (e.g., a small ◆ before deterministic, ◇
-  before uncertain rows). Considered as a minimal alternative.
-  Rejected because the symbols carry no semantic intuition and need
-  the same tooltip explanation as text labels — without buying any
-  density advantage over the typographic-label form.
+- **Color-coded badge chips** (e.g., emerald pill for deterministic, amber pill for uncertain). Considered as the obvious option. Rejected because (a) colored chips conflate Det/Unc with status semantics (pass/warn), which they are not — an uncertain output can be a passing verdict; a deterministic output can be a failed one; (b) accessibility: colorblind operators lose the entire signal, and no shape-based fallback maps cleanly onto a chip; (c) chip noise on dense rows — a 20-row events list with amber chips on every row reads as "everything is warning" and dilutes both status chips and source chips into the same visual register.
+- **Single-icon variant** (lock for Det, question mark for Unc). Considered. Rejected because icons compete with status icons (check, cross, spinner) for the same visual register; two icon families on each row crowds the start-of-row gutter where status already lives.
+- **Render only on hover/focus** (the row shows status; source tag appears on disclosure). Considered as a density-reduction option. Rejected because operators scanning a verdict list need source flavor at a glance — hidden-until-hover defeats the substrate's first-class status. ADR 0010 made provenance first-class so it could shape decisions; hiding it from default rendering reverses that decision in the surface where it matters.
+- **Selective rendering** (render only on `RunDetail` and Provenance; omit elsewhere). Considered. Rejected because the substrate doesn't have a notion of "key" surfaces — every node carries a source tag at the data level. Selective UI rendering creates the impression that some events are unattributed, which is false.
+- **Inline prefix-symbol** (e.g., a small ◆ before deterministic, ◇ before uncertain rows). Considered as a minimal alternative. Rejected because the symbols carry no semantic intuition and need the same tooltip explanation as text labels — without buying any density advantage over the typographic-label form.
 
 ## Consequences
 
 ### Positive
 
-- Operators see `SourceTag` on every surface where a substrate node
-  attribute appears. ADR 0010's first-class invariant gains UI parity.
-- A new filter axis (Det/Unc) opens for triage: "show me only
-  uncertain verdicts from this workflow" becomes a single chip
-  selection rather than a manual scan.
-- The typographic treatment costs no extra horizontal space beyond
-  the label string, important on dense surfaces (Activity stream,
-  event tables).
-- The Det/Unc distinction visibly attaches to the executor model: a
-  `claude-haiku-4.5` agent stage's verdict reads as *uncertain*<sup>†</sup>,
-  a CI verdict reads as `DETERMINISTIC` — and the operator can use
-  the distinction to calibrate trust without leaving the row.
+- Operators see `SourceTag` on every surface where a substrate node attribute appears. ADR 0010's first-class invariant gains UI parity.
+- A new filter axis (Det/Unc) opens for triage: "show me only uncertain verdicts from this workflow" becomes a single chip selection rather than a manual scan.
+- The typographic treatment costs no extra horizontal space beyond the label string, important on dense surfaces (Activity stream, event tables).
+- The Det/Unc distinction visibly attaches to the executor model: a `claude-haiku-4.5` agent stage's verdict reads as *uncertain*<sup>†</sup>, a CI verdict reads as `DETERMINISTIC` — and the operator can use the distinction to calibrate trust without leaving the row.
 
 ### Negative trade-offs
 
-- Surfaces with very high row counts (Activity stream paginated to
-  100+ rows) get a new visual element on every row. Mitigation: the
-  `compact={true}` form (`DET` / *unc*<sup>†</sup>) is permitted in
-  contexts under 100px column width and on the Activity stream by
-  default.
-- Operators unfamiliar with the dagger convention see an unfamiliar
-  symbol and need the tooltip on first encounter. Mitigation:
-  tooltip on every instance; one-time onboarding hint on first
-  verdict drill-in (FTUE event `ftue.source_tag.first_view`).
-- The italic serif typeface (Spectral or equivalent) must be
-  available on every surface that renders `SourceTag` — including
-  surfaces that don't currently load editorial type (e.g., embedded
-  preview thumbnails, OG-image generators). Mitigation: the
-  `<SourceTag>` component declares its own font dependency at the
-  bundle level, so any consuming surface inherits it transitively.
+- Surfaces with very high row counts (Activity stream paginated to 100+ rows) get a new visual element on every row. Mitigation: the `compact={true}` form (`DET` / *unc*<sup>†</sup>) is permitted in contexts under 100px column width and on the Activity stream by default.
+- Operators unfamiliar with the dagger convention see an unfamiliar symbol and need the tooltip on first encounter. Mitigation: tooltip on every instance; one-time onboarding hint on first verdict drill-in (FTUE event `ftue.source_tag.first_view`).
+- The italic serif typeface (Spectral or equivalent) must be available on every surface that renders `SourceTag` — including surfaces that don't currently load editorial type (e.g., embedded preview thumbnails, OG-image generators). Mitigation: the `<SourceTag>` component declares its own font dependency at the bundle level, so any consuming surface inherits it transitively.
 
 ### Neutral
 
-- ADR 0010's underlying schema is unchanged. No new substrate API,
-  no new event field. `source` is already on every event, verdict,
-  and version record.
-- The component lives in `components/ui/`, not in `components/governance/`
-  or `components/observers/`, signalling that it is a shared
-  UI primitive, not a subsystem widget.
-- The `xtask check-source-tag-coverage` lint (Adoption checklist) is
-  the dev-process enforcement counterpart of ADR 0010's substrate
-  invariant — same mechanism, different layer.
+- ADR 0010's underlying schema is unchanged. No new substrate API, no new event field. `source` is already on every event, verdict, and version record.
+- The component lives in `components/ui/`, not in `components/governance/` or `components/observers/`, signalling that it is a shared UI primitive, not a subsystem widget.
+- The `xtask check-source-tag-coverage` lint (Adoption checklist) is the dev-process enforcement counterpart of ADR 0010's substrate invariant — same mechanism, different layer.
 
 ## Dev-process counterpart
 
-Per ADR 0002, the dev-process analog is the spec's acceptance
-attribution. A spec's acceptance can be *verifiable* (CI pass + schema
-match) or *self-reported* (author confidence; reviewer trust).
-Treating both with the same dev-process weight is the same mistake
-the dashboard makes by rendering all provenance attributions
-identically.
+Per ADR 0002, the dev-process analog is the spec's acceptance attribution. A spec's acceptance can be *verifiable* (CI pass + schema match) or *self-reported* (author confidence; reviewer trust). Treating both with the same dev-process weight is the same mistake the dashboard makes by rendering all provenance attributions identically.
 
-The corresponding spec-authoring convention: every acceptance line in
-a spec's "Done when" section is implicitly tagged. When ambiguous,
-authors annotate explicitly: *"CI passes (Deterministic)"* /
-*"reviewer judges output correct (Uncertain)"*. This matches the UI
-convention adopted here: typographic difference where the epistemic
-weight differs.
+The corresponding spec-authoring convention: every acceptance line in a spec's "Done when" section is implicitly tagged. When ambiguous, authors annotate explicitly: *"CI passes (Deterministic)"* / *"reviewer judges output correct (Uncertain)"*. This matches the UI convention adopted here: typographic difference where the epistemic weight differs.
 
 ## Adoption checklist
 
-- [ ] Open implementation spec; assign issue number; backfill into
-  this ADR's metadata
-- [ ] Land `components/ui/source-tag.tsx` with `kind` and `compact`
-  props, tooltip integration, no color/variant props
-- [ ] Mount `<SourceTag>` on the six surfaces enumerated in the
-  Decision section
-- [ ] Add `source` chip group (`All` / `Det` / `Unc`) to `ActivityPage`
-  alongside existing source-type chips
-- [ ] Add `last verdict source` per-row indicator + tab-header filter
-  to `WorkflowsPage`
+- [ ] Open implementation spec; assign issue number; backfill into this ADR's metadata
+- [ ] Land `components/ui/source-tag.tsx` with `kind` and `compact` props, tooltip integration, no color/variant props
+- [ ] Mount `<SourceTag>` on the six surfaces enumerated in the Decision section
+- [ ] Add `source` chip group (`All` / `Det` / `Unc`) to `ActivityPage` alongside existing source-type chips
+- [ ] Add `last verdict source` per-row indicator + tab-header filter to `WorkflowsPage`
 - [ ] Tooltip copy reviewed by ADR 0010 author for substrate-fidelity
-- [ ] FTUE event `ftue.source_tag.first_view` instrumented; one-time
-  hint shipped on first verdict drill-in
-- [ ] xtask lint `check-source-tag-coverage`: detail-page row
-  components rendering a substrate node attribute must reference
-  `<SourceTag>`; escape comments `// source-tag-omit: <reason>` allowed
+- [ ] FTUE event `ftue.source_tag.first_view` instrumented; one-time hint shipped on first verdict drill-in
+- [ ] xtask lint `check-source-tag-coverage`: detail-page row components rendering a substrate node attribute must reference `<SourceTag>`; escape comments `// source-tag-omit: <reason>` allowed
 - [ ] Flip Status to `Accepted` once the above land
 
 ## Out of scope
 
-- **Detail page IA shape.** Governed by ADR 0021. This ADR depends on
-  the surfaces that ADR 0021 introduces but does not specify their
-  structure.
-- **Chat (ADR 0020) integration.** Whether scope-local Ask buttons'
-  answer rendering surfaces `SourceTag` in their responses is governed
-  by chat IA + chat persona prompt design, not this ADR.
-- **Backend Det/Unc classification heuristics.** How an event is
-  labeled at write time is governed by ADR 0010 plus per-executor
-  specs. This ADR consumes the labels; it does not produce them.
-- **Dark-theme treatment.** Visual specification covers light theme
-  only. Dark-theme color and contrast targets land when dark-theme
-  support lands.
-- **Localization of dagger convention.** The dagger is a Western
-  scholarly typographic convention; locales where it carries a
-  different signal would need a per-locale override. Out of scope for
-  this ADR — revisit when localization scope opens.
+- **Detail page IA shape.** Governed by ADR 0021. This ADR depends on the surfaces that ADR 0021 introduces but does not specify their structure.
+- **Chat (ADR 0020) integration.** Whether scope-local Ask buttons' answer rendering surfaces `SourceTag` in their responses is governed by chat IA + chat persona prompt design, not this ADR.
+- **Backend Det/Unc classification heuristics.** How an event is labeled at write time is governed by ADR 0010 plus per-executor specs. This ADR consumes the labels; it does not produce them.
+- **Dark-theme treatment.** Visual specification covers light theme only. Dark-theme color and contrast targets land when dark-theme support lands.
+- **Localization of dagger convention.** The dagger is a Western scholarly typographic convention; locales where it carries a different signal would need a per-locale override. Out of scope for this ADR — revisit when localization scope opens.


### PR DESCRIPTION
Formatting-only follow-up to #493. Removes mid-paragraph hard line breaks (the ~70-char soft wrapping) from ADRs 0019, 0020, 0021, and 0022 so each paragraph, list item, and blockquote is a single continuous line.

No prose content changes. The reflow joins wrapped lines while leaving code fences, tables, headings, and horizontal rules untouched; multi-line blockquotes collapse to a single `>` line. Content preservation was verified per file by comparing the whitespace-split word multiset before and after (identical for 0019/0021/0022; 0020 differs only by the two redundant `>` blockquote markers that were collapsed).

Trivial: doc formatting, no semantic change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0179NjkRWtnxcAoQHce3Az5z)_