### PR TITLE
Add session output-manifest MCP tools (#521)

### DIFF
--- a/apps/dashboard/src/lib/mcp-tools.ts
+++ b/apps/dashboard/src/lib/mcp-tools.ts
@@ -487,6 +487,63 @@ const get_workflow_v2: McpToolBinding = {
 }
 
 // -----------------------------------------------------------------------------
+// Session output manifest (#520 §4a / #521)
+//
+// These three are agent-session tools — an agent records its addressable
+// outputs on the main node through them. They are bound here so the
+// registry ↔ dashboard contract (`check-hitl-coverage`) stays complete;
+// in practice they are invoked by the session runtime, not from dashboard
+// chat.
+// -----------------------------------------------------------------------------
+
+const emit_artifact: McpToolBinding = {
+  name: "emit_artifact",
+  category: "constructive",
+  title: (args) => `Emit artifact · ${str(args, "kind", "output")}`,
+  buildCard: (args) => ({
+    kind: "constructive",
+    title: `Emit artifact · ${str(args, "kind", "output")}`,
+    summary: str(args, "summary", "Record an addressable deliverable on the session manifest."),
+    body: {
+      fields: [
+        field("Session", str(args, "session_id")),
+        field("Kind", str(args, "kind"), { editable: true, key: "kind" }),
+        field("Summary", str(args, "summary"), { editable: true, key: "summary" }),
+      ],
+    },
+    commit: { label: "Emit", intent: "primary" },
+    reject: { label: "Discard" },
+  }),
+}
+
+const declare_no_output: McpToolBinding = {
+  name: "declare_no_output",
+  category: "constructive",
+  title: () => "Declare no output",
+  buildCard: (args) => ({
+    kind: "constructive",
+    title: "Declare no output",
+    summary: str(args, "reason", "Declare this session produced no deliverable."),
+    body: {
+      fields: [
+        field("Session", str(args, "session_id")),
+        field("Reason", str(args, "reason"), { editable: true, key: "reason" }),
+      ],
+    },
+    commit: { label: "Declare empty", intent: "primary" },
+    reject: { label: "Cancel" },
+  }),
+}
+
+const read_emit_status: McpToolBinding = {
+  name: "read_emit_status",
+  category: "read_only",
+  title: () => "Read emit status",
+  renderInfo: (args) =>
+    `Reading the output manifest for session ${str(args, "session_id", "(unknown)")}.`,
+}
+
+// -----------------------------------------------------------------------------
 // Registry
 // -----------------------------------------------------------------------------
 
@@ -516,6 +573,10 @@ const BINDINGS: McpToolBinding[] = [
   retire_workflow,
   list_workflows_v2,
   get_workflow_v2,
+  // Session output manifest (#520 §4a / #521)
+  emit_artifact,
+  declare_no_output,
+  read_emit_status,
 ]
 
 /** All known MCP tools, in registry order. */

--- a/crates/onsager-portal/src/mcp/mod.rs
+++ b/crates/onsager-portal/src/mcp/mod.rs
@@ -305,6 +305,10 @@ mod tests {
             "retire_workflow",
             "list_workflows_v2",
             "get_workflow_v2",
+            // Session output manifest (#520 §4a / #521).
+            "emit_artifact",
+            "declare_no_output",
+            "read_emit_status",
         ] {
             assert!(
                 names.contains(&required),
@@ -332,6 +336,8 @@ mod tests {
                     | "submit_workflow"
                     | "update_workflow"
                     | "retire_workflow"
+                    | "emit_artifact"
+                    | "declare_no_output"
             );
             if is_mutation {
                 assert!(

--- a/crates/onsager-portal/src/mcp/registry.rs
+++ b/crates/onsager-portal/src/mcp/registry.rs
@@ -311,5 +311,35 @@ fn build_registry() -> Vec<ToolDescriptor> {
                 ))
             },
         },
+        // --- Session output manifest (spec #520 §4a / #521) ---
+        ToolDescriptor {
+            name: "emit_artifact",
+            description: "Record an addressable deliverable on the session output manifest. Persists `content` to addressable storage (inline base64 + sha256 checksum for the first cut) and appends an `artifact.emitted` row to `events_ext` on the `session:<session_id>` stream under the `stiglab` namespace. Returns the minted `artifact_id` and the `content_ref { uri, checksum }`. Provenance is never recorded here — `AgentExecutor` stamps `Uncertain { source: Agent }` when it reads the manifest back. Call once per deliverable a session produces.",
+            category: ToolCategory::Constructive,
+            input_schema: super::input_schema::<tools::session_manifest::EmitArtifactArgs>(),
+            invoke: |state, user, args| {
+                Box::pin(tools::session_manifest::emit_artifact(state, user, args))
+            },
+        },
+        ToolDescriptor {
+            name: "declare_no_output",
+            description: "Explicitly declare that this session produced no deliverable, with a `reason`. Appends an `output.declared_empty` row to the session manifest (`events_ext`, `session:<session_id>` stream). Lets the liveness gate distinguish \"delivered nothing on purpose\" from \"forgot to emit\". Use this instead of finishing silently when there is genuinely nothing to deliver.",
+            category: ToolCategory::Constructive,
+            input_schema: super::input_schema::<tools::session_manifest::DeclareNoOutputArgs>(),
+            invoke: |state, user, args| {
+                Box::pin(tools::session_manifest::declare_no_output(
+                    state, user, args,
+                ))
+            },
+        },
+        ToolDescriptor {
+            name: "read_emit_status",
+            description: "Summarize a session's output manifest: `{ emit_count, declared_empty }`. Counts `artifact.emitted` rows and detects any `output.declared_empty` on the `session:<session_id>` stream. Pure read (`query_ext_stream` + tally), safe to call repeatedly — the liveness Stop hook and the authoritative gate both consume it.",
+            category: ToolCategory::ReadOnly,
+            input_schema: super::input_schema::<tools::session_manifest::ReadEmitStatusArgs>(),
+            invoke: |state, user, args| {
+                Box::pin(tools::session_manifest::read_emit_status(state, user, args))
+            },
+        },
     ]
 }

--- a/crates/onsager-portal/src/mcp/tools/mod.rs
+++ b/crates/onsager-portal/src/mcp/tools/mod.rs
@@ -20,6 +20,7 @@ use super::ToolError;
 pub mod artifacts;
 pub mod diagnostics;
 pub mod runs;
+pub mod session_manifest;
 pub mod substrate_specs;
 pub mod substrate_workflows;
 pub mod workflows;

--- a/crates/onsager-portal/src/mcp/tools/session_manifest.rs
+++ b/crates/onsager-portal/src/mcp/tools/session_manifest.rs
@@ -1,0 +1,370 @@
+//! MCP tools for the agent session output manifest (spec #520 §4a /
+//! #521 — the addressable-output foundation).
+//!
+//! An agent session runs in an untrusted execution environment that
+//! holds **no DB credentials** — these three MCP tools are its only
+//! path to record (and inspect) what it produced. The credential-
+//! holding portal MCP server is the only thing that touches the
+//! database, exactly like every other tool in this directory.
+//!
+//! Storage is `events_ext` (not a new table, not a new
+//! `FactoryEventKind`) via [`EventStore::append_ext`] /
+//! [`EventStore::query_ext_stream`]. Those rows are already on the
+//! `onsager_events` pg_notify stream, so a future Observer (OBS-01,
+//! #361) can subscribe to the same manifest with no extra plumbing.
+//! The conventions below are locked in spec #520 §3 — do not
+//! re-litigate:
+//!
+//! - `namespace = "stiglab"` (the emit happens inside a stiglab-
+//!   orchestrated session; reuse the existing validated namespace).
+//! - `stream_id = "session:<session_id>"`.
+//! - `event_type = "artifact.emitted"` for a real output;
+//!   `"output.declared_empty"` for an explicit no-output declaration.
+//!
+//! **Provenance never goes into the manifest.** Records carry
+//! `content_ref / kind / summary` (plus the minted `artifact_id`
+//! identity) only — the agent must not be able to self-declare
+//! `Deterministic`. `AgentExecutor` stamps `Provenance::Uncertain`
+//! when it reads records back (spec #520 §4c, a later layer).
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ring::digest;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use onsager_spine::EventMetadata;
+use onsager_spine::EventStore;
+use onsager_spine::extension_event::ExtensionEventRecord;
+
+use crate::auth::AuthUser;
+use crate::state::AppState;
+
+use super::super::{ToolError, ToolResult};
+use super::require_workspace_access;
+
+/// Namespace the manifest rows live under (spec #520 §3).
+const MANIFEST_NAMESPACE: &str = "stiglab";
+/// `events_ext.event_type` for a real emitted output.
+const EVENT_ARTIFACT_EMITTED: &str = "artifact.emitted";
+/// `events_ext.event_type` for an explicit "I produced nothing".
+const EVENT_OUTPUT_DECLARED_EMPTY: &str = "output.declared_empty";
+
+/// Inline content-storage URI scheme. First cut matches the Script
+/// executor's convention (`crates/onsager-nodes/src/script.rs`):
+/// base64-encoded body behind an `inline:` prefix. A real warehouse-
+/// backed scheme replaces this once content storage is formalized
+/// (RUN-01 #359 — the same gap the Script executor flags).
+const INLINE_URI_PREFIX: &str = "inline:base64,";
+
+/// Build the manifest stream key for a session.
+fn session_stream_id(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+/// The actor stamp on every manifest write — the session itself, never
+/// a human or another subsystem.
+fn session_actor(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+// ---------------------------------------------------------------------------
+// emit_artifact
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EmitArtifactArgs {
+    /// Workspace that owns this session. The caller's MCP token scope
+    /// is enforced against this value before anything is written.
+    pub workspace_id: String,
+    /// The session emitting the output — the manifest stream key
+    /// (`session:<session_id>`).
+    pub session_id: String,
+    /// Raw deliverable content. Persisted to addressable storage; the
+    /// returned `content_ref` points back at it.
+    pub content: String,
+    /// Artifact kind tag (`code` / `document` / `pull_request` /
+    /// `github_issue` / a custom string). Stored verbatim.
+    pub kind: String,
+    /// Human-readable summary of what was emitted.
+    pub summary: String,
+}
+
+/// Persist `content` to addressable storage and return its
+/// `ContentRef` shape (`{ uri, checksum }`). First cut: inline base64
+/// URI + sha256 checksum, matching the Script executor path.
+fn store_content(content: &str) -> Value {
+    let bytes = content.as_bytes();
+    let uri = format!("{INLINE_URI_PREFIX}{}", BASE64.encode(bytes));
+    let checksum = hex::encode(digest::digest(&digest::SHA256, bytes).as_ref());
+    serde_json::json!({ "uri": uri, "checksum": checksum })
+}
+
+/// Append an `artifact.emitted` row to the session manifest. Returns
+/// the minted `artifact_id`. Store-level helper so the integration
+/// test can exercise the round-trip without standing up auth.
+pub async fn append_emit(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+    content_ref: Value,
+    kind: &str,
+    summary: &str,
+) -> Result<String, sqlx::Error> {
+    // Mint a stable id so the authoritative gate (spec #520 §4c) can
+    // reference this output when it packages it onto the typed DAG.
+    let artifact_id = ulid::Ulid::new().to_string();
+    let data = serde_json::json!({
+        "artifact_id": artifact_id,
+        "content_ref": content_ref,
+        "kind": kind,
+        "summary": summary,
+    });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: session_actor(session_id),
+    };
+    store
+        .append_ext(
+            workspace_id,
+            &session_stream_id(session_id),
+            MANIFEST_NAMESPACE,
+            EVENT_ARTIFACT_EMITTED,
+            data,
+            &metadata,
+            None,
+        )
+        .await?;
+    Ok(artifact_id)
+}
+
+pub async fn emit_artifact(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
+    let args: EmitArtifactArgs = serde_json::from_value(args)
+        .map_err(|e| ToolError::InvalidParams(format!("invalid emit_artifact args: {e}")))?;
+    require_workspace_access(&state.pool, auth_user, &args.workspace_id).await?;
+
+    let content_ref = store_content(&args.content);
+    let artifact_id = append_emit(
+        &state.spine,
+        &args.workspace_id,
+        &args.session_id,
+        content_ref.clone(),
+        &args.kind,
+        &args.summary,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("mcp emit_artifact append_ext failed: {e}");
+        ToolError::Internal(format!("failed to record emitted artifact: {e}"))
+    })?;
+
+    Ok(serde_json::json!({
+        "artifact_id": artifact_id,
+        "content_ref": content_ref,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// declare_no_output
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeclareNoOutputArgs {
+    /// Workspace that owns this session (token-scope enforced).
+    pub workspace_id: String,
+    /// The session declaring it produced nothing.
+    pub session_id: String,
+    /// Why the session produced no deliverable. Surfaced to operators
+    /// and the authoritative liveness gate so "delivered nothing on
+    /// purpose" is distinguishable from "delivered nothing".
+    pub reason: String,
+}
+
+/// Append an `output.declared_empty` row to the session manifest.
+/// Store-level helper, mirroring [`append_emit`].
+pub async fn append_declared_empty(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+    reason: &str,
+) -> Result<(), sqlx::Error> {
+    let data = serde_json::json!({ "reason": reason });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: session_actor(session_id),
+    };
+    store
+        .append_ext(
+            workspace_id,
+            &session_stream_id(session_id),
+            MANIFEST_NAMESPACE,
+            EVENT_OUTPUT_DECLARED_EMPTY,
+            data,
+            &metadata,
+            None,
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn declare_no_output(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
+    let args: DeclareNoOutputArgs = serde_json::from_value(args)
+        .map_err(|e| ToolError::InvalidParams(format!("invalid declare_no_output args: {e}")))?;
+    require_workspace_access(&state.pool, auth_user, &args.workspace_id).await?;
+
+    append_declared_empty(
+        &state.spine,
+        &args.workspace_id,
+        &args.session_id,
+        &args.reason,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("mcp declare_no_output append_ext failed: {e}");
+        ToolError::Internal(format!("failed to record no-output declaration: {e}"))
+    })?;
+
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+// ---------------------------------------------------------------------------
+// read_emit_status
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReadEmitStatusArgs {
+    /// Workspace that owns this session (token-scope enforced). Manifest
+    /// rows are matched against this so a session-id collision across
+    /// workspaces can never leak counts.
+    pub workspace_id: String,
+    /// The session whose manifest to summarize.
+    pub session_id: String,
+}
+
+/// Pure tally of a session's manifest records, scoped to a workspace.
+/// Counts `artifact.emitted` rows and detects any
+/// `output.declared_empty`. Separated from the DB read so it is
+/// unit-testable without Postgres.
+pub fn tally_status(records: &[ExtensionEventRecord], workspace_id: &str) -> EmitStatus {
+    let mut emit_count: u64 = 0;
+    let mut declared_empty = false;
+    for r in records {
+        // Defensive: the session stream is workspace-private by
+        // construction, but never count a row that names a different
+        // workspace.
+        if r.workspace_id != workspace_id {
+            continue;
+        }
+        match r.event_type.as_str() {
+            EVENT_ARTIFACT_EMITTED => emit_count += 1,
+            EVENT_OUTPUT_DECLARED_EMPTY => declared_empty = true,
+            _ => {}
+        }
+    }
+    EmitStatus {
+        emit_count,
+        declared_empty,
+    }
+}
+
+/// The manifest summary `read_emit_status` returns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EmitStatus {
+    pub emit_count: u64,
+    pub declared_empty: bool,
+}
+
+/// Read + tally a session's manifest. Store-level helper so the
+/// integration test can call it directly. Pure read — safe to call
+/// repeatedly.
+pub async fn read_status(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+) -> Result<EmitStatus, sqlx::Error> {
+    let records = store
+        .query_ext_stream(&session_stream_id(session_id))
+        .await?;
+    Ok(tally_status(&records, workspace_id))
+}
+
+pub async fn read_emit_status(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
+    let args: ReadEmitStatusArgs = serde_json::from_value(args)
+        .map_err(|e| ToolError::InvalidParams(format!("invalid read_emit_status args: {e}")))?;
+    require_workspace_access(&state.pool, auth_user, &args.workspace_id).await?;
+
+    let status = read_status(&state.spine, &args.workspace_id, &args.session_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("mcp read_emit_status query_ext_stream failed: {e}");
+            ToolError::Internal(format!("failed to read session manifest: {e}"))
+        })?;
+
+    serde_json::to_value(&status)
+        .map_err(|e| ToolError::Internal(format!("response serialization failed: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn record(workspace_id: &str, event_type: &str) -> ExtensionEventRecord {
+        ExtensionEventRecord {
+            id: 0,
+            stream_id: session_stream_id("s1"),
+            namespace: MANIFEST_NAMESPACE.to_string(),
+            event_type: event_type.to_string(),
+            data: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            ref_event_id: None,
+            created_at: Utc::now(),
+            correlation_id: None,
+            workspace_id: workspace_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn tally_counts_emits_and_detects_declared_empty() {
+        let recs = vec![
+            record("ws1", EVENT_ARTIFACT_EMITTED),
+            record("ws1", EVENT_ARTIFACT_EMITTED),
+            record("ws1", EVENT_OUTPUT_DECLARED_EMPTY),
+        ];
+        let status = tally_status(&recs, "ws1");
+        assert_eq!(status.emit_count, 2);
+        assert!(status.declared_empty);
+    }
+
+    #[test]
+    fn tally_untouched_session_is_zero_and_not_declared() {
+        let status = tally_status(&[], "ws1");
+        assert_eq!(status.emit_count, 0);
+        assert!(!status.declared_empty);
+    }
+
+    #[test]
+    fn tally_ignores_rows_from_a_different_workspace() {
+        let recs = vec![
+            record("other", EVENT_ARTIFACT_EMITTED),
+            record("other", EVENT_OUTPUT_DECLARED_EMPTY),
+        ];
+        let status = tally_status(&recs, "ws1");
+        assert_eq!(status.emit_count, 0);
+        assert!(!status.declared_empty);
+    }
+
+    #[test]
+    fn store_content_round_trips_via_inline_scheme() {
+        let cr = store_content("hello world");
+        let uri = cr["uri"].as_str().unwrap();
+        let payload = uri.strip_prefix(INLINE_URI_PREFIX).unwrap();
+        let decoded = BASE64.decode(payload).unwrap();
+        assert_eq!(decoded, b"hello world");
+        // Checksum present and sha256-shaped (64 hex chars).
+        assert_eq!(cr["checksum"].as_str().unwrap().len(), 64);
+    }
+}

--- a/crates/onsager-portal/src/mcp/tools/session_manifest.rs
+++ b/crates/onsager-portal/src/mcp/tools/session_manifest.rs
@@ -34,6 +34,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use onsager_artifact::ArtifactId;
 use onsager_spine::EventMetadata;
 use onsager_spine::EventStore;
 use onsager_spine::extension_event::ExtensionEventRecord;
@@ -114,7 +115,10 @@ pub async fn append_emit(
 ) -> Result<String, sqlx::Error> {
     // Mint a stable id so the authoritative gate (spec #520 §4c) can
     // reference this output when it packages it onto the typed DAG.
-    let artifact_id = ulid::Ulid::new().to_string();
+    // Use the canonical `art_<ulid>` shape (`ArtifactId::generate`) so
+    // manifest rows match every other id that flows through the
+    // artifact model — downstream `art_`-prefix matching stays uniform.
+    let artifact_id = ArtifactId::generate().as_str().to_string();
     let data = serde_json::json!({
         "artifact_id": artifact_id,
         "content_ref": content_ref,

--- a/crates/onsager-portal/tests/session_manifest.rs
+++ b/crates/onsager-portal/tests/session_manifest.rs
@@ -47,7 +47,10 @@ async fn emit_then_read_status_reports_emit_count_one() {
     )
     .await
     .expect("append_emit");
-    assert!(!artifact_id.is_empty(), "emit mints an artifact id");
+    assert!(
+        artifact_id.starts_with("art_"),
+        "emit mints a canonical `art_<ulid>` id, got {artifact_id}"
+    );
 
     let status = read_status(&store, &workspace_id, &session_id)
         .await

--- a/crates/onsager-portal/tests/session_manifest.rs
+++ b/crates/onsager-portal/tests/session_manifest.rs
@@ -1,0 +1,135 @@
+//! Integration test for spec #520 §4a / #521 — the session output
+//! manifest backed by `events_ext`.
+//!
+//! Exercises the store-level helpers (`append_emit`,
+//! `append_declared_empty`, `read_status`) directly so the assertions
+//! pin the `append_ext` → `query_ext_stream` round-trip without
+//! standing up workspace membership / auth. The tool wrappers add only
+//! `require_workspace_access` on top of these.
+//!
+//! Skipped when `DATABASE_URL` is unset — the manifest rows live on the
+//! spine, which only the Postgres-backed harness exercises.
+
+use onsager_portal::mcp::tools::session_manifest::{
+    append_declared_empty, append_emit, read_status,
+};
+use onsager_spine::EventStore;
+
+async fn try_store() -> Option<EventStore> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(EventStore::connect(&url).await.expect("spine connect"))
+}
+
+async fn cleanup(store: &EventStore, session_id: &str) {
+    let _ = sqlx::query("DELETE FROM events_ext WHERE stream_id = $1")
+        .bind(format!("session:{session_id}"))
+        .execute(store.pool())
+        .await;
+}
+
+#[tokio::test]
+async fn emit_then_read_status_reports_emit_count_one() {
+    let Some(store) = try_store().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws_{}", ulid::Ulid::new());
+    let session_id = ulid::Ulid::new().to_string();
+
+    let content_ref = serde_json::json!({ "uri": "inline:base64,aGk=", "checksum": "abc" });
+    let artifact_id = append_emit(
+        &store,
+        &workspace_id,
+        &session_id,
+        content_ref,
+        "document",
+        "first deliverable",
+    )
+    .await
+    .expect("append_emit");
+    assert!(!artifact_id.is_empty(), "emit mints an artifact id");
+
+    let status = read_status(&store, &workspace_id, &session_id)
+        .await
+        .expect("read_status");
+    assert_eq!(status.emit_count, 1);
+    assert!(!status.declared_empty);
+
+    cleanup(&store, &session_id).await;
+}
+
+#[tokio::test]
+async fn declare_no_output_then_read_status_reports_declared_empty() {
+    let Some(store) = try_store().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws_{}", ulid::Ulid::new());
+    let session_id = ulid::Ulid::new().to_string();
+
+    append_declared_empty(&store, &workspace_id, &session_id, "nothing to do")
+        .await
+        .expect("append_declared_empty");
+
+    let status = read_status(&store, &workspace_id, &session_id)
+        .await
+        .expect("read_status");
+    assert_eq!(status.emit_count, 0);
+    assert!(status.declared_empty);
+
+    cleanup(&store, &session_id).await;
+}
+
+#[tokio::test]
+async fn read_status_untouched_session_is_zero_and_not_declared() {
+    let Some(store) = try_store().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws_{}", ulid::Ulid::new());
+    let session_id = ulid::Ulid::new().to_string();
+
+    let status = read_status(&store, &workspace_id, &session_id)
+        .await
+        .expect("read_status");
+    assert_eq!(status.emit_count, 0);
+    assert!(!status.declared_empty);
+}
+
+#[tokio::test]
+async fn round_trips_workspace_id_and_is_scoped_to_it() {
+    let Some(store) = try_store().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let workspace_id = format!("ws_{}", ulid::Ulid::new());
+    let other_workspace = format!("ws_{}", ulid::Ulid::new());
+    let session_id = ulid::Ulid::new().to_string();
+
+    let content_ref = serde_json::json!({ "uri": "inline:base64,aGk=", "checksum": "abc" });
+    append_emit(
+        &store,
+        &workspace_id,
+        &session_id,
+        content_ref,
+        "code",
+        "deliverable",
+    )
+    .await
+    .expect("append_emit");
+
+    // Same stream, but the read is scoped to a different workspace: the
+    // row must not be counted (defensive cross-workspace isolation).
+    let other = read_status(&store, &other_workspace, &session_id)
+        .await
+        .expect("read_status other workspace");
+    assert_eq!(other.emit_count, 0, "row leaked across workspace scope");
+
+    // The owning workspace sees its row.
+    let owner = read_status(&store, &workspace_id, &session_id)
+        .await
+        .expect("read_status owner workspace");
+    assert_eq!(owner.emit_count, 1);
+
+    cleanup(&store, &session_id).await;
+}

--- a/xtask/src/check_tools_and_skills.rs
+++ b/xtask/src/check_tools_and_skills.rs
@@ -106,6 +106,24 @@ const PENDING_SKILL_GRANTS: &[(&str, &str)] = &[
         "run_spec_plan",
         "spec #501 — pending `onsager-author-substrate` skill",
     ),
+    // Spec #520 §4a / #521 — session output-manifest tools. Invoked by
+    // the agent session runtime, not from a public user-facing skill;
+    // their operating procedure lives in the session prompt + Stop hook
+    // (#520 §4d), not the `onsager-skills` bundle. Exempt rather than
+    // granted because there is no user-facing skill that should list
+    // them.
+    (
+        "emit_artifact",
+        "spec #521 — agent-session tool, no user-facing skill grant",
+    ),
+    (
+        "declare_no_output",
+        "spec #521 — agent-session tool, no user-facing skill grant",
+    ),
+    (
+        "read_emit_status",
+        "spec #521 — agent-session tool, no user-facing skill grant",
+    ),
 ];
 
 pub fn run() -> Result<()> {


### PR DESCRIPTION
Closes #521. Work item **4a** of #520 — the addressable-output foundation everything else in #520 depends on.

## What this does

Adds the three session-manifest tools to portal's existing MCP server (`crates/onsager-portal/src/mcp/`, ADR 0007). The agent execution environment holds no DB credentials, so these MCP tools are the only path to the manifest.

- **`emit_artifact(workspace_id, session_id, content, kind, summary) -> { artifact_id, content_ref }`** — persists `content` to addressable storage (inline base64 + sha256 checksum, matching the Script executor path / RUN-01 #359 gap), mints an `artifact_id`, and appends an `artifact.emitted` row.
- **`declare_no_output(workspace_id, session_id, reason) -> { ok }`** — appends an `output.declared_empty` row.
- **`read_emit_status(workspace_id, session_id) -> { emit_count, declared_empty }`** — pure read; `query_ext_stream` + tally, safe to call repeatedly.

## Locked design decisions honored (#520 §3)

- Storage is `events_ext` via `append_ext` / `query_ext_stream` — no new table, no new `FactoryEventKind`. Already on the `onsager_events` pg_notify stream, so a future Observer (OBS-01 #361) needs no extra plumbing.
- `namespace = "stiglab"`, `stream_id = "session:<session_id>"`, event types `artifact.emitted` / `output.declared_empty`.
- **Provenance never goes into the manifest** — records carry `content_ref / kind / summary` (plus the minted `artifact_id` identity) only. `AgentExecutor` stamps `Provenance::Uncertain { source: Agent }` on read-back (#520 §4c, a later layer).
- Workspace-scoped auth (`require_workspace_access`) like every other tool; reads are defensively scoped to the calling workspace so a session-id collision can't leak counts.

## Scope

This is **only** 4a. The widened runner contract (4b), the `AgentExecutor` post-condition / DAG packaging (4c), the Stop hook (4d), and the `NodeCompleted.declared_empty` field (4e) are separate work items under #520 and are **not** in this PR.

## Test

- New unit tests cover the pure tally (emit count, declared-empty detection, cross-workspace isolation, inline content round-trip).
- New DB-backed integration test (`tests/session_manifest.rs`) exercises the `append_ext` → `query_ext_stream` round-trip against Postgres, covering each acceptance bullet (emit→count 1, declare→declared_empty, untouched→zero, workspace scoping). Verified the round-trip and unit tests genuinely fail when the workspace-scoping line is mutated (not theater coverage).
- `check-hitl-coverage`, `check-tools-and-skills`, `lint-seams`, `check-events`, `check-file-budget`, clippy, and rustfmt all pass. Dashboard HitlCard bindings added for the registry↔dashboard contract; agent-facing tools exempted from the public skill-grant lint with a grep-able reason.

https://claude.ai/code/session_01N6QQUCxQGAKNW7UjJm8bca

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6QQUCxQGAKNW7UjJm8bca)_