### PR TITLE
Add optional declared_empty to NodeCompleted (§4e)

### DIFF
--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -501,6 +501,9 @@ impl Scheduler {
             plan_id: plan_id.as_str().to_string(),
             node_id,
             output_artifact_ids,
+            // Populated by the authoritative gate (§4c, #520); `None`
+            // here keeps behavior unchanged.
+            declared_empty: None,
         };
         self.emit(plan_id, node_id, EVENT_NODE_COMPLETED, &payload)
             .await;

--- a/crates/onsager-spine/src/factory_event.rs
+++ b/crates/onsager-spine/src/factory_event.rs
@@ -540,6 +540,13 @@ pub enum FactoryEventKind {
         /// `ArtifactId`s the executor materialized — order matches the
         /// node's declared output edges.
         output_artifact_ids: Vec<ArtifactId>,
+        /// `Some(true)` when the executor declared it produced nothing
+        /// on purpose (an intentional empty delivery), distinguishing
+        /// it from "delivered nothing" (`output_artifact_ids` empty,
+        /// field absent). Populated by the authoritative gate (§4c,
+        /// #520); `None` until then so behavior is unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        declared_empty: Option<bool>,
     },
 
     /// A node's executor returned Err. The scheduler aborts the plan

--- a/crates/onsager-substrate/src/events.rs
+++ b/crates/onsager-substrate/src/events.rs
@@ -127,6 +127,13 @@ pub struct NodeCompleted {
     /// `ArtifactId`s the executor materialized — order matches the
     /// node's declared output edges.
     pub output_artifact_ids: Vec<ArtifactId>,
+    /// `Some(true)` when the executor declared it produced nothing on
+    /// purpose (an intentional empty delivery), distinguishing it from
+    /// "delivered nothing" (`output_artifact_ids` empty, field absent).
+    /// Populated by the authoritative gate (§4c, #520); `None` until
+    /// then so behavior is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_empty: Option<bool>,
 }
 
 impl NodeCompleted {
@@ -353,11 +360,32 @@ mod tests {
             plan_id: pid(),
             node_id: nid(),
             output_artifact_ids: vec![ArtifactId::new("art_1"), ArtifactId::new("art_2")],
+            declared_empty: None,
         };
         let json = serde_json::to_value(&ev).unwrap();
         assert_eq!(json["output_artifact_ids"][0], "art_1");
+        // `None` is the absent-field case — must be omitted on the wire.
+        assert!(
+            json.get("declared_empty").is_none(),
+            "None declared_empty must be omitted, got: {json}"
+        );
         let back: NodeCompleted = serde_json::from_value(json).unwrap();
         assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn node_completed_declared_empty_roundtrip() {
+        let ev = NodeCompleted {
+            plan_id: pid(),
+            node_id: nid(),
+            output_artifact_ids: vec![],
+            declared_empty: Some(true),
+        };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["declared_empty"], true);
+        let back: NodeCompleted = serde_json::from_value(json).unwrap();
+        assert_eq!(back, ev);
+        assert_eq!(back.declared_empty, Some(true));
     }
 
     #[test]

--- a/crates/onsager-substrate/tests/spine_payload_compat.rs
+++ b/crates/onsager-substrate/tests/spine_payload_compat.rs
@@ -66,11 +66,13 @@ fn node_completed_payload_matches_variant() {
         plan_id: pid(),
         node_id: nid(),
         output_artifact_ids: vec![ArtifactId::new("art_1"), ArtifactId::new("art_2")],
+        declared_empty: Some(true),
     };
     let v = FactoryEventKind::NodeCompleted {
         plan_id: s.plan_id.clone(),
         node_id: s.node_id,
         output_artifact_ids: s.output_artifact_ids.clone(),
+        declared_empty: s.declared_empty,
     };
     assert_eq!(
         serde_json::to_value(&s).unwrap(),
@@ -314,6 +316,7 @@ fn wire_kind_constants_agree_with_factory_event_kind() {
                 plan_id: pid(),
                 node_id: nid(),
                 output_artifact_ids: vec![],
+                declared_empty: None,
             },
         ),
         (

--- a/docs/events.md
+++ b/docs/events.md
@@ -693,6 +693,7 @@ A node finished successfully; the scheduler persisted each output artifact under
 | `plan_id` | `String` |  |
 | `node_id` | `NodeId` |  |
 | `output_artifact_ids` | `Vec<ArtifactId>` | `ArtifactId`s the executor materialized — order matches the node's declared output edges. |
+| `declared_empty` | `Option<bool>` | `Some(true)` when the executor declared it produced nothing on purpose (an intentional empty delivery), distinguishing it from "delivered nothing" (`output_artifact_ids` empty, field absent). Populated by the authoritative gate (§4c, #520); `None` until then so behavior is unchanged. _(optional)_ |
 
 ### `node.failed`
 


### PR DESCRIPTION
## Overview

Work item **§4e** of #520. Adds an optional `declared_empty: Option<bool>` to the substrate `NodeCompleted` event so the authoritative gate (§4c) and the dashboard can distinguish "delivered nothing on purpose" from "delivered nothing".

Per the module's schema-stability convention (`#[serde(default, skip_serializing_if = "Option::is_none")]`), adding an optional field is wire-compatible — no registry version bump. The field defaults to `None` at the existing scheduler construction site, so behavior is unchanged until §4c populates it.

## Changes

- `crates/onsager-substrate/src/events.rs` — add `declared_empty: Option<bool>` to `NodeCompleted` (serde default + skip-if-none).
- `crates/onsager-spine/src/factory_event.rs` — mirror the field on `FactoryEventKind::NodeCompleted` to preserve the two-halves symmetry the `spine_payload_compat` test pins (and that the dashboard reads from).
- `crates/onsager-nodes/src/scheduler.rs` — set `declared_empty: None` at the one construction site.
- `docs/events.md` — regenerated via `gen-event-docs`.

## Test

- `node_completed_roundtrip` — asserts `None` is omitted on the wire and round-trips.
- `node_completed_declared_empty_roundtrip` — new test: `Some(true)` round-trips.
- `spine_payload_compat` — byte-identical compat assertion updated to exercise the new field on both halves.

`cargo test -p onsager-substrate`, `cargo build --workspace`, clippy/fmt on touched crates, `check-events`, `check-generated-types`, and `gen-event-docs --check` all pass.

Closes #522

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7UMXN5zGsUMayVdkseSvv)_