### PR TITLE
Nav redesign (sidebar + mobile drawer) + dev MCP proxy fix

### DIFF
--- a/.claude/skills/dashboard-ui/SKILL.md
+++ b/.claude/skills/dashboard-ui/SKILL.md
@@ -219,11 +219,16 @@ usePageHeader({
 })
 ```
 
-`AppLayout`'s mobile bar renders:
+`AppLayout`'s mobile bar renders (ADR 0026):
 
 ```
-[← backTo OR ☰ sidebar] [title]   [...actions] [+ QuickCreate]
+[← backTo OR ☰ drawer] [title]   [...actions] [⌘K]
 ```
+
+`☰` opens the nav drawer (`MobileNavDrawer`, a left `Sheet` holding the
+same `SidebarBody` as the desktop rail); drill-down pages show `←`
+instead. The bar holds only page actions + the `⌘K` trigger — account
+and the chat/Inbox entries live in the drawer footer, not the bar.
 
 ### Rules
 
@@ -352,13 +357,14 @@ globally.
 
 ## Account / user menu lives in the sidebar footer
 
-The avatar / account dropdown is rendered by `AppSidebar` in its
-`SidebarFooter`, using `<UserMenu variant="row" />`. **Do not add
-another `UserMenu` instance** to a header, page, or any other
+The avatar / account dropdown lives in the footer of `SidebarBody`
+(`AppLayout.tsx`) — the shared body rendered both as the desktop
+`DesktopSidebar` rail and inside the mobile `MobileNavDrawer`. **Do not
+add another `UserMenu` instance** to a header, page, or any other
 surface — there is one account control, in one place, on every
-viewport. Mobile users open the sidebar (`☰` in the chrome bar) to
-reach it; desktop users see it at the bottom of the always-visible
-sidebar. This frees the mobile top bar for page-specific actions.
+viewport. Mobile users open the drawer (`☰` in the chrome bar) to reach
+it; desktop users see it at the bottom of the always-visible sidebar.
+This frees the mobile top bar for page-specific actions.
 
 If you need to surface a sub-action (e.g. "Sign out" from a settings
 page), link the user to `/settings` or use the existing

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -1,8 +1,18 @@
-import type { ReactNode } from "react"
-import { ArrowLeft } from "lucide-react"
+import { useState } from "react"
+import type { ComponentType, ReactNode } from "react"
+import {
+  Activity,
+  ArrowLeft,
+  Menu,
+  Play,
+  Rocket,
+  Settings,
+  Workflow,
+} from "lucide-react"
 import { Link, useLocation } from "react-router-dom"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { OnsagerLogo } from "./OnsagerLogo"
 import {
   CommandPaletteProvider,
@@ -23,28 +33,37 @@ import { DesktopChatEntry } from "@/components/chat/DesktopChatEntry"
 import { ChatDeepLinkHandler } from "@/components/chat/ChatDeepLinkHandler"
 import { cn } from "@/lib/utils"
 
-// Top chrome IA (#453 / ADR 0019). Three tabs — Workflows / Runs /
-// Activity — anchor every workspace surface. The workspace switcher
-// and the avatar/user menu sit in the same row; on narrow viewports
-// the row compresses to a second row that holds the tabs.
+// Nav IA — PROTOTYPE (sidebar on desktop, slide-in drawer on mobile).
+// Supersedes the top-bar-with-tabs chrome (#453 / ADR 0019) for the
+// reasons in #517: the four section tabs could never express Settings /
+// Workspaces, so those pages showed no active item. One sidebar body
+// (`SidebarBody`) renders both as a persistent rail on desktop and the
+// contents of a left off-canvas drawer on mobile (hamburger in the top
+// bar). Every destination gets a first-class home with unambiguous
+// active state. Final shape pending the spec/ADR we agreed to write.
 
-interface TopTab {
+interface NavSection {
   key: string
   label: string
+  icon: ComponentType<{ className?: string }>
   // Path relative to the active workspace root.
   path: string
 }
 
-const TOP_TABS: TopTab[] = [
-  { key: "workflows", label: "Workflows", path: "workflows" },
-  { key: "runs", label: "Runs", path: "runs" },
+const NAV_SECTIONS: NavSection[] = [
+  { key: "workflows", label: "Workflows", icon: Workflow, path: "workflows" },
+  { key: "runs", label: "Runs", icon: Play, path: "runs" },
   // "Plans" is the noun-surface home for persisted spec plans (ADR 0023
   // / 0025, spec #514) — the launch surface that stops chat being the
   // sole spec-plan-run path. It is a sanctioned 5th nav noun; see the
   // vocabulary carve-out in the root CLAUDE.md.
-  { key: "spec-plans", label: "Plans", path: "spec-plans" },
-  { key: "activity", label: "Activity", path: "activity" },
+  { key: "spec-plans", label: "Plans", icon: Rocket, path: "spec-plans" },
+  { key: "activity", label: "Activity", icon: Activity, path: "activity" },
 ]
+
+function isActivePath(pathname: string, target: string): boolean {
+  return pathname === target || pathname.startsWith(`${target}/`)
+}
 
 export function AppLayout({ children }: { children: ReactNode }) {
   // ChatUi is mounted *above* CommandPalette so the palette's chat
@@ -66,20 +85,23 @@ function AppLayoutInner({ children }: { children: ReactNode }) {
   const { fullBleed } = usePageHeaderState()
   return (
     // Pin the shell to the viewport so the inner <main> owns scroll;
-    // html/body are overflow:hidden in index.css.
-    <div className="flex h-svh flex-col overflow-hidden">
-      <DesktopTopChrome />
-      <MobileHeader />
-      <MobileTabsRow />
-      <main
-        className={
-          fullBleed
-            ? "min-h-0 flex-1 overflow-hidden"
-            : "min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] md:p-6 md:pb-6"
-        }
-      >
-        {children}
-      </main>
+    // html/body are overflow:hidden in index.css. Desktop is a sidebar +
+    // content row; on mobile the rail collapses into the drawer and the
+    // content column fills the width.
+    <div className="flex h-svh overflow-hidden">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <MobileHeader />
+        <main
+          className={
+            fullBleed
+              ? "min-h-0 flex-1 overflow-hidden"
+              : "min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] md:p-6 md:pb-6"
+          }
+        >
+          {children}
+        </main>
+      </div>
       {/* Global chat surface (ADR 0020 / spec #471). One responsive
           mount across mobile (bottom-anchored overlay) and desktop
           (right-anchored 420px sidebar). Closed by default; ⌘J, the
@@ -96,110 +118,148 @@ function AppLayoutInner({ children }: { children: ReactNode }) {
   )
 }
 
-function DesktopTopChrome() {
+// The sidebar contents — shared verbatim between the desktop rail and
+// the mobile drawer. The parent (an <aside> or a <SheetContent>) owns
+// the column sizing; this renders the logo, workspace switcher, section
+// links, the Settings entry, and the account/chat footer cluster.
+function SidebarBody({ onNavigate }: { onNavigate?: () => void }) {
   const activeWorkspace = useOptionalActiveWorkspace()
-  const overviewPath = activeWorkspace
-    ? `/workspaces/${activeWorkspace.slug}/workflows`
-    : "/workspaces"
+  const location = useLocation()
+  const linkBase = activeWorkspace
+    ? `/workspaces/${activeWorkspace.slug}`
+    : null
+  const overviewPath = linkBase ? `${linkBase}/workflows` : "/workspaces"
+  // Settings lives in the workspace when we're in one, else the global
+  // account settings. Either way it gets a first-class, highlightable
+  // home in the footer — the gap the old top-tab IA left open.
+  const settingsPath = linkBase ? `${linkBase}/settings` : "/settings"
+  const settingsActive =
+    location.pathname === "/settings" ||
+    location.pathname.endsWith("/settings")
+
   return (
-    <header className="hidden h-14 items-center gap-3 border-b px-4 md:flex md:px-6">
-      <Link
-        to={overviewPath}
-        className="flex shrink-0 items-center gap-2"
-        aria-label="Onsager home"
-      >
-        <OnsagerLogo size={22} />
-        <span className="text-base font-semibold">Onsager</span>
-      </Link>
-      <Separator orientation="vertical" className="h-6" />
-      <WorkspaceSwitcher />
-      <Separator orientation="vertical" className="h-6" />
-      <TopTabs />
-      <div className="ml-auto flex items-center gap-1">
-        <DesktopChatEntry />
-        <ChatBell />
-        <CommandPaletteTrigger />
-        <UserMenu variant="icon" />
+    <>
+      <div className="flex h-14 shrink-0 items-center px-4">
+        <Link
+          to={overviewPath}
+          onClick={onNavigate}
+          className="flex items-center gap-2"
+          aria-label="Onsager home"
+        >
+          <OnsagerLogo size={22} />
+          <span className="text-base font-semibold">Onsager</span>
+        </Link>
       </div>
-    </header>
+      <div className="px-3 pb-3">
+        <WorkspaceSwitcher />
+      </div>
+      <Separator />
+      <nav
+        className="flex-1 space-y-1 overflow-y-auto px-3 py-3"
+        aria-label="Workspace sections"
+      >
+        {NAV_SECTIONS.map((section) => {
+          const path = linkBase ? `${linkBase}/${section.path}` : "/workspaces"
+          const active = linkBase != null && isActivePath(location.pathname, path)
+          const Icon = section.icon
+          return (
+            <Link
+              key={section.key}
+              to={path}
+              onClick={onNavigate}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                buttonVariants({
+                  variant: active ? "default" : "ghost",
+                  size: "sm",
+                }),
+                "w-full justify-start gap-2",
+                !active && "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {section.label}
+            </Link>
+          )
+        })}
+      </nav>
+      <Separator />
+      <div className="space-y-2 px-3 py-3">
+        <Link
+          to={settingsPath}
+          onClick={onNavigate}
+          aria-current={settingsActive ? "page" : undefined}
+          className={cn(
+            buttonVariants({
+              variant: settingsActive ? "default" : "ghost",
+              size: "sm",
+            }),
+            "w-full justify-start gap-2",
+            !settingsActive && "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Settings className="h-4 w-4" />
+          Settings
+        </Link>
+        <div className="flex items-center gap-1">
+          <DesktopChatEntry />
+          <ChatBell />
+          <CommandPaletteTrigger />
+          <div className="ml-auto">
+            <UserMenu variant="icon" />
+          </div>
+        </div>
+      </div>
+    </>
   )
 }
 
-function TopTabs() {
-  const activeWorkspace = useOptionalActiveWorkspace()
-  const location = useLocation()
-  const linkBase = activeWorkspace
-    ? `/workspaces/${activeWorkspace.slug}`
-    : null
+function DesktopSidebar() {
   return (
-    <nav className="flex items-center gap-1" aria-label="Workspace sections">
-      {TOP_TABS.map((tab) => {
-        const path = linkBase ? `${linkBase}/${tab.path}` : "/workspaces"
-        const isActive =
-          linkBase != null &&
-          (location.pathname === path ||
-            location.pathname.startsWith(`${path}/`))
-        return (
-          <Button
-            key={tab.key}
-            variant={isActive ? "default" : "ghost"}
-            size="sm"
-            className={cn(
-              "h-8 px-3 text-sm",
-              !isActive && "text-muted-foreground hover:text-foreground",
-            )}
-            render={<Link to={path} />}
-          >
-            {tab.label}
-          </Button>
-        )
-      })}
-    </nav>
+    <aside className="hidden w-60 shrink-0 flex-col border-r bg-background md:flex">
+      <SidebarBody />
+    </aside>
   )
 }
 
-function MobileTabsRow() {
-  const activeWorkspace = useOptionalActiveWorkspace()
-  const location = useLocation()
-  const linkBase = activeWorkspace
-    ? `/workspaces/${activeWorkspace.slug}`
-    : null
-  // The mobile top bar already owns the page-title + back arrow row;
-  // this second row holds the three workspace tabs so the chrome
-  // matches the desktop IA.
+// Mobile nav drawer — a left off-canvas Sheet holding the same sidebar
+// body. Triggered by the hamburger in the top bar; closes itself on any
+// route change (covers section links, the Settings entry, and workspace
+// switches alike) and on backdrop tap.
+function MobileNavDrawer() {
+  const [open, setOpen] = useState(false)
+  // Selecting a destination closes the drawer (handled per-link via
+  // onNavigate); backdrop tap closes it the usual way.
   return (
-    <nav
-      className="flex items-center gap-1 overflow-x-auto border-b px-2 py-1 md:hidden"
-      aria-label="Workspace sections (mobile)"
-    >
-      {TOP_TABS.map((tab) => {
-        const path = linkBase ? `${linkBase}/${tab.path}` : "/workspaces"
-        const isActive =
-          linkBase != null &&
-          (location.pathname === path ||
-            location.pathname.startsWith(`${path}/`))
-        return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
           <Button
-            key={tab.key}
-            variant={isActive ? "default" : "ghost"}
-            size="sm"
-            className={cn(
-              "h-7 shrink-0 rounded-full px-3 text-xs",
-              !isActive && "text-muted-foreground",
-            )}
-            render={<Link to={path} />}
-          >
-            {tab.label}
-          </Button>
-        )
-      })}
-    </nav>
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            aria-label="Open navigation"
+          />
+        }
+      >
+        <Menu className="h-5 w-5" />
+      </SheetTrigger>
+      <SheetContent
+        side="left"
+        showCloseButton={false}
+        className="flex w-72 flex-col gap-0 p-0"
+      >
+        <SidebarBody onNavigate={() => setOpen(false)} />
+      </SheetContent>
+    </Sheet>
   )
 }
 
 // Mobile chrome — the page-title bar on phones. Pages register
-// title/back/actions via usePageHeader. When a page hasn't registered
-// a title, fall back to the Onsager wordmark so the bar isn't empty.
+// title/back/actions via usePageHeader. Top-level surfaces show the
+// hamburger (opens the nav drawer); drill-down pages (those that set
+// `backTo`) show a back arrow instead. When no title is registered we
+// fall back to the Onsager wordmark so the bar isn't empty.
 function MobileHeader() {
   const { title, backTo, actions } = usePageHeaderState()
 
@@ -216,14 +276,13 @@ function MobileHeader() {
           <ArrowLeft className="h-5 w-5" />
         </Button>
       ) : (
-        <Link to="/" className="flex items-center gap-2 pl-1">
-          <OnsagerLogo size={20} />
-          <span className="text-base font-semibold">Onsager</span>
-        </Link>
+        <MobileNavDrawer />
       )}
       <div className="min-w-0 flex-1">
-        {title && (
+        {title ? (
           <div className="truncate text-base font-semibold">{title}</div>
+        ) : (
+          <span className="text-base font-semibold">Onsager</span>
         )}
       </div>
       <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -285,11 +285,12 @@ function MobileHeader() {
           <span className="text-base font-semibold">Onsager</span>
         )}
       </div>
+      {/* Account lives once in the drawer footer (open via ☰), per the
+          dashboard-ui skill — not duplicated here. HITL on mobile is the
+          chat FAB. The bar keeps only page actions + the ⌘K trigger. */}
       <div className="flex items-center gap-1">
         {actions}
-        <ChatBell size="sm" />
         <CommandPaletteTrigger />
-        <UserMenu variant="icon" />
       </div>
     </header>
   )

--- a/apps/dashboard/tests/smoke/top-chrome.test.tsx
+++ b/apps/dashboard/tests/smoke/top-chrome.test.tsx
@@ -11,19 +11,17 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
 
 import { AppLayout } from "@/components/layout/AppLayout"
 
-// Top chrome shell from #463 / ADR 0019. Two Test items the spec
-// pins are covered here:
+// Nav chrome (#463 / ADR 0019, superseded by the sidebar + mobile-drawer
+// IA in #517). Covered here:
 //
-//  - Component test: the top chrome renders all regions at desktop AND
-//    mobile widths. jsdom doesn't apply media queries, so both the
-//    desktop chrome (`<nav aria-label="Workspace sections">`) and the
-//    mobile tabs row (`<nav aria-label="Workspace sections (mobile)">`)
-//    are present in the DOM; we assert each region exposes the same
-//    three tabs and that the desktop chrome carries the logo, workspace
-//    switcher, ⌘K trigger, and user-menu button.
-//  - Tab switching preserves workspace scope across the three tabs:
-//    clicking each tab inside either nav navigates to
-//    `/workspaces/<slug>/<tab>`, never bare `/<tab>`.
+//  - Desktop chrome: a persistent sidebar with the logo, workspace
+//    switcher, the section nav (`<nav aria-label="Workspace sections">`),
+//    a ⌘K trigger, and a user-menu button.
+//  - Mobile chrome: the section nav lives behind a hamburger
+//    ("Open navigation") that opens a left drawer; the drawer's nav
+//    exposes the same workspace-scoped section links.
+//  - Tab switching preserves workspace scope: clicking each section
+//    navigates to `/workspaces/<slug>/<tab>`, never bare `/<tab>`.
 
 vi.mock("@/lib/auth", () => ({
   useAuth: () => ({
@@ -111,14 +109,17 @@ describe("top chrome (#463 / ADR 0019)", () => {
     ).toBeGreaterThan(0)
   })
 
-  it("renders the mobile chrome with a second tabs row carrying all three tabs", async () => {
+  it("exposes the mobile section nav via a hamburger-opened drawer", async () => {
     renderChrome()
     expect(await screen.findByText("Acme")).toBeInTheDocument()
-    const mobileNav = screen.getByRole("navigation", {
-      name: /workspace sections \(mobile\)/i,
-    })
+    // The drawer is closed initially — the section nav is reached via the
+    // hamburger in the mobile top bar.
+    fireEvent.click(screen.getByRole("button", { name: /open navigation/i }))
+    // The opened drawer is a dialog; scope to it (the desktop sidebar nav
+    // shares the same accessible name, so we must not match it here).
+    const drawer = await screen.findByRole("dialog")
     for (const tab of ["Workflows", "Runs", "Activity"]) {
-      const link = within(mobileNav).getByRole("link", { name: tab })
+      const link = within(drawer).getByRole("link", { name: tab })
       expect(link).toHaveAttribute("href", `/workspaces/acme/${tab.toLowerCase()}`)
     }
   })

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
       // After #222 Slice 6, portal (3002) owns all /api/* routes;
       // stiglab (3000) keeps only /agent/ws for agent binary connections.
       '/api': 'http://localhost:3002',
+      // Portal also hosts the MCP server at POST /mcp/messages (ADR 0007 /
+      // spec #288). The dashboard chat and the Spec Plans page are
+      // same-origin MCP clients, so dev needs the same forward Caddy's
+      // `/mcp/*` block gives production — without it `/mcp/messages` hits
+      // the Vite dev server and 404s (breaking Plans + chat).
+      '/mcp': 'http://localhost:3002',
       '/agent': {
         target: 'ws://localhost:3000',
         ws: true,

--- a/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
+++ b/docs/adr/0019-dashboard-ia-pipeline-centric-three-tab-surface.md
@@ -1,11 +1,11 @@
 # ADR 0019 — Dashboard IA: pipeline-centric three-tab surface
 
-- **Status**: Accepted
+- **Status**: Superseded by ADR 0026
 - **Date**: 2026-05-22
 - **Identity impact**: no
 - **Tracking issues**: #450 (implementation spec). Refines the IA frame set by spec #289 (closed 2026-05-13 as completed, sub-PRs 2a–6 unshipped) and the FTUE umbrella spec #397 (closed 2026-05-19). Retires spec #398 (universal-chat-entry, closed 2026-05-18) as a side effect. The chat surface restructuring it implies is named in the sibling ADR 0020.
 - **Supersedes**: none. The predecessor specs (#289, #397, #398) are the prior dashboard-IA frame in prose; the repo convention reserves the `Supersedes` field for ADR-to-ADR replacement, so no entry here.
-- **Superseded by**: none
+- **Superseded by**: ADR 0026 (nav IA: desktop sidebar + mobile drawer). The top-bar-with-tabs chrome below could not host non-section destinations (Settings, Workspaces), leaving those pages with no active nav item; ADR 0026 returns to a sidebar (+ mobile drawer) to fix that.
 
 ## Context
 

--- a/docs/adr/0026-nav-ia-sidebar-and-mobile-drawer.md
+++ b/docs/adr/0026-nav-ia-sidebar-and-mobile-drawer.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-05-31
 - **Identity impact**: no
-- **Adoption**: ongoing
+- **Adoption**: enforced
 - **Tracking issues**: #519 (implementation spec). Carries the nav half of #517 (L2-testing findings). Lands folded into PR #518 alongside the `/mcp` dev-proxy fix.
 - **Supersedes**: ADR 0019 (dashboard IA: pipeline-centric three-tab surface) — the top-bar-with-tabs chrome it adopted.
 - **Superseded by**: none
@@ -83,6 +83,8 @@ entry, the bell, and the mobile FAB all move into the new chrome as-is.
 - [x] `top-chrome.test.tsx` updated to the hamburger-drawer behaviour
       (mutation-checked).
 - [x] ADR 0019 marked superseded by this ADR.
-- [ ] `dashboard-ui` skill mobile-chrome rules updated in the sibling
-      repo (one global mobile bar / avatar-in-footer / ⌘K-for-nav
-      wording) — follow-up PR (#519).
+- [x] `dashboard-ui` skill (in-repo, `.claude/skills/`) reconciled: the
+      mobile-bar diagram and account-footer component references now
+      match the shipped `SidebarBody` / `DesktopSidebar` /
+      `MobileNavDrawer`. (The skill already prescribed the sidebar +
+      `☰` drawer; ADR 0019's top-tabs had diverged from it.)

--- a/docs/adr/0026-nav-ia-sidebar-and-mobile-drawer.md
+++ b/docs/adr/0026-nav-ia-sidebar-and-mobile-drawer.md
@@ -1,0 +1,88 @@
+# ADR 0026 — Nav IA: desktop sidebar + mobile drawer
+
+- **Status**: Accepted
+- **Date**: 2026-05-31
+- **Identity impact**: no
+- **Adoption**: ongoing
+- **Tracking issues**: #519 (implementation spec). Carries the nav half of #517 (L2-testing findings). Lands folded into PR #518 alongside the `/mcp` dev-proxy fix.
+- **Supersedes**: ADR 0019 (dashboard IA: pipeline-centric three-tab surface) — the top-bar-with-tabs chrome it adopted.
+- **Superseded by**: none
+
+## Context
+
+ADR 0019 adopted a pipeline-centric top-level IA: the sidebar was removed
+and the section nouns became tabs in the top chrome, with the workspace
+switcher and user menu beside them. The section set has since grown from
+three to four+ (`Plans` was added as a sanctioned fifth noun, ADR 0023 /
+0025).
+
+That chrome can only express the section nouns. Every other destination
+falls outside it:
+
+- **Global Settings** (`/settings`), the **Workspaces list**
+  (`/workspaces`), and **per-workspace Settings**
+  (`/workspaces/:slug/settings`) match none of the tabs, so the nav shows
+  **no active item** on those pages — disorienting "where am I?" state.
+- On the global pages the four tabs still render but point at
+  `/workspaces` (inert), and the switcher shows a "Select workspace"
+  placeholder — clickable-but-dead chrome.
+- On mobile the top row carries title + a horizontally-scrolling tab
+  strip competing for ~375px, and Settings/Workspaces have no home there
+  at all.
+
+This surfaced during L2 UI testing (#517). The root shape is structural:
+a flat tab bar cannot host destinations that aren't sections.
+
+## Decision
+
+Adopt a **persistent left sidebar on desktop** and a **left off-canvas
+drawer on mobile**, rendered from **one shared `SidebarBody`**.
+
+`SidebarBody` (`apps/dashboard/src/components/layout/AppLayout.tsx`):
+logo → workspace switcher → section links (vertical, active-highlighted)
+→ a first-class **Settings** entry → the account / chat / ⌘K footer
+cluster. Every destination — sections *and* Settings — gets an
+unambiguous active state. The dead-active-state and inert-tab problems
+disappear because nav is no longer constrained to the section set.
+
+- **Desktop:** `SidebarBody` inside a `w-60` `<aside>` rail.
+- **Mobile:** `SidebarBody` inside a left `Sheet` drawer, opened by a
+  hamburger in `MobileHeader`. Drill-down pages (those that set
+  `usePageHeader({ backTo })`) keep the back arrow instead of the
+  hamburger. The drawer closes on nav-link selection (`onNavigate`) and
+  on backdrop tap.
+
+Nav items are plain `<Link>`s styled with `buttonVariants`, not
+`<Button render={<Link/>}>`. This keeps the correct `role="link"`
+semantics for navigating elements and avoids Base UI's `nativeButton`
+console warning — the recurring nag #517 flagged. (Setting
+`nativeButton={false}` on a `Button` is the wrong fix: it stamps
+`role="button"` onto the anchor.)
+
+The chat surface (ADR 0020 / 0025) is unchanged: the desktop labeled
+entry, the bell, and the mobile FAB all move into the new chrome as-is.
+
+## Rejected alternatives
+
+- **Mobile bottom tab bar.** Prototyped first (thumb-reachable, always
+  visible). Rejected in review in favour of the drawer pattern: the
+  drawer hosts the *full* sidebar body (sections + Settings + workspace
+  switcher + account) in one place, matching the desktop rail exactly,
+  whereas a bottom bar can only carry the section nouns and re-splits
+  Settings/account elsewhere — reintroducing the asymmetry this ADR
+  exists to remove.
+- **Keep the top tabs, add a Settings tab.** Settings is not a section
+  noun (CLAUDE.md vocabulary); promoting it to a top-level tab muddies
+  the four-noun surface. The rail/drawer gives it a footer home without
+  making it a peer of the sections.
+
+## Adoption checklist
+
+- [x] `SidebarBody` / `DesktopSidebar` / `MobileNavDrawer` implemented;
+      top-tab rows removed.
+- [x] `top-chrome.test.tsx` updated to the hamburger-drawer behaviour
+      (mutation-checked).
+- [x] ADR 0019 marked superseded by this ADR.
+- [ ] `dashboard-ui` skill mobile-chrome rules updated in the sibling
+      repo (one global mobile bar / avatar-in-footer / ⌘K-for-nav
+      wording) — follow-up PR (#519).


### PR DESCRIPTION
Closes #519. Part of #517.

Two changes from an L2 UI-testing pass (`web-testing` skill, `just dev`, desktop 1280×720 + mobile 375×812).

## 1. Nav redesign — desktop sidebar + mobile drawer (ADR 0026, supersedes ADR 0019)

The top-bar-with-four-section-tabs chrome could only express section nouns, so **Settings / Workspaces / workspace-Settings showed no active nav item** (and on global pages rendered inert tabs with a "Select workspace" placeholder). Replaced with one shared `SidebarBody`:

- **Desktop:** persistent left rail — logo, workspace switcher, section links (active-highlighted), a first-class **Settings** entry, account/chat/⌘K footer.
- **Mobile:** the same body in a left off-canvas **drawer** opened by a hamburger; drill-down pages keep the back arrow; drawer closes on nav select + backdrop tap.
- Nav items are plain `<Link>`s styled via `buttonVariants` → correct `role="link"` and no Base UI `nativeButton` warning (the right answer to #517 item 2).

ADR 0026 records the decision and supersedes ADR 0019. Follow-up tracked in #519: update the `dashboard-ui` skill's mobile-chrome wording (sibling repo).

## 2. `/mcp` dev-proxy fix

The dashboard MCP client POSTs to `/mcp/messages`, but the Vite dev proxy only forwarded `/api` and `/agent` — so the **Spec Plans page and chat 404'd in local dev**. Added `'/mcp' → portal`, mirroring Caddy's production `/mcp/*`. Production unaffected.

## Verification
- `pnpm --filter dashboard test` green (42 files / 248 tests). `top-chrome.test.tsx` updated to the hamburger-drawer behaviour and **mutation-checked** (forcing the drawer closed fails the new assertion).
- `tsc --noEmit` + eslint clean.
- L2 in-browser (dev-login workspace): Settings now highlights; drawer opens/closes and navigates; Spec Plans renders its empty state instead of the 404; no overflow at either viewport.

## History note
An earlier commit's `nativeButton={false}` Button change was reverted — it broke `role="link"` semantics and 4 smoke tests. The plain-`<Link>` approach above is the correct fix.

https://claude.ai/code/session_01EBsxuDv3bYt44DeCjRJbw1