### PR TITLE
dashboard: flatten workspace switcher into top chrome

### DIFF
--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -106,9 +106,7 @@ function DesktopTopChrome() {
         <span className="text-base font-semibold">Onsager</span>
       </Link>
       <Separator orientation="vertical" className="h-6" />
-      <div className="w-56">
-        <WorkspaceSwitcher />
-      </div>
+      <WorkspaceSwitcher />
       <Separator orientation="vertical" className="h-6" />
       <TopTabs />
       <div className="ml-auto flex items-center gap-1">

--- a/apps/dashboard/src/components/workspaces/WorkspaceSwitcher.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
-import { Building2, Check, ChevronsUpDown, Plus } from "lucide-react"
+import { Building2, Check, ChevronDown, Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -64,7 +64,7 @@ function WorkspaceBadge({ workspace }: { workspace: Workspace | null }) {
   }
   // First letter of the slug (lowercased) gives a stable "avatar" without
   // requiring a generated image. Avoids manual-input territory while still
-  // distinguishing workspaces visually in the sidebar.
+  // distinguishing workspaces visually in the picker rows.
   const initial = (workspace.slug[0] ?? "?").toUpperCase()
   return (
     <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-xs font-semibold text-primary">
@@ -101,37 +101,22 @@ export function WorkspaceSwitcher() {
   }
 
   return (
-    <div className="px-2 pt-2">
+    <>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           render={
             <Button
-              variant="outline"
+              variant="ghost"
+              size="sm"
               role="combobox"
               aria-expanded={open}
               aria-label="Switch workspace"
-              className="h-auto w-full justify-between gap-2 px-2 py-1.5"
+              className="h-8 gap-1.5 px-2 text-sm font-medium"
             >
-              <span className="flex min-w-0 flex-1 items-center gap-2">
-                <WorkspaceBadge workspace={active} />
-                <span className="min-w-0 flex-1 truncate text-left">
-                  {active ? (
-                    <>
-                      <span className="block truncate text-sm font-medium">
-                        {active.name}
-                      </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {active.slug}
-                      </span>
-                    </>
-                  ) : (
-                    <span className="block truncate text-sm text-muted-foreground">
-                      Select workspace
-                    </span>
-                  )}
-                </span>
+              <span className="max-w-[12rem] truncate">
+                {active ? active.name : "Select workspace"}
               </span>
-              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
             </Button>
           }
         />
@@ -183,6 +168,6 @@ export function WorkspaceSwitcher() {
         </PopoverContent>
       </Popover>
       <NewWorkspaceDialog open={createOpen} onOpenChange={setCreateOpen} />
-    </div>
+    </>
   )
 }

--- a/apps/dashboard/tests/smoke/workspace-switcher.test.tsx
+++ b/apps/dashboard/tests/smoke/workspace-switcher.test.tsx
@@ -68,10 +68,9 @@ function renderSwitcher(initialPath = "/workspaces/acme/sessions") {
 describe("WorkspaceSwitcher", () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it("renders the active workspace's name and slug", async () => {
+  it("renders the active workspace's name", async () => {
     renderSwitcher()
     expect(await screen.findByText("Acme")).toBeInTheDocument()
-    expect(screen.getByText("acme")).toBeInTheDocument()
   })
 
   it("opens the picker and lists every membership", async () => {
@@ -80,6 +79,9 @@ describe("WorkspaceSwitcher", () => {
       await screen.findByRole("combobox", { name: /switch workspace/i }),
     )
     expect(await screen.findByText("Beta")).toBeInTheDocument()
+    // The slug lives in the picker rows, not on the closed trigger
+    // (the trigger now shows the name only — see #496).
+    expect(screen.getByText("acme")).toBeInTheDocument()
     expect(screen.getByText(/create workspace/i)).toBeInTheDocument()
   })
 
@@ -127,6 +129,5 @@ describe("WorkspaceSwitcher", () => {
       </QueryClientProvider>,
     )
     expect(await screen.findByText("Acme")).toBeInTheDocument()
-    expect(screen.getByText("acme")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #496

## What

The `WorkspaceSwitcher` was authored for the old sidebar layout and kept its bordered, two-line, fixed-width styling after moving into the desktop top chrome (ADR 0019 / #453). In the flat `h-14` strip it read as a separate "card" rather than as chrome.

## Changes

**`WorkspaceSwitcher.tsx`**
- Outer `<div className="px-2 pt-2">` (leftover sidebar padding) → fragment; `Popover` and `NewWorkspaceDialog` are now fragment siblings.
- Trigger `Button`: `variant="outline"` → `variant="ghost"` `size="sm"`, `className="h-8 gap-1.5 px-2 text-sm font-medium"`. Single-line, content-width, no border, vertically centered in the row.
- Trigger label shows `active.name` only (`max-w-[12rem] truncate`); the "Select workspace" placeholder stays for the empty-active case. Dropped the `WorkspaceBadge` and `active.slug` line from the trigger.
- Chevron: `ChevronsUpDown` → `ChevronDown` (`h-3.5 w-3.5 shrink-0 opacity-50`). `role="combobox"` and `aria-label="Switch workspace"` preserved.
- Picker `CommandList` rows unchanged — badge + name + slug + `Check` still there (disambiguation lives where you pick).
- Updated the stale `WorkspaceBadge` JSDoc that still said "the sidebar".

**`AppLayout.tsx`**
- Removed the `<div className="w-56">` wrapper in `DesktopTopChrome`; the switcher sizes to its content. Flanking vertical separators unchanged.

**`tests/smoke/workspace-switcher.test.tsx`**
- Closed-trigger test renamed to `renders the active workspace's name` and now asserts the name only.
- `opens the picker…` test now also asserts the slug (`"acme"`) is present after opening — it moved from the trigger into the picker rows (commented, linked to #496).
- The outside-`WorkspaceScope` test drops its closed-state slug assertion.

## Verification

- `pnpm --filter dashboard test tests/smoke/workspace-switcher.test.tsx` — 4 passed.
- `pnpm tsc --noEmit` — clean.
- `eslint` on the three changed files — clean.

`targetPathForSwitch` / `RESOURCE_SEGMENTS` navigation untouched; no new prop on `WorkspaceSwitcher` (sole consumer is `AppLayout`). The "Onsager appears twice" wordmark/switcher coincidence is explicitly out of scope per the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb31867VJvqYDkn3yz8oEL)_