### PR TITLE
Phase 3 UI: run buttons, Spec Plans surface, chat narrowing (#514)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,19 @@ The four canonical nouns:
   parameters). A workflow's structural unit; never a top-level
   navigation noun.
 
+**Sanctioned carve-out — "Plans" (spec plans).** ADR 0023 made the
+authored spec-plan graph a first-class user concept, and ADR 0025 /
+spec #514 require a noun-surface launch path for it so chat stops
+being the sole way to run one. The dashboard therefore carries a
+fifth top-level nav noun, **Plans** (`/workspaces/:slug/spec-plans`),
+listing persisted spec plans with a HitlCard-routed "Run" button.
+This is *not* a violation of the four-noun rule but a deliberate
+exception under it: a spec **plan** (a substrate authoring artifact —
+a DAG of specs run in dependency order) is distinct from the
+internal-only dev-process **spec** (a GitHub issue with implementation
+intent) demoted below. The carve-out is scoped to this one surface;
+new top-level nav nouns still default to "no" and need their own ADR.
+
 **Demoted to internal-only.** These terms stay rich in Rust /
 migration / spine vocabulary but never surface to users:
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -32,6 +32,9 @@ const WorkflowDetailPage = lazy(() =>
 const RunDetailPage = lazy(() =>
   import("@/pages/RunDetailPage").then((m) => ({ default: m.RunDetailPage })),
 )
+const SpecPlansPage = lazy(() =>
+  import("@/pages/SpecPlansPage").then((m) => ({ default: m.SpecPlansPage })),
+)
 const RunsPage = lazy(() =>
   import("@/pages/RunsPage").then((m) => ({ default: m.RunsPage })),
 )
@@ -346,6 +349,13 @@ function AppRoutes() {
                         <Route
                           path="runs/:runId"
                           element={<LazyRoute variant="detail"><RunDetailPage /></LazyRoute>}
+                        />
+                        {/* Spec Plans surface (ADR 0023 / 0025, spec
+                            #514). List of persisted plans, each with a
+                            HitlCard-routed run button. */}
+                        <Route
+                          path="spec-plans"
+                          element={<LazyRoute variant="list"><SpecPlansPage /></LazyRoute>}
                         />
                         {/* Spine event stream at operator grain
                             (#454 / ADR 0019). */}

--- a/apps/dashboard/src/components/chat/DesktopChatEntry.tsx
+++ b/apps/dashboard/src/components/chat/DesktopChatEntry.tsx
@@ -1,0 +1,38 @@
+import { MessageSquare } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useChatUi } from "@/lib/chat/use-chat-ui"
+import { WORKSPACE_SCOPE } from "@/lib/chat/scope"
+
+// DesktopChatEntry (ADR 0025 § Desktop gains a labeled chat entry, spec
+// #514).
+//
+// The labeled, general-purpose way *into a conversation* on desktop. ADR
+// 0020 left desktop with only the bell (which opens the Inbox/Queue) and
+// the bare `⌘J` toggle — no discoverable "start a conversation" affordance.
+// This is it: a labeled button that opens the chat at the workspace scope
+// on the Thread tab (the design/maintenance surface), distinct from the
+// bell's "what needs my attention" Queue.
+//
+// Lives in the desktop top chrome only (its parent row is `md:flex`); the
+// mobile FAB and the bell are unchanged.
+
+export function DesktopChatEntry() {
+  const { open } = useChatUi()
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-9 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+      aria-label="Open chat"
+      onClick={() => open({ scope: WORKSPACE_SCOPE, tab: "thread" })}
+      data-slot="desktop-chat-entry"
+    >
+      <MessageSquare className="h-4 w-4" />
+      <span className="text-sm">Chat</span>
+      <kbd className="ml-0.5 hidden rounded border bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground lg:inline">
+        ⌘J
+      </kbd>
+    </Button>
+  )
+}

--- a/apps/dashboard/src/components/chat/HitlActionButton.tsx
+++ b/apps/dashboard/src/components/chat/HitlActionButton.tsx
@@ -1,0 +1,191 @@
+import { type ReactNode, useCallback, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { HitlCard } from "@/components/chat/HitlCard"
+import type { HitlCardState } from "@/components/chat/hitl-types"
+import { findMcpTool } from "@/lib/mcp-tools"
+import { McpClientError, mcpCallTool } from "@/lib/mcp-client"
+
+// Standalone HitlCard host for the noun surfaces (ADR 0025 / spec #514).
+//
+// ADR 0025 moves routine actions ("run a batch", "run this plan") off
+// the chat thread and onto the noun surfaces, but HITL principle 1 still
+// holds: every mutation routes through a HitlCard the user commits or
+// rejects. ChatBuilder is the chat-side host; this is its page-button
+// counterpart — a button that opens a dialog containing the same
+// `HitlCard` primitive, then commits the call through the same
+// `mcpCallTool` path. No new business logic: the card config comes from
+// the shared `mcp-tools.ts` binding (`buildCard`), so the page button
+// and the chat render an identical review surface for the same tool.
+
+export interface HitlActionDialogProps {
+  /** Whether the review dialog is open. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** MCP mutation tool to invoke. Must carry a `buildCard` binding. */
+  toolName: string
+  /** Proposed tool arguments; HitlCard edits are merged in at commit. */
+  args: Record<string, unknown>
+  /** Called with the tool's result text after a committed success. */
+  onCommitted?: (resultText: string | undefined) => void
+}
+
+/**
+ * Controlled review dialog — open/close owned by the caller. Use this
+ * directly when the trigger is not a plain button (e.g. a dropdown menu
+ * item); use {@link HitlActionButton} for the common button case.
+ */
+export function HitlActionDialog({
+  open,
+  onOpenChange,
+  toolName,
+  args,
+  onCommitted,
+}: HitlActionDialogProps) {
+  const binding = findMcpTool(toolName)
+  // `args` is a fresh object each render; key the memo on its serialized
+  // form so the card only rebuilds when the proposed values change.
+  const card = useMemo(
+    () => binding?.buildCard?.(args),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [binding, toolName, JSON.stringify(args)],
+  )
+
+  const [state, setState] = useState<HitlCardState>("pending")
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined)
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      onOpenChange(next)
+      if (!next) {
+        // Reset to pending so the next open starts fresh, not on a
+        // stale committed/failed state from the prior run.
+        setState("pending")
+        setErrorMessage(undefined)
+      }
+    },
+    [onOpenChange],
+  )
+
+  const handleCommit = useCallback(
+    async (edits: Record<string, string>) => {
+      setState("committing")
+      setErrorMessage(undefined)
+      const merged = { ...args, ...edits }
+      try {
+        const result = await mcpCallTool(toolName, merged)
+        if (result.isError) {
+          setState("failed")
+          setErrorMessage(result.content[0]?.text ?? "tool returned isError=true")
+          return
+        }
+        setState("committed")
+        onCommitted?.(result.content[0]?.text)
+        // Close once committed — the noun surface (new run, refreshed
+        // list) is the confirmation, not a lingering dialog.
+        handleOpenChange(false)
+      } catch (err) {
+        setState("failed")
+        setErrorMessage(errorText(err))
+      }
+    },
+    [args, toolName, onCommitted, handleOpenChange],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {/* The HitlCard carries the visible title; the dialog header is
+            screen-reader-only so the primitive owns the visual heading. */}
+        <DialogHeader className="sr-only">
+          <DialogTitle>{card?.title ?? "Confirm action"}</DialogTitle>
+          <DialogDescription>
+            Review this action and confirm before it runs.
+          </DialogDescription>
+        </DialogHeader>
+        {card ? (
+          <HitlCard
+            card={card}
+            state={state}
+            errorMessage={errorMessage}
+            onCommit={handleCommit}
+            onReject={() => handleOpenChange(false)}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            This action can&apos;t be reviewed — `{toolName}` is not in the
+            dashboard&apos;s tool registry.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export interface HitlActionButtonProps {
+  toolName: string
+  args: Record<string, unknown>
+  /** Button content (icon + label). */
+  children: ReactNode
+  onCommitted?: (resultText: string | undefined) => void
+  variant?: "default" | "outline" | "ghost" | "destructive" | "secondary"
+  size?: "sm" | "default" | "icon"
+  className?: string
+  disabled?: boolean
+  /** Accessible name for the trigger button (required for icon-only). */
+  ariaLabel?: string
+}
+
+/**
+ * Button that opens a {@link HitlActionDialog} for one mutation tool.
+ * The common case behind the "Run a batch" / "Run" affordances.
+ */
+export function HitlActionButton({
+  toolName,
+  args,
+  children,
+  onCommitted,
+  variant = "default",
+  size = "sm",
+  className,
+  disabled,
+  ariaLabel,
+}: HitlActionButtonProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        className={className}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onClick={() => setOpen(true)}
+        data-slot="hitl-action-button"
+        data-tool={toolName}
+      >
+        {children}
+      </Button>
+      <HitlActionDialog
+        open={open}
+        onOpenChange={setOpen}
+        toolName={toolName}
+        args={args}
+        onCommitted={onCommitted}
+      />
+    </>
+  )
+}
+
+function errorText(err: unknown): string {
+  if (err instanceof McpClientError) return `MCP error (${err.code}): ${err.message}`
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -19,6 +19,7 @@ import { ChatUiProvider } from "@/lib/chat/use-chat-ui"
 import { ChatContainer } from "@/components/chat/ChatContainer"
 import { ChatFab } from "@/components/chat/ChatFab"
 import { ChatBell } from "@/components/chat/ChatBell"
+import { DesktopChatEntry } from "@/components/chat/DesktopChatEntry"
 import { ChatDeepLinkHandler } from "@/components/chat/ChatDeepLinkHandler"
 import { cn } from "@/lib/utils"
 
@@ -37,6 +38,11 @@ interface TopTab {
 const TOP_TABS: TopTab[] = [
   { key: "workflows", label: "Workflows", path: "workflows" },
   { key: "runs", label: "Runs", path: "runs" },
+  // "Plans" is the noun-surface home for persisted spec plans (ADR 0023
+  // / 0025, spec #514) — the launch surface that stops chat being the
+  // sole spec-plan-run path. It is a sanctioned 5th nav noun; see the
+  // vocabulary carve-out in the root CLAUDE.md.
+  { key: "spec-plans", label: "Plans", path: "spec-plans" },
   { key: "activity", label: "Activity", path: "activity" },
 ]
 
@@ -110,6 +116,7 @@ function DesktopTopChrome() {
       <Separator orientation="vertical" className="h-6" />
       <TopTabs />
       <div className="ml-auto flex items-center gap-1">
+        <DesktopChatEntry />
         <ChatBell />
         <CommandPaletteTrigger />
         <UserMenu variant="icon" />

--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
   Building2,
   GitBranch,
   MessageSquare,
+  Rocket,
   Search,
   Settings as SettingsIcon,
   Terminal,
@@ -242,6 +243,10 @@ function CommandPaletteDialog() {
               <CommandItem onSelect={() => go(scoped("runs"))}>
                 <Activity className="mr-2 h-4 w-4" />
                 Runs
+              </CommandItem>
+              <CommandItem onSelect={() => go(scoped("spec-plans"))}>
+                <Rocket className="mr-2 h-4 w-4" />
+                Plans
               </CommandItem>
               <CommandItem onSelect={() => go(scoped("activity"))}>
                 <Zap className="mr-2 h-4 w-4" />

--- a/apps/dashboard/src/components/workflows/WorkflowActions.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowActions.tsx
@@ -3,6 +3,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
 import { MoreHorizontal, Pause, Play, Rocket, Trash2 } from "lucide-react"
 import { api, type Workflow } from "@/lib/api"
+import {
+  HitlActionButton,
+  HitlActionDialog,
+} from "@/components/chat/HitlActionButton"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -28,6 +32,15 @@ import {
 // for confirmation in a modal — a workflow is durable state with a
 // webhook and a label side effect, not a typo.
 //
+// The "Run a batch" affordance (ADR 0024 / 0025, spec #514) gates on the
+// `readiness` axis, not `active`: a `ready + off` (manual-only) workflow
+// is a first-class state that still earns the button. The button only
+// applies to manual-trigger workflows — `run_workflow` requires a
+// `TriggerKind::Manual` binding — so a non-manual `ready` workflow shows
+// no manual-run button (it fires on its own trigger). The mutation
+// routes through a `HitlCard` (HITL principle 1), reusing the shared
+// `run_workflow` MCP path rather than the REST manual-trigger endpoint.
+//
 // `variant`:
 //   - "buttons" (default): full-width labeled buttons. Used in the
 //     desktop page-level header block.
@@ -47,20 +60,23 @@ export function WorkflowActions({
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const [confirming, setConfirming] = useState(false)
+  const [runOpen, setRunOpen] = useState(false)
 
   const isActive = workflow.status === "active"
   const isManualTrigger = workflow.trigger.kind_tag === "manual"
   const manualName = workflow.trigger.manual_name ?? ""
+  // ADR 0024: `ready` (any trigger binding), not `active`, earns the run
+  // button. `run_workflow` needs a `Manual` trigger, so the affordance is
+  // manual-trigger-only.
+  const canRunBatch =
+    workflow.readiness === "ready" && isManualTrigger && manualName !== ""
 
-  const fireManual = useMutation({
-    mutationFn: () => api.fireManualTrigger(workflow.id, manualName),
-    onSuccess: () => {
-      // The trigger.fired event lands within ~50ms; refresh runs so
-      // the new artifact appears without waiting for the 5s poll.
-      queryClient.invalidateQueries({ queryKey: ["workflow-runs", workflow.id] })
-      queryClient.invalidateQueries({ queryKey: ["spine-events"] })
-    },
-  })
+  const onRunCommitted = () => {
+    // The trigger.fired event lands within ~50ms; refresh runs so the
+    // new artifact appears without waiting for the 5s poll.
+    queryClient.invalidateQueries({ queryKey: ["workflow-runs", workflow.id] })
+    queryClient.invalidateQueries({ queryKey: ["spine-events"] })
+  }
 
   const toggle = useMutation({
     mutationFn: (active: boolean) => api.setWorkflowActive(workflow.id, active),
@@ -103,13 +119,10 @@ export function WorkflowActions({
           <MoreHorizontal className="h-5 w-5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
-          {isManualTrigger && isActive && (
-            <DropdownMenuItem
-              disabled={fireManual.isPending}
-              onClick={() => fireManual.mutate()}
-            >
+          {canRunBatch && (
+            <DropdownMenuItem onClick={() => setRunOpen(true)}>
               <Rocket className="mr-2 h-4 w-4" />
-              {fireManual.isPending ? "Firing…" : "Run now"}
+              Run a batch
             </DropdownMenuItem>
           )}
           <DropdownMenuItem
@@ -133,17 +146,17 @@ export function WorkflowActions({
         className="flex flex-wrap items-center gap-2"
         data-testid="workflow-actions"
       >
-        {isManualTrigger && isActive && (
-          <Button
-            type="button"
+        {canRunBatch && (
+          <HitlActionButton
+            toolName="run_workflow"
+            args={{ workflow_id: workflow.id, trigger_name: manualName }}
+            onCommitted={onRunCommitted}
             variant="default"
             size="sm"
-            disabled={fireManual.isPending}
-            onClick={() => fireManual.mutate()}
           >
             <Rocket className="h-4 w-4" />
-            {fireManual.isPending ? "Firing…" : "Run now"}
-          </Button>
+            Run a batch
+          </HitlActionButton>
         )}
         <Button
           type="button"
@@ -171,19 +184,23 @@ export function WorkflowActions({
               : "Failed to update workflow"}
           </p>
         )}
-        {fireManual.isError && (
-          <p className="w-full text-xs text-destructive">
-            {fireManual.error instanceof Error
-              ? fireManual.error.message
-              : "Run now failed"}
-          </p>
-        )}
       </div>
     )
 
   return (
     <>
       {controls}
+      {/* Menu-variant run trigger opens this controlled review dialog;
+          the buttons variant uses its own HitlActionButton inline. */}
+      {variant === "menu" && canRunBatch && (
+        <HitlActionDialog
+          open={runOpen}
+          onOpenChange={setRunOpen}
+          toolName="run_workflow"
+          args={{ workflow_id: workflow.id, trigger_name: manualName }}
+          onCommitted={onRunCommitted}
+        />
+      )}
       <Dialog open={confirming} onOpenChange={setConfirming}>
         <DialogContent>
           <DialogHeader>

--- a/apps/dashboard/src/lib/chat/use-auto-scope.ts
+++ b/apps/dashboard/src/lib/chat/use-auto-scope.ts
@@ -11,20 +11,29 @@ import {
   writePinnedScope,
 } from "./pinned-scope"
 
-// Route → scope mapping (ADR 0020 § Contextual auto-scope).
+// Route → default chat scope (ADR 0020 § Contextual auto-scope,
+// *narrowed* by ADR 0025 § Chat's scope narrows to two jobs, spec #514).
 //
-// Workflows tab list      → workspace
-// Workflow detail         → workflow:{id}
-// Cross-workflow runs     → workspace
-// Run detail              → run:{runId}
-// Verdict detail (future) → verdict:{verdictId}
-// Activity / settings /…  → workspace
+// ADR 0025 names chat's two jobs: **design** (authoring/drafting, which
+// happens at the workspace level — the CAD bench) and **maintenance**
+// (incident handling on a specific run — scope=run). The default scope a
+// bare route resolves to is therefore one of exactly two kinds:
 //
-// Verdicts don't have a dedicated route today (they live inside the
-// run-detail surface); the verdict scope is reserved for when the
-// `/runs/:runId?verdict=…` deep link or a future verdict-detail page
-// lands. The hook also reads `?verdict=` off the run-detail surface so
-// invocation channels that pass it (#472) get the right scope.
+//   Run detail              → run:{runId}      (maintenance)
+//   Everything else          → workspace        (design)
+//
+// A workflow detail page no longer auto-scopes to `workflow:{id}` — a
+// workflow is *designed* at the workspace level, not maintained from its
+// detail route, so the route default folds into the design (workspace)
+// surface. The `workflow` scope still exists for the explicit
+// `ChatAskButton` override ("Ask about this workflow"); it just isn't a
+// route *default* any more. That keeps the resolver to design +
+// maintenance only.
+//
+// `?verdict=` is a maintenance sub-scope of a run, carried explicitly by
+// invocation channels (push notifications, scope-local Ask on verdict
+// cards, #472) — it is an override the resolver honours, never a bare
+// route default.
 //
 // Routes outside `/workspaces/:slug/*` (account settings, picker) fall
 // back to the workspace scope of the resolved workspace; if there is
@@ -39,28 +48,19 @@ export function deriveAutoScope(pathname: string, search: string): ChatScope {
   if (!wsMatch) return WORKSPACE_SCOPE
   const rest = wsMatch[1] ?? ""
 
-  // Verdict deep link wins on any sub-route — invocation channels
-  // (push notifications, scope-local Ask on verdict cards) carry it
-  // explicitly.
+  // Verdict deep link wins on any sub-route — a maintenance sub-scope
+  // carried explicitly by invocation channels.
   if (verdictId) return { type: "verdict", id: verdictId }
 
-  // Workflow detail. Excludes `/workflows/start` (creation surface,
-  // which is workspace-scoped).
-  const wfMatch = rest.match(/^\/workflows\/([^/]+)$/)
-  if (wfMatch && wfMatch[1] !== "start") {
-    return { type: "workflow", id: wfMatch[1] }
-  }
-
-  // Run detail.
+  // Maintenance — run detail is the one route that scopes to a run.
   const runMatch = rest.match(/^\/runs\/([^/]+)$/)
   if (runMatch) {
     return { type: "run", id: runMatch[1] }
   }
 
-  // Everything else under the workspace — workflows list, runs list,
-  // activity, settings, artifact detail, issue detail — is workspace
-  // scope per the ADR's "tab switch preserves scope at current level"
-  // rule.
+  // Design — everything else under the workspace (workflows list +
+  // detail, runs list, plans, activity, settings, artifact detail)
+  // resolves to the workspace authoring thread.
   return WORKSPACE_SCOPE
 }
 

--- a/apps/dashboard/src/pages/SpecPlansPage.tsx
+++ b/apps/dashboard/src/pages/SpecPlansPage.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { AlertTriangle, ChevronDown, ChevronRight, Rocket } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { HitlActionButton } from "@/components/chat/HitlActionButton"
+import { SpecPlanDAG } from "@/components/chat/SpecPlanDAG"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { mcpCallTool } from "@/lib/mcp-client"
+import type { SpecPlan } from "@/lib/spec-plan"
+import { useActiveWorkspace } from "@/lib/workspace"
+
+// Spec Plans surface (ADR 0023 / 0025, spec #514). The noun-surface home
+// for persisted spec plans: a list, each row with a HitlCard-routed "Run"
+// button (`run_spec_plan`). Plans are *authored* in chat (the design
+// surface, ADR 0025 F1) but no longer *only* runnable there — this page
+// is the launch + monitor entry ADR 0025 requires so chat stops being
+// the sole spec-plan-run path.
+//
+// Listing is MCP-only today (`list_spec_plans`; no REST mirror), so the
+// page talks same-origin to the MCP server the same way ChatBuilder
+// does. Plan bodies render their authored DAG on demand via the shared
+// `SpecPlanDAG` primitive.
+
+interface StoredSpecPlan {
+  workspace_id: string
+  spec_plan_id: string
+  plan: SpecPlan
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+function parsePlans(text: string | undefined): StoredSpecPlan[] {
+  if (!text) return []
+  try {
+    const parsed = JSON.parse(text) as { spec_plans?: StoredSpecPlan[] }
+    return Array.isArray(parsed.spec_plans) ? parsed.spec_plans : []
+  } catch {
+    return []
+  }
+}
+
+function planShape(plan: SpecPlan): string {
+  const specs = plan.specs?.length ?? 0
+  const deps = plan.deps?.length ?? 0
+  return `${specs} spec${specs === 1 ? "" : "s"}, ${deps} dep${deps === 1 ? "" : "s"}`
+}
+
+export function SpecPlansPage() {
+  const workspace = useActiveWorkspace()
+  usePageHeader({
+    title: "Spec Plans",
+    backTo: `/workspaces/${workspace.slug}/workflows`,
+  })
+
+  const plansQuery = useQuery({
+    queryKey: ["spec-plans", workspace.id],
+    queryFn: async () => {
+      const res = await mcpCallTool("list_spec_plans", {
+        workspace_id: workspace.id,
+      })
+      if (res.isError) {
+        throw new Error(res.content[0]?.text ?? "Failed to list spec plans")
+      }
+      return parsePlans(res.content[0]?.text)
+    },
+  })
+
+  const plans = plansQuery.data ?? []
+
+  return (
+    <div className="space-y-6">
+      <div className="hidden space-y-1 md:block">
+        <h1 className="text-2xl font-bold tracking-tight">Spec Plans</h1>
+        <p className="text-sm text-muted-foreground">
+          Authored in chat, runnable here. Each plan compiles to a DAG of
+          specs and runs them in dependency order.
+        </p>
+      </div>
+
+      {plansQuery.isLoading ? (
+        <LoadingState />
+      ) : plansQuery.isError ? (
+        <ErrorState message={(plansQuery.error as Error).message} />
+      ) : plans.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ul className="space-y-3">
+          {plans.map((p) => (
+            <li key={p.spec_plan_id}>
+              <SpecPlanRow
+                plan={p}
+                workspaceId={workspace.id}
+                onRan={() => plansQuery.refetch()}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function SpecPlanRow({
+  plan,
+  workspaceId,
+  onRan,
+}: {
+  plan: StoredSpecPlan
+  workspaceId: string
+  onRan: () => void
+}) {
+  const [showGraph, setShowGraph] = useState(false)
+  const kinds = useMemo(
+    () => Array.from(new Set((plan.plan.specs ?? []).map((s) => s.kind))),
+    [plan.plan.specs],
+  )
+  return (
+    <Card>
+      <CardHeader className="px-4 pb-2 pt-4 md:px-6">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="truncate font-mono text-base">
+              {plan.spec_plan_id}
+            </CardTitle>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {planShape(plan.plan)}
+              {kinds.length > 0 ? ` · ${kinds.join(", ")}` : ""}
+            </p>
+          </div>
+          <HitlActionButton
+            toolName="run_spec_plan"
+            args={{ workspace_id: workspaceId, spec_plan_id: plan.spec_plan_id }}
+            onCommitted={onRan}
+            variant="default"
+            size="sm"
+            className="shrink-0"
+          >
+            <Rocket className="h-4 w-4" />
+            Run
+          </HitlActionButton>
+        </div>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 md:px-6">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+          onClick={() => setShowGraph((v) => !v)}
+          aria-expanded={showGraph}
+        >
+          {showGraph ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          {showGraph ? "Hide graph" : "View graph"}
+        </Button>
+        {showGraph ? (
+          <div className="mt-2 rounded-md border">
+            <SpecPlanDAG plan={plan.plan} />
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-3">
+      {[0, 1].map((i) => (
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-muted/60" />
+      ))}
+    </div>
+  )
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <span>Could not load spec plans — {message}</span>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-2 py-10 text-center text-sm text-muted-foreground">
+        <Rocket className="h-8 w-8 text-muted-foreground/50" />
+        <div>No spec plans yet.</div>
+        <div className="max-w-sm text-xs text-muted-foreground/80">
+          Spec plans are authored in chat — open the chat and describe the
+          batch of specs you want to run. Submitted plans show up here,
+          ready to launch.
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/tests/smoke/chat-container.test.tsx
+++ b/apps/dashboard/tests/smoke/chat-container.test.tsx
@@ -218,7 +218,11 @@ describe("ChatContainer", () => {
     expect(nav.textContent).toContain("acme")
   })
 
-  it("calls getThread with the workflow scope on workflow detail", async () => {
+  it("defaults to workspace (design) scope on workflow detail", async () => {
+    // ADR 0025 / #514: a workflow's detail route no longer auto-scopes
+    // to workflow:{id} — it folds into the workspace design thread. The
+    // workflow scope survives only as an explicit ChatAskButton override
+    // (see chat-ask-button.test.tsx), not as a route default.
     mountAt("/workspaces/acme/workflows/wf-1")
     await act(async () => {
       fireEvent.click(await screen.findByTestId("open-chat"))
@@ -229,8 +233,7 @@ describe("ChatContainer", () => {
       await new Promise((r) => setTimeout(r, 0))
     })
     expect(apiMock.getThread).toHaveBeenCalledWith("ws-1", {
-      scope_type: "workflow",
-      scope_id: "wf-1",
+      scope_type: "workspace",
     })
   })
 
@@ -254,7 +257,8 @@ describe("ChatContainer", () => {
     await act(async () => {
       fireEvent.click(await screen.findByTestId("open-chat"))
     })
-    // Confirm scope is workflow.
+    // Confirm scope is the workspace design thread (workflow detail now
+    // folds into workspace scope per ADR 0025 / #514).
     const nav = await screen.findByRole("navigation", { name: /chat scope/i })
     expect(nav.textContent).toContain("acme")
     // Click pin.
@@ -267,7 +271,7 @@ describe("ChatContainer", () => {
     // localStorage carries the pinned scope.
     expect(
       window.localStorage.getItem("onsager.chat.pinned_scope.user-1.ws-1"),
-    ).toBe("workflow:wf-1")
+    ).toBe("workspace")
 
     // Rerender wouldn't actually move the route; in jsdom we rely on
     // the localStorage assertion + button-state assertion above to

--- a/apps/dashboard/tests/smoke/desktop-chat-entry.test.tsx
+++ b/apps/dashboard/tests/smoke/desktop-chat-entry.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, act } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { DesktopChatEntry } from "@/components/chat/DesktopChatEntry"
+import { ChatBell } from "@/components/chat/ChatBell"
+import { ChatContainer } from "@/components/chat/ChatContainer"
+import { ChatUiProvider } from "@/lib/chat/use-chat-ui"
+import { WorkspaceScope } from "@/lib/workspace"
+
+// ADR 0025 / spec #514: the labeled desktop chat entry opens the
+// conversation surface (Thread tab) at workspace scope — distinct from
+// the bell, which stays the Inbox/Queue counter. Both are asserted here.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "user-1", login: "tester" }, authEnabled: true }),
+}))
+
+const apiMock = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  getThread: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return {
+    ...actual,
+    api: { ...actual.api, listWorkspaces: apiMock.listWorkspaces },
+  }
+})
+
+vi.mock("@/lib/api/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/chat")>(
+    "@/lib/api/chat",
+  )
+  return {
+    ...actual,
+    chat: {
+      getThread: apiMock.getThread,
+      appendMessage: vi.fn(),
+      search: vi.fn(),
+    },
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiMock.listWorkspaces.mockResolvedValue({
+    workspaces: [
+      {
+        id: "ws-1",
+        slug: "acme",
+        name: "Acme",
+        account: "acme",
+        account_type: "organization" as const,
+      },
+    ],
+  })
+  apiMock.getThread.mockResolvedValue({
+    thread: {
+      id: "t-1",
+      user_id: "user-1",
+      workspace_id: "ws-1",
+      scope_type: "workspace",
+      scope_id: null,
+      created_at: "",
+      updated_at: "",
+    },
+    messages: [],
+  })
+})
+
+function mount() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/workspaces/acme/workflows"]}>
+        <ChatUiProvider>
+          <Routes>
+            <Route
+              path="/workspaces/:workspace/*"
+              element={
+                <WorkspaceScope>
+                  <DesktopChatEntry />
+                  <ChatBell />
+                  <Routes>
+                    <Route path="workflows" element={<div />} />
+                  </Routes>
+                </WorkspaceScope>
+              }
+            />
+          </Routes>
+          <ChatContainer />
+        </ChatUiProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("DesktopChatEntry (spec #514)", () => {
+  it("opens the chat at workspace scope on the Thread tab", async () => {
+    mount()
+    const entry = await screen.findByRole("button", { name: /open chat/i })
+    await act(async () => {
+      fireEvent.click(entry)
+    })
+    await screen.findByRole("dialog", { name: /onsager chat/i })
+
+    const thread = screen.getByRole("tab", { name: /thread/i })
+    expect(
+      thread.getAttribute("data-state") ?? thread.getAttribute("aria-selected"),
+    ).toMatch(/active|true/)
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(apiMock.getThread).toHaveBeenCalledWith("ws-1", {
+      scope_type: "workspace",
+    })
+  })
+
+  it("leaves the bell as the Inbox/Queue entry", async () => {
+    mount()
+    const bell = await screen.findByRole("button", { name: /open inbox/i })
+    await act(async () => {
+      fireEvent.click(bell)
+    })
+    await screen.findByRole("dialog", { name: /onsager chat/i })
+    const queue = screen.getByRole("tab", { name: /queue/i })
+    expect(
+      queue.getAttribute("data-state") ?? queue.getAttribute("aria-selected"),
+    ).toMatch(/active|true/)
+  })
+})

--- a/apps/dashboard/tests/smoke/spec-plans-page.test.tsx
+++ b/apps/dashboard/tests/smoke/spec-plans-page.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+
+import { SpecPlansPage } from "@/pages/SpecPlansPage"
+import { WorkspaceScope } from "@/lib/workspace"
+
+// Spec Plans surface (ADR 0023 / 0025, spec #514): the page lists
+// persisted plans (MCP-only `list_spec_plans`) and each row's "Run"
+// button emits `plan.run_requested` via `run_spec_plan` through a
+// HitlCard. The mutation check asserts the exact `mcpCallTool` call.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "user-1" }, authEnabled: false }),
+}))
+
+const apiMock = vi.hoisted(() => ({ listWorkspaces: vi.fn() }))
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api")
+  return {
+    ...actual,
+    api: { ...actual.api, listWorkspaces: apiMock.listWorkspaces },
+  }
+})
+
+const mcpMock = vi.hoisted(() => ({ mcpCallTool: vi.fn() }))
+vi.mock("@/lib/mcp-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/mcp-client")>("@/lib/mcp-client")
+  return { ...actual, mcpCallTool: mcpMock.mcpCallTool }
+})
+
+const PLANS = {
+  spec_plans: [
+    {
+      workspace_id: "ws_1",
+      spec_plan_id: "plan-alpha",
+      plan: {
+        specs: [{ id: "s1", kind: "Issue" }],
+        deps: [],
+      },
+      created_by: "user-1",
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiMock.listWorkspaces.mockResolvedValue({
+    workspaces: [
+      {
+        id: "ws_1",
+        slug: "acme",
+        name: "Acme",
+        account: "acme",
+        account_type: "organization" as const,
+      },
+    ],
+  })
+  mcpMock.mcpCallTool.mockImplementation((name: string) => {
+    if (name === "list_spec_plans") {
+      return Promise.resolve({
+        content: [{ type: "text", text: JSON.stringify(PLANS) }],
+        isError: false,
+      })
+    }
+    if (name === "run_spec_plan") {
+      return Promise.resolve({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              spec_plan_id: "plan-alpha",
+              workspace_id: "ws_1",
+              plan_id: "run-xyz",
+              run_requested_event_id: 9,
+            }),
+          },
+        ],
+        isError: false,
+      })
+    }
+    return Promise.resolve({ content: [], isError: false })
+  })
+})
+
+function mount() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/workspaces/acme/spec-plans"]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route path="spec-plans" element={<SpecPlansPage />} />
+                </Routes>
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("SpecPlansPage (spec #514)", () => {
+  it("lists persisted plans and runs one via run_spec_plan", async () => {
+    mount()
+
+    // The persisted plan renders.
+    await screen.findByText("plan-alpha")
+    expect(mcpMock.mcpCallTool).toHaveBeenCalledWith("list_spec_plans", {
+      workspace_id: "ws_1",
+    })
+
+    // Run → HitlCard review dialog → commit.
+    const runBtn = screen.getByRole("button", { name: "Run" })
+    await act(async () => {
+      fireEvent.click(runBtn)
+    })
+    const commit = await screen.findByRole("button", { name: /run plan/i })
+    await act(async () => {
+      fireEvent.click(commit)
+    })
+
+    await waitFor(() => {
+      expect(mcpMock.mcpCallTool).toHaveBeenCalledWith("run_spec_plan", {
+        workspace_id: "ws_1",
+        spec_plan_id: "plan-alpha",
+      })
+    })
+  })
+
+  it("shows an empty state when there are no plans", async () => {
+    mcpMock.mcpCallTool.mockResolvedValueOnce({
+      content: [{ type: "text", text: JSON.stringify({ spec_plans: [] }) }],
+      isError: false,
+    })
+    mount()
+    await screen.findByText(/no spec plans yet/i)
+  })
+})

--- a/apps/dashboard/tests/smoke/workflow-run-batch.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-run-batch.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+
+import { WorkflowActions } from "@/components/workflows/WorkflowActions"
+import type { Workflow } from "@/lib/api"
+
+// ADR 0024 / 0025, spec #514: the "Run a batch" button gates on the
+// `readiness` axis (not `active`) and routes through a HitlCard +
+// `run_workflow` MCP tool. The mutation check below asserts the exact
+// `mcpCallTool` invocation — breaking the args wiring fails the test.
+
+const mcpMock = vi.hoisted(() => ({ mcpCallTool: vi.fn() }))
+
+vi.mock("@/lib/mcp-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/mcp-client")>("@/lib/mcp-client")
+  return { ...actual, mcpCallTool: mcpMock.mcpCallTool }
+})
+
+function manualWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "wf_1",
+    workspace_id: "ws_1",
+    name: "Nightly batch",
+    preset: null,
+    status: "active",
+    readiness: "ready",
+    autofire: "off",
+    trigger: {
+      kind: "github-label",
+      install_id: "",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      label: "",
+      kind_tag: "manual",
+      manual_name: "nightly",
+    },
+    stages: [],
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function renderActions(workflow: Workflow) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <WorkflowActions workflow={workflow} variant="buttons" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("WorkflowActions — Run a batch (spec #514)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mcpMock.mcpCallTool.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            workflow_id: "wf_1",
+            trigger_event_id: 7,
+            fired_at: "2026-05-30T00:00:00Z",
+          }),
+        },
+      ],
+      isError: false,
+    })
+  })
+
+  it("shows the button for a ready manual workflow and fires run_workflow", async () => {
+    renderActions(manualWorkflow())
+
+    const runBtn = screen.getByRole("button", { name: /run a batch/i })
+    await act(async () => {
+      fireEvent.click(runBtn)
+    })
+
+    // The HitlCard review dialog renders the destructive commit button.
+    const commit = await screen.findByRole("button", { name: /run workflow/i })
+    await act(async () => {
+      fireEvent.click(commit)
+    })
+
+    await waitFor(() => {
+      expect(mcpMock.mcpCallTool).toHaveBeenCalledWith("run_workflow", {
+        workflow_id: "wf_1",
+        trigger_name: "nightly",
+      })
+    })
+  })
+
+  it("hides the button for a drafted workflow (gate on readiness)", () => {
+    renderActions(manualWorkflow({ readiness: "drafted" }))
+    expect(
+      screen.queryByRole("button", { name: /run a batch/i }),
+    ).toBeNull()
+  })
+
+  it("hides the button for a non-manual ready workflow", () => {
+    renderActions(
+      manualWorkflow({
+        trigger: {
+          kind: "github-label",
+          install_id: "42",
+          repo_owner: "onsager-ai",
+          repo_name: "onsager",
+          label: "factory",
+          kind_tag: "github_issue_webhook",
+          manual_name: "",
+        },
+      }),
+    )
+    expect(
+      screen.queryByRole("button", { name: /run a batch/i }),
+    ).toBeNull()
+  })
+})

--- a/apps/dashboard/tests/unit/chat-auto-scope.test.tsx
+++ b/apps/dashboard/tests/unit/chat-auto-scope.test.tsx
@@ -1,13 +1,14 @@
 import { describe, it, expect } from "vitest"
 import { deriveAutoScope } from "@/lib/chat/use-auto-scope"
 
-// Route → scope mapping (ADR 0020 § Contextual auto-scope, spec #471
-// Plan: "Hook test: route → scope mapping for each of the four scope
-// types"). The hook itself is route-reactive — the pure derivation is
-// unit-tested here; the React-level pin/unpin behavior is covered by
-// the smoke tests.
+// Route → default chat scope (ADR 0020 § Contextual auto-scope, narrowed
+// by ADR 0025 § Chat's scope narrows to two jobs, spec #514). The default
+// scope a bare route resolves to is design (workspace) or maintenance
+// (run / verdict) — never a workflow scope. The `workflow` scope survives
+// only as an explicit ChatAskButton override, exercised in the smoke
+// tests, not as a route default.
 
-describe("deriveAutoScope", () => {
+describe("deriveAutoScope (design + maintenance only)", () => {
   it("maps the workflows list to workspace scope", () => {
     expect(deriveAutoScope("/workspaces/acme/workflows", "")).toEqual({
       type: "workspace",
@@ -15,11 +16,23 @@ describe("deriveAutoScope", () => {
     })
   })
 
-  it("maps the workflow detail to workflow:{id}", () => {
+  it("maps workflow detail to workspace (design), not workflow scope", () => {
+    // ADR 0025: a workflow is *designed* at the workspace level; its
+    // detail route no longer auto-scopes to workflow:{id}.
     expect(deriveAutoScope("/workspaces/acme/workflows/wf-1", "")).toEqual({
-      type: "workflow",
-      id: "wf-1",
+      type: "workspace",
+      id: null,
     })
+  })
+
+  it("never returns a workflow scope from any bare route", () => {
+    for (const path of [
+      "/workspaces/acme/workflows/wf-1",
+      "/workspaces/acme/workflows/start",
+      "/workspaces/acme/spec-plans",
+    ]) {
+      expect(deriveAutoScope(path, "").type).not.toBe("workflow")
+    }
   })
 
   it("does not treat /workflows/start as a workflow scope", () => {

--- a/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
+++ b/docs/adr/0020-chat-as-portable-global-component-with-contextual-auto-scope.md
@@ -6,7 +6,7 @@
 - **Tracking issues**: #451 (implementation spec). Sibling to ADR 0019, which removes the top-level Chat tab. This ADR governs what chat *becomes* once it is no longer a tab. Builds on ADR 0007 (tools and skills as the public contract) and ADR 0008 (portal owns the agent control plane).
 - **Supersedes**: none. Predecessor specs (#398 universal-chat-entry, #400 chat empty-state chips, #401 DraftStrip + chat surface) are the prior frame in prose; the repo convention reserves the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
 - **Superseded by**: none
-- **Amended by**: ADR 0025 (2026-05-29) — names chat's dashboard role as design + maintenance (not a pure interchangeable frontend) and adds a labeled desktop entry. The responsive-mount, auto-scope, pin, and storage decisions below are unchanged.
+- **Amended by**: ADR 0025 (2026-05-29) — names chat's dashboard role as design + maintenance (not a pure interchangeable frontend) and adds a labeled desktop entry. The responsive-mount, auto-scope *mechanism* (the hook, pin override, storage schema) is unchanged; the route → default-scope *table* below is narrowed to design (workspace) + maintenance (run / verdict) by ADR 0025 / spec #514 — a workflow detail route no longer auto-scopes to `workflow:{id}` (that scope survives only as an explicit Ask override).
 
 ## Context
 

--- a/docs/adr/0024-workflow-lifecycle-orthogonal-readiness-autofire-axes.md
+++ b/docs/adr/0024-workflow-lifecycle-orthogonal-readiness-autofire-axes.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-05-29
 - **Identity impact**: no
-- **Adoption**: ongoing
+- **Adoption**: enforced
 - **Tracking issues**: #506 (umbrella spec). Supersedes the `(active, install_id)` status-derivation introduced under ADR 0019 / spec #456.
 - **Supersedes**: none at the ADR level. The `(active, install_id)`-derived `WorkflowStatus` is a code shortcut taken under ADR 0019; this ADR replaces that shortcut, not ADR 0019's IA decision.
 - **Superseded by**: none
@@ -83,8 +83,8 @@ Per ADR 0002, the dev-process analog of the two axes is the split between a spec
 - [x] Phase 1 — reroute token minting / webhook-secret resolution through `workflow → trigger binding → project → installation`; keep `workflows.install_id` only as an optional mint cache, out of the status path. `Workflow.install_id` is now `Option<i64>` (nullable column, NULL-tolerant read), and `activate_workflow` / `deactivate_workflow` resolve the install via `pick_install_id` — `(workspace_id, repo) → projects.github_app_installation_id`, with the cached column as fallback. (#506)
 - [x] Phase 1 — remove the `install_id is required` create gate; a Manual/Telegram/Schedule workflow is creatable and can reach `ready`. `POST /api/workflows` now takes a structured `trigger: TriggerKind` (the registry union, matching the MCP create path); the `github_issue_webhook`-only gate is gone and any registry trigger kind is accepted. (spec #509)
 - [x] Phase 1 — remap `apps/dashboard/src/components/workflows/WorkflowStatusChips.tsx` to the two axes; leave the spec #404 FTUE funnel events untouched. The chip strip is now two independent filter groups (readiness: Drafted/Ready; autofire: Manual/Active/Paused) backed by the list endpoint's independent `readiness` + `autofire` params and per-axis counts. (spec #509)
-- [ ] Phase 3 — `ready` workflows earn the manual "run a batch" button (reuse `run_spec_plan` / `run_workflow`); no button-time gate.
-- [ ] Flip `Adoption` to `enforced` and tick the boxes once Phases 1 + 3 land.
+- [x] Phase 3 — `ready` workflows earn the manual "run a batch" button (reuse `run_spec_plan` / `run_workflow`); no button-time gate. The button gates on `readiness === "ready"` and routes through a `HitlCard` + `run_workflow` (manual-trigger workflows) — `WorkflowActions`'s legacy REST "Run now" is replaced by it. Persisted spec plans get the same treatment on the Spec Plans surface via `run_spec_plan`. No button-time gate; run-time Verify/HITL owns safety. (spec #514)
+- [x] Flip `Adoption` to `enforced` and tick the boxes once Phases 1 + 3 land. (spec #514)
 
 ## Out of scope
 

--- a/docs/adr/0025-chat-as-design-and-maintenance-surface.md
+++ b/docs/adr/0025-chat-as-design-and-maintenance-surface.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-05-29
 - **Identity impact**: no
-- **Adoption**: ongoing
+- **Adoption**: enforced
 - **Tracking issues**: #506 (umbrella spec). Amends ADR 0020 (chat as portable global component); reconciles ADR 0023 (spec-plan run orchestration).
 - **Supersedes**: none. Amends ADR 0020 — see the note below; the responsive-mount + auto-scope decisions of 0020 stand.
 - **Superseded by**: none
@@ -63,11 +63,11 @@ Per ADR 0002, the dev-process analog: the issue/PR thread is the *design + maint
 ## Adoption checklist
 
 - [x] Decision recorded (this ADR), `Identity impact: no`.
-- [ ] Phase 3 — add a labeled desktop chat entry opening `tab=thread`; keep `ChatBell` as the Inbox/Queue counter; `ChatFab` stays mobile-only.
-- [ ] Phase 3 — add the "run a batch" button to `ready` workflows and persisted spec plans (reuse `run_spec_plan` / `run_workflow`); a routine run is startable without opening chat.
-- [ ] Phase 3 — narrow chat default scope to design (drafted) + maintenance (scope=run); remove chat as the only launch path for spec-plan runs.
-- [ ] Add an "amended by ADR 0025" note to ADR 0020's metadata block.
-- [ ] Flip `Adoption` to `enforced` and tick the boxes once Phase 3 lands.
+- [x] Phase 3 — add a labeled desktop chat entry opening `tab=thread`; keep `ChatBell` as the Inbox/Queue counter; `ChatFab` stays mobile-only. `DesktopChatEntry` (MessageSquare + "Chat" + `⌘J` hint) mounts in the desktop top chrome and opens `{ scope: workspace, tab: thread }`. (spec #514)
+- [x] Phase 3 — add the "run a batch" button to `ready` workflows and persisted spec plans (reuse `run_spec_plan` / `run_workflow`); a routine run is startable without opening chat. `HitlActionButton` is the standalone HitlCard host (page button → review dialog → `mcpCallTool`); it backs the workflow "Run a batch" and the Spec Plans surface "Run". (spec #514)
+- [x] Phase 3 — narrow chat default scope to design (drafted) + maintenance (scope=run); remove chat as the only launch path for spec-plan runs. `deriveAutoScope` now resolves bare routes to workspace (design) or run/verdict (maintenance) only — workflow detail folds into workspace; the Spec Plans surface is the noun-surface launch path. (spec #514)
+- [x] Add an "amended by ADR 0025" note to ADR 0020's metadata block. The note names the design/maintenance role, the desktop entry, and the narrowed route → default-scope table.
+- [x] Flip `Adoption` to `enforced` and tick the boxes once Phase 3 lands. (spec #514)
 
 ## Out of scope
 


### PR DESCRIPTION
Closes #514. Carries the UI half deferred from #512, governed by ADR 0024 (a `ready` workflow earns the run button) and ADR 0025 (chat is the design + maintenance surface; routine runs move to the noun surfaces).

## What landed

**1. Standalone HitlCard host (`HitlActionButton` / `HitlActionDialog`).** The page-button counterpart to ChatBuilder's chat-side host: a button opens a review dialog containing the shared `HitlCard` primitive and commits the call through the same `mcpCallTool` path. No new business logic — the card config comes from the existing `mcp-tools.ts` binding (`buildCard`), so the page button and the chat render an identical review surface. This is the "standalone HitlCard host usable from a page button" option from the spec's first Plan item, chosen over wiring tools into `ChatThreadView` because ADR 0025 makes a routine run a noun-surface action, not a conversational one.

**2. Workflow "Run a batch" button.** `WorkflowActions`' legacy REST "Run now" (gated on `active`, via `fireManualTrigger`) is **replaced** by a HitlCard-routed "Run a batch" gated on `readiness === "ready"`, reusing the `run_workflow` MCP tool (HITL principle 1). Because `run_workflow` requires a `TriggerKind::Manual` binding, the button is **manual-trigger only** — a non-manual `ready` workflow (GitHub/schedule) shows no manual-run button and fires on its own trigger. (Confirmed affordance per the spec's open question.)

**3. Spec Plans surface.** A new **`Plans`** top-nav tab + `/workspaces/:slug/spec-plans` page lists persisted plans (listing is MCP-only — `list_spec_plans`), each row with a HitlCard-routed **Run** (`run_spec_plan`) and an on-demand authored DAG. Run-progress monitoring intentionally stays the existing in-chat `SpecPlanRunView` (ADR 0023 F2): ADR 0025 names "folding plan runs into a noun surface" as a deliberate **follow-up**, so this PR ships the launch path (`plan.run_requested`) and leaves the substrate-progress subscriber where the ADR puts it.

**4. Labeled desktop chat entry (`DesktopChatEntry`).** A `MessageSquare` + "Chat" + `⌘J` button in the desktop top chrome opening `{ scope: workspace, tab: thread }` — the design/maintenance surface, distinct from the bell's Inbox/Queue. `ChatBell` and the mobile `ChatFab` are unchanged.

**5. Narrowed chat default scope.** `deriveAutoScope` now resolves bare routes to design (workspace) or maintenance (run / verdict) only; a workflow detail route no longer auto-scopes to `workflow:{id}` (that scope survives as an explicit "Ask about this workflow" override). The Spec Plans surface removes chat as the sole spec-plan-run launch path.

**6/7. Docs.** ADR 0024 Phase 3 + ADR 0025 three Phase 3 items ticked; both flipped to `Adoption: enforced`. ADR 0020's amended-by note made precise about the narrowed route → default-scope table. CLAUDE.md carries a sanctioned vocabulary carve-out for the `Plans` noun (a substrate spec **plan** ≠ the internal dev-process **spec**), since the spec chose a top-nav tab.

## Tests

New smoke/unit coverage, each with a real mutation check:
- `workflow-run-batch` — ready Manual shows the button and fires `run_workflow` with the exact args; drafted and non-manual `ready` show no button.
- `spec-plans-page` — lists plans and fires `run_spec_plan` with the exact args; empty state.
- `desktop-chat-entry` — entry opens `{workspace, thread}`; the bell still opens Queue.
- `chat-auto-scope` / `chat-container` — updated to assert the narrowed design/maintenance-only resolver.

Green locally: full dashboard suite (248 tests), eslint, `tsc -b`, `vite build`, plus `check-hitl-coverage` (24/24), `check-file-budget` (0 over), `check-api-contract` (clean), and `check-adr-adoption` (0024/0025 drop off the warn list).

## Notes

The REST manual-trigger endpoint and its typed client (`fireManualTrigger`) remain as a programmatic surface (and keep `check-api-contract` satisfied), matching the pre-existing callerless `replayTrigger`; the dashboard's manual-run UI now goes exclusively through the HITL-gated `run_workflow` path.

https://claude.ai/code/session_016ufam4ZCG9UYC2v1FUxRPg

---
_Generated by [Claude Code](https://claude.ai/code/session_016ufam4ZCG9UYC2v1FUxRPg)_