### PR TITLE
Close the spec-plan run path: durable scheduler → run_spec_plan → in-chat DAG (ADR 0023)

### DIFF
--- a/apps/dashboard/src/components/chat/SpecPlanDAG.tsx
+++ b/apps/dashboard/src/components/chat/SpecPlanDAG.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from "react"
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  type Node,
+  type Edge,
+} from "@xyflow/react"
+import "@xyflow/react/dist/style.css"
+import type { SpecPlan, SpecRunState } from "@/lib/spec-plan"
+
+// Distinct from `WorkflowDAGPreview` (a single workflow's linear stage
+// chain): this renders a *Spec Plan* — nodes = specs, edges = deps —
+// as a layered DAG (F1 #503). An optional `runState` map overlays
+// per-spec execution state for the plan-run progress surface (F2 #504).
+
+const NODE_W = 180
+const NODE_H = 56
+const GAP_X = 70
+const GAP_Y = 24
+
+// Per-run-state visual token. `pending` is the authored-only default.
+const STATE_META: Record<SpecRunState, { color: string; label: string }> = {
+  pending: { color: "#64748b", label: "Pending" },
+  running: { color: "#3b82f6", label: "Running" },
+  done: { color: "#10b981", label: "Done" },
+  failed: { color: "#ef4444", label: "Failed" },
+}
+
+export interface SpecPlanDAGProps {
+  plan: SpecPlan
+  /**
+   * Optional per-spec run state (keyed by `SpecRef.id`). When present,
+   * nodes are coloured by state and finished/failed edges stop
+   * animating — the F2 plan-run progress overlay. Omit for the
+   * authored (pre-run) graph.
+   */
+  runState?: Record<string, SpecRunState>
+  /** Fixed pixel height for the embedded canvas. Defaults to 240. */
+  height?: number
+}
+
+/**
+ * Assign each spec a layer = longest dependency path from a root, so
+ * upstream specs sit left of their dependents. Specs with no deps are
+ * roots (layer 0). Cycles can't occur — the compiler rejects them
+ * (`SpecPlan::validate`) — but a defensive visited-set keeps the
+ * layout terminating regardless.
+ */
+function layerOf(
+  id: string,
+  incoming: Map<string, string[]>,
+  memo: Map<string, number>,
+  stack: Set<string>,
+): number {
+  const cached = memo.get(id)
+  if (cached !== undefined) return cached
+  if (stack.has(id)) return 0
+  stack.add(id)
+  const parents = incoming.get(id) ?? []
+  const layer =
+    parents.length === 0
+      ? 0
+      : 1 + Math.max(...parents.map((p) => layerOf(p, incoming, memo, stack)))
+  stack.delete(id)
+  memo.set(id, layer)
+  return layer
+}
+
+function buildGraph(
+  plan: SpecPlan,
+  runState?: Record<string, SpecRunState>,
+): { nodes: Node[]; edges: Edge[] } {
+  const incoming = new Map<string, string[]>()
+  for (const spec of plan.specs) incoming.set(spec.id, [])
+  for (const dep of plan.deps) {
+    if (!incoming.has(dep.to)) incoming.set(dep.to, [])
+    incoming.get(dep.to)!.push(dep.from)
+  }
+
+  const memo = new Map<string, number>()
+  const layers = new Map<string, number>()
+  for (const spec of plan.specs) {
+    layers.set(spec.id, layerOf(spec.id, incoming, memo, new Set()))
+  }
+  // Track how many nodes already sit in each layer for vertical stacking.
+  const perLayerCount = new Map<number, number>()
+
+  const nodes: Node[] = plan.specs.map((spec) => {
+    const layer = layers.get(spec.id) ?? 0
+    const row = perLayerCount.get(layer) ?? 0
+    perLayerCount.set(layer, row + 1)
+    const state = runState?.[spec.id] ?? "pending"
+    const meta = STATE_META[state]
+    return {
+      id: spec.id,
+      type: "default",
+      position: {
+        x: layer * (NODE_W + GAP_X),
+        y: row * (NODE_H + GAP_Y),
+      },
+      data: {
+        label: (
+          <SpecBox
+            title={spec.id}
+            kind={spec.kind}
+            color={meta.color}
+            stateLabel={runState ? meta.label : undefined}
+          />
+        ),
+      },
+      style: nodeStyle(meta.color),
+    }
+  })
+
+  const edges: Edge[] = plan.deps.map((dep) => {
+    const toState = runState?.[dep.to]
+    return {
+      id: `e-${dep.from}-${dep.to}`,
+      source: dep.from,
+      target: dep.to,
+      // Keep animating only while the downstream spec hasn't finished.
+      animated: !runState || toState === "running" || toState === undefined,
+      style: { stroke: "#94a3b8", strokeWidth: 1.5 },
+    }
+  })
+
+  return { nodes, edges }
+}
+
+function nodeStyle(color: string): React.CSSProperties {
+  return {
+    width: NODE_W,
+    height: NODE_H,
+    borderRadius: 8,
+    border: `1.5px solid ${color}55`,
+    background: `${color}11`,
+    padding: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  }
+}
+
+function SpecBox({
+  title,
+  kind,
+  color,
+  stateLabel,
+}: {
+  title: string
+  kind: string
+  color: string
+  stateLabel?: string
+}) {
+  return (
+    <div style={{ textAlign: "center", lineHeight: 1.25, padding: "0 6px" }}>
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          color,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ fontSize: 10, color: "#94a3b8", marginTop: 1 }}>
+        {kind}
+        {stateLabel ? ` · ${stateLabel}` : ""}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Render a Spec Plan as a specs+deps DAG. Read-only — nodes are not
+ * draggable or connectable; this is a preview, not an editor.
+ */
+export function SpecPlanDAG({ plan, runState, height = 240 }: SpecPlanDAGProps) {
+  const { nodes, edges } = useMemo(
+    () => buildGraph(plan, runState),
+    [plan, runState],
+  )
+
+  if (plan.specs.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-md border text-xs text-muted-foreground"
+        style={{ height }}
+      >
+        Empty plan — no specs to show.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border" style={{ height }}>
+      <ReactFlowProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background color="#94a3b820" gap={20} size={1} />
+          <Controls showInteractive={false} position="bottom-right" />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/chat/SpecPlanRunView.tsx
+++ b/apps/dashboard/src/components/chat/SpecPlanRunView.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { mcpCallTool } from "@/lib/mcp-client"
+import { SpecPlanDAG } from "@/components/chat/SpecPlanDAG"
+import { runStateFromEvents, type SpecPlan } from "@/lib/spec-plan"
+
+// F2 (#504, ADR 0023): the run-time counterpart of F1's authored graph.
+// Renders a launched Spec Plan with live per-spec state overlaid on the
+// same DAG. Sources progress from the substrate `node.*` events the
+// scheduler emits (same-origin via portal's `/api/spine/events`), maps
+// each node back to its spec via `get_execution_plan`'s `node_index`,
+// and keys the run by the derived `plan_id` `run_spec_plan` returned.
+
+interface SpecPlanRunViewProps {
+  workspaceId: string
+  specPlanId: string
+  /** Derived run id from `run_spec_plan`'s result. */
+  planId: string
+}
+
+/** Parse the first text block of an MCP tool result as JSON. */
+function parseResult(text: string | undefined): unknown {
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+export function SpecPlanRunView({
+  workspaceId,
+  specPlanId,
+  planId,
+}: SpecPlanRunViewProps) {
+  // The authored plan body — fetched once.
+  const planQuery = useQuery({
+    queryKey: ["spec-plan", workspaceId, specPlanId],
+    queryFn: async () => {
+      const res = await mcpCallTool("get_spec_plan", {
+        workspace_id: workspaceId,
+        spec_plan_id: specPlanId,
+      })
+      const parsed = parseResult(res.content?.[0]?.text) as
+        | { spec_plan?: { plan?: SpecPlan } }
+        | null
+      return parsed?.spec_plan?.plan ?? null
+    },
+  })
+
+  // node_id → spec_id, so node events attribute to the right spec.
+  const nodeIndexQuery = useQuery({
+    queryKey: ["spec-plan-node-index", workspaceId, specPlanId],
+    queryFn: async () => {
+      const res = await mcpCallTool("get_execution_plan", {
+        workspace_id: workspaceId,
+        spec_plan_id: specPlanId,
+      })
+      const parsed = parseResult(res.content?.[0]?.text) as
+        | { execution_plan?: { node_index?: Record<string, string> } }
+        | null
+      return parsed?.execution_plan?.node_index ?? {}
+    },
+  })
+
+  // Live substrate node events, polled. Filtered client-side to this
+  // plan via `data.plan_id` (the stream-type filter narrows the read;
+  // the per-plan filter happens in `runStateFromEvents`).
+  const eventsQuery = useQuery({
+    queryKey: ["spec-plan-run-events", workspaceId, planId],
+    queryFn: () =>
+      api.getSpineEvents(workspaceId, { stream_type: "substrate", limit: 200 }),
+    refetchInterval: 3000,
+  })
+
+  const runState = useMemo(() => {
+    const events = eventsQuery.data?.events ?? []
+    const nodeIndex = nodeIndexQuery.data ?? {}
+    return runStateFromEvents(events, planId, nodeIndex)
+  }, [eventsQuery.data, nodeIndexQuery.data, planId])
+
+  const plan = planQuery.data
+  if (!plan) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {planQuery.isLoading ? "Loading plan…" : "Plan graph unavailable."}
+      </p>
+    )
+  }
+
+  return <SpecPlanDAG plan={plan} runState={runState} />
+}

--- a/apps/dashboard/src/components/workflows/ChatBuilder.tsx
+++ b/apps/dashboard/src/components/workflows/ChatBuilder.tsx
@@ -1,5 +1,15 @@
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react"
+import {
+  type FormEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { AlertTriangle, Send, Sparkles } from "lucide-react"
+import { SpecPlanDAG } from "@/components/chat/SpecPlanDAG"
+import { SpecPlanRunView } from "@/components/chat/SpecPlanRunView"
+import { extractSpecPlan } from "@/lib/spec-plan"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
@@ -318,21 +328,24 @@ export function ChatBuilder({ workspaceId }: ChatBuilderProps) {
                         {call.state === "committed" && call.resultText ? (
                           <ResultBlock text={call.resultText} />
                         ) : null}
+                        {renderSpecPlanGraph(call)}
                       </div>
                     )
                   }
                   return (
-                    <InfoBlock
-                      key={call.id}
-                      title={call.binding.title(call.input)}
-                      body={
-                        call.binding.renderInfo?.(call.input) ??
-                        `Calling ${call.toolName}.`
-                      }
-                      state={call.state}
-                      resultText={call.resultText}
-                      errorMessage={call.errorMessage}
-                    />
+                    <div key={call.id} className="flex flex-col gap-1.5">
+                      <InfoBlock
+                        title={call.binding.title(call.input)}
+                        body={
+                          call.binding.renderInfo?.(call.input) ??
+                          `Calling ${call.toolName}.`
+                        }
+                        state={call.state}
+                        resultText={call.resultText}
+                        errorMessage={call.errorMessage}
+                      />
+                      {renderSpecPlanGraph(call)}
+                    </div>
                   )
                 })}
                 {turn.error ? (
@@ -369,6 +382,52 @@ export function ChatBuilder({ workspaceId }: ChatBuilderProps) {
       </CardContent>
     </Card>
   )
+}
+
+/**
+ * The spec-plan DAG to render beneath a tool call's card/info block
+ * (F1 #503 / F2 #504, ADR 0023):
+ *
+ * - `submit_spec_plan` / `compile_dry_run` carry the full `{ specs,
+ *   deps }` body in their args — render the authored graph directly.
+ * - `run_spec_plan` carries only the plan id; once committed, its
+ *   result includes the derived `plan_id`, so render the live run view
+ *   that overlays per-spec progress.
+ *
+ * Returns `null` for every other tool.
+ */
+function renderSpecPlanGraph(call: ToolCallEntry): ReactNode {
+  if (call.toolName === "run_spec_plan") {
+    if (call.state !== "committed" || !call.resultText) return null
+    let planId: string | undefined
+    try {
+      const parsed = JSON.parse(call.resultText) as { plan_id?: unknown }
+      if (typeof parsed.plan_id === "string") planId = parsed.plan_id
+    } catch {
+      planId = undefined
+    }
+    const workspaceId = call.input.workspace_id
+    const specPlanId = call.input.spec_plan_id
+    if (
+      !planId ||
+      typeof workspaceId !== "string" ||
+      typeof specPlanId !== "string"
+    ) {
+      return null
+    }
+    return (
+      <SpecPlanRunView
+        workspaceId={workspaceId}
+        specPlanId={specPlanId}
+        planId={planId}
+      />
+    )
+  }
+  if (call.toolName === "submit_spec_plan" || call.toolName === "compile_dry_run") {
+    const plan = extractSpecPlan(call.input)
+    return plan ? <SpecPlanDAG plan={plan} /> : null
+  }
+  return null
 }
 
 function UserBubble({ content }: { content: string }) {

--- a/apps/dashboard/src/lib/mcp-tools.ts
+++ b/apps/dashboard/src/lib/mcp-tools.ts
@@ -377,6 +377,27 @@ const get_execution_plan: McpToolBinding = {
     `Recompiling stored plan ${str(args, "spec_plan_id", "(unknown)")} on read.`,
 }
 
+const run_spec_plan: McpToolBinding = {
+  name: "run_spec_plan",
+  category: "destructive",
+  title: (args) => `Run spec plan · ${str(args, "spec_plan_id", "unknown")}`,
+  buildCard: (args) => ({
+    kind: "destructive",
+    title: `Run spec plan · ${str(args, "spec_plan_id", "unknown")}`,
+    body: {
+      info: `Launches the stored plan and runs every spec in dependency order. Progress shows on the plan graph below as each node advances.`,
+    },
+    sideEffects: [
+      "Emits `plan.run_requested` on the spine",
+      "The substrate scheduler compiles the stored plan and runs all specs",
+    ],
+    reversibility:
+      "Reversible — a re-run resumes the same plan; cancel individual runs from their detail page.",
+    commit: { label: "Run plan", intent: "destructive" },
+    reject: { label: "Don't run" },
+  }),
+}
+
 const submit_workflow: McpToolBinding = {
   name: "submit_workflow",
   category: "constructive",
@@ -489,6 +510,7 @@ const BINDINGS: McpToolBinding[] = [
   get_spec_plan,
   compile_dry_run,
   get_execution_plan,
+  run_spec_plan,
   submit_workflow,
   update_workflow,
   retire_workflow,

--- a/apps/dashboard/src/lib/spec-plan.ts
+++ b/apps/dashboard/src/lib/spec-plan.ts
@@ -1,0 +1,104 @@
+// Spec-plan shapes the dashboard renders (F1 #503 / F2 #504, ADR 0023).
+//
+// Hand-typed for v1, mirroring the Rust `SpecPlan` / `SpecRef` /
+// `SpecDep` serde structs in `crates/onsager-substrate/src/spec_plan.rs`.
+// The schemars-derived Rust-as-SSOT TS codegen is the same follow-up
+// that covers the MCP tool args (see `mcp-tools.ts`); once it lands
+// these collapse to generated imports.
+
+import type { SpineEvent } from "@/lib/api/types"
+
+export interface SpecInputs {
+  artifacts?: string[]
+}
+
+export interface SpecRef {
+  id: string
+  kind: string
+  inputs?: SpecInputs
+}
+
+export interface SpecDep {
+  from: string
+  to: string
+}
+
+export interface SpecPlan {
+  specs: SpecRef[]
+  deps: SpecDep[]
+}
+
+/** Per-spec run state overlaid on the plan graph (F2). */
+export type SpecRunState = "pending" | "running" | "done" | "failed"
+
+/**
+ * Pull a `SpecPlan` out of an MCP tool's arguments. `submit_spec_plan`
+ * and `compile_dry_run` carry the full `{ specs, deps }` body under
+ * `spec_plan`; other spec-plan tools reference a plan by id and carry
+ * no body. Returns `null` when no renderable plan is present.
+ */
+export function extractSpecPlan(args: Record<string, unknown>): SpecPlan | null {
+  const raw = args.spec_plan
+  if (!raw || typeof raw !== "object") return null
+  const obj = raw as Record<string, unknown>
+  const specs = Array.isArray(obj.specs) ? (obj.specs as SpecRef[]) : null
+  if (!specs) return null
+  const deps = Array.isArray(obj.deps) ? (obj.deps as SpecDep[]) : []
+  return { specs, deps }
+}
+
+/**
+ * Reduce a batch of substrate `node.*` spine events into a per-spec
+ * run state, given the `node_id → spec_id` index from
+ * `get_execution_plan`. Events are filtered to `planId` (their
+ * `data.plan_id`); each node's latest lifecycle event wins, and a
+ * spec's state is the max-severity over its nodes
+ * (failed > running > done > pending).
+ */
+export function runStateFromEvents(
+  events: SpineEvent[],
+  planId: string,
+  nodeIndex: Record<string, string>,
+): Record<string, SpecRunState> {
+  // node_id → latest state seen.
+  const nodeState: Record<string, SpecRunState> = {}
+  // Events arrive newest-first from the API; walk oldest-first so the
+  // last write per node wins.
+  for (const e of [...events].reverse()) {
+    if (e.data?.plan_id !== planId) continue
+    const nodeId = typeof e.data?.node_id === "string" ? e.data.node_id : null
+    if (!nodeId) continue
+    const next = eventTypeToState(e.event_type)
+    if (next) nodeState[nodeId] = next
+  }
+
+  const rank: Record<SpecRunState, number> = {
+    pending: 0,
+    done: 1,
+    running: 2,
+    failed: 3,
+  }
+  const out: Record<string, SpecRunState> = {}
+  for (const [nodeId, state] of Object.entries(nodeState)) {
+    const specId = nodeIndex[nodeId]
+    if (!specId) continue
+    const prev = out[specId]
+    if (prev === undefined || rank[state] > rank[prev]) {
+      out[specId] = state
+    }
+  }
+  return out
+}
+
+function eventTypeToState(eventType: string): SpecRunState | null {
+  switch (eventType) {
+    case "node.started":
+      return "running"
+    case "node.completed":
+      return "done"
+    case "node.failed":
+      return "failed"
+    default:
+      return null
+  }
+}

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -558,6 +558,24 @@ impl Scheduler {
                 inputs.push((edge.artifact_id.clone(), artifact));
             }
         }
+        // B4 (#502): an entry node's spec may declare external input
+        // artifacts (`SpecInputs.artifacts`). The compiler carried
+        // them onto this node in `plan.entry_inputs`; materialize each
+        // from the PlanStore and add it to the executor context. A
+        // declared input that isn't in the store yet is skipped (same
+        // shape as an absent edge input) rather than failing the node.
+        if let Some(artifact_ids) = plan.entry_inputs.get(&node.id) {
+            for artifact_id in artifact_ids {
+                if let Some(artifact) = self
+                    .store
+                    .get_artifact(plan_id, artifact_id)
+                    .await
+                    .map_err(|e| SchedulerError::Store(e.0))?
+                {
+                    inputs.push((artifact_id.clone(), artifact));
+                }
+            }
+        }
         Ok(inputs)
     }
 
@@ -652,6 +670,7 @@ mod tests {
                 },
             ],
             spec_index: HashMap::new(),
+            entry_inputs: HashMap::new(),
         }
     }
 
@@ -751,6 +770,97 @@ mod tests {
         let states = store.node_states(&plan_id).await.unwrap();
         assert_eq!(states.get(&a_id), Some(&NodeState::Completed));
         assert_eq!(states.get(&b_id), Some(&NodeState::Completed));
+    }
+
+    /// Records the `ArtifactId`s its executor context received as
+    /// inputs, so a test can assert B4 wiring delivered a spec's
+    /// declared entry inputs. Registers under `noop` to override the
+    /// default.
+    #[derive(Debug, Default)]
+    struct RecordingExecutor {
+        seen: std::sync::Mutex<Vec<ArtifactId>>,
+    }
+
+    #[async_trait]
+    impl crate::Executor for RecordingExecutor {
+        fn executor_kind(&self) -> &'static str {
+            "noop"
+        }
+        fn declared_provenance(
+            &self,
+            _: &[onsager_artifact::Provenance],
+        ) -> onsager_artifact::Provenance {
+            onsager_artifact::Provenance::external_deterministic()
+        }
+        async fn execute(
+            &self,
+            ctx: ExecutorContext,
+        ) -> Result<crate::context::ExecutorOutputs, ExecutorError> {
+            let mut seen = self.seen.lock().unwrap();
+            for (id, _) in &ctx.inputs {
+                seen.push(id.clone());
+            }
+            Ok(crate::context::ExecutorOutputs::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn entry_node_receives_declared_spec_inputs() {
+        // Single entry node with a declared external input artifact
+        // (the shape the compiler emits from SpecInputs.artifacts).
+        let edge_out = EdgeId::generate();
+        let node_id = NodeId::generate();
+        let node = SubstrateNode {
+            id: node_id,
+            executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+            inputs: vec![],
+            outputs: vec![EdgeRef::new(edge_out)],
+        };
+        let external_input = ArtifactId::new("ext-input");
+        let mut entry_inputs = HashMap::new();
+        entry_inputs.insert(node_id, vec![external_input.clone()]);
+        let plan = ExecutionPlan {
+            nodes: vec![node],
+            edges: vec![Edge {
+                id: edge_out,
+                artifact_id: ArtifactId::new("out"),
+                requires_deterministic: false,
+            }],
+            spec_index: HashMap::new(),
+            entry_inputs,
+        };
+
+        let recorder = Arc::new(RecordingExecutor::default());
+        let mut registry = ExecutorRegistry::new();
+        registry.register(Arc::clone(&recorder) as Arc<dyn crate::Executor>);
+        let store = Arc::new(InMemoryPlanStore::new());
+        let spine = Arc::new(MockSpine::default());
+        let scheduler = Scheduler::new(
+            Arc::new(registry),
+            Arc::clone(&store) as Arc<dyn PlanStore>,
+            Arc::clone(&spine) as Arc<dyn SpineClient>,
+        );
+        let plan_id = PlanId::generate();
+
+        // Materialize the declared input artifact in the store, keyed
+        // by its external ArtifactId — the same key the compiler put
+        // in entry_inputs.
+        store
+            .put_artifact(
+                &plan_id,
+                &external_input,
+                Artifact::new(Kind::Document, "fixture", "marvin", "test", vec![]),
+            )
+            .await
+            .unwrap();
+
+        scheduler.run(&plan_id, &plan).await.unwrap();
+
+        let seen = recorder.seen.lock().unwrap();
+        assert!(
+            seen.contains(&external_input),
+            "entry node executor should have received its declared input artifact, saw: {seen:?}",
+        );
     }
 
     /// Failing executor: registers under the `noop` kind so it

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -671,6 +671,7 @@ mod tests {
             ],
             spec_index: HashMap::new(),
             entry_inputs: HashMap::new(),
+            node_spec_index: HashMap::new(),
         }
     }
 
@@ -828,6 +829,7 @@ mod tests {
             }],
             spec_index: HashMap::new(),
             entry_inputs,
+            node_spec_index: HashMap::new(),
         };
 
         let recorder = Arc::new(RecordingExecutor::default());

--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -300,6 +300,7 @@ impl SubWorkflowRunner for SchedulerSubWorkflowRunner {
             edges: inst.edges,
             spec_index: HashMap::new(),
             entry_inputs: HashMap::new(),
+            node_spec_index: HashMap::new(),
         };
         let exit_edges = inst.exit_edges.clone();
         let entry_edge_ids = inst.entry_edges.clone();

--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -299,6 +299,7 @@ impl SubWorkflowRunner for SchedulerSubWorkflowRunner {
             nodes: inst.nodes,
             edges: inst.edges,
             spec_index: HashMap::new(),
+            entry_inputs: HashMap::new(),
         };
         let exit_edges = inst.exit_edges.clone();
         let entry_edge_ids = inst.entry_edges.clone();

--- a/crates/onsager-nodes/tests/scheduler_event_contract.rs
+++ b/crates/onsager-nodes/tests/scheduler_event_contract.rs
@@ -119,6 +119,7 @@ fn script_agent_verify_plan() -> (ExecutionPlan, NodeId, NodeId, NodeId) {
             },
         ],
         spec_index: Default::default(),
+        entry_inputs: Default::default(),
     };
     (plan, script_node_id, agent_node_id, verify_node_id)
 }
@@ -289,6 +290,7 @@ async fn verify_failure_still_emits_synodic_verdict() {
             },
         ],
         spec_index: Default::default(),
+        entry_inputs: Default::default(),
     };
 
     // Per-node executor configuration is not yet routed through the

--- a/crates/onsager-nodes/tests/scheduler_event_contract.rs
+++ b/crates/onsager-nodes/tests/scheduler_event_contract.rs
@@ -120,6 +120,7 @@ fn script_agent_verify_plan() -> (ExecutionPlan, NodeId, NodeId, NodeId) {
         ],
         spec_index: Default::default(),
         entry_inputs: Default::default(),
+        node_spec_index: Default::default(),
     };
     (plan, script_node_id, agent_node_id, verify_node_id)
 }
@@ -291,6 +292,7 @@ async fn verify_failure_still_emits_synodic_verdict() {
         ],
         spec_index: Default::default(),
         entry_inputs: Default::default(),
+        node_spec_index: Default::default(),
     };
 
     // Per-node executor configuration is not yet routed through the

--- a/crates/onsager-nodes/tests/subworkflow_end_to_end.rs
+++ b/crates/onsager-nodes/tests/subworkflow_end_to_end.rs
@@ -174,6 +174,7 @@ async fn outer_subworkflow_node_propagates_inner_uncertain_to_outer_exit() {
         }],
         spec_index: HashMap::new(),
         entry_inputs: HashMap::new(),
+        node_spec_index: HashMap::new(),
     };
 
     // ----- Run the outer scheduler.

--- a/crates/onsager-nodes/tests/subworkflow_end_to_end.rs
+++ b/crates/onsager-nodes/tests/subworkflow_end_to_end.rs
@@ -173,6 +173,7 @@ async fn outer_subworkflow_node_propagates_inner_uncertain_to_outer_exit() {
             requires_deterministic: false,
         }],
         spec_index: HashMap::new(),
+        entry_inputs: HashMap::new(),
     };
 
     // ----- Run the outer scheduler.

--- a/crates/onsager-portal/src/mcp/registry.rs
+++ b/crates/onsager-portal/src/mcp/registry.rs
@@ -248,6 +248,15 @@ fn build_registry() -> Vec<ToolDescriptor> {
             },
         },
         ToolDescriptor {
+            name: "run_spec_plan",
+            description: "Launch a persisted `SpecPlan` (ADR 0023). Emits `plan.run_requested` on the spine; the substrate scheduler host loads the stored plan, compiles it, and runs every spec in dependency order to a terminal state. Portal does not run the plan itself (seam rule). The plan must already exist (`submit_spec_plan`); a re-invocation resumes the same run rather than forking. The peer of `submit_spec_plan` / `get_execution_plan`.",
+            category: ToolCategory::Destructive,
+            input_schema: super::input_schema::<tools::substrate_specs::RunSpecPlanArgs>(),
+            invoke: |state, user, args| {
+                Box::pin(tools::substrate_specs::run_spec_plan(state, user, args))
+            },
+        },
+        ToolDescriptor {
             name: "submit_workflow",
             description: "Register a new `Workflow` (ADR 0016) for `spec_kind` in the substrate Workflow Library. Inserts a fresh monotonic version (per-kind `MAX(version) + 1`); the new row becomes the active version the Plan Compiler resolves. Workflow payload round-trips via the substrate's `Workflow` serde derive (executors flow through `typetag`'s `kind` discriminator).",
             category: ToolCategory::Constructive,

--- a/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
+++ b/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
@@ -407,9 +407,15 @@ pub async fn run_spec_plan(state: &AppState, auth_user: &AuthUser, args: Value) 
             ToolError::Internal(format!("failed to emit plan.run_requested: {e}"))
         })?;
 
+    // Derived run id (shared with the scheduler, ADR 0023) so the
+    // dashboard can subscribe to this run's `node.*` events on the
+    // `substrate:<plan_id>:` stream prefix for the F2 progress surface.
+    let plan_id = onsager_substrate::derive_plan_id(&args.workspace_id, &stored.spec_plan_id);
+
     Ok(serde_json::json!({
         "spec_plan_id": stored.spec_plan_id,
         "workspace_id": args.workspace_id,
+        "plan_id": plan_id,
         "run_requested_event_id": event_id,
     }))
 }
@@ -444,12 +450,23 @@ fn compile_result_value(
                     )
                 })
                 .collect();
+            // node_id → spec_id, so the dashboard plan-run progress
+            // surface (F2, #504) can attribute `node.*` events to the
+            // spec they belong to.
+            let node_index: serde_json::Map<String, Value> = execution_plan
+                .node_spec_index
+                .iter()
+                .map(|(node_id, spec_id)| {
+                    (node_id.to_string(), Value::from(spec_id.as_str()))
+                })
+                .collect();
             serde_json::json!({
                 "ok": true,
                 "execution_plan": {
                     "node_count": execution_plan.nodes.len(),
                     "edge_count": execution_plan.edges.len(),
                     "spec_index": spec_index,
+                    "node_index": node_index,
                     "library_versions": snapshot
                         .versions
                         .iter()

--- a/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
+++ b/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
@@ -340,6 +340,81 @@ pub async fn get_execution_plan(state: &AppState, auth_user: &AuthUser, args: Va
 }
 
 // =============================================================================
+// run_spec_plan
+// =============================================================================
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunSpecPlanArgs {
+    pub workspace_id: String,
+    pub spec_plan_id: String,
+}
+
+/// Launch a stored `SpecPlan` (B3, #501, ADR 0023). Portal does **not**
+/// run the plan — it emits `plan.run_requested` on the spine and the
+/// substrate scheduler host consumes it, loads the stored plan,
+/// compiles it, and drives it to completion (the seam rule: portal is
+/// the edge, the scheduler is the runtime). The peer of
+/// `submit_spec_plan` / `get_execution_plan`.
+pub async fn run_spec_plan(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
+    let args: RunSpecPlanArgs = serde_json::from_value(args)
+        .map_err(|e| ToolError::InvalidParams(format!("invalid run_spec_plan args: {e}")))?;
+    if args.spec_plan_id.trim().is_empty() {
+        return Err(ToolError::InvalidParams("spec_plan_id is required".into()));
+    }
+    require_workspace_access(&state.pool, auth_user, &args.workspace_id).await?;
+
+    let spec_plan_id = args.spec_plan_id.trim();
+    // Confirm the plan exists before firing — a run request for a
+    // missing plan is a client error, not a dropped event.
+    let stored = spec_plan_db::get(&state.pool, &args.workspace_id, spec_plan_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("mcp run_spec_plan get failed: {e}");
+            ToolError::Internal(format!("failed to load spec plan: {e}"))
+        })?
+        .ok_or_else(|| ToolError::NotFound(format!("spec plan `{spec_plan_id}` not found")))?;
+
+    // Raw `{ spec_plan_id, workspace_id }` payload — the scheduler's
+    // `decode_spec_plan_run_requested` accepts this shape (alongside a
+    // FactoryEvent envelope / bare kind), mirroring how `run_workflow`
+    // emits `trigger.fired`.
+    let payload = serde_json::json!({
+        "spec_plan_id": stored.spec_plan_id,
+        "workspace_id": args.workspace_id,
+        "actor": auth_user.user_id,
+        "source": "mcp",
+    });
+    let metadata = onsager_spine::EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: auth_user.user_id.clone(),
+    };
+    let stream_id = format!("plan:{}:{}", args.workspace_id, stored.spec_plan_id);
+    let event_id = state
+        .spine
+        .append_ext(
+            &args.workspace_id,
+            &stream_id,
+            "plan",
+            "plan.run_requested",
+            payload,
+            &metadata,
+            None,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("mcp run_spec_plan emit failed: {e}");
+            ToolError::Internal(format!("failed to emit plan.run_requested: {e}"))
+        })?;
+
+    Ok(serde_json::json!({
+        "spec_plan_id": stored.spec_plan_id,
+        "workspace_id": args.workspace_id,
+        "run_requested_event_id": event_id,
+    }))
+}
+
+// =============================================================================
 // shared compile-response formatting
 // =============================================================================
 
@@ -423,6 +498,17 @@ mod tests {
         let parsed: UpdateSpecArgs = serde_json::from_value(raw).unwrap();
         let spec: SpecRef = serde_json::from_value(parsed.spec).unwrap();
         assert_eq!(spec.kind, "feature");
+    }
+
+    #[test]
+    fn run_spec_plan_args_round_trip() {
+        let raw = json!({
+            "workspace_id": "ws1",
+            "spec_plan_id": "github:42"
+        });
+        let parsed: RunSpecPlanArgs = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.workspace_id, "ws1");
+        assert_eq!(parsed.spec_plan_id, "github:42");
     }
 
     #[test]

--- a/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
+++ b/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
@@ -456,9 +456,7 @@ fn compile_result_value(
             let node_index: serde_json::Map<String, Value> = execution_plan
                 .node_spec_index
                 .iter()
-                .map(|(node_id, spec_id)| {
-                    (node_id.to_string(), Value::from(spec_id.as_str()))
-                })
+                .map(|(node_id, spec_id)| (node_id.to_string(), Value::from(spec_id.as_str())))
                 .collect();
             serde_json::json!({
                 "ok": true,

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -606,6 +606,20 @@ pub const EVENTS: EventManifest = EventManifest {
             operator_grain: true,
             description: "All gates on a stage resolved and the artifact advanced.",
         },
+        EventDefinition {
+            kind: "plan.run_requested",
+            schema_version: 1,
+            // Portal's `run_spec_plan` MCP tool emits this; the
+            // substrate scheduler host consumes it, loads the stored
+            // SpecPlan, compiles it, and runs it (#501, ADR 0023).
+            producers: &[Subsystem::Portal],
+            consumers: &[Subsystem::Substrate],
+            diagnostic_only: false,
+            reason: None,
+            tracking_issue: None,
+            operator_grain: true,
+            description: "A persisted multi-spec SpecPlan was requested to run.",
+        },
         // -- Registry events removed by spec #285 ---------------------------
         // The nine `registry.*` mutation events had no in-tree consumer
         // or dashboard reader. The registry tables remain the source of

--- a/crates/onsager-scheduler/src/bridge.rs
+++ b/crates/onsager-scheduler/src/bridge.rs
@@ -269,9 +269,9 @@ mod tests {
         Executor, ExecutorContext, ExecutorError, ExecutorOutputs, InMemoryPlanStore, PlanStore,
         SpineClient, SpineError,
     };
-    use std::sync::Arc;
     use onsager_substrate::ids::EdgeId;
     use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec};
+    use std::sync::Arc;
     use std::sync::Mutex;
 
     #[derive(Debug, Default)]

--- a/crates/onsager-scheduler/src/bridge.rs
+++ b/crates/onsager-scheduler/src/bridge.rs
@@ -34,16 +34,17 @@
 //! construction path here.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use onsager_nodes::{InMemoryPlanStore, PlanId, PlanStore, Scheduler, SchedulerError, SpineClient};
-use onsager_substrate::compiler::{CompileError, compile};
+use onsager_nodes::PlanId;
 use onsager_substrate::ids::WorkflowId;
 use onsager_substrate::library::WorkflowLibrary as WorkflowLookup;
 use onsager_substrate::spec_plan::{SpecId, SpecPlan, SpecRef};
 use onsager_substrate::workflow::Workflow;
 use serde_json::Value;
 use thiserror::Error;
+
+use crate::plan_registry::derive_plan_id;
+use crate::plan_runner::{PlanRunError, PlanRunner};
 
 /// Outcome of running [`TriggerBridge::handle_payload`].
 #[derive(Debug, Error)]
@@ -59,23 +60,14 @@ pub enum TriggerBridgeError {
     #[error("no workflow registered for spec_kind `{kind}` (workflow `{workflow_id}`)")]
     MissingKind { workflow_id: String, kind: String },
 
-    /// Compile-step failure — Spec Plan invalid, kernel invariant
-    /// violated, etc.
-    #[error("compile failed for workflow `{workflow_id}` (kind `{kind}`): {source}")]
-    Compile {
+    /// Compile or scheduler failure running the synthesized single-spec
+    /// plan, surfaced from the shared [`PlanRunner`].
+    #[error("run failed for workflow `{workflow_id}` (kind `{kind}`): {source}")]
+    Run {
         workflow_id: String,
         kind: String,
         #[source]
-        source: CompileError,
-    },
-
-    /// Scheduler-step failure — a node failed, the plan got stuck.
-    #[error("scheduler failed for workflow `{workflow_id}` (kind `{kind}`): {source}")]
-    Scheduler {
-        workflow_id: String,
-        kind: String,
-        #[source]
-        source: SchedulerError,
+        source: PlanRunError,
     },
 }
 
@@ -93,14 +85,15 @@ pub struct WorkflowMeta {
 /// Stateless bridge: trigger payload + workflow library → one
 /// executed plan.
 ///
-/// Holds the scheduler-side wiring (registry, store, spine) once at
-/// construction time; each call to [`Self::handle_payload`] builds a
-/// fresh [`PlanId`] and runs the resolved plan through
-/// [`Scheduler::run`].
+/// A thin adapter over the shared [`PlanRunner`] (B2, ADR 0023): it
+/// resolves the `spec_kind`, builds the single-element [`SpecPlan`]
+/// the trigger path needs, derives a workflow-stable [`PlanId`], and
+/// delegates the compile-and-run to the runner — the same entry the
+/// multi-spec `plan.run_requested` path uses. No parallel run loop
+/// lives here anymore.
 #[derive(Clone)]
 pub struct TriggerBridge {
-    registry: Arc<onsager_nodes::ExecutorRegistry>,
-    spine: Arc<dyn SpineClient>,
+    runner: PlanRunner,
 }
 
 impl std::fmt::Debug for TriggerBridge {
@@ -110,11 +103,8 @@ impl std::fmt::Debug for TriggerBridge {
 }
 
 impl TriggerBridge {
-    pub fn new(
-        registry: Arc<onsager_nodes::ExecutorRegistry>,
-        spine: Arc<dyn SpineClient>,
-    ) -> Self {
-        Self { registry, spine }
+    pub fn new(runner: PlanRunner) -> Self {
+        Self { runner }
     }
 
     /// Run a single trigger.fired payload to completion.
@@ -154,20 +144,15 @@ impl TriggerBridge {
             deps: vec![],
         };
         let single = SingleWorkflowLookup::new(kind.clone(), workflow);
-        let exec_plan =
-            compile(&spec_plan, &single).map_err(|source| TriggerBridgeError::Compile {
-                workflow_id: workflow_id.to_string(),
-                kind: kind.clone(),
-                source,
-            })?;
-
-        let store: Arc<dyn PlanStore> = Arc::new(InMemoryPlanStore::new());
-        let scheduler = Scheduler::new(Arc::clone(&self.registry), store, Arc::clone(&self.spine));
-        let plan_id = PlanId::generate();
-        scheduler
-            .run(&plan_id, &exec_plan)
+        // Stable per-workflow id so a re-fire resumes rather than
+        // forking; the single-spec path keys off the workflow id (no
+        // persisted spec_plan_id), the multi-spec path keys off
+        // (workspace_id, spec_plan_id).
+        let plan_id = derive_plan_id("trigger", workflow_id);
+        self.runner
+            .run(&plan_id, &spec_plan, &single)
             .await
-            .map_err(|source| TriggerBridgeError::Scheduler {
+            .map_err(|source| TriggerBridgeError::Run {
                 workflow_id: workflow_id.to_string(),
                 kind,
                 source,
@@ -280,7 +265,11 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use onsager_artifact::{Artifact, ArtifactId, NodeId, Provenance};
-    use onsager_nodes::{Executor, ExecutorContext, ExecutorError, ExecutorOutputs, SpineError};
+    use onsager_nodes::{
+        Executor, ExecutorContext, ExecutorError, ExecutorOutputs, InMemoryPlanStore, PlanStore,
+        SpineClient, SpineError,
+    };
+    use std::sync::Arc;
     use onsager_substrate::ids::EdgeId;
     use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec};
     use std::sync::Mutex;
@@ -361,10 +350,13 @@ mod tests {
         let mut registry = onsager_nodes::ExecutorRegistry::new();
         registry.register(Arc::new(EchoExecutor));
         let spine = Arc::new(CapturingSpine::default());
-        let bridge = TriggerBridge::new(
+        let store: Arc<dyn PlanStore> = Arc::new(InMemoryPlanStore::new());
+        let runner = PlanRunner::new(
             Arc::new(registry),
+            store,
             Arc::clone(&spine) as Arc<dyn SpineClient>,
         );
+        let bridge = TriggerBridge::new(runner);
         (bridge, spine)
     }
 

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -34,9 +34,15 @@
 //! spine / artifact only — never on a sibling subsystem crate.
 
 pub mod bridge;
+pub mod migrate;
+pub mod plan_registry;
+pub mod plan_runner;
+pub mod plan_store;
 pub mod service;
 pub mod spine_client;
 
 pub use bridge::{TriggerBridge, TriggerBridgeError};
+pub use plan_runner::{PlanRunError, PlanRunner, SchedulerLibrarySnapshot};
+pub use plan_store::SqlxPlanStore;
 pub use service::{SchedulerService, ServiceConfig};
 pub use spine_client::SpineEventStoreClient;

--- a/crates/onsager-scheduler/src/migrate.rs
+++ b/crates/onsager-scheduler/src/migrate.rs
@@ -1,0 +1,30 @@
+//! Scheduler-owned table bootstrap.
+//!
+//! The substrate scheduler persists run state in three spine tables
+//! (`execution_plans`, `execution_plan_nodes`, `execution_plan_artifacts`
+//! — #499 / #500). Their canonical schema is the spine migration
+//! `crates/onsager-spine/migrations/006_execution_plans.sql`, applied in
+//! production by the migration runner that owns the spine schema.
+//!
+//! The scheduler host connects via [`onsager_spine::EventStore`], which
+//! does **not** run migrations. So this module ensures the tables exist
+//! idempotently at startup by replaying the same canonical `.sql`
+//! (inlined via `include_str!` — no DDL drift). On a fresh deploy
+//! whichever process migrates first wins; the `CREATE TABLE IF NOT
+//! EXISTS` shape makes the loser a no-op. Mirrors the stiglab
+//! `run_migrations` fallback pattern.
+
+use sqlx::PgPool;
+
+const EXECUTION_PLANS_SQL: &str =
+    include_str!("../../onsager-spine/migrations/006_execution_plans.sql");
+
+/// Ensure the scheduler's durable-state tables exist. Idempotent —
+/// safe to call on every startup.
+pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
+    sqlx::raw_sql(EXECUTION_PLANS_SQL)
+        .execute(pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("scheduler execution-plan migration failed: {e}"))?;
+    Ok(())
+}

--- a/crates/onsager-scheduler/src/plan_registry.rs
+++ b/crates/onsager-scheduler/src/plan_registry.rs
@@ -19,19 +19,17 @@ use onsager_nodes::PlanId;
 use onsager_substrate::spec_plan::SpecPlan;
 use sqlx::{PgPool, Row};
 
-/// Stable namespace for [`derive_plan_id`] — frozen UUID v4.
-const PLAN_ID_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
-    0x4f, 0x4e, 0x53, 0x47, 0x52, 0x50, 0x4c, 0x41, 0x4e, 0x52, 0x55, 0x4e, 0x49, 0x44, 0x06, 0x06,
-]);
-
 /// Derive a stable [`PlanId`] from `(workspace_id, spec_plan_id)`.
 ///
-/// A `run_spec_plan` re-invocation for the same stored plan resolves
-/// to the same `PlanId`, so the durable store sees a resume rather
-/// than a forked second run (ADR 0023 decision 1).
+/// Thin wrapper over [`onsager_substrate::spec_plan::derive_plan_id`]
+/// (the single source of truth, shared with portal's `run_spec_plan`)
+/// so the durable store sees a resume rather than a forked second run
+/// on re-invocation (ADR 0023 decision 1).
 pub fn derive_plan_id(workspace_id: &str, spec_plan_id: &str) -> PlanId {
-    let seed = format!("{workspace_id}:{spec_plan_id}");
-    PlanId::new(uuid::Uuid::new_v5(&PLAN_ID_NAMESPACE, seed.as_bytes()).to_string())
+    PlanId::new(onsager_substrate::spec_plan::derive_plan_id(
+        workspace_id,
+        spec_plan_id,
+    ))
 }
 
 /// Load the authored `SpecPlan` for `(workspace_id, spec_plan_id)` from

--- a/crates/onsager-scheduler/src/plan_registry.rs
+++ b/crates/onsager-scheduler/src/plan_registry.rs
@@ -1,0 +1,143 @@
+//! `execution_plans` registry + the stored-`SpecPlan` reader (B2,
+//! #500, ADR 0023 decision 1).
+//!
+//! Two responsibilities:
+//!
+//! 1. **Read the authored plan.** `run_spec_plan` (#501) only carries
+//!    `(workspace_id, spec_plan_id)`; the orchestration loads the
+//!    actual `SpecPlan` from the `spec_plans` table that
+//!    `submit_spec_plan` writes (`crates/onsager-portal/src/spec_plan_db.rs`).
+//!    We read that table **directly via SQL** — the scheduler does not
+//!    import `onsager-portal` (seam rule); the table is shared spine
+//!    Postgres, read like any other spine table.
+//! 2. **Record the run.** `execution_plans` maps a [`PlanId`] to the
+//!    compiled-from `SpecPlan` JSON so a host restart can reload +
+//!    recompile + resume any plan with non-terminal nodes
+//!    ([`list_recoverable`]).
+
+use onsager_nodes::PlanId;
+use onsager_substrate::spec_plan::SpecPlan;
+use sqlx::{PgPool, Row};
+
+/// Stable namespace for [`derive_plan_id`] — frozen UUID v4.
+const PLAN_ID_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x4f, 0x4e, 0x53, 0x47, 0x52, 0x50, 0x4c, 0x41, 0x4e, 0x52, 0x55, 0x4e, 0x49, 0x44, 0x06, 0x06,
+]);
+
+/// Derive a stable [`PlanId`] from `(workspace_id, spec_plan_id)`.
+///
+/// A `run_spec_plan` re-invocation for the same stored plan resolves
+/// to the same `PlanId`, so the durable store sees a resume rather
+/// than a forked second run (ADR 0023 decision 1).
+pub fn derive_plan_id(workspace_id: &str, spec_plan_id: &str) -> PlanId {
+    let seed = format!("{workspace_id}:{spec_plan_id}");
+    PlanId::new(uuid::Uuid::new_v5(&PLAN_ID_NAMESPACE, seed.as_bytes()).to_string())
+}
+
+/// Load the authored `SpecPlan` for `(workspace_id, spec_plan_id)` from
+/// the portal-written `spec_plans` table. `Ok(None)` when absent.
+pub async fn load_spec_plan(
+    pool: &PgPool,
+    workspace_id: &str,
+    spec_plan_id: &str,
+) -> anyhow::Result<Option<SpecPlan>> {
+    let row = sqlx::query(
+        "SELECT plan_json FROM spec_plans WHERE workspace_id = $1 AND spec_plan_id = $2",
+    )
+    .bind(workspace_id)
+    .bind(spec_plan_id)
+    .fetch_optional(pool)
+    .await?;
+    match row {
+        None => Ok(None),
+        Some(row) => {
+            let json: serde_json::Value = row.try_get("plan_json")?;
+            Ok(Some(serde_json::from_value(json)?))
+        }
+    }
+}
+
+/// Record (or refresh) a run in `execution_plans` with status
+/// `running`. Idempotent on `plan_id` so a resume re-asserts the row.
+pub async fn register_plan(
+    pool: &PgPool,
+    plan_id: &PlanId,
+    workspace_id: &str,
+    spec_plan_id: Option<&str>,
+    spec_plan: &SpecPlan,
+) -> anyhow::Result<()> {
+    let plan_json = serde_json::to_value(spec_plan)?;
+    sqlx::query(
+        "INSERT INTO execution_plans \
+         (plan_id, workspace_id, spec_plan_id, spec_plan_json, status, updated_at) \
+         VALUES ($1, $2, $3, $4, 'running', NOW()) \
+         ON CONFLICT (plan_id) DO UPDATE \
+         SET spec_plan_json = EXCLUDED.spec_plan_json, status = 'running', updated_at = NOW()",
+    )
+    .bind(plan_id.as_str())
+    .bind(workspace_id)
+    .bind(spec_plan_id)
+    .bind(&plan_json)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Set a plan's terminal status (`completed` / `failed`).
+pub async fn set_status(pool: &PgPool, plan_id: &PlanId, status: &str) -> anyhow::Result<()> {
+    sqlx::query("UPDATE execution_plans SET status = $2, updated_at = NOW() WHERE plan_id = $1")
+        .bind(plan_id.as_str())
+        .bind(status)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// A plan that was still `running` at startup — its source `SpecPlan`
+/// to recompile and resume.
+#[derive(Debug)]
+pub struct RecoverablePlan {
+    pub plan_id: PlanId,
+    pub workspace_id: String,
+    pub spec_plan: SpecPlan,
+}
+
+/// Every plan left in `running` status. The host recompiles each and
+/// re-drives `Scheduler::run`, which resets non-terminal node states
+/// to pending and re-dispatches (RUN-01 fault-tolerance note).
+pub async fn list_recoverable(pool: &PgPool) -> anyhow::Result<Vec<RecoverablePlan>> {
+    let rows = sqlx::query(
+        "SELECT plan_id, workspace_id, spec_plan_json FROM execution_plans WHERE status = 'running'",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let plan_id: String = row.try_get("plan_id")?;
+        let workspace_id: String = row.try_get("workspace_id")?;
+        let json: serde_json::Value = row.try_get("spec_plan_json")?;
+        let spec_plan: SpecPlan = serde_json::from_value(json)?;
+        out.push(RecoverablePlan {
+            plan_id: PlanId::new(plan_id),
+            workspace_id,
+            spec_plan,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_plan_id_is_stable_and_workspace_scoped() {
+        let a = derive_plan_id("ws1", "github:42");
+        let b = derive_plan_id("ws1", "github:42");
+        assert_eq!(a, b, "same inputs must derive the same plan id");
+        let other_ws = derive_plan_id("ws2", "github:42");
+        assert_ne!(a, other_ws, "workspace must scope the derived id");
+        let other_plan = derive_plan_id("ws1", "github:43");
+        assert_ne!(a, other_plan, "spec plan id must scope the derived id");
+    }
+}

--- a/crates/onsager-scheduler/src/plan_runner.rs
+++ b/crates/onsager-scheduler/src/plan_runner.rs
@@ -1,0 +1,345 @@
+//! [`PlanRunner`] — the one run entry both front doors share (B2,
+//! #500, ADR 0023 decision 1).
+//!
+//! Before this, the single-spec `trigger.fired` flow
+//! ([`crate::bridge`]) was the only deployed `Scheduler::run` caller,
+//! and it hardcoded a one-element [`SpecPlan`] over an ephemeral store.
+//! `PlanRunner` collapses that into a single entry: compile a
+//! [`SpecPlan`] against a workflow-library lookup, then drive
+//! [`Scheduler::run`] against the durable [`PlanStore`]. Both the
+//! single-spec trigger path and the multi-spec `plan.run_requested`
+//! path call it — no parallel run loops.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use onsager_nodes::{ExecutorRegistry, PlanId, PlanStore, Scheduler, SchedulerError, SpineClient};
+use onsager_substrate::compiler::{CompileError, compile};
+use onsager_substrate::ids::WorkflowId;
+use onsager_substrate::spec_plan::SpecPlan;
+use onsager_substrate::workflow::Workflow;
+use onsager_substrate::workflow_library::WorkflowLibrary as PersistedWorkflowLibrary;
+use onsager_substrate::{WorkflowLibraryError, WorkflowLookup};
+use thiserror::Error;
+
+/// Failure running a [`SpecPlan`] end-to-end.
+#[derive(Debug, Error)]
+pub enum PlanRunError {
+    /// The Spec Plan failed to compile (structural error, missing
+    /// kind, kernel invariant violation, …).
+    #[error("compile failed: {0}")]
+    Compile(#[from] CompileError),
+
+    /// The scheduler aborted the run (a node failed, the plan got
+    /// stuck).
+    #[error("scheduler failed: {0}")]
+    Scheduler(#[from] SchedulerError),
+}
+
+/// Compiles a [`SpecPlan`] and runs it through [`Scheduler`] against a
+/// durable [`PlanStore`]. Built once at host startup (the store,
+/// registry, and spine are process-wide) and reused per run.
+#[derive(Clone)]
+pub struct PlanRunner {
+    registry: Arc<ExecutorRegistry>,
+    store: Arc<dyn PlanStore>,
+    spine: Arc<dyn SpineClient>,
+}
+
+impl std::fmt::Debug for PlanRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PlanRunner").finish_non_exhaustive()
+    }
+}
+
+impl PlanRunner {
+    pub fn new(
+        registry: Arc<ExecutorRegistry>,
+        store: Arc<dyn PlanStore>,
+        spine: Arc<dyn SpineClient>,
+    ) -> Self {
+        Self {
+            registry,
+            store,
+            spine,
+        }
+    }
+
+    /// Compile `spec_plan` against `library` and run it under
+    /// `plan_id` to a terminal state. Restart-safe via the durable
+    /// store: re-running the same `plan_id` resumes rather than
+    /// restarting (see [`Scheduler::run`]).
+    ///
+    /// `library` is generic + `Sync` (rather than a bare `&dyn
+    /// WorkflowLookup`) so the produced future is `Send` — the spine
+    /// listener loop requires a `Send` handler, and a `&dyn` trait
+    /// object defaults to non-`Sync` even though every concrete lookup
+    /// here is `Send + Sync` (the `Executor` trait is `Send + Sync`).
+    pub async fn run<L: WorkflowLookup + Sync>(
+        &self,
+        plan_id: &PlanId,
+        spec_plan: &SpecPlan,
+        library: &L,
+    ) -> Result<(), PlanRunError> {
+        let exec_plan = compile(spec_plan, library)?;
+        let scheduler = Scheduler::new(
+            Arc::clone(&self.registry),
+            Arc::clone(&self.store),
+            Arc::clone(&self.spine),
+        );
+        scheduler.run(plan_id, &exec_plan).await?;
+        Ok(())
+    }
+}
+
+/// An in-memory snapshot of the workflow library covering exactly the
+/// kinds a [`SpecPlan`] references, built by resolving each spec's
+/// `kind` through the persisted [`PersistedWorkflowLibrary`] once.
+///
+/// The Plan Compiler needs a synchronous `&dyn WorkflowLookup`, but
+/// the persisted library is async (one query per `latest(kind)`); this
+/// snapshot bridges the two — the same shape portal's `compile_dry_run`
+/// uses on its side. SubWorkflow refs ([`WorkflowLookup::get`] by
+/// `WorkflowId`) are not resolved here (v1 — same limitation as the
+/// single-spec trigger path); a plan whose workflow embeds a
+/// SubWorkflow executor fails invariant 4 at compile, loudly.
+#[derive(Debug, Default)]
+pub struct SchedulerLibrarySnapshot {
+    by_kind: HashMap<String, Workflow>,
+}
+
+impl SchedulerLibrarySnapshot {
+    /// Resolve every distinct `kind` in `spec_plan` against the
+    /// persisted library. Kinds with no registered workflow are simply
+    /// absent from the snapshot — the compiler then surfaces
+    /// `CompileError::MissingKind`, which is the correct hard failure
+    /// per ADR 0017.
+    pub async fn build(
+        spec_plan: &SpecPlan,
+        library: &PersistedWorkflowLibrary,
+    ) -> Result<Self, WorkflowLibraryError> {
+        let mut by_kind = HashMap::new();
+        for spec in &spec_plan.specs {
+            if by_kind.contains_key(&spec.kind) {
+                continue;
+            }
+            if let Some(workflow) = library.lookup(&spec.kind).await? {
+                by_kind.insert(spec.kind.clone(), workflow);
+            }
+        }
+        Ok(Self { by_kind })
+    }
+}
+
+impl WorkflowLookup for SchedulerLibrarySnapshot {
+    fn get(&self, _id: WorkflowId) -> Option<&Workflow> {
+        None
+    }
+    fn by_kind(&self, kind: &str) -> Option<&Workflow> {
+        self.by_kind.get(kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use onsager_artifact::{Artifact, ArtifactId, Kind, NodeId, Provenance};
+    use onsager_nodes::{
+        Executor, ExecutorContext, ExecutorError, ExecutorOutputs, ExecutorRegistry,
+        InMemoryPlanStore, SpineError,
+    };
+    use onsager_substrate::executor::NoOpExecutor;
+    use onsager_substrate::ids::EdgeId;
+    use onsager_substrate::spec_plan::{SpecDep, SpecId, SpecRef};
+    use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec};
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct NoopSpine;
+
+    #[async_trait]
+    impl SpineClient for NoopSpine {
+        async fn emit(&self, _: &str, _: serde_json::Value) -> Result<(), SpineError> {
+            Ok(())
+        }
+        async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+            Ok(None)
+        }
+    }
+
+    /// Runtime executor (kind `noop`) that records every input
+    /// artifact id its context received and produces one output
+    /// artifact per declared output edge. Lets a test prove the
+    /// downstream spec's node observed the upstream spec's output —
+    /// i.e. the dep was wired and ordering was honored.
+    #[derive(Debug, Default)]
+    struct RecordingEcho {
+        seen_inputs: Mutex<Vec<ArtifactId>>,
+    }
+
+    #[async_trait]
+    impl Executor for RecordingEcho {
+        fn executor_kind(&self) -> &'static str {
+            "noop"
+        }
+        fn declared_provenance(&self, _: &[Provenance]) -> Provenance {
+            Provenance::external_deterministic()
+        }
+        async fn execute(&self, ctx: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+            {
+                let mut seen = self.seen_inputs.lock().unwrap();
+                for (id, _) in &ctx.inputs {
+                    seen.push(id.clone());
+                }
+            }
+            let art = Artifact::new(Kind::Document, "echo", "marvin", "scheduler", vec![]);
+            let id = art.artifact_id.clone();
+            Ok(ExecutorOutputs::single(id, art))
+        }
+    }
+
+    /// Workflow with one node: (entry) -> [noop] -> (exit). Used for
+    /// both specs so the only difference is the dep wiring.
+    fn passthrough_workflow() -> Workflow {
+        let entry = EdgeId::generate();
+        let exit = EdgeId::generate();
+        Workflow {
+            nodes: vec![Node {
+                id: NodeId::generate(),
+                executor: Box::new(NoOpExecutor),
+                inputs: vec![EdgeRef::new(entry)],
+                outputs: vec![EdgeRef::new(exit)],
+            }],
+            edges: vec![
+                Edge {
+                    id: entry,
+                    artifact_id: ArtifactId::new("art_in"),
+                    requires_deterministic: false,
+                },
+                Edge {
+                    id: exit,
+                    artifact_id: ArtifactId::new("art_out"),
+                    requires_deterministic: false,
+                },
+            ],
+            entry_specs: vec![EntrySpec { edge_id: entry }],
+            output_specs: vec![OutputSpec {
+                edge_id: exit,
+                provenance: Provenance::external_deterministic(),
+            }],
+        }
+    }
+
+    struct TwoKindLibrary {
+        up: Workflow,
+        down: Workflow,
+    }
+
+    impl WorkflowLookup for TwoKindLibrary {
+        fn get(&self, _: WorkflowId) -> Option<&Workflow> {
+            None
+        }
+        fn by_kind(&self, kind: &str) -> Option<&Workflow> {
+            match kind {
+                "up" => Some(&self.up),
+                "down" => Some(&self.down),
+                _ => None,
+            }
+        }
+    }
+
+    fn build_runner() -> (PlanRunner, std::sync::Arc<RecordingEcho>) {
+        let recorder = std::sync::Arc::new(RecordingEcho::default());
+        let mut registry = ExecutorRegistry::new();
+        registry.register(std::sync::Arc::clone(&recorder) as std::sync::Arc<dyn Executor>);
+        let store: std::sync::Arc<dyn PlanStore> = std::sync::Arc::new(InMemoryPlanStore::new());
+        let runner = PlanRunner::new(
+            std::sync::Arc::new(registry),
+            store,
+            std::sync::Arc::new(NoopSpine) as std::sync::Arc<dyn SpineClient>,
+        );
+        (runner, recorder)
+    }
+
+    /// A persisted 2-spec plan with one dep compiles and runs both
+    /// specs in dependency order: the downstream node observes the
+    /// upstream node's output artifact, persisted under the rewired
+    /// exit edge.
+    ///
+    /// Mutation check: drop the `deps` edge (see
+    /// `two_spec_plan_without_dep_sees_no_upstream_output`) and the
+    /// downstream node sees no inputs — this assertion fails.
+    #[tokio::test]
+    async fn two_spec_plan_runs_in_dependency_order() {
+        let (runner, recorder) = build_runner();
+        let lib = TwoKindLibrary {
+            up: passthrough_workflow(),
+            down: passthrough_workflow(),
+        };
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("s1"),
+                    kind: "up".into(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("s2"),
+                    kind: "down".into(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![SpecDep {
+                from: SpecId::new("s1"),
+                to: SpecId::new("s2"),
+            }],
+        };
+        let plan_id = PlanId::generate();
+        runner.run(&plan_id, &plan, &lib).await.expect("run ok");
+
+        // s1's exit edge artifact id is `s1:art_out` (namespaced by
+        // instantiate); the dep rewires s2's entry to consume it, so
+        // the downstream node must have seen it.
+        let seen = recorder.seen_inputs.lock().unwrap();
+        assert!(
+            seen.iter().any(|a| a.as_str() == "s1:art_out"),
+            "downstream node should have consumed the upstream output, saw: {seen:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn two_spec_plan_without_dep_sees_no_upstream_output() {
+        // Same plan, no dep — the mutation. Each spec's entry edge
+        // stays its own (no producer), so the downstream node sees no
+        // input and the dependency-order assertion above would fail.
+        let (runner, recorder) = build_runner();
+        let lib = TwoKindLibrary {
+            up: passthrough_workflow(),
+            down: passthrough_workflow(),
+        };
+        let plan = SpecPlan {
+            specs: vec![
+                SpecRef {
+                    id: SpecId::new("s1"),
+                    kind: "up".into(),
+                    inputs: Default::default(),
+                },
+                SpecRef {
+                    id: SpecId::new("s2"),
+                    kind: "down".into(),
+                    inputs: Default::default(),
+                },
+            ],
+            deps: vec![],
+        };
+        let plan_id = PlanId::generate();
+        runner.run(&plan_id, &plan, &lib).await.expect("run ok");
+
+        let seen = recorder.seen_inputs.lock().unwrap();
+        assert!(
+            !seen.iter().any(|a| a.as_str() == "s1:art_out"),
+            "without the dep, the downstream node must not see s1's output",
+        );
+    }
+}

--- a/crates/onsager-scheduler/src/plan_store.rs
+++ b/crates/onsager-scheduler/src/plan_store.rs
@@ -1,0 +1,197 @@
+//! [`SqlxPlanStore`] — a durable, spine-backed [`PlanStore`] (B1, #499).
+//!
+//! Replaces the ephemeral `InMemoryPlanStore` on the deployed run path
+//! so node states and materialized artifacts survive a host restart
+//! (RUN-01 #359 specced the scheduler as "spine-persisted,
+//! restart-safe"). Persists all four [`PlanStore`] methods against the
+//! `execution_plan_nodes` / `execution_plan_artifacts` tables
+//! (`crates/onsager-spine/migrations/006_execution_plans.sql`).
+//!
+//! Lives in the scheduler host (not in `onsager-nodes`) for the same
+//! reason [`crate::spine_client::SpineEventStoreClient`] does: the
+//! executor-catalog crate stays database-free and test-friendly, and
+//! only the deployed host pays the sqlx cost. `InMemoryPlanStore`
+//! remains the test seam; no production path constructs it.
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId, NodeId};
+use onsager_nodes::{NodeState, PlanId, PlanStore, PlanStoreError};
+use sqlx::PgPool;
+use sqlx::Row;
+
+/// Map a [`NodeState`] to its persisted text form. Matches the
+/// `CHECK (state IN (...))` constraint and the serde `snake_case`
+/// rename, kept explicit so a constraint mismatch is a compile-time
+/// match-exhaustiveness signal rather than a runtime surprise.
+fn node_state_to_str(state: NodeState) -> &'static str {
+    match state {
+        NodeState::Pending => "pending",
+        NodeState::Ready => "ready",
+        NodeState::Running => "running",
+        NodeState::Completed => "completed",
+        NodeState::Failed => "failed",
+    }
+}
+
+/// Inverse of [`node_state_to_str`]. A row carrying an unknown state
+/// is a schema-vs-code drift; surface it as a store error rather than
+/// guessing.
+fn node_state_from_str(s: &str) -> Result<NodeState, PlanStoreError> {
+    match s {
+        "pending" => Ok(NodeState::Pending),
+        "ready" => Ok(NodeState::Ready),
+        "running" => Ok(NodeState::Running),
+        "completed" => Ok(NodeState::Completed),
+        "failed" => Ok(NodeState::Failed),
+        other => Err(PlanStoreError::new(format!(
+            "unknown node state '{other}' in execution_plan_nodes"
+        ))),
+    }
+}
+
+/// Durable [`PlanStore`] over the spine Postgres. Cheap to clone
+/// (wraps a reference-counted `PgPool`).
+#[derive(Clone)]
+pub struct SqlxPlanStore {
+    pool: PgPool,
+}
+
+impl std::fmt::Debug for SqlxPlanStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqlxPlanStore").finish_non_exhaustive()
+    }
+}
+
+impl SqlxPlanStore {
+    /// Wrap a pool. The pool must point at a database with the
+    /// execution-plan tables applied (see
+    /// `crates/onsager-spine/migrations/006_execution_plans.sql`; the
+    /// scheduler host ensures them at startup via [`crate::migrate`]).
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl PlanStore for SqlxPlanStore {
+    async fn set_node_state(
+        &self,
+        plan_id: &PlanId,
+        node_id: NodeId,
+        state: NodeState,
+    ) -> Result<(), PlanStoreError> {
+        sqlx::query(
+            "INSERT INTO execution_plan_nodes (plan_id, node_id, state, updated_at) \
+             VALUES ($1, $2, $3, NOW()) \
+             ON CONFLICT (plan_id, node_id) \
+             DO UPDATE SET state = EXCLUDED.state, updated_at = NOW()",
+        )
+        .bind(plan_id.as_str())
+        .bind(node_id.to_string())
+        .bind(node_state_to_str(state))
+        .execute(&self.pool)
+        .await
+        .map_err(|e| PlanStoreError::new(format!("set_node_state failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn node_states(
+        &self,
+        plan_id: &PlanId,
+    ) -> Result<std::collections::HashMap<NodeId, NodeState>, PlanStoreError> {
+        let rows = sqlx::query("SELECT node_id, state FROM execution_plan_nodes WHERE plan_id = $1")
+            .bind(plan_id.as_str())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| PlanStoreError::new(format!("node_states failed: {e}")))?;
+
+        let mut out = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let node_id_str: String = row
+                .try_get("node_id")
+                .map_err(|e| PlanStoreError::new(format!("node_id decode failed: {e}")))?;
+            let state_str: String = row
+                .try_get("state")
+                .map_err(|e| PlanStoreError::new(format!("state decode failed: {e}")))?;
+            let uuid = uuid::Uuid::parse_str(&node_id_str)
+                .map_err(|e| PlanStoreError::new(format!("node_id not a uuid: {e}")))?;
+            out.insert(NodeId::new(uuid), node_state_from_str(&state_str)?);
+        }
+        Ok(out)
+    }
+
+    async fn put_artifact(
+        &self,
+        plan_id: &PlanId,
+        artifact_id: &ArtifactId,
+        artifact: Artifact,
+    ) -> Result<(), PlanStoreError> {
+        let json = serde_json::to_value(&artifact)
+            .map_err(|e| PlanStoreError::new(format!("artifact serialize failed: {e}")))?;
+        sqlx::query(
+            "INSERT INTO execution_plan_artifacts (plan_id, artifact_id, artifact_json, updated_at) \
+             VALUES ($1, $2, $3, NOW()) \
+             ON CONFLICT (plan_id, artifact_id) \
+             DO UPDATE SET artifact_json = EXCLUDED.artifact_json, updated_at = NOW()",
+        )
+        .bind(plan_id.as_str())
+        .bind(artifact_id.as_str())
+        .bind(&json)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| PlanStoreError::new(format!("put_artifact failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_artifact(
+        &self,
+        plan_id: &PlanId,
+        artifact_id: &ArtifactId,
+    ) -> Result<Option<Artifact>, PlanStoreError> {
+        let row = sqlx::query(
+            "SELECT artifact_json FROM execution_plan_artifacts \
+             WHERE plan_id = $1 AND artifact_id = $2",
+        )
+        .bind(plan_id.as_str())
+        .bind(artifact_id.as_str())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| PlanStoreError::new(format!("get_artifact failed: {e}")))?;
+
+        match row {
+            None => Ok(None),
+            Some(row) => {
+                let json: serde_json::Value = row
+                    .try_get("artifact_json")
+                    .map_err(|e| PlanStoreError::new(format!("artifact_json decode failed: {e}")))?;
+                let artifact = serde_json::from_value(json)
+                    .map_err(|e| PlanStoreError::new(format!("artifact deserialize failed: {e}")))?;
+                Ok(Some(artifact))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_state_round_trips_through_text() {
+        for state in [
+            NodeState::Pending,
+            NodeState::Ready,
+            NodeState::Running,
+            NodeState::Completed,
+            NodeState::Failed,
+        ] {
+            let s = node_state_to_str(state);
+            assert_eq!(node_state_from_str(s).unwrap(), state);
+        }
+    }
+
+    #[test]
+    fn unknown_node_state_is_an_error() {
+        assert!(node_state_from_str("bogus").is_err());
+    }
+}

--- a/crates/onsager-scheduler/src/plan_store.rs
+++ b/crates/onsager-scheduler/src/plan_store.rs
@@ -99,11 +99,12 @@ impl PlanStore for SqlxPlanStore {
         &self,
         plan_id: &PlanId,
     ) -> Result<std::collections::HashMap<NodeId, NodeState>, PlanStoreError> {
-        let rows = sqlx::query("SELECT node_id, state FROM execution_plan_nodes WHERE plan_id = $1")
-            .bind(plan_id.as_str())
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| PlanStoreError::new(format!("node_states failed: {e}")))?;
+        let rows =
+            sqlx::query("SELECT node_id, state FROM execution_plan_nodes WHERE plan_id = $1")
+                .bind(plan_id.as_str())
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| PlanStoreError::new(format!("node_states failed: {e}")))?;
 
         let mut out = std::collections::HashMap::with_capacity(rows.len());
         for row in rows {
@@ -161,11 +162,12 @@ impl PlanStore for SqlxPlanStore {
         match row {
             None => Ok(None),
             Some(row) => {
-                let json: serde_json::Value = row
-                    .try_get("artifact_json")
-                    .map_err(|e| PlanStoreError::new(format!("artifact_json decode failed: {e}")))?;
-                let artifact = serde_json::from_value(json)
-                    .map_err(|e| PlanStoreError::new(format!("artifact deserialize failed: {e}")))?;
+                let json: serde_json::Value = row.try_get("artifact_json").map_err(|e| {
+                    PlanStoreError::new(format!("artifact_json decode failed: {e}"))
+                })?;
+                let artifact = serde_json::from_value(json).map_err(|e| {
+                    PlanStoreError::new(format!("artifact deserialize failed: {e}"))
+                })?;
                 Ok(Some(artifact))
             }
         }

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -181,7 +181,10 @@ async fn recover_running_plans(
     if plans.is_empty() {
         return Ok(());
     }
-    tracing::info!(count = plans.len(), "resuming in-flight plans after restart");
+    tracing::info!(
+        count = plans.len(),
+        "resuming in-flight plans after restart"
+    );
     for rec in plans {
         let snapshot = match SchedulerLibrarySnapshot::build(&rec.spec_plan, library).await {
             Ok(s) => s,
@@ -497,7 +500,10 @@ fn decode_spec_plan_run_requested(
         return Some((spec_plan_id, workspace_id));
     }
     // Raw payload fallback.
-    let spec_plan_id = data.get("spec_plan_id").and_then(|v| v.as_str())?.to_string();
+    let spec_plan_id = data
+        .get("spec_plan_id")
+        .and_then(|v| v.as_str())?
+        .to_string();
     let workspace_id = data
         .get("workspace_id")
         .and_then(|v| v.as_str())
@@ -635,7 +641,10 @@ mod tests {
         let (spec_plan_id, workspace_id) =
             decode_spec_plan_run_requested(&data, "row-ws").expect("decodes");
         assert_eq!(spec_plan_id, "github:42");
-        assert_eq!(workspace_id, "row-ws", "missing workspace falls back to the row column");
+        assert_eq!(
+            workspace_id, "row-ws",
+            "missing workspace falls back to the row column"
+        );
     }
 
     #[test]

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -613,4 +613,47 @@ mod tests {
         let data = serde_json::json!({ "not_a_workflow": "nope" });
         assert!(decode_trigger_fired(&data).is_none());
     }
+
+    #[test]
+    fn decode_plan_run_requested_from_raw_payload() {
+        // The shape portal's `run_spec_plan` MCP tool writes.
+        let data = serde_json::json!({
+            "spec_plan_id": "github:42",
+            "workspace_id": "ws-7",
+            "actor": "mcp-client",
+            "source": "mcp",
+        });
+        let (spec_plan_id, workspace_id) =
+            decode_spec_plan_run_requested(&data, "fallback").expect("decodes");
+        assert_eq!(spec_plan_id, "github:42");
+        assert_eq!(workspace_id, "ws-7");
+    }
+
+    #[test]
+    fn decode_plan_run_requested_falls_back_to_row_workspace() {
+        let data = serde_json::json!({ "spec_plan_id": "github:42" });
+        let (spec_plan_id, workspace_id) =
+            decode_spec_plan_run_requested(&data, "row-ws").expect("decodes");
+        assert_eq!(spec_plan_id, "github:42");
+        assert_eq!(workspace_id, "row-ws", "missing workspace falls back to the row column");
+    }
+
+    #[test]
+    fn decode_plan_run_requested_from_bare_kind() {
+        let kind = FactoryEventKind::SpecPlanRunRequested {
+            spec_plan_id: "github:99".into(),
+            workspace_id: "ws-9".into(),
+        };
+        let data = serde_json::to_value(&kind).unwrap();
+        let (spec_plan_id, workspace_id) =
+            decode_spec_plan_run_requested(&data, "fallback").expect("decodes");
+        assert_eq!(spec_plan_id, "github:99");
+        assert_eq!(workspace_id, "ws-9");
+    }
+
+    #[test]
+    fn decode_plan_run_requested_none_without_spec_plan_id() {
+        let data = serde_json::json!({ "workspace_id": "ws" });
+        assert!(decode_spec_plan_run_requested(&data, "fallback").is_none());
+    }
 }

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -22,13 +22,16 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use onsager_nodes::{ExecutorRegistry, NoOpExecutor, SpineClient};
+use onsager_nodes::{ExecutorRegistry, NoOpExecutor, PlanStore, SpineClient};
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 use onsager_substrate::workflow_library::WorkflowLibrary as PersistedWorkflowLibrary;
 use sqlx::Row;
 
 use crate::bridge::{PreloadedWorkflow, TriggerBridge, WorkflowMeta};
+use crate::plan_registry::{self, derive_plan_id};
+use crate::plan_runner::{PlanRunner, SchedulerLibrarySnapshot};
+use crate::plan_store::SqlxPlanStore;
 use crate::spine_client::SpineEventStoreClient;
 
 /// Configuration the service reads from env / CLI.
@@ -89,16 +92,35 @@ impl SchedulerService {
         let store = EventStore::connect(&self.config.database_url)
             .await
             .with_context(|| format!("connecting to {}", self.config.database_url))?;
+        // Ensure the durable execution-plan tables exist (idempotent;
+        // the canonical schema is the spine migration, but the
+        // scheduler connects via EventStore which does not migrate).
+        crate::migrate::run(store.pool())
+            .await
+            .context("ensuring execution-plan tables")?;
         let library = PersistedWorkflowLibrary::new(store.pool().clone());
         let base_spine = SpineEventStoreClient::new(store.clone(), &self.config.actor);
         let registry = self
             .registry
             .unwrap_or_else(|| Arc::new(default_executor_registry()));
+        let plan_store: Arc<dyn PlanStore> = Arc::new(SqlxPlanStore::new(store.pool().clone()));
+
+        // Recovery: a prior host may have died mid-run. Re-drive every
+        // plan still marked `running` — Scheduler::run resets
+        // non-terminal node states to pending and re-dispatches
+        // (RUN-01 fault-tolerance, B1 #499).
+        if let Err(e) =
+            recover_running_plans(&store, &registry, &base_spine, &library, &plan_store).await
+        {
+            tracing::warn!("plan recovery pass failed (continuing to live listen): {e}");
+        }
+
         let handler = TriggerHandler {
             registry,
             base_spine,
             library,
             store: store.clone(),
+            plan_store,
         };
 
         // Default: live-only. `replay_history = true` rewinds to id=0
@@ -133,11 +155,55 @@ impl SchedulerService {
         tracing::info!(
             actor = %self.config.actor,
             replay = self.config.replay_history,
-            "substrate scheduler listening for trigger.fired",
+            "substrate scheduler listening for trigger.fired / plan.run_requested",
         );
         listener.run(handler).await?;
         Ok(())
     }
+}
+
+/// Re-drive every plan left in `running` status by a prior host. Each
+/// plan's source `SpecPlan` is recompiled against the current library
+/// and handed to the shared [`PlanRunner`]; [`Scheduler::run`] resets
+/// any non-terminal node state read from the durable store and
+/// re-dispatches, so an interrupted multi-node run resumes to
+/// completion (B1 #499 / B2 #500).
+async fn recover_running_plans(
+    store: &EventStore,
+    registry: &Arc<ExecutorRegistry>,
+    base_spine: &SpineEventStoreClient,
+    library: &PersistedWorkflowLibrary,
+    plan_store: &Arc<dyn PlanStore>,
+) -> anyhow::Result<()> {
+    let plans = plan_registry::list_recoverable(store.pool())
+        .await
+        .context("listing recoverable plans")?;
+    if plans.is_empty() {
+        return Ok(());
+    }
+    tracing::info!(count = plans.len(), "resuming in-flight plans after restart");
+    for rec in plans {
+        let snapshot = match SchedulerLibrarySnapshot::build(&rec.spec_plan, library).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(plan_id = %rec.plan_id, "recovery library snapshot failed: {e}");
+                continue;
+            }
+        };
+        let scoped: Arc<dyn SpineClient> = Arc::new(base_spine.with_workspace(&rec.workspace_id));
+        let runner = PlanRunner::new(Arc::clone(registry), Arc::clone(plan_store), scoped);
+        match runner.run(&rec.plan_id, &rec.spec_plan, &snapshot).await {
+            Ok(()) => {
+                let _ = plan_registry::set_status(store.pool(), &rec.plan_id, "completed").await;
+                tracing::info!(plan_id = %rec.plan_id, "resumed plan completed");
+            }
+            Err(e) => {
+                let _ = plan_registry::set_status(store.pool(), &rec.plan_id, "failed").await;
+                tracing::warn!(plan_id = %rec.plan_id, "resumed plan failed: {e}");
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Read `MAX(id) FROM events_ext`, returning `None` when the table is
@@ -171,21 +237,30 @@ pub fn default_executor_registry() -> ExecutorRegistry {
     r
 }
 
-/// Spine [`EventHandler`] that dispatches `trigger.fired` events
-/// through the bridge.
+/// Spine [`EventHandler`] that dispatches the scheduler's two front
+/// doors — `trigger.fired` (single-spec) and `plan.run_requested`
+/// (multi-spec) — through the shared [`PlanRunner`].
 struct TriggerHandler {
     registry: Arc<ExecutorRegistry>,
     base_spine: SpineEventStoreClient,
     library: PersistedWorkflowLibrary,
     store: EventStore,
+    plan_store: Arc<dyn PlanStore>,
 }
 
 #[async_trait]
 impl EventHandler for TriggerHandler {
     async fn handle(&self, event: EventNotification) -> anyhow::Result<()> {
-        if event.event_type != "trigger.fired" {
-            return Ok(());
+        match event.event_type.as_str() {
+            "trigger.fired" => self.handle_trigger_fired(event).await,
+            "plan.run_requested" => self.handle_plan_run_requested(event).await,
+            _ => Ok(()),
         }
+    }
+}
+
+impl TriggerHandler {
+    async fn handle_trigger_fired(&self, event: EventNotification) -> anyhow::Result<()> {
         // Pull the row's data + workspace_id. Notifications carry
         // only stream_id + event_type; the body lives on
         // `events_ext`. workspace_id is the indexed tenant column —
@@ -245,7 +320,12 @@ impl EventHandler for TriggerHandler {
             .unwrap_or_else(|| "default".to_string());
         let scoped_spine: Arc<dyn SpineClient> =
             Arc::new(self.base_spine.with_workspace(&workspace_id));
-        let bridge = TriggerBridge::new(Arc::clone(&self.registry), scoped_spine);
+        let runner = PlanRunner::new(
+            Arc::clone(&self.registry),
+            Arc::clone(&self.plan_store),
+            scoped_spine,
+        );
+        let bridge = TriggerBridge::new(runner);
         match bridge
             .handle_payload(&workflow_id, &payload, &meta, lookup)
             .await
@@ -262,6 +342,91 @@ impl EventHandler for TriggerHandler {
                 %workflow_id,
                 "trigger.fired dispatch failed: {e}",
             ),
+        }
+        Ok(())
+    }
+
+    /// Load a persisted multi-spec `SpecPlan`, compile it, and run it
+    /// to completion through the shared [`PlanRunner`] (B2 #500 / B3
+    /// #501). Portal's `run_spec_plan` tool emitted the
+    /// `plan.run_requested` event this consumes.
+    async fn handle_plan_run_requested(&self, event: EventNotification) -> anyhow::Result<()> {
+        let row = sqlx::query("SELECT data, workspace_id FROM events_ext WHERE id = $1")
+            .bind(event.id)
+            .fetch_optional(self.store.pool())
+            .await
+            .context("loading plan.run_requested body")?;
+        let Some(row) = row else { return Ok(()) };
+        let data: serde_json::Value = row.try_get("data")?;
+        let row_workspace_id: String = row.try_get("workspace_id").unwrap_or_default();
+
+        let Some((spec_plan_id, workspace_id)) =
+            decode_spec_plan_run_requested(&data, &row_workspace_id)
+        else {
+            tracing::warn!(
+                event_id = event.id,
+                "plan.run_requested body did not decode (no spec_plan_id)"
+            );
+            return Ok(());
+        };
+
+        let spec_plan =
+            match plan_registry::load_spec_plan(self.store.pool(), &workspace_id, &spec_plan_id)
+                .await
+                .context("loading stored spec plan")?
+            {
+                Some(plan) => plan,
+                None => {
+                    tracing::warn!(
+                        event_id = event.id,
+                        %workspace_id,
+                        %spec_plan_id,
+                        "plan.run_requested for unknown spec plan — dropped",
+                    );
+                    return Ok(());
+                }
+            };
+
+        let plan_id = derive_plan_id(&workspace_id, &spec_plan_id);
+        plan_registry::register_plan(
+            self.store.pool(),
+            &plan_id,
+            &workspace_id,
+            Some(&spec_plan_id),
+            &spec_plan,
+        )
+        .await
+        .context("registering plan run")?;
+
+        let snapshot = SchedulerLibrarySnapshot::build(&spec_plan, &self.library)
+            .await
+            .context("building library snapshot")?;
+        let scoped_spine: Arc<dyn SpineClient> =
+            Arc::new(self.base_spine.with_workspace(&workspace_id));
+        let runner = PlanRunner::new(
+            Arc::clone(&self.registry),
+            Arc::clone(&self.plan_store),
+            scoped_spine,
+        );
+        match runner.run(&plan_id, &spec_plan, &snapshot).await {
+            Ok(()) => {
+                let _ = plan_registry::set_status(self.store.pool(), &plan_id, "completed").await;
+                tracing::info!(
+                    event_id = event.id,
+                    %workspace_id,
+                    %spec_plan_id,
+                    plan_id = %plan_id,
+                    "plan.run_requested completed",
+                );
+            }
+            Err(e) => {
+                let _ = plan_registry::set_status(self.store.pool(), &plan_id, "failed").await;
+                tracing::warn!(
+                    event_id = event.id,
+                    %spec_plan_id,
+                    "plan.run_requested failed: {e}",
+                );
+            }
         }
         Ok(())
     }
@@ -308,6 +473,38 @@ fn decode_trigger_fired(data: &serde_json::Value) -> Option<FactoryEventKind> {
         trigger_kind,
         payload: data.clone(),
     })
+}
+
+/// Extract `(spec_plan_id, workspace_id)` from a `plan.run_requested`
+/// `events_ext.data` column. Accepts the same three shapes as
+/// [`decode_trigger_fired`]: a `FactoryEvent` envelope, a bare
+/// `FactoryEventKind`, or a raw `{ spec_plan_id, workspace_id }`
+/// payload (the shape portal's MCP tool writes). The events_ext row's
+/// `workspace_id` column is the fallback when the payload omits it.
+fn decode_spec_plan_run_requested(
+    data: &serde_json::Value,
+    fallback_workspace_id: &str,
+) -> Option<(String, String)> {
+    let from_kind = serde_json::from_value::<FactoryEvent>(data.clone())
+        .map(|env| env.event)
+        .ok()
+        .or_else(|| serde_json::from_value::<FactoryEventKind>(data.clone()).ok());
+    if let Some(FactoryEventKind::SpecPlanRunRequested {
+        spec_plan_id,
+        workspace_id,
+    }) = from_kind
+    {
+        return Some((spec_plan_id, workspace_id));
+    }
+    // Raw payload fallback.
+    let spec_plan_id = data.get("spec_plan_id").and_then(|v| v.as_str())?.to_string();
+    let workspace_id = data
+        .get("workspace_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback_workspace_id)
+        .to_string();
+    Some((spec_plan_id, workspace_id))
 }
 
 /// Pull the workflow row's workspace_id. Returns `Ok(None)` if no

--- a/crates/onsager-scheduler/tests/durable_plan_store.rs
+++ b/crates/onsager-scheduler/tests/durable_plan_store.rs
@@ -17,10 +17,10 @@ use onsager_nodes::{
 };
 use onsager_scheduler::{PlanRunner, SqlxPlanStore};
 use onsager_substrate::ids::EdgeId;
+use onsager_substrate::ids::WorkflowId;
 use onsager_substrate::spec_plan::{SpecDep, SpecId, SpecPlan, SpecRef};
 use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
 use onsager_substrate::{WorkflowLibraryError, WorkflowLookup};
-use onsager_substrate::ids::WorkflowId;
 use sqlx::PgPool;
 
 async fn try_pool() -> Option<PgPool> {
@@ -136,7 +136,10 @@ fn build_runner(store: Arc<dyn PlanStore>) -> PlanRunner {
 }
 
 async fn snapshot() -> Result<TwoKindLibrary, WorkflowLibraryError> {
-    Ok(TwoKindLibrary(passthrough_workflow(), passthrough_workflow()))
+    Ok(TwoKindLibrary(
+        passthrough_workflow(),
+        passthrough_workflow(),
+    ))
 }
 
 #[tokio::test]

--- a/crates/onsager-scheduler/tests/durable_plan_store.rs
+++ b/crates/onsager-scheduler/tests/durable_plan_store.rs
@@ -1,0 +1,186 @@
+//! Integration test for the durable [`SqlxPlanStore`] (B1, #499) and
+//! restart-resume of a multi-node run (ADR 0023 decision 1).
+//!
+//! Skipped when `DATABASE_URL` is unset — matches the portal
+//! integration-test convention. The execution-plan tables
+//! (`crates/onsager-spine/migrations/006_execution_plans.sql`) are
+//! ensured by `onsager_scheduler::migrate::run`, so the test is
+//! self-contained against a bare spine Postgres.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use onsager_artifact::{Artifact, ArtifactId, Kind, NodeId, Provenance};
+use onsager_nodes::{
+    Executor, ExecutorContext, ExecutorError, ExecutorOutputs, ExecutorRegistry, NodeState, PlanId,
+    PlanStore, SpineClient, SpineError,
+};
+use onsager_scheduler::{PlanRunner, SqlxPlanStore};
+use onsager_substrate::ids::EdgeId;
+use onsager_substrate::spec_plan::{SpecDep, SpecId, SpecPlan, SpecRef};
+use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
+use onsager_substrate::{WorkflowLibraryError, WorkflowLookup};
+use onsager_substrate::ids::WorkflowId;
+use sqlx::PgPool;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+#[derive(Debug, Default)]
+struct NoopSpine;
+
+#[async_trait]
+impl SpineClient for NoopSpine {
+    async fn emit(&self, _: &str, _: serde_json::Value) -> Result<(), SpineError> {
+        Ok(())
+    }
+    async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+struct EmitOne;
+
+#[async_trait]
+impl Executor for EmitOne {
+    fn executor_kind(&self) -> &'static str {
+        "noop"
+    }
+    fn declared_provenance(&self, _: &[Provenance]) -> Provenance {
+        Provenance::external_deterministic()
+    }
+    async fn execute(&self, _: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
+        let art = Artifact::new(Kind::Document, "durable", "marvin", "test", vec![]);
+        let id = art.artifact_id.clone();
+        Ok(ExecutorOutputs::single(id, art))
+    }
+}
+
+fn passthrough_workflow() -> Workflow {
+    let entry = EdgeId::generate();
+    let exit = EdgeId::generate();
+    Workflow {
+        nodes: vec![Node {
+            id: NodeId::generate(),
+            executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+            inputs: vec![EdgeRef::new(entry)],
+            outputs: vec![EdgeRef::new(exit)],
+        }],
+        edges: vec![
+            Edge {
+                id: entry,
+                artifact_id: ArtifactId::new("art_in"),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: exit,
+                artifact_id: ArtifactId::new("art_out"),
+                requires_deterministic: false,
+            },
+        ],
+        entry_specs: vec![EntrySpec { edge_id: entry }],
+        output_specs: vec![OutputSpec {
+            edge_id: exit,
+            provenance: Provenance::external_deterministic(),
+        }],
+    }
+}
+
+struct TwoKindLibrary(Workflow, Workflow);
+
+impl WorkflowLookup for TwoKindLibrary {
+    fn get(&self, _: WorkflowId) -> Option<&Workflow> {
+        None
+    }
+    fn by_kind(&self, kind: &str) -> Option<&Workflow> {
+        match kind {
+            "up" => Some(&self.0),
+            "down" => Some(&self.1),
+            _ => None,
+        }
+    }
+}
+
+fn two_spec_plan() -> SpecPlan {
+    SpecPlan {
+        specs: vec![
+            SpecRef {
+                id: SpecId::new("s1"),
+                kind: "up".into(),
+                inputs: Default::default(),
+            },
+            SpecRef {
+                id: SpecId::new("s2"),
+                kind: "down".into(),
+                inputs: Default::default(),
+            },
+        ],
+        deps: vec![SpecDep {
+            from: SpecId::new("s1"),
+            to: SpecId::new("s2"),
+        }],
+    }
+}
+
+fn build_runner(store: Arc<dyn PlanStore>) -> PlanRunner {
+    let mut registry = ExecutorRegistry::new();
+    registry.register(Arc::new(EmitOne));
+    PlanRunner::new(
+        Arc::new(registry),
+        store,
+        Arc::new(NoopSpine) as Arc<dyn SpineClient>,
+    )
+}
+
+async fn snapshot() -> Result<TwoKindLibrary, WorkflowLibraryError> {
+    Ok(TwoKindLibrary(passthrough_workflow(), passthrough_workflow()))
+}
+
+#[tokio::test]
+async fn durable_store_persists_node_state_and_resumes_after_restart() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_scheduler::migrate::run(&pool)
+        .await
+        .expect("ensure execution-plan tables");
+
+    let store: Arc<dyn PlanStore> = Arc::new(SqlxPlanStore::new(pool.clone()));
+    let lib = snapshot().await.unwrap();
+    let plan = two_spec_plan();
+    // Unique plan id per test run so reruns don't collide.
+    let plan_id = PlanId::new(format!("test-{}", uuid::Uuid::new_v4()));
+
+    // First run: both nodes complete; state lands in the spine.
+    build_runner(Arc::clone(&store))
+        .run(&plan_id, &plan, &lib)
+        .await
+        .expect("first run completes");
+    let states = store.node_states(&plan_id).await.unwrap();
+    assert_eq!(states.len(), 2, "both nodes persisted");
+    assert!(states.values().all(|s| *s == NodeState::Completed));
+
+    // Simulate a crash mid-run: rewind the downstream node to Running
+    // and clear nothing else. A *fresh* runner (no in-memory state)
+    // sharing the same durable store must resume to completion — proof
+    // the state was read from the spine, not memory.
+    let some_node = *states.keys().next().expect("at least one node");
+    store
+        .set_node_state(&plan_id, some_node, NodeState::Running)
+        .await
+        .unwrap();
+
+    build_runner(Arc::clone(&store))
+        .run(&plan_id, &plan, &lib)
+        .await
+        .expect("resumed run completes");
+    let resumed = store.node_states(&plan_id).await.unwrap();
+    assert!(
+        resumed.values().all(|s| *s == NodeState::Completed),
+        "every node terminal after resume: {resumed:?}",
+    );
+}

--- a/crates/onsager-scheduler/tests/trigger_round_trip.rs
+++ b/crates/onsager-scheduler/tests/trigger_round_trip.rs
@@ -17,10 +17,12 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, ArtifactId, Kind, NodeId, Provenance};
 use onsager_nodes::{
-    Executor, ExecutorContext, ExecutorError, ExecutorOutputs, ExecutorRegistry, SpineClient,
-    SpineError,
+    Executor, ExecutorContext, ExecutorError, ExecutorOutputs, ExecutorRegistry, InMemoryPlanStore,
+    PlanStore, SpineClient, SpineError,
 };
-use onsager_scheduler::{TriggerBridge, bridge::PreloadedWorkflow, bridge::WorkflowMeta};
+use onsager_scheduler::{
+    PlanRunner, TriggerBridge, bridge::PreloadedWorkflow, bridge::WorkflowMeta,
+};
 use onsager_substrate::ids::EdgeId;
 use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
 
@@ -96,10 +98,13 @@ async fn trigger_fired_drives_scheduler_and_emits_node_events() {
     let mut registry = ExecutorRegistry::new();
     registry.register(Arc::new(EmitOne));
     let spine = Arc::new(CapturingSpine::default());
-    let bridge = TriggerBridge::new(
+    let store: Arc<dyn PlanStore> = Arc::new(InMemoryPlanStore::new());
+    let runner = PlanRunner::new(
         Arc::new(registry),
+        store,
         Arc::clone(&spine) as Arc<dyn SpineClient>,
     );
+    let bridge = TriggerBridge::new(runner);
 
     // Simulate a manual fire: `onsager trigger fire wf-e2e --manual run --payload '{"spec_kind":"e2e-kind"}'`
     let payload = serde_json::json!({

--- a/crates/onsager-spine/migrations/006_execution_plans.sql
+++ b/crates/onsager-spine/migrations/006_execution_plans.sql
@@ -1,0 +1,62 @@
+-- Onsager #499 / #500 (RUN-01 #359, RUN-03 #386) — durable substrate
+-- scheduler state.
+--
+-- RUN-01 specced the substrate scheduler as "spine-persisted,
+-- restart-safe" but the shipped run path used an in-memory PlanStore.
+-- These tables back the durable `PlanStore` so node states and
+-- materialized artifacts survive a host restart, and a small plan
+-- registry lets the host reload + recompile any plan with non-terminal
+-- nodes and re-drive it to completion (ADR 0023, decision 1).
+--
+-- The scheduler host also ensures these tables idempotently at startup
+-- (crates/onsager-scheduler/src/migrate.rs) so a fresh deploy works
+-- whichever process migrates first — same `CREATE TABLE IF NOT EXISTS`
+-- shape, the loser is a no-op.
+--
+-- Pre-launch posture (CLAUDE.md): no backfill, no FK constraints
+-- (matches the rest of the spine schema — joins happen at the app
+-- layer).
+
+-- One row per Execution Plan run. `spec_plan_json` is the compiled-from
+-- source so a restart can recompile against the current library and
+-- resume; `spec_plan_id` is the originating persisted plan id when the
+-- run came from `run_spec_plan` (NULL for the single-spec trigger.fired
+-- path, whose source is synthesized).
+CREATE TABLE IF NOT EXISTS execution_plans (
+    plan_id         TEXT        NOT NULL PRIMARY KEY,
+    workspace_id    TEXT        NOT NULL DEFAULT 'default',
+    spec_plan_id    TEXT,
+    spec_plan_json  JSONB       NOT NULL,
+    status          TEXT        NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'completed', 'failed')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Recovery scan: "plans that are still running".
+CREATE INDEX IF NOT EXISTS idx_execution_plans_status
+    ON execution_plans (status)
+    WHERE status = 'running';
+
+-- Per-node lifecycle state, one row per (plan, node). The scheduler
+-- writes a transition before and after dispatch; recovery reads this
+-- map and resets non-terminal (ready/running) states to pending.
+CREATE TABLE IF NOT EXISTS execution_plan_nodes (
+    plan_id     TEXT        NOT NULL,
+    node_id     TEXT        NOT NULL,
+    state       TEXT        NOT NULL
+        CHECK (state IN ('pending', 'ready', 'running', 'completed', 'failed')),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (plan_id, node_id)
+);
+
+-- Materialized artifacts keyed by (plan, artifact_id). Single-writer
+-- per ArtifactId is enforced at compile time (invariant 5), so the
+-- upsert is the same write on a re-dispatch, not contention.
+CREATE TABLE IF NOT EXISTS execution_plan_artifacts (
+    plan_id       TEXT        NOT NULL,
+    artifact_id   TEXT        NOT NULL,
+    artifact_json JSONB       NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (plan_id, artifact_id)
+);

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -464,6 +464,19 @@ pub enum FactoryEventKind {
         to_stage_index: Option<u32>,
     },
 
+    /// A persisted multi-spec `SpecPlan` was requested to run (#501,
+    /// ADR 0023). Emitted by portal's `run_spec_plan` MCP tool;
+    /// consumed by the substrate scheduler host, which loads the stored
+    /// plan from `spec_plans`, compiles it, and drives it to
+    /// completion. Portal does not run the plan itself — the seam rule
+    /// (portal is the edge, the scheduler host is the runtime).
+    SpecPlanRunRequested {
+        /// `(workspace_id, spec_plan_id)` keys the `spec_plans` row the
+        /// scheduler loads and compiles.
+        spec_plan_id: String,
+        workspace_id: String,
+    },
+
     // -- Registry events removed by spec #285 -------------------------------
     // The nine `registry.*` mutation events (`type_proposed`, `type_approved`,
     // `type_deprecated`, `adapter_registered`, `adapter_deprecated`,
@@ -659,6 +672,7 @@ impl FactoryEventKind {
             Self::WorkflowManualTriggered { .. } => "workflow.manual_triggered",
             Self::StageEntered { .. } => "stage.entered",
             Self::StageAdvanced { .. } => "stage.advanced",
+            Self::SpecPlanRunRequested { .. } => "plan.run_requested",
             Self::GateCheckUpdated { .. } => "gate.check_updated",
             Self::GateManualApprovalSignal { .. } => "gate.manual_approval_signal",
             Self::NodeStarted { .. } => "node.started",
@@ -715,6 +729,10 @@ impl FactoryEventKind {
             Self::TriggerFired { .. } | Self::StageEntered { .. } | Self::StageAdvanced { .. } => {
                 "workflow"
             }
+            // Plan-run intent (portal → scheduler host). Its own
+            // namespace so the dashboard can scope plan-run requests
+            // without mixing them with per-node substrate lifecycle.
+            Self::SpecPlanRunRequested { .. } => "plan",
             // Audit-only fan-out for manual fires (#241). Lives in the
             // `audit` namespace so audit views can filter without
             // mixing with first-class workflow runtime events.
@@ -788,6 +806,10 @@ impl FactoryEventKind {
             Self::StageEntered { artifact_id, .. } | Self::StageAdvanced { artifact_id, .. } => {
                 format!("workflow:{artifact_id}")
             }
+            Self::SpecPlanRunRequested {
+                workspace_id,
+                spec_plan_id,
+            } => format!("plan:{workspace_id}:{spec_plan_id}"),
             Self::GateCheckUpdated {
                 repo_owner,
                 repo_name,

--- a/crates/onsager-substrate/src/compiler.rs
+++ b/crates/onsager-substrate/src/compiler.rs
@@ -22,6 +22,8 @@
 
 use std::collections::HashMap;
 
+use onsager_artifact::{ArtifactId, NodeId};
+
 use crate::ids::EdgeId;
 use crate::library::WorkflowLibrary;
 use crate::spec_plan::{SpecDep, SpecId, SpecPlan, SpecPlanError};
@@ -43,6 +45,12 @@ pub struct ExecutionPlan {
     /// the original `SpecId`s from the input Spec Plan; entry edges
     /// reflect rewiring from `connect`.
     pub spec_index: HashMap<SpecId, SpecSlot>,
+    /// `entry_node_id → external input artifact ids` declared by the
+    /// spec the node entered (its `SpecInputs.artifacts`). The
+    /// scheduler materializes these from the [`PlanStore`] and hands
+    /// them to the entry node's executor context at run time (B4,
+    /// #502). Empty for specs that declare no inputs.
+    pub entry_inputs: HashMap<NodeId, Vec<ArtifactId>>,
 }
 
 /// Where a single spec landed in the merged Execution Plan.
@@ -225,6 +233,33 @@ pub fn compile(
     // loop preserves every surviving edge verbatim — duplicate
     // artifact ids surface as a kernel-invariant violation rather
     // than a silent compile-time merge.
+    // B4 (#502): carry each spec's declared entry-side input artifacts
+    // onto its entry node(s). The entry node of a spec is the node
+    // whose `inputs` reference one of the spec's instantiated entry
+    // edges. Built from the pre-merge instantiation (node ids survive
+    // the merge unchanged — only edge refs are rewritten) so the map
+    // keys match the merged plan's node ids. A spec with empty
+    // `inputs.artifacts` contributes nothing.
+    let mut entry_inputs: HashMap<NodeId, Vec<ArtifactId>> = HashMap::new();
+    for spec in &spec_plan.specs {
+        if spec.inputs.artifacts.is_empty() {
+            continue;
+        }
+        let (_, inst) = &instantiated[&spec.id];
+        for node in &inst.nodes {
+            let is_entry_node = node
+                .inputs
+                .iter()
+                .any(|r| inst.entry_edges.contains(&r.edge_id));
+            if is_entry_node {
+                entry_inputs
+                    .entry(node.id)
+                    .or_default()
+                    .extend(spec.inputs.artifacts.iter().cloned());
+            }
+        }
+    }
+
     let mut nodes: Vec<Node> = Vec::new();
     let mut edges: Vec<Edge> = Vec::new();
     let mut spec_index: HashMap<SpecId, SpecSlot> = HashMap::new();
@@ -282,6 +317,7 @@ pub fn compile(
         nodes: merged.nodes,
         edges: merged.edges,
         spec_index,
+        entry_inputs,
     })
 }
 
@@ -731,6 +767,61 @@ mod tests {
     // the spec_index back-pointer inconsistent with the merged
     // node's actual inputs.
     // ---------------------------------------------------------------
+
+    // ---------------------------------------------------------------
+    // B4 (#502): a spec's declared input artifacts are carried onto
+    // its entry node in `entry_inputs`.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn spec_inputs_are_carried_onto_the_entry_node() {
+        let mut lib = TestLibrary::new();
+        lib.register("passthrough", passthrough_workflow());
+
+        let plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new("s1"),
+                kind: "passthrough".to_string(),
+                inputs: crate::spec_plan::SpecInputs {
+                    artifacts: vec![ArtifactId::new("ext-in-1"), ArtifactId::new("ext-in-2")],
+                },
+            }],
+            deps: vec![],
+        };
+        let compiled = compile(&plan, &lib).unwrap();
+
+        // passthrough has a single node and that node consumes the
+        // entry edge, so it is the entry node.
+        assert_eq!(compiled.nodes.len(), 1);
+        let entry_node = compiled.nodes[0].id;
+        let carried = compiled
+            .entry_inputs
+            .get(&entry_node)
+            .expect("entry node should have declared inputs");
+        assert_eq!(
+            carried,
+            &vec![ArtifactId::new("ext-in-1"), ArtifactId::new("ext-in-2")],
+        );
+    }
+
+    #[test]
+    fn empty_spec_inputs_leave_entry_inputs_unset() {
+        let mut lib = TestLibrary::new();
+        lib.register("passthrough", passthrough_workflow());
+        let plan = SpecPlan {
+            specs: vec![SpecRef {
+                id: SpecId::new("s1"),
+                kind: "passthrough".to_string(),
+                inputs: Default::default(),
+            }],
+            deps: vec![],
+        };
+        let compiled = compile(&plan, &lib).unwrap();
+        assert!(
+            compiled.entry_inputs.is_empty(),
+            "a spec with no declared inputs must not populate entry_inputs",
+        );
+    }
 
     #[test]
     fn multiple_incoming_deps_into_same_spec_are_rejected() {

--- a/crates/onsager-substrate/src/compiler.rs
+++ b/crates/onsager-substrate/src/compiler.rs
@@ -51,6 +51,12 @@ pub struct ExecutionPlan {
     /// them to the entry node's executor context at run time (B4,
     /// #502). Empty for specs that declare no inputs.
     pub entry_inputs: HashMap<NodeId, Vec<ArtifactId>>,
+    /// `node_id → originating SpecId`. Every node in the merged plan
+    /// came from exactly one spec's instantiated workflow; this records
+    /// which. The dashboard plan-run progress surface (F2, #504) uses
+    /// it to attribute `node.*` lifecycle events back to the spec they
+    /// belong to.
+    pub node_spec_index: HashMap<NodeId, SpecId>,
 }
 
 /// Where a single spec landed in the merged Execution Plan.
@@ -263,6 +269,7 @@ pub fn compile(
     let mut nodes: Vec<Node> = Vec::new();
     let mut edges: Vec<Edge> = Vec::new();
     let mut spec_index: HashMap<SpecId, SpecSlot> = HashMap::new();
+    let mut node_spec_index: HashMap<NodeId, SpecId> = HashMap::new();
 
     // Iterate in spec_plan.specs declaration order so the resulting
     // node/edge ordering is deterministic across runs (HashMap
@@ -281,6 +288,7 @@ pub fn compile(
                     *output = EdgeRef::new(*target);
                 }
             }
+            node_spec_index.insert(node.id, spec.id.clone());
             nodes.push(node);
         }
 
@@ -318,6 +326,7 @@ pub fn compile(
         edges: merged.edges,
         spec_index,
         entry_inputs,
+        node_spec_index,
     })
 }
 

--- a/crates/onsager-substrate/src/spec_plan.rs
+++ b/crates/onsager-substrate/src/spec_plan.rs
@@ -116,6 +116,22 @@ pub struct SpecPlan {
     pub deps: Vec<SpecDep>,
 }
 
+/// Stable namespace for [`derive_plan_id`] — frozen UUID v4.
+const PLAN_ID_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x4f, 0x4e, 0x53, 0x47, 0x52, 0x50, 0x4c, 0x41, 0x4e, 0x52, 0x55, 0x4e, 0x49, 0x44, 0x06, 0x06,
+]);
+
+/// Derive a stable run-`PlanId` string from `(workspace_id,
+/// spec_plan_id)`. Single source of truth (ADR 0023): both portal's
+/// `run_spec_plan` (which returns it so the dashboard can subscribe to
+/// the run's node events) and the scheduler's `plan_registry` derive
+/// the same id, so a re-invocation resumes the same run rather than
+/// forking a second one.
+pub fn derive_plan_id(workspace_id: &str, spec_plan_id: &str) -> String {
+    let seed = format!("{workspace_id}:{spec_plan_id}");
+    uuid::Uuid::new_v5(&PLAN_ID_NAMESPACE, seed.as_bytes()).to_string()
+}
+
 /// Why a Spec Plan failed validation. The compiler surfaces these
 /// before any workflow lookup so authors see structural errors
 /// without having to populate the library first.

--- a/crates/onsager-substrate/src/spec_plan.rs
+++ b/crates/onsager-substrate/src/spec_plan.rs
@@ -68,15 +68,17 @@ impl From<&str> for SpecId {
 
 /// Entry-side artifact references for a spec.
 ///
-/// Today this is a flat list of `ArtifactId`s the spec expects to
-/// have available at its workflow's entry edge. v1 does not type or
-/// position-tag these — single-entry / single-exit per ADR 0015 means
-/// at most one entry edge, and the compiler does not need to address
-/// individual inputs to wire deps.
+/// A flat list of `ArtifactId`s the spec expects to have available at
+/// its workflow's entry edge. v1 does not type or position-tag these —
+/// single-entry / single-exit per ADR 0015 means at most one entry
+/// edge, and the compiler does not need to address individual inputs
+/// to wire deps.
 ///
-/// The field is here so the Spec Plan shape matches ADR 0015's
-/// declared contract; downstream consumers (the scheduler, executor
-/// runtime) will pick it up later.
+/// Consumed end-to-end as of B4 (#502, ADR 0023): the Plan Compiler
+/// carries these onto the spec's entry node
+/// ([`crate::compiler::ExecutionPlan::entry_inputs`]) and the
+/// substrate scheduler materializes them from the `PlanStore` into the
+/// entry node's executor context at run time.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpecInputs {
     #[serde(default)]

--- a/crates/stiglab/src/server/spine.rs
+++ b/crates/stiglab/src/server/spine.rs
@@ -245,6 +245,7 @@ fn artifact_id_for_workspace_lookup(event: &FactoryEventKind) -> Option<&str> {
         | FactoryEventKind::IsingAnalyzerError { .. }
         | FactoryEventKind::IsingCatchupCompleted { .. }
         | FactoryEventKind::TriggerFired { .. }
+        | FactoryEventKind::SpecPlanRunRequested { .. }
         | FactoryEventKind::WorkflowManualTriggered { .. }
         | FactoryEventKind::GateCheckUpdated { .. }
         | FactoryEventKind::GateManualApprovalSignal { .. }

--- a/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
+++ b/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
@@ -1,0 +1,157 @@
+# ADR 0023 — Spec-plan run orchestration and dashboard placement
+
+- **Status**: Accepted
+- **Date**: 2026-05-29 (accepted 2026-05-29)
+- **Identity impact**: no
+- **Tracking issues**: #498 (umbrella spec) and sub-issues #499 (B1),
+  #500 (B2), #501 (B3), #502 (B4), #503 (F1), #504 (F2).
+- **Supersedes**: none. Builds on ADR 0009 (three-layer pipeline),
+  ADR 0015 (Spec Plan as DAG external contract), and ADR 0017 (plan
+  compiler).
+- **Superseded by**: none
+
+## Context
+
+The `Spec Plan → Workflow → Execution Plan → run` pipeline (ADR 0009 /
+0015 / 0017) is complete on the **authoring + compile** side but never
+closes into **execution** for a persisted multi-spec Spec Plan. As of
+the issue audit on `main`:
+
+- `submit_spec_plan` persists a multi-spec `SpecPlan`
+  (`crates/onsager-portal/src/spec_plan_db.rs`); `get_execution_plan`
+  (`crates/onsager-portal/src/mcp/tools/substrate_specs.rs`) reads it
+  back and `compile()`s it — but stops there. No reader compiles **and
+  runs** a persisted plan.
+- The only non-test `Scheduler::run` on a deployed path is
+  `crates/onsager-scheduler/src/bridge.rs` (`handle_payload`). Per
+  `trigger.fired` it hardcodes a **single-spec** plan (`specs: [one],
+  deps: []`) and uses an ephemeral `InMemoryPlanStore::new()` — despite
+  RUN-01 (#359) speccing the scheduler as "spine-persisted,
+  restart-safe."
+- No `run_spec_plan` MCP tool and no plan-level trigger exist.
+- The dashboard has no surface for an authored spec-plan graph or for
+  plan-run progress; chat renders spec-plan tool calls as text-only
+  HitlCards.
+
+Two decisions in closing this gap are architectural, not mechanical,
+and the umbrella spec (#498) flagged both for an ADR.
+
+## Decision 1 — Run orchestration
+
+**The existing `onsager-scheduler` host (RUN-03, #386) drives persisted
+multi-spec plans. Portal does not run plans; it emits an intent on the
+spine and the scheduler host consumes it.**
+
+- **Invocation is an event, not an HTTP call.** The `run_spec_plan` MCP
+  tool (B3, on portal — the edge) emits a new spine event
+  `plan.run_requested` (`FactoryEventKind::SpecPlanRunRequested`,
+  producer = `Portal`, consumer = `Substrate`). Portal does not import
+  the scheduler and does not run the plan itself — this is the seam
+  rule: portal is the edge, the scheduler host is the runtime. The
+  event mirrors how `trigger.fired` already crosses the same seam.
+- **One run entry, two front doors.** The single-spec `trigger.fired`
+  flow and the multi-spec `plan.run_requested` flow share **one**
+  `PlanRunner::run` entry inside the scheduler host (compile a
+  `SpecPlan` against a library snapshot, generate/derive a `PlanId`,
+  drive `Scheduler::run` against the durable store). `bridge.rs`
+  becomes a thin adapter that builds the single-element `SpecPlan` and
+  delegates to that shared entry — no parallel run loops.
+- **The store is durable and restart-safe.** The deployed run path
+  binds a spine-backed `PlanStore` (B1) over `execution_plan_nodes` /
+  `execution_plan_artifacts`, replacing the ephemeral
+  `InMemoryPlanStore`. A small `execution_plans` registry maps a
+  `PlanId` to the `SpecPlan` JSON it compiled from, so a host restart
+  reloads any plan with non-terminal nodes, recompiles it against the
+  current library, and re-drives `Scheduler::run` — which already
+  resets `Ready`/`Running` to `Pending` and re-dispatches.
+- **`PlanId` is derived from the source, not random, on the
+  invocation path.** A `run_spec_plan` for `(workspace_id,
+  spec_plan_id)` derives a stable `PlanId` so a re-invocation resumes
+  the same run rather than forking a second one. The `trigger.fired`
+  path keeps its workflow-derived id.
+
+**Why the scheduler host, not portal or a new process.** The scheduler
+host already owns the spine listener loop, the executor registry, and
+the `Scheduler`. Portal is the edge (ADR 0006) and must stay free of
+runtime concerns; the `onsager` dispatcher commits to zero business
+deps. Adding a second listener (`plan.run_requested`) to the existing
+host reuses all of that wiring and keeps one process responsible for
+"compile a SpecPlan and run it."
+
+`InMemoryPlanStore` remains for tests and is the seam at which the
+orchestration logic is unit-tested without a database; the
+`SqlxPlanStore` round-trip is covered by a `DATABASE_URL`-gated
+integration test in the same style as the portal reconciliation tests.
+
+## Decision 2 — Dashboard placement (IA)
+
+**No `/plans` top-level noun. The authored spec-plan graph and the
+plan-run progress both live in chat, the portable global component
+(ADR 0020). A spec-plan run is a *Run* (one of the canonical four
+nouns); folding plan runs into the Runs surface is a deliberate
+follow-up, not part of this slice.**
+
+The canonical user-facing vocabulary (spec #286) is exactly four
+top-level nouns — Workflow / Run / Artifact / Stage. A `/plans` route
+would introduce a fifth, which the vocabulary commitment forbids
+without a deliberate decision. We decline to add it.
+
+- **F1 — authored graph: in-chat, attached to spec-plan tool cards.**
+  When a spec-plan tool (`submit_spec_plan` / `get_spec_plan` /
+  `run_spec_plan`) is rendered in chat, a `SpecPlanDAG` preview renders
+  the `{ specs, deps }` shape as a graph beneath the HitlCard — the
+  same place `WorkflowDAGPreview` renders a single workflow's stage
+  chain. This is a graph-of-specs, distinct from the stage-chain
+  component. Chat is reachable from every workspace surface (ADR 0020),
+  so the view is reachable without a new route.
+- **F2 — run progress: the same in-chat graph, with live node state.**
+  Once `run_spec_plan` (B3) launches a stored plan, the same
+  `SpecPlanDAG` overlays per-spec/per-node state (pending / running /
+  done / failed) sourced from the scheduler's `node.*` spine events
+  (read same-origin through portal's `/api/spine/events`, keyed by the
+  `substrate:<plan_id>:` stream prefix). The run is launched from chat
+  and its progress shows in chat — the "reachable from where a run is
+  launched" requirement is met without a new noun.
+- **Future fold into Runs.** A spec-plan run *is* a Run conceptually.
+  Listing plan runs alongside workflow runs on the Runs surface
+  requires the backend to expose plan runs in the run-listing read
+  path (today `WorkflowRun`-shaped). That is filed as a follow-up; this
+  ADR fixes the placement so F1/F2 are not dangling routes in the
+  meantime.
+
+**Why in-chat rather than a detail page.** Spec plans are authored in
+chat (the `issue-spec` / spec-plan authoring loop) and launched from
+chat. ADR 0019 / 0021 organize detail pages around substrate primitives
+that already have list views (Workflows / Runs); a spec-plan run has no
+list view yet, so a `RunDetailPage`-style page would be a dangling
+surface. Rendering on the chat card the plan was authored/launched from
+keeps the graph reachable and avoids inventing navigation for a noun we
+deliberately are not adding.
+
+## Consequences
+
+- A new `FactoryEventKind::SpecPlanRunRequested` variant + manifest row
+  (`plan.run_requested`, producer Portal, consumer Substrate) — both
+  ends declared, `check-events` satisfied.
+- A new `run_spec_plan` mutation tool routes through a HitlCard
+  (`check-hitl-coverage`), like `run_workflow`.
+- New spine tables `execution_plans`, `execution_plan_nodes`,
+  `execution_plan_artifacts` (the names RUN-01 / RUN-03 reserved). The
+  scheduler host ensures them idempotently at startup and they ship as
+  a canonical spine migration.
+- `SpecInputs.artifacts` (B4) becomes load-bearing: the compiler
+  carries each spec's declared input artifacts onto its entry node and
+  the scheduler materializes them from the `PlanStore` at execution.
+- The dashboard gains a `SpecPlanDAG` component and the typed
+  `SpecPlan` / `SpecRef` / `SpecDep` shapes it consumes.
+
+## Adoption checklist
+
+- [x] Decision recorded (this ADR), `Identity impact: no`.
+- [ ] B1 — durable `PlanStore` + recovery (#499).
+- [ ] B2 — run a persisted multi-spec `SpecPlan` via the shared entry
+  (#500).
+- [ ] B3 — `run_spec_plan` tool + `plan.run_requested` trigger (#501).
+- [ ] B4 — wire `SpecInputs` at run (#502).
+- [ ] F1 — `SpecPlanDAG` in-chat (#503).
+- [ ] F2 — plan-run progress overlay in-chat (#504).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ see [`../architecture.md`](../architecture.md).
 | [0020](0020-chat-as-portable-global-component-with-contextual-auto-scope.md) | Chat as portable global component with contextual auto-scope | Accepted (2026-05-22) — `Identity impact: no` |
 | [0021](0021-detail-page-ia-node-as-section.md) | Detail page IA: node-as-section, attribute-as-expanded-detail | Accepted (2026-05-28) — `Identity impact: no` |
 | [0022](0022-provenance-source-tag-first-class-ui.md) | Provenance source tag as first-class UI | Proposed (2026-05-27) — `Identity impact: no` |
+| [0023](0023-spec-plan-run-orchestration-and-dashboard-placement.md) | Spec-plan run orchestration and dashboard placement | Accepted (2026-05-29) — `Identity impact: no` |
 
 ## How to add an ADR
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -61,6 +61,7 @@ that requires a coordinated rollout.
 | `ising` | ising | 6 |
 | `workflow` | stiglab (trigger) / substrate scheduler (stage) | 3 |
 | `audit` | (unknown — update `stream_producer` in xtask) | 1 |
+| `plan` | (unknown — update `stream_producer` in xtask) | 1 |
 | `gate` | onsager-portal (GitHub) / substrate scheduler (manual) | 2 |
 | `substrate` | substrate scheduler (onsager-nodes) + executor catalog (RUN-02, #360) | 10 |
 
@@ -613,6 +614,22 @@ Audit record for a manual / CLI / replay trigger fire (#241). Emitted alongside 
 | `actor` | `String` |  |
 | `event_subtype` | `String` |  |
 | `detail` | `serde_json::Value` |  |
+
+## `plan` events
+
+Producer subsystem: **(unknown — update `stream_producer` in xtask)**.
+
+### `plan.run_requested`
+
+- Variant: `FactoryEventKind::SpecPlanRunRequested`
+- Stream: `plan`
+
+A persisted multi-spec `SpecPlan` was requested to run (#501, ADR 0023). Emitted by portal's `run_spec_plan` MCP tool; consumed by the substrate scheduler host, which loads the stored plan from `spec_plans`, compiles it, and drives it to completion. Portal does not run the plan itself — the seam rule (portal is the edge, the scheduler host is the runtime).
+
+| Field | Type | Description |
+|---|---|---|
+| `spec_plan_id` | `String` | `(workspace_id, spec_plan_id)` keys the `spec_plans` row the scheduler loads and compiles. |
+| `workspace_id` | `String` |  |
 
 ## `gate` events
 

--- a/xtask/src/check_tools_and_skills.rs
+++ b/xtask/src/check_tools_and_skills.rs
@@ -99,6 +99,13 @@ const PENDING_SKILL_GRANTS: &[(&str, &str)] = &[
         "get_workflow_v2",
         "spec #395 — pending `onsager-author-substrate` skill",
     ),
+    // Spec #501 (ADR 0023) — run a persisted SpecPlan. Pairs with the
+    // same `onsager-author-substrate` skill grant; the sibling-repo PR
+    // is a follow-up since this session is scoped to onsager-ai/onsager.
+    (
+        "run_spec_plan",
+        "spec #501 — pending `onsager-author-substrate` skill",
+    ),
 ];
 
 pub fn run() -> Result<()> {


### PR DESCRIPTION
Closes #498. Closes #499. Closes #500. Closes #501. Closes #502. Closes #503. Closes #504.

Closes the gap where a user could author and persist a multi-spec `SpecPlan` but nothing turned it into a run. Implements the full dependency chain from #498 plus **ADR 0023** (the two architectural decisions the umbrella flagged: run-orchestration + dashboard placement).

## ADR 0023 — decisions
- **Run orchestration:** the existing `onsager-scheduler` host drives persisted multi-spec plans. Portal emits `plan.run_requested` on the spine; the scheduler consumes it (seam rule — portal is the edge, the scheduler is the runtime). The single-spec `trigger.fired` path and the multi-spec path share **one** `PlanRunner::run` entry — no parallel run loops.
- **Dashboard placement:** no new `/plans` top-level noun (the four-noun vocabulary, spec #286, forbids it). The authored spec-plan graph (F1) and plan-run progress (F2) live **in chat** (ADR 0020), the latter as a live overlay on the same DAG.

## Backend
- **B1 (#499) — durable PlanStore.** `SqlxPlanStore` over `execution_plan_nodes` / `execution_plan_artifacts` (spine migration `006_execution_plans.sql`), replacing the ephemeral `InMemoryPlanStore` on the deployed path. Startup recovery re-drives any plan left `running`. `InMemoryPlanStore` stays the test seam. (Placed in `onsager-scheduler`, not `onsager-nodes`, to keep the executor-catalog crate database-free — same precedent as `SpineEventStoreClient`; noted in the ADR.)
- **B2 (#500) — multi-spec orchestration.** `PlanRunner` (shared entry) loads a stored `SpecPlan` via SQL against the `spec_plans` table (no `onsager-portal` import), compiles it, and runs every spec in dependency order; `bridge.rs` is now a thin adapter over it. `execution_plans` registry maps `PlanId → SpecPlan` for resume.
- **B3 (#501) — invocation surface.** `run_spec_plan` MCP tool emits `plan.run_requested` (new `FactoryEventKind` variant + manifest row, producer Portal / consumer Substrate). Destructive tool → routes through a HitlCard.
- **B4 (#502) — wire `SpecInputs`.** The compiler carries each spec's declared input artifacts onto its entry node (`ExecutionPlan.entry_inputs`); the scheduler materializes them from the `PlanStore` into the entry node's executor context. The `spec_plan.rs` "downstream consumers … later" comment is gone.

## Frontend
- **F1 (#503) — spec-plan DAG.** `SpecPlanDAG` renders `{ specs, deps }` as a layered DAG (distinct from `WorkflowDAGPreview`'s stage chain). Rendered in chat beneath `submit_spec_plan` / `compile_dry_run` cards.
- **F2 (#504) — run progress.** `SpecPlanRunView` overlays per-spec state (pending/running/done/failed) on the same DAG, sourced from substrate `node.*` events (attributed to specs via `get_execution_plan`'s new `node_index`, keyed by the `plan_id` `run_spec_plan` returns). Rendered after a `run_spec_plan` commit.

## Tests / checks
- Mutation-checked unit tests: B4 entry-input delivery, B2 dependency-order + data-flow (paired no-dep negative), event decode, plan-id derivation. `DATABASE_URL`-gated integration test proves durable persistence + restart-resume.
- `check-events`, `check-tools-and-skills`, `check-hitl-coverage`, `check-file-budget`, `lint-seams`, `check-api-contract`, `check-generated-types` all clean; `cargo fmt`/`clippy -D warnings` clean; dashboard `tsc -b` + eslint clean.

## Follow-ups (filed in the ADR, not silently deferred)
- Fold plan runs into the top-level Runs surface once the run-listing read path exposes them (backend is `WorkflowRun`-shaped today).
- `run_spec_plan` skill grant in `onsager-ai/onsager-skills` (`PENDING_SKILL_GRANTS` entry; sibling-repo PR — this session is scoped to `onsager-ai/onsager`).

https://claude.ai/code/session_01QQBFBbiBnJpXgDFKRzpkLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQBFBbiBnJpXgDFKRzpkLh)_