### PR TITLE
Pin workflow versions on recovery (#511), just ci-local (#513), workflow axes + run gate (#512)

### DIFF
--- a/apps/dashboard/src/lib/api/generated/Workflow.ts
+++ b/apps/dashboard/src/lib/api/generated/Workflow.ts
@@ -31,4 +31,20 @@ install_id: number | null,
  * Preset id this workflow was expanded from (e.g. `github-issue-to-pr`).
  * `None` for custom workflows built in the card editor.
  */
-preset_id: string | null, active: boolean, created_by: string, created_at: string, updated_at: string, };
+preset_id: string | null, active: boolean, 
+/**
+ * Lifecycle **readiness** axis (ADR 0024): `"drafted"` → `"ready"`.
+ * `ready` ⇔ the workflow has ≥1 trigger binding of any kind. Per
+ * spec #512 a `ready` workflow earns the manual "run a batch"
+ * button; the dashboard gates that button on this field rather than
+ * re-deriving from `active`.
+ */
+readiness: string, 
+/**
+ * Lifecycle **autofire** axis (ADR 0024): `"off"` / `"active"` /
+ * `"paused"`. Orthogonal to `readiness` — a `ready` workflow may be
+ * `off` (manual-only), `active` (auto-firing), or `paused`. `active`
+ * (the legacy firing pin) is kept in sync with this by portal's
+ * single writer path.
+ */
+autofire: string, created_by: string, created_at: string, updated_at: string, };

--- a/apps/dashboard/src/lib/api/types.ts
+++ b/apps/dashboard/src/lib/api/types.ts
@@ -191,6 +191,17 @@ export interface Workflow {
   name: string;
   preset?: string | null;
   status: WorkflowStatus;
+  /**
+   * ADR 0024 readiness axis (#512). `ready` ⇔ the workflow has a
+   * trigger binding of any kind. The "Run a batch" button gates on this
+   * (`readiness === "ready"`) rather than re-deriving from `status`.
+   */
+  readiness: "drafted" | "ready";
+  /**
+   * ADR 0024 autofire axis (#512) — orthogonal to `readiness`. `off`
+   * (manual-only) / `active` (auto-firing) / `paused`.
+   */
+  autofire: "off" | "active" | "paused";
   trigger: WorkflowTrigger;
   stages: WorkflowStage[];
   created_at: string;

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -104,8 +104,10 @@ function workflowFromBackend(
     // ADR 0024 lifecycle axes (#512), carried straight from the wire so
     // the detail page + run button gate on `readiness` rather than
     // re-deriving from `active`. Narrow the generated `string` to the UI
-    // union; unknown values fall back to the safe default.
-    readiness: w.readiness === "drafted" ? "drafted" : "ready",
+    // union, defaulting to the *safe* side: only an exact `"ready"`
+    // enables ready-gated affordances (e.g. the run button), so an
+    // unknown/new backend state never silently unlocks them.
+    readiness: w.readiness === "ready" ? "ready" : "drafted",
     autofire:
       w.autofire === "active" ? "active" : w.autofire === "paused" ? "paused" : "off",
     trigger: {

--- a/apps/dashboard/src/lib/api/workflows.ts
+++ b/apps/dashboard/src/lib/api/workflows.ts
@@ -101,6 +101,13 @@ function workflowFromBackend(
     name: w.name,
     preset: w.preset_id,
     status: w.active ? "active" : "draft",
+    // ADR 0024 lifecycle axes (#512), carried straight from the wire so
+    // the detail page + run button gate on `readiness` rather than
+    // re-deriving from `active`. Narrow the generated `string` to the UI
+    // union; unknown values fall back to the safe default.
+    readiness: w.readiness === "drafted" ? "drafted" : "ready",
+    autofire:
+      w.autofire === "active" ? "active" : w.autofire === "paused" ? "paused" : "off",
     trigger: {
       kind: "github-label",
       // `install_id` is a nullable token-mint cache (ADR 0024); null means

--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -213,6 +213,12 @@ pub async fn create_workflow(
         install_id: body.install_id.filter(|id| *id > 0),
         preset_id: body.preset_id.clone(),
         active: false,
+        // Mirrors what `insert_workflow_with_stages` persists (ADR 0024):
+        // a freshly created workflow carries a trigger binding → `ready`;
+        // `autofire` tracks `active`, which is `false` until activation
+        // runs below.
+        readiness: "ready".to_string(),
+        autofire: "off".to_string(),
         created_by: user_id,
         created_at: now,
         updated_at: now,
@@ -249,6 +255,10 @@ pub async fn create_workflow(
     let activated = body.active;
     let created = Workflow {
         active: activated,
+        // `set_workflow_active` flips `autofire` in lockstep with
+        // `active` (ADR 0024); reflect that in the returned struct so the
+        // create response matches a subsequent read.
+        autofire: if activated { "active" } else { "off" }.to_string(),
         ..workflow
     };
     (

--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -252,14 +252,25 @@ pub async fn create_workflow(
         }
     }
 
-    let activated = body.active;
-    let created = Workflow {
-        active: activated,
-        // `set_workflow_active` flips `autofire` in lockstep with
-        // `active` (ADR 0024); reflect that in the returned struct so the
-        // create response matches a subsequent read.
-        autofire: if activated { "active" } else { "off" }.to_string(),
-        ..workflow
+    // Return the persisted row as the source of truth rather than
+    // re-deriving active/autofire in memory — activation flips both via
+    // `set_workflow_active`, and re-reading avoids the divergent-state
+    // drift the root CLAUDE.md warns against (and stays correct if
+    // activation ever touches more axes). The row was just inserted
+    // (and activated above, if requested), so a missing/errored read is
+    // exceptional; fall back to the in-memory struct with the flag set.
+    let created = match workflow_db::get_workflow(spine, &workflow.id).await {
+        Ok(Some(latest)) => latest,
+        other => {
+            if let Err(e) = other {
+                tracing::warn!("re-fetch workflow after create failed: {e}");
+            }
+            Workflow {
+                active: body.active,
+                autofire: if body.active { "active" } else { "off" }.to_string(),
+                ..workflow
+            }
+        }
     };
     (
         StatusCode::CREATED,

--- a/crates/onsager-portal/src/mcp/tools/workflows.rs
+++ b/crates/onsager-portal/src/mcp/tools/workflows.rs
@@ -118,6 +118,10 @@ pub async fn propose_workflow(state: &AppState, auth_user: &AuthUser, args: Valu
         install_id: (args.install_id > 0).then_some(args.install_id),
         preset_id: None,
         active: false,
+        // Mirrors what `insert_workflow_with_stages` persists (ADR 0024):
+        // `ready` on create, `autofire` off until activation.
+        readiness: "ready".to_string(),
+        autofire: "off".to_string(),
         created_by: auth_user.user_id.clone(),
         created_at: now,
         updated_at: now,
@@ -292,9 +296,15 @@ pub async fn run_workflow(state: &AppState, auth_user: &AuthUser, args: Value) -
             )));
         }
     }
-    if !workflow.active {
+    // Gate on `readiness`, not `active` (ADR 0024 / spec #512). The
+    // two-axis model makes "ready + off" (manual-only) a first-class
+    // state: a human can press "run a batch" without arming autofire.
+    // Gating on `active` here would make the run button unreachable for
+    // exactly the manual-only case it exists to serve. Run-time safety
+    // stays the Verify/HITL gate, not a button-time gate.
+    if workflow.readiness != "ready" {
         return Err(ToolError::InvalidParams(
-            "workflow is inactive — activate before firing".into(),
+            "workflow is not ready — it needs a trigger binding before it can run".into(),
         ));
     }
 

--- a/crates/onsager-portal/src/workflow.rs
+++ b/crates/onsager-portal/src/workflow.rs
@@ -105,6 +105,18 @@ pub struct Workflow {
     /// `None` for custom workflows built in the card editor.
     pub preset_id: Option<String>,
     pub active: bool,
+    /// Lifecycle **readiness** axis (ADR 0024): `"drafted"` → `"ready"`.
+    /// `ready` ⇔ the workflow has ≥1 trigger binding of any kind. Per
+    /// spec #512 a `ready` workflow earns the manual "run a batch"
+    /// button; the dashboard gates that button on this field rather than
+    /// re-deriving from `active`.
+    pub readiness: String,
+    /// Lifecycle **autofire** axis (ADR 0024): `"off"` / `"active"` /
+    /// `"paused"`. Orthogonal to `readiness` — a `ready` workflow may be
+    /// `off` (manual-only), `active` (auto-firing), or `paused`. `active`
+    /// (the legacy firing pin) is kept in sync with this by portal's
+    /// single writer path.
+    pub autofire: String,
     pub created_by: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/crates/onsager-portal/src/workflow_db.rs
+++ b/crates/onsager-portal/src/workflow_db.rs
@@ -229,7 +229,8 @@ pub async fn insert_workflow_with_stages(
 pub async fn get_workflow(pool: &PgPool, workflow_id: &str) -> anyhow::Result<Option<Workflow>> {
     let row = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows WHERE workflow_id = $1",
     )
     .bind(workflow_id)
@@ -244,7 +245,8 @@ pub async fn list_workflows_for_workspace(
 ) -> anyhow::Result<Vec<Workflow>> {
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows WHERE workspace_id = $1 ORDER BY created_at ASC",
     )
     .bind(workspace_id)
@@ -504,7 +506,8 @@ pub async fn find_active_github_workflows_for_label(
     // registered under install B.
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND trigger_kind = 'github_issue_webhook' \
@@ -534,7 +537,8 @@ pub async fn find_active_github_workflows_for_label_in_workspace(
     let repo = format!("{repo_owner}/{repo_name}");
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND workspace_id = $1 \
@@ -562,7 +566,8 @@ pub async fn find_active_github_workflows_for_workspace_repo(
     let repo = format!("{repo_owner}/{repo_name}");
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND workspace_id = $1 \
@@ -587,7 +592,8 @@ pub async fn find_active_pull_request_closed_workflows(
     let repo = format!("{repo_owner}/{repo_name}");
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND trigger_kind = 'github_pull_request_closed' \
@@ -610,7 +616,8 @@ pub async fn find_active_workflow_run_completed_workflows(
     let repo = format!("{repo_owner}/{repo_name}");
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND trigger_kind = 'github_workflow_run_completed' \
@@ -632,7 +639,8 @@ pub async fn find_active_workflow_run_completed_workflows(
 pub async fn list_active_telegram_workflows(pool: &PgPool) -> anyhow::Result<Vec<Workflow>> {
     let rows = sqlx::query(
         "SELECT workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                workspace_id, install_id, created_by, created_at, updated_at \
+                workspace_id, install_id, created_by, created_at, updated_at, \
+                readiness, autofire \
            FROM workflows \
           WHERE active = TRUE \
             AND trigger_kind = 'telegram_webhook'",
@@ -731,6 +739,11 @@ fn row_to_workflow(row: sqlx::postgres::PgRow) -> anyhow::Result<Workflow> {
     }
     let created_at: DateTime<Utc> = row.try_get("created_at")?;
     let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+    // The two ADR 0024 lifecycle axes — read as the canonical wire
+    // strings ("drafted"/"ready", "off"/"active"/"paused"). The CHECK
+    // constraints on the columns (migration 007) guarantee the values.
+    let readiness: String = row.try_get("readiness")?;
+    let autofire: String = row.try_get("autofire")?;
 
     let trigger = TriggerKind::from_storage(&trigger_kind_raw, &trigger_config)
         .with_context(|| format!("workflow {id} has unparseable trigger"))?;
@@ -751,6 +764,8 @@ fn row_to_workflow(row: sqlx::postgres::PgRow) -> anyhow::Result<Workflow> {
         install_id,
         preset_id,
         active,
+        readiness,
+        autofire,
         created_by: created_by.unwrap_or_default(),
         created_at,
         updated_at,

--- a/crates/onsager-portal/src/workflow_db.rs
+++ b/crates/onsager-portal/src/workflow_db.rs
@@ -352,7 +352,8 @@ pub async fn list_workflows_for_workspace_filtered(
     filter: WorkflowFilter,
 ) -> anyhow::Result<Vec<Workflow>> {
     const COLS: &str = "workflow_id, name, trigger_kind, trigger_config, active, preset_id, \
-                        workspace_id, install_id, created_by, created_at, updated_at";
+                        workspace_id, install_id, created_by, created_at, updated_at, \
+                        readiness, autofire";
     let sql = match filter.where_clause() {
         None => {
             format!("SELECT {COLS} FROM workflows WHERE workspace_id = $1 ORDER BY created_at ASC")

--- a/crates/onsager-portal/src/workflow_install.rs
+++ b/crates/onsager-portal/src/workflow_install.rs
@@ -82,6 +82,8 @@ mod tests {
             install_id: cached,
             preset_id: None,
             active: false,
+            readiness: "ready".into(),
+            autofire: "off".into(),
             created_by: "u1".into(),
             created_at: now,
             updated_at: now,

--- a/crates/onsager-portal/src/workflow_version_db.rs
+++ b/crates/onsager-portal/src/workflow_version_db.rs
@@ -539,6 +539,8 @@ mod tests {
             install_id: Some(42),
             preset_id: None,
             active: false,
+            readiness: "ready".into(),
+            autofire: "off".into(),
             created_by: "user-1".into(),
             created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),

--- a/crates/onsager-portal/tests/showcase_dogfood.rs
+++ b/crates/onsager-portal/tests/showcase_dogfood.rs
@@ -42,6 +42,8 @@ async fn seed_dogfood_workflow(spine: &PgPool, workspace_id: &str) -> String {
         install_id: Some(1),
         preset_id: Some("onsager-dogfood".into()),
         active: true,
+        readiness: "ready".into(),
+        autofire: "active".into(),
         created_by: "tester".into(),
         created_at: now,
         updated_at: now,

--- a/crates/onsager-portal/tests/workflow_delete.rs
+++ b/crates/onsager-portal/tests/workflow_delete.rs
@@ -35,6 +35,8 @@ async fn seed_workflow(spine: &PgPool, workspace_id: &str) -> String {
         install_id: Some(1),
         preset_id: None,
         active: false,
+        readiness: "ready".into(),
+        autofire: "off".into(),
         created_by: "u1".into(),
         created_at: now,
         updated_at: now,

--- a/crates/onsager-portal/tests/workflow_delete.rs
+++ b/crates/onsager-portal/tests/workflow_delete.rs
@@ -165,3 +165,36 @@ async fn delete_workflow_without_artifacts_still_works() {
         .get(0);
     assert_eq!(wf_count, 0);
 }
+
+/// Regression for the #515 review: `list_workflows_for_workspace_filtered`
+/// builds its SELECT from a `COLS` constant. When the `Workflow` read
+/// shape gained `readiness`/`autofire` (#512), `row_to_workflow` started
+/// requiring those columns — `COLS` had to grow too, or this path errors
+/// at `try_get("readiness")` at runtime (the other read paths use an
+/// inline column list that was updated separately).
+///
+/// Mutation check: drop `readiness, autofire` from `COLS` and the
+/// `.expect(...)` below fails.
+#[tokio::test]
+async fn filtered_list_reads_lifecycle_axes() {
+    let Some(spine) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws-{}", Uuid::new_v4());
+    let workflow_id = seed_workflow(&spine, &workspace_id).await;
+
+    let listed = workflow_db::list_workflows_for_workspace_filtered(
+        &spine,
+        &workspace_id,
+        Default::default(),
+    )
+    .await
+    .expect("filtered list must not fail (COLS must include the lifecycle axes)");
+    let got = listed
+        .iter()
+        .find(|w| w.id == workflow_id)
+        .expect("seeded workflow is listed");
+    assert_eq!(got.readiness, "ready");
+    assert_eq!(got.autofire, "off");
+}

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -42,7 +42,7 @@ pub mod service;
 pub mod spine_client;
 
 pub use bridge::{TriggerBridge, TriggerBridgeError};
-pub use plan_runner::{PlanRunError, PlanRunner, SchedulerLibrarySnapshot};
+pub use plan_runner::{PlanRunError, PlanRunner, SchedulerLibrarySnapshot, resolve_kind_versions};
 pub use plan_store::SqlxPlanStore;
 pub use service::{SchedulerService, ServiceConfig};
 pub use spine_client::SpineEventStoreClient;

--- a/crates/onsager-scheduler/src/migrate.rs
+++ b/crates/onsager-scheduler/src/migrate.rs
@@ -13,11 +13,19 @@
 //! whichever process migrates first wins; the `CREATE TABLE IF NOT
 //! EXISTS` shape makes the loser a no-op. Mirrors the stiglab
 //! `run_migrations` fallback pattern.
+//!
+//! The additive `kind_versions` column (migration 008, #511) is
+//! replayed the same way — `ADD COLUMN IF NOT EXISTS` is idempotent, so
+//! a host that pins workflow versions can run against a spine that has
+//! not yet seen migration 008.
 
 use sqlx::PgPool;
 
 const EXECUTION_PLANS_SQL: &str =
     include_str!("../../onsager-spine/migrations/006_execution_plans.sql");
+
+const KIND_VERSIONS_SQL: &str =
+    include_str!("../../onsager-spine/migrations/008_execution_plan_kind_versions.sql");
 
 /// Ensure the scheduler's durable-state tables exist. Idempotent —
 /// safe to call on every startup.
@@ -26,5 +34,9 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
         .execute(pool)
         .await
         .map_err(|e| anyhow::anyhow!("scheduler execution-plan migration failed: {e}"))?;
+    sqlx::raw_sql(KIND_VERSIONS_SQL)
+        .execute(pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("scheduler kind-versions migration failed: {e}"))?;
     Ok(())
 }

--- a/crates/onsager-scheduler/src/plan_registry.rs
+++ b/crates/onsager-scheduler/src/plan_registry.rs
@@ -63,8 +63,13 @@ pub async fn load_spec_plan(
 /// `kind_versions` is the `{kind → workflow-library version}` snapshot
 /// the plan compiled against ([`resolve_kind_versions`](crate::resolve_kind_versions)),
 /// persisted so a recovery after a host restart recompiles against the
-/// same versions, not whatever is latest then (#511). The map is
-/// re-asserted on a resume so a re-invocation keeps the original pins.
+/// same versions, not whatever is latest then (#511). The pin is set
+/// **once, at first registration**: on the `ON CONFLICT` resume path the
+/// existing `kind_versions` is preserved, so a replay/retry that reuses
+/// the same derived `plan_id` keeps the original pin even though it
+/// re-resolves `latest_version()` at call time. Overwriting it here
+/// would silently re-pin the resumed run to whatever is latest now,
+/// defeating the pinning guarantee.
 pub async fn register_plan(
     pool: &PgPool,
     plan_id: &PlanId,
@@ -81,7 +86,6 @@ pub async fn register_plan(
          VALUES ($1, $2, $3, $4, $5, 'running', NOW()) \
          ON CONFLICT (plan_id) DO UPDATE \
          SET spec_plan_json = EXCLUDED.spec_plan_json, \
-             kind_versions = EXCLUDED.kind_versions, \
              status = 'running', updated_at = NOW()",
     )
     .bind(plan_id.as_str())

--- a/crates/onsager-scheduler/src/plan_registry.rs
+++ b/crates/onsager-scheduler/src/plan_registry.rs
@@ -15,6 +15,8 @@
 //!    recompile + resume any plan with non-terminal nodes
 //!    ([`list_recoverable`]).
 
+use std::collections::HashMap;
+
 use onsager_nodes::PlanId;
 use onsager_substrate::spec_plan::SpecPlan;
 use sqlx::{PgPool, Row};
@@ -57,25 +59,36 @@ pub async fn load_spec_plan(
 
 /// Record (or refresh) a run in `execution_plans` with status
 /// `running`. Idempotent on `plan_id` so a resume re-asserts the row.
+///
+/// `kind_versions` is the `{kind → workflow-library version}` snapshot
+/// the plan compiled against ([`resolve_kind_versions`](crate::resolve_kind_versions)),
+/// persisted so a recovery after a host restart recompiles against the
+/// same versions, not whatever is latest then (#511). The map is
+/// re-asserted on a resume so a re-invocation keeps the original pins.
 pub async fn register_plan(
     pool: &PgPool,
     plan_id: &PlanId,
     workspace_id: &str,
     spec_plan_id: Option<&str>,
     spec_plan: &SpecPlan,
+    kind_versions: &HashMap<String, i32>,
 ) -> anyhow::Result<()> {
     let plan_json = serde_json::to_value(spec_plan)?;
+    let kind_versions_json = serde_json::to_value(kind_versions)?;
     sqlx::query(
         "INSERT INTO execution_plans \
-         (plan_id, workspace_id, spec_plan_id, spec_plan_json, status, updated_at) \
-         VALUES ($1, $2, $3, $4, 'running', NOW()) \
+         (plan_id, workspace_id, spec_plan_id, spec_plan_json, kind_versions, status, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, 'running', NOW()) \
          ON CONFLICT (plan_id) DO UPDATE \
-         SET spec_plan_json = EXCLUDED.spec_plan_json, status = 'running', updated_at = NOW()",
+         SET spec_plan_json = EXCLUDED.spec_plan_json, \
+             kind_versions = EXCLUDED.kind_versions, \
+             status = 'running', updated_at = NOW()",
     )
     .bind(plan_id.as_str())
     .bind(workspace_id)
     .bind(spec_plan_id)
     .bind(&plan_json)
+    .bind(&kind_versions_json)
     .execute(pool)
     .await?;
     Ok(())
@@ -92,12 +105,16 @@ pub async fn set_status(pool: &PgPool, plan_id: &PlanId, status: &str) -> anyhow
 }
 
 /// A plan that was still `running` at startup — its source `SpecPlan`
-/// to recompile and resume.
+/// to recompile and resume, plus the `{kind → version}` pins it was
+/// registered with so the recompile targets the same workflow versions
+/// (#511). An empty map is a legacy row (registered before #511) and
+/// recovers via `latest()`.
 #[derive(Debug)]
 pub struct RecoverablePlan {
     pub plan_id: PlanId,
     pub workspace_id: String,
     pub spec_plan: SpecPlan,
+    pub kind_versions: HashMap<String, i32>,
 }
 
 /// Every plan left in `running` status. The host recompiles each and
@@ -105,7 +122,8 @@ pub struct RecoverablePlan {
 /// to pending and re-dispatches (RUN-01 fault-tolerance note).
 pub async fn list_recoverable(pool: &PgPool) -> anyhow::Result<Vec<RecoverablePlan>> {
     let rows = sqlx::query(
-        "SELECT plan_id, workspace_id, spec_plan_json FROM execution_plans WHERE status = 'running'",
+        "SELECT plan_id, workspace_id, spec_plan_json, kind_versions \
+         FROM execution_plans WHERE status = 'running'",
     )
     .fetch_all(pool)
     .await?;
@@ -115,10 +133,13 @@ pub async fn list_recoverable(pool: &PgPool) -> anyhow::Result<Vec<RecoverablePl
         let workspace_id: String = row.try_get("workspace_id")?;
         let json: serde_json::Value = row.try_get("spec_plan_json")?;
         let spec_plan: SpecPlan = serde_json::from_value(json)?;
+        let kind_versions_json: serde_json::Value = row.try_get("kind_versions")?;
+        let kind_versions: HashMap<String, i32> = serde_json::from_value(kind_versions_json)?;
         out.push(RecoverablePlan {
             plan_id: PlanId::new(plan_id),
             workspace_id,
             spec_plan,
+            kind_versions,
         });
     }
     Ok(out)

--- a/crates/onsager-scheduler/src/plan_runner.rs
+++ b/crates/onsager-scheduler/src/plan_runner.rs
@@ -110,25 +110,75 @@ pub struct SchedulerLibrarySnapshot {
 
 impl SchedulerLibrarySnapshot {
     /// Resolve every distinct `kind` in `spec_plan` against the
-    /// persisted library. Kinds with no registered workflow are simply
-    /// absent from the snapshot — the compiler then surfaces
+    /// persisted library, pinning each kind to the version recorded in
+    /// `kind_versions` (#511). Kinds with no registered workflow are
+    /// simply absent from the snapshot — the compiler then surfaces
     /// `CompileError::MissingKind`, which is the correct hard failure
     /// per ADR 0017.
+    ///
+    /// `kind_versions` is the `{kind → version}` snapshot persisted at
+    /// registration ([`resolve_kind_versions`]). A kind present in the
+    /// map resolves via [`lookup_versioned`](PersistedWorkflowLibrary::lookup_versioned)
+    /// so a plan recovered after a restart recompiles against the
+    /// version it began on. A kind **absent** from the map (legacy rows
+    /// registered before #511, whose `kind_versions` is `{}`) or one
+    /// whose pinned version was retired falls back to
+    /// [`lookup`](PersistedWorkflowLibrary::lookup) (latest), logging a
+    /// warning so the divergence is observable rather than silent.
     pub async fn build(
         spec_plan: &SpecPlan,
         library: &PersistedWorkflowLibrary,
+        kind_versions: &HashMap<String, i32>,
     ) -> Result<Self, WorkflowLibraryError> {
         let mut by_kind = HashMap::new();
         for spec in &spec_plan.specs {
             if by_kind.contains_key(&spec.kind) {
                 continue;
             }
-            if let Some(workflow) = library.lookup(&spec.kind).await? {
+            let resolved = match kind_versions.get(&spec.kind) {
+                Some(&version) => match library.lookup_versioned(&spec.kind, version).await? {
+                    Some(workflow) => Some(workflow),
+                    None => {
+                        tracing::warn!(
+                            kind = %spec.kind,
+                            pinned_version = version,
+                            "pinned workflow version is absent or retired; \
+                             recovering against latest() instead",
+                        );
+                        library.lookup(&spec.kind).await?
+                    }
+                },
+                None => library.lookup(&spec.kind).await?,
+            };
+            if let Some(workflow) = resolved {
                 by_kind.insert(spec.kind.clone(), workflow);
             }
         }
         Ok(Self { by_kind })
     }
+}
+
+/// Snapshot the `{kind → version}` map a [`SpecPlan`] compiles against:
+/// the latest registered version for every distinct kind it
+/// references. Persisted by `register_plan` (#511) so a later recovery
+/// recompiles against these exact versions rather than whatever is
+/// latest at restart. Kinds with no registered workflow are omitted —
+/// the recovering `build` then falls through to its (also empty)
+/// `latest()` lookup and the compiler surfaces the missing kind.
+pub async fn resolve_kind_versions(
+    spec_plan: &SpecPlan,
+    library: &PersistedWorkflowLibrary,
+) -> Result<HashMap<String, i32>, WorkflowLibraryError> {
+    let mut versions = HashMap::new();
+    for spec in &spec_plan.specs {
+        if versions.contains_key(&spec.kind) {
+            continue;
+        }
+        if let Some(version) = library.latest_version(&spec.kind).await? {
+            versions.insert(spec.kind.clone(), version);
+        }
+    }
+    Ok(versions)
 }
 
 impl WorkflowLookup for SchedulerLibrarySnapshot {

--- a/crates/onsager-scheduler/src/plan_runner.rs
+++ b/crates/onsager-scheduler/src/plan_runner.rs
@@ -174,8 +174,21 @@ pub async fn resolve_kind_versions(
         if versions.contains_key(&spec.kind) {
             continue;
         }
-        if let Some(version) = library.latest_version(&spec.kind).await? {
-            versions.insert(spec.kind.clone(), version);
+        match library.latest_version(&spec.kind).await? {
+            Some(version) => {
+                versions.insert(spec.kind.clone(), version);
+            }
+            None => {
+                // No registered version to pin — the compile will
+                // surface `MissingKind` for this spec. Log it so the
+                // unregistered kind is visible at registration time, not
+                // only when the run later fails to compile.
+                tracing::warn!(
+                    kind = %spec.kind,
+                    "no registered workflow version for kind at plan registration; \
+                     it will not be pinned",
+                );
+            }
         }
     }
     Ok(versions)

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -30,7 +30,7 @@ use sqlx::Row;
 
 use crate::bridge::{PreloadedWorkflow, TriggerBridge, WorkflowMeta};
 use crate::plan_registry::{self, derive_plan_id};
-use crate::plan_runner::{PlanRunner, SchedulerLibrarySnapshot};
+use crate::plan_runner::{PlanRunner, SchedulerLibrarySnapshot, resolve_kind_versions};
 use crate::plan_store::SqlxPlanStore;
 use crate::spine_client::SpineEventStoreClient;
 
@@ -186,7 +186,13 @@ async fn recover_running_plans(
         "resuming in-flight plans after restart"
     );
     for rec in plans {
-        let snapshot = match SchedulerLibrarySnapshot::build(&rec.spec_plan, library).await {
+        let snapshot = match SchedulerLibrarySnapshot::build(
+            &rec.spec_plan,
+            library,
+            &rec.kind_versions,
+        )
+        .await
+        {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(plan_id = %rec.plan_id, "recovery library snapshot failed: {e}");
@@ -391,17 +397,26 @@ impl TriggerHandler {
             };
 
         let plan_id = derive_plan_id(&workspace_id, &spec_plan_id);
+        // Pin the workflow-library versions this run compiles against so
+        // a later recovery recompiles against the same versions, not
+        // whatever is latest then (#511). Resolved once and shared with
+        // both the persisted pin and the live snapshot so they cannot
+        // diverge.
+        let kind_versions = resolve_kind_versions(&spec_plan, &self.library)
+            .await
+            .context("resolving workflow-library versions")?;
         plan_registry::register_plan(
             self.store.pool(),
             &plan_id,
             &workspace_id,
             Some(&spec_plan_id),
             &spec_plan,
+            &kind_versions,
         )
         .await
         .context("registering plan run")?;
 
-        let snapshot = SchedulerLibrarySnapshot::build(&spec_plan, &self.library)
+        let snapshot = SchedulerLibrarySnapshot::build(&spec_plan, &self.library, &kind_versions)
             .await
             .context("building library snapshot")?;
         let scoped_spine: Arc<dyn SpineClient> =

--- a/crates/onsager-scheduler/tests/version_pinning.rs
+++ b/crates/onsager-scheduler/tests/version_pinning.rs
@@ -164,6 +164,78 @@ async fn recovered_plan_resolves_pinned_version_not_latest() {
         .unwrap();
 }
 
+/// Pinning survives a resume that reuses the same `plan_id` (#515
+/// review): the `ON CONFLICT` path on `register_plan` must NOT overwrite
+/// the original pin with the re-resolved (now newer) version, or a
+/// replay/retry would silently re-pin the resumed run to latest.
+///
+/// Mutation check: restore `kind_versions = EXCLUDED.kind_versions` to
+/// the ON CONFLICT clause and the final assertion sees v2 and fails.
+#[tokio::test]
+async fn resume_preserves_original_pin() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_scheduler::migrate::run(&pool)
+        .await
+        .expect("ensure execution-plan tables");
+    let library = WorkflowLibrary::new(pool.clone());
+
+    let kind = format!("resume-pin-{}", uuid::Uuid::new_v4());
+    library
+        .register(&kind, &tagged_workflow("v1"))
+        .await
+        .expect("register v1");
+
+    let plan = one_spec_plan(&kind);
+    let plan_id = PlanId::new(format!("plan-{}", uuid::Uuid::new_v4()));
+
+    // First registration pins v1.
+    let pin_v1 = resolve_kind_versions(&plan, &library)
+        .await
+        .expect("resolve v1");
+    assert_eq!(pin_v1.get(&kind), Some(&1));
+    plan_registry::register_plan(&pool, &plan_id, "default", None, &plan, &pin_v1)
+        .await
+        .expect("register plan");
+
+    // v2 lands; a resume re-resolves latest (v2) and re-registers the
+    // SAME plan_id — the original v1 pin must survive the ON CONFLICT.
+    library
+        .register(&kind, &tagged_workflow("v2"))
+        .await
+        .expect("register v2");
+    let pin_v2 = resolve_kind_versions(&plan, &library)
+        .await
+        .expect("resolve v2");
+    assert_eq!(
+        pin_v2.get(&kind),
+        Some(&2),
+        "the resume would pin v2 if allowed to overwrite",
+    );
+    plan_registry::register_plan(&pool, &plan_id, "default", None, &plan, &pin_v2)
+        .await
+        .expect("re-register plan (resume)");
+
+    let recovered = plan_registry::list_recoverable(&pool)
+        .await
+        .expect("list recoverable");
+    let rec = recovered
+        .iter()
+        .find(|r| r.plan_id.as_str() == plan_id.as_str())
+        .expect("our plan is recoverable");
+    assert_eq!(
+        rec.kind_versions.get(&kind),
+        Some(&1),
+        "resume must preserve the original v1 pin, not the re-resolved v2",
+    );
+
+    plan_registry::set_status(&pool, &plan_id, "completed")
+        .await
+        .unwrap();
+}
+
 /// A legacy row (registered before #511) carries an empty
 /// `kind_versions` map and recovers via `latest()` exactly as before.
 #[tokio::test]

--- a/crates/onsager-scheduler/tests/version_pinning.rs
+++ b/crates/onsager-scheduler/tests/version_pinning.rs
@@ -1,0 +1,253 @@
+//! Integration tests for run-path version pinning (#511, #506 Phase 2).
+//!
+//! A plan recovered after a host restart must recompile against the
+//! workflow-library version it was *registered* with, not whatever is
+//! latest at restart. These tests exercise the full persisted path:
+//! register a workflow version → register a plan (which pins
+//! `{kind → version}`) → register a *newer* version → recover → assert
+//! the recovered snapshot resolves the original version.
+//!
+//! Skipped when `DATABASE_URL` is unset — matches the portal /
+//! `durable_plan_store` integration-test convention. Requires the spine
+//! `workflow_library` table (migration 004) plus the execution-plan
+//! tables (migrations 006 + 008, ensured idempotently by
+//! `onsager_scheduler::migrate::run`).
+
+use std::collections::HashMap;
+
+use onsager_artifact::{ArtifactId, NodeId, Provenance};
+use onsager_nodes::PlanId;
+use onsager_scheduler::{SchedulerLibrarySnapshot, plan_registry, resolve_kind_versions};
+use onsager_substrate::WorkflowLookup;
+use onsager_substrate::ids::EdgeId;
+use onsager_substrate::spec_plan::{SpecId, SpecPlan, SpecRef};
+use onsager_substrate::workflow::{Edge, EdgeRef, EntrySpec, Node, OutputSpec, Workflow};
+use onsager_substrate::workflow_library::WorkflowLibrary;
+use sqlx::PgPool;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("spine connect"))
+}
+
+/// A one-node passthrough workflow whose entry edge carries a `tag`ed
+/// artifact id, so two registered versions of the same kind survive a
+/// round-trip through the library distinguishably.
+fn tagged_workflow(tag: &str) -> Workflow {
+    let entry = EdgeId::generate();
+    let exit = EdgeId::generate();
+    Workflow {
+        nodes: vec![Node {
+            id: NodeId::generate(),
+            executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+            inputs: vec![EdgeRef::new(entry)],
+            outputs: vec![EdgeRef::new(exit)],
+        }],
+        edges: vec![
+            Edge {
+                id: entry,
+                artifact_id: ArtifactId::new(format!("art_in_{tag}")),
+                requires_deterministic: false,
+            },
+            Edge {
+                id: exit,
+                artifact_id: ArtifactId::new(format!("art_out_{tag}")),
+                requires_deterministic: false,
+            },
+        ],
+        entry_specs: vec![EntrySpec { edge_id: entry }],
+        output_specs: vec![OutputSpec {
+            edge_id: exit,
+            provenance: Provenance::external_deterministic(),
+        }],
+    }
+}
+
+/// The entry edge's artifact id (`art_in_<tag>`) — the field that tells
+/// two registered versions of a kind apart.
+fn entry_tag(wf: &Workflow) -> &str {
+    let entry_edge = wf.entry_specs[0].edge_id;
+    wf.edges
+        .iter()
+        .find(|e| e.id == entry_edge)
+        .map(|e| e.artifact_id.as_str())
+        .expect("entry edge present")
+}
+
+fn one_spec_plan(kind: &str) -> SpecPlan {
+    SpecPlan {
+        specs: vec![SpecRef {
+            id: SpecId::new("s1"),
+            kind: kind.into(),
+            inputs: Default::default(),
+        }],
+        deps: vec![],
+    }
+}
+
+/// The core DoD: a plan registered against v1, recovered after v2 lands,
+/// recompiles against **v1**.
+///
+/// Mutation check: make `SchedulerLibrarySnapshot::build` ignore the pin
+/// (resolve `library.lookup(kind)` unconditionally) and this assertion
+/// flips to `art_in_v2` and fails.
+#[tokio::test]
+async fn recovered_plan_resolves_pinned_version_not_latest() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_scheduler::migrate::run(&pool)
+        .await
+        .expect("ensure execution-plan tables");
+    let library = WorkflowLibrary::new(pool.clone());
+
+    // Unique kind per run so reruns don't collide on workflow_library.
+    let kind = format!("pin-test-{}", uuid::Uuid::new_v4());
+
+    // Register version 1, then pin a plan against it.
+    let v1 = library
+        .register(&kind, &tagged_workflow("v1"))
+        .await
+        .expect("register v1");
+    assert_eq!(v1, 1);
+
+    let plan = one_spec_plan(&kind);
+    let kind_versions = resolve_kind_versions(&plan, &library)
+        .await
+        .expect("resolve versions");
+    assert_eq!(kind_versions.get(&kind), Some(&1), "pinned at v1");
+
+    let plan_id = PlanId::new(format!("plan-{}", uuid::Uuid::new_v4()));
+    plan_registry::register_plan(&pool, &plan_id, "default", None, &plan, &kind_versions)
+        .await
+        .expect("register plan");
+
+    // A NEW version lands after registration — latest() now points at it.
+    let v2 = library
+        .register(&kind, &tagged_workflow("v2"))
+        .await
+        .expect("register v2");
+    assert_eq!(v2, 2);
+    assert_eq!(
+        entry_tag(&library.lookup(&kind).await.unwrap().unwrap()),
+        "art_in_v2",
+        "latest() now resolves v2",
+    );
+
+    // Recover: the persisted pin must round-trip and resolve v1.
+    let recovered = plan_registry::list_recoverable(&pool)
+        .await
+        .expect("list recoverable");
+    let rec = recovered
+        .iter()
+        .find(|r| r.plan_id.as_str() == plan_id.as_str())
+        .expect("our plan is recoverable");
+    assert_eq!(
+        rec.kind_versions.get(&kind),
+        Some(&1),
+        "pin survived the JSONB round-trip",
+    );
+
+    let snapshot = SchedulerLibrarySnapshot::build(&rec.spec_plan, &library, &rec.kind_versions)
+        .await
+        .expect("build snapshot");
+    assert_eq!(
+        entry_tag(snapshot.by_kind(&kind).expect("kind resolved")),
+        "art_in_v1",
+        "recovery recompiles against the pinned v1, not latest v2",
+    );
+
+    // Don't leave a `running` row behind for other tests' recovery scans.
+    plan_registry::set_status(&pool, &plan_id, "completed")
+        .await
+        .unwrap();
+}
+
+/// A legacy row (registered before #511) carries an empty
+/// `kind_versions` map and recovers via `latest()` exactly as before.
+#[tokio::test]
+async fn absent_pin_recovers_via_latest() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_scheduler::migrate::run(&pool)
+        .await
+        .expect("ensure execution-plan tables");
+    let library = WorkflowLibrary::new(pool.clone());
+
+    let kind = format!("absent-pin-{}", uuid::Uuid::new_v4());
+    library
+        .register(&kind, &tagged_workflow("v1"))
+        .await
+        .expect("register v1");
+    library
+        .register(&kind, &tagged_workflow("v2"))
+        .await
+        .expect("register v2");
+
+    let plan = one_spec_plan(&kind);
+    let no_pins: HashMap<String, i32> = HashMap::new();
+    let snapshot = SchedulerLibrarySnapshot::build(&plan, &library, &no_pins)
+        .await
+        .expect("build snapshot");
+    assert_eq!(
+        entry_tag(snapshot.by_kind(&kind).expect("kind resolved")),
+        "art_in_v2",
+        "an absent pin resolves latest()",
+    );
+}
+
+/// A pinned version that was later retired (`retired_at IS NOT NULL`)
+/// falls back to `latest()` — `lookup_versioned` treats the retired row
+/// as absent, so `build` takes the warn-and-fall-back branch.
+#[tokio::test]
+async fn retired_pin_falls_back_to_latest() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("DATABASE_URL not set; skipping");
+        return;
+    };
+    onsager_scheduler::migrate::run(&pool)
+        .await
+        .expect("ensure execution-plan tables");
+    let library = WorkflowLibrary::new(pool.clone());
+
+    let kind = format!("retired-pin-{}", uuid::Uuid::new_v4());
+    library
+        .register(&kind, &tagged_workflow("v1"))
+        .await
+        .expect("register v1");
+    library
+        .register(&kind, &tagged_workflow("v2"))
+        .await
+        .expect("register v2");
+
+    // Retire v1 out from under the pin.
+    sqlx::query(
+        "UPDATE workflow_library SET retired_at = NOW() \
+         WHERE spec_kind = $1 AND version = 1",
+    )
+    .bind(&kind)
+    .execute(&pool)
+    .await
+    .expect("retire v1");
+
+    // lookup_versioned ignores the retired row entirely.
+    assert!(
+        library.lookup_versioned(&kind, 1).await.unwrap().is_none(),
+        "a retired version is invisible to lookup_versioned",
+    );
+
+    // Pin still points at v1; build must warn and fall back to latest v2.
+    let plan = one_spec_plan(&kind);
+    let pins = HashMap::from([(kind.clone(), 1)]);
+    let snapshot = SchedulerLibrarySnapshot::build(&plan, &library, &pins)
+        .await
+        .expect("build snapshot");
+    assert_eq!(
+        entry_tag(snapshot.by_kind(&kind).expect("kind resolved")),
+        "art_in_v2",
+        "a retired pin falls back to latest()",
+    );
+}

--- a/crates/onsager-spine/migrations/008_execution_plan_kind_versions.sql
+++ b/crates/onsager-spine/migrations/008_execution_plan_kind_versions.sql
@@ -1,0 +1,23 @@
+-- Onsager #511 (#506 Phase 2, governed by ADR 0024) — pin the
+-- workflow-library version each run compiled against.
+--
+-- A plan recovered after a host restart silently recompiled against the
+-- *latest* workflow-library version, not the version it was registered
+-- with: `recover_running_plans` rebuilds each plan via the library's
+-- `lookup(kind)`, which returns `latest()`. If a new workflow version
+-- was registered between a plan starting and the host restarting, the
+-- in-flight plan resumed on a different compiled graph — and failed at
+-- runtime if node/gate signatures changed.
+--
+-- `kind_versions` maps each referenced spec `kind` to the
+-- `workflow_library.version` resolved at registration. Recovery looks
+-- each kind up at its pinned version; an absent map (legacy rows) or a
+-- retired pinned version (`retired_at IS NOT NULL`) falls back to
+-- `latest()` with a logged warning so the divergence is observable.
+--
+-- Additive with a safe default so existing `running` rows recover with
+-- today's latest-lookup behavior (empty map ⇒ no pins ⇒ `latest()`).
+-- The scheduler host ensures this column idempotently at startup
+-- (crates/onsager-scheduler/src/migrate.rs) alongside migration 006.
+ALTER TABLE execution_plans
+    ADD COLUMN IF NOT EXISTS kind_versions JSONB NOT NULL DEFAULT '{}';

--- a/crates/onsager-substrate/src/workflow_library.rs
+++ b/crates/onsager-substrate/src/workflow_library.rs
@@ -126,7 +126,7 @@ impl WorkflowLibrary {
             {
                 // The race-loser does not know which version it lost
                 // — re-read the latest to report a useful error.
-                let current = self.latest_version(kind).await.unwrap_or(0);
+                let current = self.latest_version(kind).await.ok().flatten().unwrap_or(0);
                 Err(WorkflowLibraryError::DuplicateKind {
                     kind: kind.to_string(),
                     version: current,
@@ -166,16 +166,48 @@ impl WorkflowLibrary {
         }
     }
 
-    /// Helper for the `DuplicateKind` error path — read the current
-    /// `MAX(version)` for a kind, returning `None` if no rows yet.
-    async fn latest_version(&self, kind: &str) -> Option<i32> {
-        sqlx::query_scalar::<_, Option<i32>>(
+    /// Return the `Workflow` registered at exactly `(kind, version)`,
+    /// or `Ok(None)` when no such non-retired row exists.
+    ///
+    /// The run-path recovery counterpart of [`latest`](Self::latest)
+    /// (#511): a plan recovered after a restart resolves each kind at
+    /// the version it was *registered* with, not whatever is latest
+    /// now. Retired rows (`retired_at IS NOT NULL`) are treated as
+    /// absent so the caller falls back to [`latest`](Self::latest)
+    /// rather than resuming on a withdrawn version.
+    pub async fn lookup_versioned(
+        &self,
+        kind: &str,
+        version: i32,
+    ) -> Result<Option<Workflow>, WorkflowLibraryError> {
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(
+            "SELECT workflow_json FROM workflow_library \
+             WHERE spec_kind = $1 AND version = $2 AND retired_at IS NULL",
+        )
+        .bind(kind)
+        .bind(version)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some((json,)) => Ok(Some(serde_json::from_value(json)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Read the current `MAX(version)` for a kind, returning `Ok(None)`
+    /// if the kind has no rows yet.
+    ///
+    /// Used to snapshot the `{kind → version}` pin at plan registration
+    /// (#511) and to report the winning version on the `DuplicateKind`
+    /// race-loser path.
+    pub async fn latest_version(&self, kind: &str) -> Result<Option<i32>, WorkflowLibraryError> {
+        let version = sqlx::query_scalar::<_, Option<i32>>(
             "SELECT MAX(version) FROM workflow_library WHERE spec_kind = $1",
         )
         .bind(kind)
         .fetch_one(&self.pool)
-        .await
-        .ok()
-        .flatten()
+        .await?;
+        Ok(version)
     }
 }

--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ lint-rust: _check-tools-and-skills
     cargo run -p xtask --quiet -- gen-event-docs --check
     cargo run -p xtask --quiet -- lint-seams
     cargo run -p xtask --quiet -- check-api-contract
+    cargo run -p xtask --quiet -- check-events
     cargo run -p xtask --quiet -- check-generated-types
     cargo run -p xtask --quiet -- check-metaphor-leakage
     cargo run -p xtask --quiet -- check-detail-page-tabs
@@ -69,6 +70,59 @@ _check-tools-and-skills:
 
 lint-ui:
     pnpm --filter dashboard lint
+
+# ── CI parity (spec #513) ────────────────────────────────────────────
+#
+# `just ci-local` runs the exact gate set CI runs — the union of
+# rust.yml's `check` job and frontend.yml's `build` job — fail-fast,
+# against the committed tree. It exists because "I verified locally"
+# kept meaning narrower per-crate commands (`cargo test -p X --lib`,
+# `tsc --noEmit`) that passed while the real CI jobs (workspace clippy
+# /test, the frontend lint+BUILD+test triad) failed (PR #510, ~12 red
+# rounds). Run it ONCE before pushing — not on every edit (it's slow:
+# workspace clippy + workspace test + dashboard build).
+#
+# check-ci-parity: the step set below must stay a superset of every
+# `run:` step in .github/workflows/rust.yml (`check` job) and
+# frontend.yml (`build` job). When a CI step is added in either file,
+# mirror it here (or in the recipe it composes — `lint-rust`). The
+# Postgres-gated spine/stiglab integration tests are left to CI /
+# `just test-spine`; `ci-local-full` adds them when Postgres is up.
+ci-local: ci-local-rust ci-local-ui
+
+# Rust half — mirrors rust.yml's `check` job. `lint-rust` already runs
+# fmt + workspace clippy + every xtask lint CI runs (incl. check-events);
+# this adds the explicit workspace build + test. The DB-gated spine
+# /stiglab tests skip without DATABASE_URL, exactly as in the "Test
+# remaining crates" CI step — see `ci-local-full` to include them.
+ci-local-rust: lint-rust
+    cargo build --workspace
+    cargo test --workspace
+
+# Frontend half — mirrors frontend.yml's `build` job exactly. The
+# `build` step (`pnpm --filter dashboard build`, the `tsc -b` + vite
+# step) is the one that was invisible to a narrower `tsc --noEmit` and
+# only runs in CI on PRs touching apps/dashboard/** — so a backend-only
+# base PR's green CI says nothing about a dashboard-touching child.
+ci-local-ui:
+    pnpm install
+    pnpm --filter dashboard lint
+    pnpm --filter dashboard build
+    pnpm --filter dashboard test
+
+# Full parity including the Postgres-gated spine/stiglab integration
+# tests. Requires a running Postgres (`just dev-infra`) with DATABASE_URL
+# set; otherwise use plain `ci-local` (DB-free). Mirrors CI's three-way
+# test split exactly — spine and stiglab run serial (`--test-threads=1`)
+# because they share one DB schema — rather than `cargo test --workspace`,
+# which would race them. `lint-rust` (fmt + clippy + xtask lints) runs
+# first as a dependency.
+ci-local-full: lint-rust
+    cargo build --workspace
+    cargo test -p onsager-spine -- --test-threads=1
+    cargo test -p stiglab -- --test-threads=1
+    cargo test --workspace --exclude onsager-spine --exclude stiglab
+    just ci-local-ui
 
 # ── Docs ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #511. Closes #513. Part of #512 (UI half split to #514).

Three issues, one branch. Each commit is self-contained.

## #511 — Pin workflow-library version at register_plan (Phase 2)

A plan recovered after a host restart silently recompiled against the **latest** workflow-library version, not the version it was registered with (`recover_running_plans` rebuilt via `lookup(kind)` → `latest()`). A version registered between a plan starting and the host restarting would resume the in-flight plan on a different compiled graph — failing at runtime if node/gate signatures changed.

- Spine migration `008` adds `kind_versions JSONB DEFAULT '{}'` to `execution_plans`; the scheduler host ensures it idempotently at startup (`ADD COLUMN IF NOT EXISTS`).
- `resolve_kind_versions` snapshots the `{kind → version}` the plan compiles against; `register_plan` persists it; `RecoverablePlan` carries it back.
- `WorkflowLibrary::lookup_versioned(kind, version)` selects an exact, non-retired version. `SchedulerLibrarySnapshot::build` resolves each pinned kind through it, falling back to `latest()` **with a logged warning** only when the pin is absent (legacy `'{}'` rows) or the pinned version was retired.
- The live run path resolves versions once and shares them with both the persisted pin and the live snapshot, so they cannot diverge.

**Tests** (DB-gated, like `durable_plan_store`): a plan pinned at v1 recovers against v1 after v2 lands; an absent pin recovers via `latest()`; a retired pin falls back to `latest()`. Ran against a real Postgres — all green, and **mutation-checked**: making `build` ignore the pin flips the core test to v2 and fails. Existing `durable_store_persists_node_state_and_resumes_after_restart` stays green.

## #513 — `just ci-local`

PR #510 went through ~12 red CI rounds because "verified locally" meant narrower commands (`cargo test -p X --lib`, `tsc --noEmit`) that passed while the real CI jobs failed. New recipes compose the exact union of `rust.yml`'s `check` job and `frontend.yml`'s `build` job, fail-fast:

- `ci-local` = `ci-local-rust` (lint-rust + workspace build + test) + `ci-local-ui` (pnpm lint + **build** + test). `ci-local-full` adds the Postgres-gated spine/stiglab serial tests.
- Also closes a latent gap: `lint-rust` was missing `check-events`, which CI runs — `just lint` now matches CI.

`ci-local-ui` was run end-to-end here (lint + build + 240 tests, all green).

**Deferred:** the cross-repo `onsager-pre-push` skill amendment (Plan item 3) lives in `onsager-ai/dev-skills`, outside this session's write scope. It's a docs change needing a separate dev-skills PR — flagged here rather than silently dropped.

## #512 — Workflow readiness/autofire axes + loosened run gate (backend prerequisite)

Landed the **verifiable backend prerequisite**; the UI half is split to **#514** (a tracked sub-issue) because it depends on tool-call + HitlCard routing in the general chat thread that doesn't exist yet (`ChatThreadView` runs turns with `tools: []`; only `ChatBuilder` hosts HitlCards today). Landing a button now would be a non-functional, half-wired UI.

- Portal `Workflow` struct gains `readiness` + `autofire`; all 8 read paths SELECT them and `row_to_workflow` populates them; create paths mirror what's persisted. Generated `Workflow.ts` regenerated.
- `run_workflow` now gates on `readiness != "ready"` instead of `!active` (ADR 0024 / the spec's open question): "ready + off" (manual-only) is a first-class state, so gating on `active` made the run path unreachable for exactly the case it serves.
- Dashboard UI `Workflow` type + `workflowFromBackend` adapter carry the two axes so the detail page / future run button can gate on `readiness === "ready"`.

The ADR 0024/0025 Phase-3 adoption boxes stay unticked until #514 lands (they require the full UI).

## Verification

- `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --all --check` clean.
- Rust tests vs a real Postgres: scheduler + substrate + portal lib (270) all green.
- `check-{generated-types,hitl-coverage,api-contract,events,file-budget}` clean.
- Dashboard `lint` + `build` + `test` (240) green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H1TDuRVE9fyT3bnVZfvAmF)_