### PR TITLE
Workflow lifecycle refactor: ADRs 0024 + 0025 and check-adr-adoption lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,6 +128,8 @@ jobs:
         run: cargo run -p xtask --quiet -- check-single-impl-traits --mode=warn
       - name: Deferred-TODO check (spec #275, warn-mode landing)
         run: cargo run -p xtask --quiet -- check-deferred-todos --mode=warn
+      - name: ADR-adoption check (ADR 0024 / 0025, spec #506, warn-mode landing)
+        run: cargo run -p xtask --quiet -- check-adr-adoption --mode=warn
       - name: Checkout onsager-skills (spec #323)
         uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -637,8 +637,14 @@ Same warn-then-ratchet rollout as `check-file-budget`.
 - **`xtask check-events`** also surfaces diagnostic-only event rows
   without a `tracking_issue` (warn-mode), so dangling skeletons in the
   manifest get re-examined too.
+- **`xtask check-adr-adoption`** (ADR 0024 / 0025, spec #506) — flags
+  `Accepted` ADRs (`docs/adr/`) whose `## Adoption checklist` still has
+  unchecked `- [ ]` items. An Accepted decision with owed follow-through
+  is a wire connected at one end. Escape: mark the ADR `Adoption:
+  ongoing` in its metadata block while implementation is genuinely in
+  flight, then flip to `enforced` and tick the boxes as the work lands.
 
-All four land in warn mode initially (warn-then-ratchet); a follow-up
+All five land in warn mode initially (warn-then-ratchet); a follow-up
 spec will ratchet them to fail once the floor is clean.
 
 ## Workspace layout

--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -6,6 +6,7 @@
 - **Tracking issues**: #451 (implementation spec). Sibling to ADR 0019, which removes the top-level Chat tab. This ADR governs what chat *becomes* once it is no longer a tab. Builds on ADR 0007 (tools and skills as the public contract) and ADR 0008 (portal owns the agent control plane).
 - **Supersedes**: none. Predecessor specs (#398 universal-chat-entry, #400 chat empty-state chips, #401 DraftStrip + chat surface) are the prior frame in prose; the repo convention reserves the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
 - **Superseded by**: none
+- **Amended by**: ADR 0025 (2026-05-29) — names chat's dashboard role as design + maintenance (not a pure interchangeable frontend) and adds a labeled desktop entry. The responsive-mount, auto-scope, pin, and storage decisions below are unchanged.
 
 ## Context
 
@@ -154,23 +155,23 @@ The contextual auto-scope rule maps to: a dashboard chat scoped to `workflow:{id
 
 Phase 0 (responsive mount + push + FAB + bell + scope-local Ask):
 
-- [ ] Land the `ChatContainer` with state machine, storage interface, conversation feed, and the Queue / Thread segmented control — one responsive shell across mobile and desktop
-- [ ] Land the contextual auto-scope hook that observes route changes and computes scope; surface the breadcrumb in the chat header
-- [ ] Land the pin affordance + pinned-scope persistence
-- [ ] Land the storage backend with the new `(user_id, scope_type, scope_id)` key shape; keep the old `localStorage` reads available behind a one-release “previous conversations” surface
-- [ ] Land the scope-aware FAB (mobile): Active / Muted / Hidden states, long-press → Inbox, first-time hint on third use
-- [ ] Land the top-chrome bell (mobile + desktop) → Queue at `scope=workspace`
-- [ ] Land the scope-local "Ask" on step / verdict / artifact surfaces
-- [ ] Land push notifications with Approve / Reject for approval-kind HITL and Open-only for selection / clarify kinds; deep link scrolls Queue to the matching card
-- [ ] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in `App.tsx` with the global container; remove the `/chat` and `/workspaces/:slug/chat` page routes (the 301 redirects land in ADR 0019’s adoption checklist)
-- [ ] Migrate the DraftStrip’s function into the Workflows tab’s `Drafted` filter chip; delete `components/chat/DraftStrip.tsx`
+- [x] Land the `ChatContainer` with state machine, storage interface, conversation feed, and the Queue / Thread segmented control — one responsive shell across mobile and desktop (`components/chat/ChatContainer.tsx`, `ChatQueueView.tsx`, `ChatThreadView.tsx`)
+- [x] Land the contextual auto-scope hook that observes route changes and computes scope; surface the breadcrumb in the chat header (`lib/chat/use-auto-scope.ts`, `lib/chat/scope.ts`, `components/chat/ChatBreadcrumb.tsx`)
+- [x] Land the pin affordance + pinned-scope persistence (`lib/chat/pinned-scope.ts`)
+- [x] Land the storage backend with the new `(user_id, scope_type, scope_id)` key shape; keep the old `localStorage` reads available behind a one-release “previous conversations” surface (`components/chat/PreviousConversationsLink.tsx`)
+- [x] Land the scope-aware FAB (mobile): Active / Muted / Hidden states, long-press → Inbox, first-time hint on third use (`components/chat/ChatFab.tsx`)
+- [x] Land the top-chrome bell (mobile + desktop) → Queue at `scope=workspace` (`components/chat/ChatBell.tsx`)
+- [x] Land the scope-local "Ask" on step / verdict / artifact surfaces (`components/chat/ChatAskButton.tsx`)
+- [x] Land push notifications with Approve / Reject for approval-kind HITL and Open-only for selection / clarify kinds; deep link scrolls Queue to the matching card (`components/chat/PushNotificationsCard.tsx`, `ChatDeepLinkHandler.tsx`)
+- [x] Replace `apps/dashboard/src/pages/ChatPage.tsx` mounts in `App.tsx` with the global container; remove the `/chat` and `/workspaces/:slug/chat` page routes (the 301 redirects land in ADR 0019’s adoption checklist) — routes retired in `App.tsx` (#457); the residual `ChatPage.tsx` file is an unreferenced leftover to delete in a hygiene follow-up
+- [x] Migrate the DraftStrip’s function into the Workflows tab’s `Drafted` filter chip; delete `components/chat/DraftStrip.tsx` (file removed)
 
 Phase 1 (⌘K invocation) and closeout:
 
-- [ ] Land the ⌘K palette invocation on desktop, opening Thread at the current route's scope
-- [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager root) Timeline with an entry for this ADR
-- [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and #400
-- [ ] Flip Status to `Accepted` once phase 0 ships
+- [x] Land the ⌘K palette invocation on desktop, opening Thread at the current route's scope (`lib/chat/use-chat-ui.tsx` #473)
+- [ ] Update KB page `35cd79199ca68131b4f6efac9ed8c3d6` (Onsager root) Timeline with an entry for this ADR — external (Notion); not verifiable from the repo
+- [ ] Add `closed by ADR 0020` follow-up comments to specs #398 and #400 — external (GitHub); not verifiable from the repo
+- [x] Flip Status to `Accepted` once phase 0 ships
 
 ## Out of scope
 

--- a/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
+++ b/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
@@ -148,10 +148,18 @@ deliberately are not adding.
 ## Adoption checklist
 
 - [x] Decision recorded (this ADR), `Identity impact: no`.
-- [ ] B1 — durable `PlanStore` + recovery (#499).
-- [ ] B2 — run a persisted multi-spec `SpecPlan` via the shared entry
-  (#500).
-- [ ] B3 — `run_spec_plan` tool + `plan.run_requested` trigger (#501).
-- [ ] B4 — wire `SpecInputs` at run (#502).
-- [ ] F1 — `SpecPlanDAG` in-chat (#503).
-- [ ] F2 — plan-run progress overlay in-chat (#504).
+- [x] B1 — durable `PlanStore` + recovery (#499). `SqlxPlanStore`
+  (`crates/onsager-scheduler/src/plan_store.rs`) + recovery in
+  `service.rs`.
+- [x] B2 — run a persisted multi-spec `SpecPlan` via the shared entry
+  (#500). `PlanRunner::run` (`crates/onsager-scheduler/src/plan_runner.rs`).
+- [x] B3 — `run_spec_plan` tool + `plan.run_requested` trigger (#501).
+  `FactoryEventKind::SpecPlanRunRequested` + the MCP tool.
+- [x] B4 — wire `SpecInputs` at run (#502).
+- [x] F1 — `SpecPlanDAG` in-chat (#503)
+  (`apps/dashboard/src/components/chat/SpecPlanDAG.tsx`).
+- [x] F2 — plan-run progress overlay in-chat (#504)
+  (`apps/dashboard/src/components/chat/SpecPlanRunView.tsx`).
+
+All landed via #505. The future fold of plan runs into the Runs surface
+remains the deliberate follow-up named in Decision 2.

--- a/docs/adr/0024-workflow-lifecycle-orthogonal-readiness-autofire-axes.md
+++ b/docs/adr/0024-workflow-lifecycle-orthogonal-readiness-autofire-axes.md
@@ -1,0 +1,94 @@
+# ADR 0024 — Workflow lifecycle: orthogonal readiness/autofire axes + trigger-neutral binding
+
+- **Status**: Accepted
+- **Date**: 2026-05-29
+- **Identity impact**: no
+- **Adoption**: ongoing
+- **Tracking issues**: #506 (umbrella spec). Supersedes the `(active, install_id)` status-derivation introduced under ADR 0019 / spec #456.
+- **Supersedes**: none at the ADR level. The `(active, install_id)`-derived `WorkflowStatus` is a code shortcut taken under ADR 0019; this ADR replaces that shortcut, not ADR 0019's IA decision.
+- **Superseded by**: none
+
+## Context
+
+The dashboard surfaces a four-state workflow lifecycle — Drafted / Bound / Active / Paused (ADR 0019 filter chips, spec #456). The spine has **no discrete status column**. `WorkflowStatus` (`crates/onsager-portal/src/workflow_db.rs` L248-281) derives all four states from two booleans, `(active, install_id)`:
+
+- `Drafted` = `active = false AND (install_id IS NULL OR install_id = '')`
+- `Bound` = `active = false AND install_id IS NOT NULL AND install_id <> ''`
+- `Active` = `active = true`
+- `Paused` = the literal SQL predicate `"false"` — a dead arm that never matches a row
+
+Spec #456's own Open Question flagged the gap: *"Does the spine already track `workflows.status ∈ {draft,bound,active,paused}` on a single column? … confirm the other three pin to the same column or come from a join."* They never did. The four chips were wired against a column that does not exist, and the derivation papered over it. Three defects follow:
+
+1. **`Drafted` is unreachable.** Portal's create handler requires `install_id` (`crates/onsager-portal/src/handlers/workflows.rs` L213-214) and the domain type (`crates/onsager-portal/src/workflow.rs:98`) types it `i64`, non-optional. No write path produces an empty `install_id`, so the `Drafted` predicate matches zero rows through the only writer.
+2. **`Bound` leaks GitHub into a generic lifecycle concept.** `install_id` is a GitHub App installation id. Defining "bound" as "has a non-empty install_id" means a Telegram / Manual / Schedule workflow can *never* be Bound — it has no install. The lifecycle vocabulary silently became GitHub-specific.
+3. **`Paused` is a dangling wire.** A status the UI offers that the backend can never produce.
+
+The binding `install_id` describes is real, but it lives at the wrong altitude. The authoritative binding is workspace/account level in `github_app_installations` (`crates/onsager-portal/migrations/007_github_app_installations.sql`: `workspace_id × install_id` UNIQUE × account), and the repo layer is already modelled by `projects` (`crates/onsager-spine/migrations/004_workflows.sql` L43-57, column `github_app_installation_id`). The same migration denormalizes `install_id` onto every workflow row (L79, `install_id TEXT`, nullable) — a copy of an account-level fact stamped onto each preset and then promoted to *define* lifecycle status. This is the "denormalized external state" and "divergent state from multiple write paths" drift the root `CLAUDE.md` enumerates, applied to the lifecycle model.
+
+Triggers, by contrast, are already trigger-source-neutral at the substrate. `TriggerKind` (`crates/onsager-spine/src/trigger.rs:37`) is plural and GitHub-agnostic: `GithubIssueWebhook`, `GithubPullRequestClosed`, `GithubWorkflowRunCompleted`, `TelegramWebhook`, `Cron` / `Delay` / `Interval`, `SpineEvent` / `PgNotify` / `OutboxRow`, `Manual { name }` (`crates/onsager-trigger/src/main.rs`), `Replay`. Substrate, nodes, and scheduler do **not** import `onsager-github`; the GitHub coupling is edge-only. The status model is the one place GitHub leaks into generic semantics.
+
+## Decision
+
+Replace the derived status with two **explicit, orthogonal, trigger-source-neutral** columns. A workflow is a reusable preset; how *ready to run* it is and whether it *fires by itself* are independent facts.
+
+### Two axes
+
+- **`readiness`** — `drafted` → `ready`.
+  - `ready` ⇔ the workflow has **≥1 trigger binding of any kind** (GitHub webhook / Telegram / Manual / Schedule / spine-event / …). Not GitHub-specific.
+  - `drafted` ⇔ no trigger binding yet — authored, debugged in chat, not yet wired to fire.
+- **`autofire`** — `off` / `active` / `paused`.
+  - `off` — manual-only; the workflow runs only when a human presses "run a batch".
+  - `active` — auto-fires on its trigger binding.
+  - `paused` — was `active`, temporarily suspended; representable as a first-class state, not a dead predicate.
+
+The axes are independent: a `ready` workflow may be `off` (manual-only), `active` (auto-firing), or `paused`. `drafted` workflows are `off` by construction (nothing to fire on).
+
+### `install_id` is demoted to a trigger-binding attribute
+
+`install_id` stops defining status. It becomes an attribute of a GitHub trigger binding, resolved through `workflow → trigger binding → project → installation` (the layers `projects` and `github_app_installations` already model). The `workflows.install_id` column may persist **only** as an optional mint cache for token resolution; it must not participate in `readiness` or `autofire`. Token minting and webhook-secret resolution (`crates/onsager-portal/src/handlers/workflows.rs` ~L748 / L775 / L828, `resolve_install_webhook_secret` ~L919) reroute through the binding → project → installation path rather than reading `workflows.install_id` directly.
+
+### `ready` earns the run button; safety is run-time, not button-time
+
+A `ready` workflow immediately earns the manual "run a batch" button. There is **no** separate button-time promotion gate. Run-time safety is the existing Verify / HITL (Synodic) gate that already guards every run — not a gate bolted onto the button. Adding a button-time gate would duplicate the run-time gate and re-introduce a second control point for one decision.
+
+### Create no longer requires `install_id`
+
+The hard `install_id is required` gate at workflow create is removed. A Manual-only, Telegram-only, or Schedule-only workflow must be creatable and must be able to reach `ready` via its (non-GitHub) trigger binding.
+
+## Rejected alternatives
+
+- **Keep `(active, install_id)`, just add the `paused` column.** Fixes the dead `Paused` arm but leaves `Bound` GitHub-specific and `Drafted` unreachable. The leak is structural, not a missing column.
+- **One enum `status ∈ {drafted, bound, active, paused}` on a single column.** The shape spec #456 assumed. Rejected because `bound`/`ready` (do I have a trigger?) and `active`/`paused` (do I fire automatically?) are orthogonal — collapsing them onto one axis cannot express "ready but manual-only" or "ready and paused" without inventing combinatorial states.
+- **Keep status GitHub-derived, special-case non-GitHub triggers.** Rejected — it spreads the integration-specific branch across every status read and violates "status must not depend on a single integration's fields."
+- **Store the binding only in `github_app_installations` and join at read.** Correct for GitHub, but `readiness` must hold for non-GitHub triggers too; the readiness fact is "has any trigger binding", which is a workflow-level fact, not an installation join.
+- **A button-time promotion gate (`ready` → `armed` → runnable).** Rejected per Decision 1b — run-time Verify/HITL already owns run safety; a button-time gate is a redundant second control point.
+
+## Consequences
+
+- `workflows` gains `readiness` and `autofire` columns; the `(active, install_id)` derivation and the dead `Paused => "false"` predicate are deleted. `active` is backfilled into `autofire`; `readiness` is backfilled from trigger-binding presence.
+- The lifecycle vocabulary becomes trigger-source-neutral: a Telegram-only or Manual-only workflow reaches `ready` exactly like a GitHub one.
+- `install_id` is no longer load-bearing for status. Any remaining read is a token-mint cache, resolved through the binding → project → installation path; status reads never touch it.
+- The dashboard `WorkflowStatusChips` remap from the single derived axis to the two explicit axes. The FTUE funnel events (`ftue.inspected/drafted/bound/activated`, spec #404) are analytics and are **not** touched by this ADR.
+- Substrate stays GitHub-agnostic — no `onsager-github` dependency is added to substrate / nodes / scheduler.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog of the two axes is the split between a spec issue's *readiness* (does it have an actionable Plan + a linked trigger — a label, a milestone, an assignee) and its *autofire* (is it picked up automatically by the queue, held manually, or paused). A spec with no entry condition is `drafted`; one with a trigger is `ready`; whether the queue auto-pulls it is the `autofire` axis. The orthogonality is the same: a ready spec can sit manual-only or be auto-scheduled.
+
+## Adoption checklist
+
+- [x] Decision recorded (this ADR), `Identity impact: no`.
+- [ ] Phase 1 — add `readiness` + `autofire` columns to `workflows`; backfill `autofire` from `active`, `readiness` from trigger-binding presence (transitional fallback: any trigger / install_id present → `ready`).
+- [ ] Phase 1 — delete the `(active, install_id)` derivation and the dead `Paused` predicate from `workflow_db.rs`; `readiness` is driven by trigger-binding existence for any `TriggerKind`.
+- [ ] Phase 1 — reroute token minting / webhook-secret resolution through `workflow → trigger binding → project → installation`; keep `workflows.install_id` only as an optional mint cache, out of the status path.
+- [ ] Phase 1 — remove the `install_id is required` create gate; a Manual/Telegram/Schedule workflow is creatable and can reach `ready`.
+- [ ] Phase 1 — remap `apps/dashboard/src/components/workflows/WorkflowStatusChips.tsx` to the two axes; leave the spec #404 FTUE funnel events untouched.
+- [ ] Phase 3 — `ready` workflows earn the manual "run a batch" button (reuse `run_spec_plan` / `run_workflow`); no button-time gate.
+- [ ] Flip `Adoption` to `enforced` and tick the boxes once Phases 1 + 3 land.
+
+## Out of scope
+
+- **Multiple trigger bindings per workflow.** The current schema persists one trigger per workflow; `readiness` is defined over "≥1 binding" so it already accommodates a future multi-trigger schema, but adding that schema is a separate spec.
+- **Chat-surface relocation and the run-button UI placement.** Governed by ADR 0025; this ADR fixes the lifecycle model and that `ready` earns the button, not where the button renders.
+- **Run-path recovery determinism.** The `register_plan` library-version pinning fix is independent (#506 Phase 2); not part of the lifecycle model.
+- **Dropping the `workflows.install_id` column entirely.** Deferred until the token-mint path is confirmed to no longer need the cache; this ADR removes it from the *status* path only.

--- a/docs/adr/0025-chat-as-design-and-maintenance-surface.md
+++ b/docs/adr/0025-chat-as-design-and-maintenance-surface.md
@@ -1,0 +1,76 @@
+# ADR 0025 — Chat as design + maintenance surface
+
+- **Status**: Accepted
+- **Date**: 2026-05-29
+- **Identity impact**: no
+- **Adoption**: ongoing
+- **Tracking issues**: #506 (umbrella spec). Amends ADR 0020 (chat as portable global component); reconciles ADR 0023 (spec-plan run orchestration).
+- **Supersedes**: none. Amends ADR 0020 — see the note below; the responsive-mount + auto-scope decisions of 0020 stand.
+- **Superseded by**: none
+
+## Context
+
+ADR 0020 framed dashboard chat as "one MCP client among many" (ADR 0007) — a portable global component with no privileged top-level position. That framing is right at the **protocol** layer: the MCP control plane exposes intent / spec_plan / compile / run / status / artifacts / verdicts, and Claude, Cursor, the dashboard chat, and any custom agent are interchangeable consumers of it.
+
+But the product surface drifted away from the framing in two opposite directions, and they collide:
+
+- **Chat became undiscoverable on desktop.** ADR 0020's invocation table makes the FAB mobile-only (`apps/dashboard/src/components/chat/ChatFab.tsx` is `md:hidden`). On desktop the only entries are the top-chrome bell (`ChatBell`, `aria-label="Open Inbox"` — it opens the *Queue*, not a conversation) and the keyboard toggle `⌘J` (`apps/dashboard/src/lib/chat/use-chat-ui.tsx`). A first-time desktop user has no labeled way to *start a conversation*; the only visible affordance opens an inbox. This is the predicted output of ADR 0020's "more prominent entry → more specific scope" table, which left desktop with no general-purpose, labeled entry.
+- **Chat became the *sole* launch+monitor surface for spec-plan runs.** ADR 0023 Decision 2 placed both the authored spec-plan graph (F1) and live run progress (F2) exclusively in chat, with no noun-surface alternative. So the one surface that is hard to find on desktop is also the only place a routine run can be started or watched. A user who cannot find chat cannot run a workflow.
+
+The "N interchangeable frontends" principle (ADR 0007) is about *intent formation* through the MCP control plane. It does not require that every routine action be reachable *only* through a conversational frontend. Conflating the two produced a surface that is simultaneously privileged (sole launch path) and hidden (no desktop entry).
+
+## Decision
+
+Chat is the **design + maintenance** surface — not a pure interchangeable frontend, and not the routine-action surface. The boundary:
+
+> **Actions default to the noun surfaces. Chat carries only design (drafted) + maintenance (scope=run incident handling).**
+
+This amends ADR 0020's "chat is one interchangeable frontend, not privileged" to: chat has a *specific role* (design + maintenance) on the dashboard, while the MCP-intent-layer "N interchangeable frontends" of ADR 0007 still holds at the protocol layer. The two are not in tension once the layers are named — ADR 0007 governs the protocol; this ADR governs the dashboard's chat *role*.
+
+### Chat's scope narrows to two jobs
+
+- **Design (drafted).** Authoring and debugging a workflow preset — the CAD bench. This is where a `drafted` workflow is shaped before it earns a trigger binding (ADR 0024). The spec-plan authoring loop (`submit_spec_plan` / `get_spec_plan`) and its in-chat `SpecPlanDAG` (ADR 0023 F1) live here.
+- **Maintenance (scope=run).** Incident handling on a specific run — the maintenance port. When something goes wrong with a run, the run-scoped chat thread is where it is diagnosed. ADR 0023's in-chat run-progress overlay (F2) stays available here as the maintenance view of a run already launched.
+
+### Routine actions move to the noun surfaces
+
+- A **"run a batch" button** lands on `ready` workflows (ADR 0024) and on persisted spec plans, reusing `run_spec_plan` / `run_workflow`. Starting a routine run no longer requires opening chat. Chat is no longer the *sole* launch path for spec-plan runs — this is the reconciliation with ADR 0023 Decision 2.
+
+### Desktop gains a labeled chat entry
+
+A labeled desktop chat entry (e.g. `MessageSquare` icon + "Chat" + the `⌘J` hint) opens the conversation surface at `tab=thread` — the *design/maintenance* surface, not the Inbox/Queue. The existing `ChatBell` stays as the Inbox / HITL counter (`tab=queue`); `ChatFab` stays mobile-only. The two entries are distinct: the bell is "what needs my attention" (Queue), the new entry is "let me design or diagnose" (Thread).
+
+ADR 0020's responsive mount, contextual auto-scope, pin affordance, and storage schema are unchanged. This ADR changes chat's *role and discoverability*, not its mount mechanics.
+
+## Rejected alternatives
+
+- **Keep ADR 0020 as-is (chat as pure interchangeable frontend).** Rejected — it leaves chat undiscoverable on desktop and, combined with ADR 0023, makes a hidden surface the sole launch path. The framing needs the design/maintenance role named explicitly.
+- **Make chat a top-level tab again.** Rejected — re-creates the mode-split ADR 0019 retired and re-privileges chat as a navigation noun. The fix is a labeled *entry*, not a tab.
+- **Put the run button only in chat, but make chat discoverable.** Rejected — discoverability alone does not fix the layering error. A routine run is a noun-surface action; routing it through a conversational frontend is the wrong altitude even when the frontend is easy to find.
+- **Drop the in-chat run-progress overlay (ADR 0023 F2) entirely in favour of a noun surface.** Rejected for this ADR — F2 is the *maintenance* view of a run and belongs in run-scoped chat. Folding plan runs into the Runs surface remains the deliberate follow-up ADR 0023 named; this ADR does not pull it forward.
+
+## Consequences
+
+- Desktop users get a discoverable, labeled way to start a conversation; the bell stops being the only (mislabeled) entry.
+- Routine runs are startable from the noun surfaces without opening chat. Chat's job is legible: design and maintenance, not routine operation.
+- ADR 0023 Decision 2 is amended in one respect — chat is no longer the *sole* launch surface for spec-plan runs — without disturbing its in-chat authored-graph (F1) and run-progress (F2) views, which become the design and maintenance views respectively.
+- ADR 0007's protocol-layer "N interchangeable frontends" is untouched and explicitly reaffirmed.
+
+## Dev-process counterpart
+
+Per ADR 0002, the dev-process analog: the issue/PR thread is the *design + maintenance* surface (where a change is shaped and where incidents on it are discussed), while the merge button, the CI re-run button, and the label controls are the *noun-surface actions* — you do not type a sentence to merge a PR. This ADR brings the dashboard into line with that split: conversation for design and diagnosis, buttons for routine operation.
+
+## Adoption checklist
+
+- [x] Decision recorded (this ADR), `Identity impact: no`.
+- [ ] Phase 3 — add a labeled desktop chat entry opening `tab=thread`; keep `ChatBell` as the Inbox/Queue counter; `ChatFab` stays mobile-only.
+- [ ] Phase 3 — add the "run a batch" button to `ready` workflows and persisted spec plans (reuse `run_spec_plan` / `run_workflow`); a routine run is startable without opening chat.
+- [ ] Phase 3 — narrow chat default scope to design (drafted) + maintenance (scope=run); remove chat as the only launch path for spec-plan runs.
+- [ ] Add an "amended by ADR 0025" note to ADR 0020's metadata block.
+- [ ] Flip `Adoption` to `enforced` and tick the boxes once Phase 3 lands.
+
+## Out of scope
+
+- **Folding spec-plan runs into the Runs surface.** Remains the deliberate follow-up ADR 0023 named; not pulled forward here.
+- **Chat mount mechanics.** Responsive mount, auto-scope, pin, storage — governed by ADR 0020, unchanged.
+- **Notification action button → MCP elicitation binding.** Still the follow-up ADR 0020 deferred.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,8 @@ see [`../architecture.md`](../architecture.md).
 | [0021](0021-detail-page-ia-node-as-section.md) | Detail page IA: node-as-section, attribute-as-expanded-detail | Accepted (2026-05-28) — `Identity impact: no` |
 | [0022](0022-provenance-source-tag-first-class-ui.md) | Provenance source tag as first-class UI | Proposed (2026-05-27) — `Identity impact: no` |
 | [0023](0023-spec-plan-run-orchestration-and-dashboard-placement.md) | Spec-plan run orchestration and dashboard placement | Accepted (2026-05-29) — `Identity impact: no` |
+| [0024](0024-workflow-lifecycle-orthogonal-readiness-autofire-axes.md) | Workflow lifecycle: orthogonal readiness/autofire axes + trigger-neutral binding | Accepted (2026-05-29, adoption ongoing) — `Identity impact: no` |
+| [0025](0025-chat-as-design-and-maintenance-surface.md) | Chat as design + maintenance surface | Accepted (2026-05-29, adoption ongoing) — `Identity impact: no` — amends ADR 0020 |
 
 ## How to add an ADR
 

--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ lint-rust: _check-tools-and-skills
     cargo run -p xtask --quiet -- check-orphan-crates --mode=warn
     cargo run -p xtask --quiet -- check-single-impl-traits --mode=warn
     cargo run -p xtask --quiet -- check-deferred-todos --mode=warn
+    cargo run -p xtask --quiet -- check-adr-adoption --mode=warn
 
 # Resolve the skills bundle then run check-tools-and-skills.
 # Override: ONSAGER_SKILLS_DIR=../onsager-skills just lint  (two-checkout local dev)

--- a/xtask/src/check_adr_adoption.rs
+++ b/xtask/src/check_adr_adoption.rs
@@ -15,11 +15,12 @@
 //!
 //! ## Escape hatch
 //!
-//! An ADR whose metadata block carries `Adoption: ongoing` (matched
-//! case-insensitively as the substring `adoption: ongoing`) is exempt —
-//! its implementation is acknowledged as still in flight. Flip it to
-//! `Adoption: enforced` (or drop the line) and tick the boxes as the
-//! work lands.
+//! An ADR whose metadata block opts out via an `Adoption: ongoing`
+//! marker is exempt — its implementation is acknowledged as still in
+//! flight. Two forms are recognized, both case-insensitively: the
+//! rendered metadata line `- **Adoption**: ongoing` (the normal shape)
+//! and a bare `Adoption: ongoing`. Flip it to `Adoption: enforced` (or
+//! drop the line) and tick the boxes as the work lands.
 //!
 //! ## Modes
 //!
@@ -217,13 +218,24 @@ fn collect_adr_files(dir: &Path) -> Result<Vec<PathBuf>> {
         if path.extension().and_then(|s| s.to_str()) != Some("md") {
             continue;
         }
-        // ADR files start with a four-digit number; README.md does not.
-        if name.as_bytes().first().is_some_and(u8::is_ascii_digit) {
+        // ADR files are `NNNN-slug.md` — exactly four leading digits
+        // then a hyphen. The `README.md` index and any other stray
+        // markdown are skipped.
+        if is_adr_filename(name) {
             out.push(path);
         }
     }
     out.sort();
     Ok(out)
+}
+
+/// True for the ADR filename shape `NNNN-slug.md` — exactly four leading
+/// ASCII digits followed by a hyphen. The extension is checked by the
+/// caller; this only vets the numeric prefix so `README.md`, `1.md`, or
+/// a hypothetical `notes.md` are rejected.
+fn is_adr_filename(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() > 4 && bytes[..4].iter().all(u8::is_ascii_digit) && bytes[4] == b'-'
 }
 
 #[cfg(test)]
@@ -316,6 +328,18 @@ mod tests {
     #[test]
     fn ongoing_exemption_absent_by_default() {
         assert!(!is_adoption_ongoing(ACCEPTED_WITH_UNCHECKED));
+    }
+
+    #[test]
+    fn adr_filename_predicate() {
+        assert!(is_adr_filename("0024-workflow-lifecycle.md"));
+        assert!(is_adr_filename("0001-event-bus.md"));
+        // Rejected: the index, short/garbled prefixes, no hyphen.
+        assert!(!is_adr_filename("README.md"));
+        assert!(!is_adr_filename("1.md"));
+        assert!(!is_adr_filename("12-x.md"));
+        assert!(!is_adr_filename("9abc-x.md"));
+        assert!(!is_adr_filename("0024_underscore.md"));
     }
 
     #[test]

--- a/xtask/src/check_adr_adoption.rs
+++ b/xtask/src/check_adr_adoption.rs
@@ -1,0 +1,329 @@
+//! ADR-adoption lint (ADR 0024 / 0025, spec #506 Phase 4) — the "no
+//! dangling wires" value applied to the ADR corpus.
+//!
+//! An `Accepted` ADR is a decision the codebase claims to have adopted.
+//! Its **Adoption checklist** is the contract: unchecked `- [ ]` items
+//! are work the ADR says is still owed. An Accepted ADR carrying
+//! unchecked items is either (a) genuinely in flight — which the ADR
+//! should declare — or (b) drift: a decision marked landed whose
+//! follow-through silently stalled. This lint surfaces (b).
+//!
+//! For every `docs/adr/NNNN-*.md` whose metadata block carries
+//! `Status: Accepted`, count the unchecked items in its `## Adoption
+//! checklist` section. Any unchecked item is a finding — unless the ADR
+//! opts out via `Adoption: ongoing` (see escape hatch).
+//!
+//! ## Escape hatch
+//!
+//! An ADR whose metadata block carries `Adoption: ongoing` (matched
+//! case-insensitively as the substring `adoption: ongoing`) is exempt —
+//! its implementation is acknowledged as still in flight. Flip it to
+//! `Adoption: enforced` (or drop the line) and tick the boxes as the
+//! work lands.
+//!
+//! ## Modes
+//!
+//! - `--mode=warn` (default): print findings, exit 0.
+//! - `--mode=fail`: exit non-zero on any finding.
+//!
+//! Lands in warn mode (warn-then-ratchet, like the Occam's-razor lints
+//! of spec #275); a follow-up ratchets to fail once the ADR corpus is
+//! clean.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+const ADR_DIR: &str = "docs/adr";
+const ADOPTION_HEADING: &str = "## Adoption checklist";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug)]
+struct Finding {
+    adr: String,
+    unchecked: usize,
+    /// The first unchecked item's text, for a human-legible pointer.
+    first_unchecked: String,
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    let mode = parse_mode(&args)?;
+    let root = workspace_root()?;
+    let dir = root.join(ADR_DIR);
+
+    let files = collect_adr_files(&dir)?;
+
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut accepted = 0usize;
+    let mut exempt: Vec<String> = Vec::new();
+
+    for file in &files {
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .to_string();
+        let text = std::fs::read_to_string(file).with_context(|| format!("read {rel}"))?;
+
+        if !is_accepted(&text) {
+            continue;
+        }
+        accepted += 1;
+
+        if is_adoption_ongoing(&text) {
+            exempt.push(rel);
+            continue;
+        }
+
+        let unchecked = unchecked_adoption_items(&text);
+        if !unchecked.is_empty() {
+            findings.push(Finding {
+                adr: rel,
+                unchecked: unchecked.len(),
+                first_unchecked: unchecked[0].clone(),
+            });
+        }
+    }
+
+    if !exempt.is_empty() {
+        eprintln!("check-adr-adoption: Adoption: ongoing exemptions:");
+        for adr in &exempt {
+            eprintln!("  {adr}");
+        }
+        eprintln!();
+    }
+
+    if findings.is_empty() {
+        println!(
+            "check-adr-adoption: clean ({accepted} Accepted ADR(s) scanned, {} ongoing-exempt)",
+            exempt.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-adr-adoption: {} Accepted ADR(s) with unchecked adoption items:",
+        findings.len()
+    );
+    for f in &findings {
+        eprintln!(
+            "  {} — {} unchecked (e.g. \"{}\")",
+            f.adr,
+            f.unchecked,
+            f.first_unchecked.trim()
+        );
+    }
+    eprintln!();
+    eprintln!("An Accepted ADR's adoption checklist is a contract: tick the items as");
+    eprintln!("the work lands, or mark the ADR `Adoption: ongoing` in its metadata block");
+    eprintln!("while implementation is genuinely in flight.");
+
+    match mode {
+        Mode::Warn => {
+            eprintln!("(warn mode — not failing)");
+            Ok(())
+        }
+        Mode::Fail => bail!("adr-adoption lint failed"),
+    }
+}
+
+/// True when the metadata block declares `Status: ... Accepted ...`.
+/// Tolerates the `- **Status**: Accepted (2026-05-22) — note` shape the
+/// ADRs use; matches on the `Status` line specifically so the word
+/// "Accepted" elsewhere in prose doesn't count.
+fn is_accepted(text: &str) -> bool {
+    text.lines()
+        .filter_map(status_value)
+        .any(|v| v.to_lowercase().contains("accepted"))
+}
+
+/// Return the value of a `- **Status**: <value>` metadata line, if this
+/// line is one.
+fn status_value(line: &str) -> Option<&str> {
+    let l = line.trim_start();
+    let rest = l.strip_prefix("- **Status**:")?;
+    Some(rest.trim())
+}
+
+/// True when the metadata block opts out via `Adoption: ongoing`
+/// (case-insensitive). Matches the rendered `- **Adoption**: ongoing`
+/// line as well as a bare `Adoption: ongoing`.
+fn is_adoption_ongoing(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    lower.contains("adoption: ongoing") || lower.contains("adoption**: ongoing")
+}
+
+/// Collect the unchecked `- [ ]` items inside the `## Adoption checklist`
+/// section (up to the next `## ` heading or EOF). Checked items (`- [x]`)
+/// and nested continuation lines are ignored.
+fn unchecked_adoption_items(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_section = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("## ") {
+            // Entering or leaving a section. The adoption section ends at
+            // the next top-level heading.
+            in_section = trimmed == ADOPTION_HEADING;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some(item) = trimmed.strip_prefix("- [ ]") {
+            out.push(item.trim().to_string());
+        }
+    }
+    out
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode> {
+    let mut mode = Mode::Warn;
+    for arg in args {
+        match arg.as_str() {
+            "--mode=warn" => mode = Mode::Warn,
+            "--mode=fail" => mode = Mode::Fail,
+            other => bail!("unknown flag for check-adr-adoption: {other}"),
+        }
+    }
+    Ok(mode)
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo run -p xtask`")?;
+    Ok(Path::new(&manifest)
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest has no parent"))?
+        .to_path_buf())
+}
+
+/// All `NNNN-*.md` ADR files (numbered), sorted. The `README.md` index
+/// is skipped — it carries no `Status` line of its own.
+fn collect_adr_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !dir.is_dir() {
+        bail!("ADR dir not found: {}", dir.display());
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        // ADR files start with a four-digit number; README.md does not.
+        if name.as_bytes().first().is_some_and(u8::is_ascii_digit) {
+            out.push(path);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCEPTED_WITH_UNCHECKED: &str = "\
+# ADR 9001 — Test
+
+- **Status**: Accepted
+- **Identity impact**: no
+
+## Adoption checklist
+
+- [x] Decision recorded.
+- [ ] Land the thing.
+- [ ] Land the other thing.
+
+## Out of scope
+- [ ] not counted (different section)
+";
+
+    const ONGOING: &str = "\
+# ADR 9002 — Test
+
+- **Status**: Accepted
+- **Adoption**: ongoing
+
+## Adoption checklist
+
+- [ ] Still in flight.
+";
+
+    const PROPOSED: &str = "\
+# ADR 9003 — Test
+
+- **Status**: Proposed
+
+## Adoption checklist
+
+- [ ] Not adopted yet, but not Accepted either.
+";
+
+    const CLEAN: &str = "\
+# ADR 9004 — Test
+
+- **Status**: Accepted (2026-05-22) — note
+
+## Adoption checklist
+
+- [x] Decision recorded.
+- [x] Landed.
+";
+
+    #[test]
+    fn accepted_status_detected_with_parenthetical() {
+        assert!(is_accepted(CLEAN));
+        assert!(is_accepted(ACCEPTED_WITH_UNCHECKED));
+    }
+
+    #[test]
+    fn proposed_is_not_accepted() {
+        assert!(!is_accepted(PROPOSED));
+    }
+
+    #[test]
+    fn accepted_word_in_prose_does_not_count() {
+        let body = "- **Status**: Proposed\n\nWe Accepted nothing in the body.";
+        assert!(!is_accepted(body));
+    }
+
+    #[test]
+    fn unchecked_items_only_from_adoption_section() {
+        let items = unchecked_adoption_items(ACCEPTED_WITH_UNCHECKED);
+        // The two in-section unchecked items, not the Out-of-scope one.
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], "Land the thing.");
+    }
+
+    #[test]
+    fn checked_items_are_not_counted() {
+        assert!(unchecked_adoption_items(CLEAN).is_empty());
+    }
+
+    #[test]
+    fn ongoing_exemption_matches_rendered_metadata() {
+        assert!(is_adoption_ongoing(ONGOING));
+    }
+
+    #[test]
+    fn ongoing_exemption_absent_by_default() {
+        assert!(!is_adoption_ongoing(ACCEPTED_WITH_UNCHECKED));
+    }
+
+    #[test]
+    fn live_adr_corpus_is_scannable() {
+        // The lint must at least parse every in-tree ADR without error.
+        // It runs in warn mode here so unchecked items on existing
+        // Accepted ADRs don't fail the unit test; the CI invocation owns
+        // the warn/fail decision.
+        super::run(vec!["--mode=warn".to_string()]).expect("lint must run over the ADR corpus");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@
 //!     cargo run -p xtask -- check-detail-page-tabs   # check ADR 0021 no-tabs-as-primary-IA (#487)
 //!     cargo run -p xtask -- check-generated-types    # check Rust → TS generated dashboard types (#298)
 //!     cargo run -p xtask -- check-file-budget        # bound per-file token cost (#261)
+//!     cargo run -p xtask -- check-adr-adoption        # Accepted ADRs with unchecked adoption items (#506)
 //!     cargo run -p xtask -- slot <subcommand>        # per-worktree dev slot allocator (#194)
 //!
 //! The event catalog is derived from `crates/onsager-spine/src/factory_event.rs`
@@ -36,6 +37,7 @@
 //! `slot` allocates and manages per-worktree dev slots backed by docker-compose
 //! projects on disjoint ports. See [`slot`] for the full surface.
 
+mod check_adr_adoption;
 mod check_deferred_todos;
 mod check_detail_page_tabs;
 mod check_events;
@@ -131,6 +133,7 @@ fn main() -> ExitCode {
                 check_generated_types::run()
             }
         }
+        Some("check-adr-adoption") => check_adr_adoption::run(args.collect()),
         Some("check-file-budget") => check_file_budget::run(args.collect()),
         Some("check-orphan-crates") => check_orphan_crates::run(args.collect()),
         Some("check-single-impl-traits") => check_single_impl_traits::run(args.collect()),
@@ -139,7 +142,7 @@ fn main() -> ExitCode {
         Some("slot") => slot::run(args.collect()),
         Some(other) => Err(anyhow!("unknown subcommand: {other}")),
         None => Err(anyhow!(
-            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- check-triggers\n  cargo run -p xtask -- check-tools-and-skills\n  cargo run -p xtask -- check-hitl-coverage\n  cargo run -p xtask -- check-metaphor-leakage\n  cargo run -p xtask -- check-detail-page-tabs\n  cargo run -p xtask -- check-generated-types\n  cargo run -p xtask -- check-file-budget [--mode=warn|fail] [--budget=N]\n  cargo run -p xtask -- check-orphan-crates [--mode=warn|fail]\n  cargo run -p xtask -- check-single-impl-traits [--mode=warn|fail]\n  cargo run -p xtask -- check-deferred-todos [--mode=warn|fail]\n  cargo run -p xtask -- count-tokens <file>\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
+            "usage:\n  cargo run -p xtask -- gen-event-docs [--check]\n  cargo run -p xtask -- lint-seams\n  cargo run -p xtask -- check-api-contract\n  cargo run -p xtask -- check-events\n  cargo run -p xtask -- check-triggers\n  cargo run -p xtask -- check-tools-and-skills\n  cargo run -p xtask -- check-hitl-coverage\n  cargo run -p xtask -- check-metaphor-leakage\n  cargo run -p xtask -- check-detail-page-tabs\n  cargo run -p xtask -- check-generated-types\n  cargo run -p xtask -- check-file-budget [--mode=warn|fail] [--budget=N]\n  cargo run -p xtask -- check-orphan-crates [--mode=warn|fail]\n  cargo run -p xtask -- check-single-impl-traits [--mode=warn|fail]\n  cargo run -p xtask -- check-deferred-todos [--mode=warn|fail]\n  cargo run -p xtask -- check-adr-adoption [--mode=warn|fail]\n  cargo run -p xtask -- count-tokens <file>\n  cargo run -p xtask -- slot <alloc|free|list|env|get|project|tunnel> ..."
         )),
     };
 


### PR DESCRIPTION
Part of #506.

Foundation slice of the workflow lifecycle two-axis refactor: the two governing ADRs (Phase 0, the gate for everything else) plus the lint that guards them (Phase 4, landed first per the umbrella plan).

## ADR 0024 — Workflow lifecycle: orthogonal readiness/autofire axes

Supersedes the `(active, install_id)`-derived `WorkflowStatus` (`crates/onsager-portal/src/workflow_db.rs` L248-281), which had three defects: `Drafted` unreachable (portal create requires `install_id`, typed `i64` non-optional), `Bound` GitHub-specific (defined as "has install_id", so Telegram/Manual/Schedule workflows can never reach it), and `Paused` a dead `"false"` predicate. Spec #456's own Open Question flagged that the assumed `workflows.status` column never existed.

Target: two explicit, orthogonal, trigger-source-neutral columns —
- **readiness**: `drafted` → `ready` (ready = ≥1 trigger binding of any `TriggerKind`)
- **autofire**: `off` / `active` / `paused`

`install_id` is demoted to a GH trigger-binding attribute (resolved via `workflow → trigger binding → project → installation`, the layers `projects` + `github_app_installations` already model). `ready` earns the run button; run safety stays the run-time Verify/HITL gate, not a button-time gate.

## ADR 0025 — Chat as design + maintenance surface

Amends ADR 0020. Chat became undiscoverable on desktop (`ChatFab` is `md:hidden`; the only desktop entry is the `ChatBell`, which opens the Inbox/Queue) while ADR 0023 made it the *sole* launch path for spec-plan runs — a hidden surface as the only way to run a workflow. Boundary: **actions default to the noun surfaces; chat carries only design (drafted) + maintenance (scope=run)**. The MCP-layer "N interchangeable frontends" of ADR 0007 still holds at the protocol layer.

## check-adr-adoption lint (warn-mode)

`xtask check-adr-adoption` flags `Accepted` ADRs whose `## Adoption checklist` still has unchecked `- [ ]` items — an Accepted decision with owed follow-through is a wire connected at one end. `Adoption: ongoing` in the metadata block exempts in-flight ADRs (0024/0025 carry it). Warn-then-ratchet, same family as the spec #275 Occam lints. Wired into `just lint` + CI. It currently surfaces 15 ADRs of real adoption drift in warn mode.

## Doc hygiene

- Tick ADR 0023's checklist (all items landed via #505, surfaces verified present).
- Tick ADR 0020's code items (surfaces verified present); leave its two external KB/comment items honestly unchecked.
- Note "amended by ADR 0025" on ADR 0020; index both new ADRs in the README.

## Follow-on (this umbrella, #506)

Phase 1 (explicit columns + binding reroute), Phase 2 (run-path recovery version-pinning), and Phase 3 (run buttons + chat relocation) land as subsequent commits/PRs against the ADRs introduced here.

## Test

- `cargo test -p xtask` — 8 new `check_adr_adoption` unit tests pass; the live-corpus test confirms the lint parses every ADR.
- `cargo fmt --all --check` + `cargo clippy -p xtask --all-targets -D warnings` clean.

https://claude.ai/code/session_01PS74hbifdSsXYJVacbcX91

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS74hbifdSsXYJVacbcX91)_