### PR TITLE
Authoritative liveness gate + widened runner contract (§4c/§4b)

### DIFF
--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -23,7 +23,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use onsager_artifact::{Artifact, Kind, Provenance, SourceTag};
+use chrono::Utc;
+use onsager_artifact::{Artifact, ArtifactVersion, Kind, Provenance, SourceTag};
 use onsager_substrate::events as se;
 use onsager_substrate::executor::Executor as SubstrateExecutor;
 use serde::{Deserialize, Serialize};
@@ -33,6 +34,7 @@ use uuid::Uuid;
 use crate::context::{ExecutorContext, ExecutorOutputs};
 use crate::error::ExecutorError;
 use crate::executor::Executor;
+use crate::spine::{EmittedArtifact, SessionManifest};
 
 /// LLM-agent executor.
 ///
@@ -120,17 +122,33 @@ pub struct AgentRequest {
     /// artifact. The v1 assembler is intentionally crude; the full
     /// templating story lands with the scheduler (RUN-01, #359).
     pub user_prompt: String,
+    /// Identifier for this agent session. The executor mints it and
+    /// hands it to the runner so the agent's execution environment
+    /// attributes its `emit_artifact` / `declare_no_output` MCP calls
+    /// to the same `session:<id>` manifest stream the executor reads
+    /// back authoritatively (spec #520 §4b/§4c).
+    pub session_id: String,
 }
 
 /// Response returned by an [`AgentRunner`].
 ///
-/// The agent session's final assistant text is the only piece the
-/// executor commits to today — tool-call traces and intermediate
-/// messages are an observability concern, not part of the artifact
-/// the executor emits.
+/// The agent session's final assistant text is carried in `output`.
+/// Per spec #520 §4b the response is *widened* to also surface the
+/// outputs the session emitted via `emit_artifact` — an **optimization
+/// channel only**. The authoritative source of "what came out" is the
+/// `events_ext` manifest, which [`AgentExecutor::execute`] reads back
+/// directly (spec #520 §4c). A runner that can't cheaply surface the
+/// emitted refs (e.g. the stiglab NDJSON stdout stream, where emits
+/// flow out-of-band through MCP) leaves `emitted` empty and the gate
+/// still works off the manifest.
 #[derive(Debug, Clone)]
 pub struct AgentResponse {
     pub output: String,
+    /// Outputs the runner observed the session emit. Optimization only
+    /// — never the authoritative source (see struct docs); the
+    /// executor cross-checks it against the manifest and warns on
+    /// divergence.
+    pub emitted: Vec<EmittedArtifact>,
 }
 
 /// Error returned by an [`AgentRunner::run`] call.
@@ -198,6 +216,10 @@ impl AgentRunner for StubAgentRunner {
     async fn run(&self, _request: AgentRequest) -> Result<AgentResponse, AgentRunError> {
         Ok(AgentResponse {
             output: self.output.clone(),
+            // The stub reports "session over" only — the manifest (set
+            // up by the test's `MockSpine`) is the authoritative source
+            // the gate reads (spec #520 §4c).
+            emitted: Vec::new(),
         })
     }
 }
@@ -238,20 +260,22 @@ impl Executor for AgentExecutor {
     }
 
     async fn execute(&self, ctx: ExecutorContext) -> Result<ExecutorOutputs, ExecutorError> {
-        let request = AgentRequest {
-            model: self.model.clone(),
-            system_prompt: self.system_prompt.clone(),
-            tools: self.tools.clone(),
-            credential_ref: self.credential_ref.clone(),
-            user_prompt: render_user_prompt(&ctx),
-        };
-
         // RUN-02 (#360) lifecycle events. `plan_id` comes off
         // `ExecutorContext`, populated by the scheduler so the
         // spine envelope's `stream_id` (`plan:<plan>:<node>`)
         // correlates verdicts back to a specific run.
         let plan_id = ctx.plan_id.as_str().to_string();
         let session_id = Uuid::new_v4().to_string();
+
+        let request = AgentRequest {
+            model: self.model.clone(),
+            system_prompt: self.system_prompt.clone(),
+            tools: self.tools.clone(),
+            credential_ref: self.credential_ref.clone(),
+            user_prompt: render_user_prompt(&ctx),
+            session_id: session_id.clone(),
+        };
+
         emit_event(
             &ctx,
             se::KIND_AGENT_SESSION_STARTED,
@@ -286,9 +310,9 @@ impl Executor for AgentExecutor {
             &ctx,
             se::KIND_AGENT_SESSION_COMPLETED,
             &se::AgentSessionCompleted {
-                plan_id,
+                plan_id: plan_id.clone(),
                 node_id: ctx.node_id,
-                session_id,
+                session_id: session_id.clone(),
                 // Token usage is not surfaced through `AgentResponse`
                 // yet; the live runner will fill it in via a runner-
                 // side hook in a follow-up. Leaving `None` keeps the
@@ -298,24 +322,79 @@ impl Executor for AgentExecutor {
         )
         .await;
 
-        let mut artifact = Artifact::new(
-            Kind::Document,
-            "agent-output",
-            "agent",
-            ctx.node_id.to_string(),
-            Vec::new(),
-        );
-        artifact.provenance = Executor::declared_provenance(self, &[]);
-        artifact.produced_by_node = Some(ctx.node_id);
-        // The response body lives on an `ArtifactVersion`; full
-        // version persistence (content-ref, change summary) lands
-        // with the scheduler (RUN-01, #359). For now, route the
-        // body through the artifact's `name` slot so the test
-        // harness can assert it.
-        artifact.name = response.output;
+        // ---------------------------------------------------------------
+        // Authoritative liveness gate (spec #520 §4c).
+        //
+        // The manifest — not the runner's response — is the source of
+        // truth for "what came out". Read it back over the spine port;
+        // the deployed adapter queries the `events_ext` `session:<id>`
+        // stream the agent's MCP `emit_artifact` / `declare_no_output`
+        // calls wrote to. This judgment does not depend on the in-
+        // session Stop hook (§4d) having fired.
+        // ---------------------------------------------------------------
+        let manifest = ctx
+            .spine
+            .read_session_manifest(&session_id)
+            .await
+            .map_err(|e| {
+                ExecutorError::failed(format!(
+                    "agent liveness gate: failed to read session manifest for {session_id}: {e}"
+                ))
+            })?;
 
-        let artifact_id = artifact.artifact_id.clone();
-        Ok(ExecutorOutputs::single(artifact_id, artifact))
+        // The widened response (spec #520 §4b) is an optimization
+        // channel only; cross-check it against the authoritative
+        // manifest and warn on divergence rather than trusting it.
+        cross_check_response(&ctx, &response, &manifest);
+
+        if manifest.emitted.is_empty() {
+            if manifest.declared_empty {
+                // Declared empty on purpose — finish cleanly with no
+                // artifacts, flagging the intentional empty delivery so
+                // the dashboard / scheduler can distinguish it from a
+                // silent nothing (§4e `node.completed.declared_empty`).
+                return Ok(ExecutorOutputs::declared_empty());
+            }
+            // Neither delivered nor declared empty — escalate. Reuse the
+            // existing human-escalation channel (do not invent a new
+            // one) and park the run via the Escalate-flavored
+            // `ExecutorError::Failed`, consistent with
+            // `VerifyExecutor`'s `FailPolicy::Escalate`.
+            emit_event(
+                &ctx,
+                se::KIND_NODE_AWAITING_HUMAN,
+                &se::NodeAwaitingHuman {
+                    plan_id,
+                    node_id: ctx.node_id,
+                    prompt: "Agent session ended with no output and no explicit no-output \
+                             declaration — forgotten, or genuinely nothing to deliver? Confirm."
+                        .to_string(),
+                },
+            )
+            .await;
+            return Err(ExecutorError::failed(format!(
+                "agent liveness gate: escalating — session {session_id} ended with no emitted \
+                 output and no declare_no_output; parked for human decision"
+            )));
+        }
+
+        // Non-empty: package one `Artifact` per emitted record. Each is
+        // stamped `Provenance::Uncertain { source: Agent }` HERE — never
+        // read from the manifest. Only a Verify node may upgrade
+        // provenance (ADR 0010 / ADR 0018 invariant 2); liveness is not
+        // a Verify node.
+        let artifacts: Vec<_> = manifest
+            .emitted
+            .iter()
+            .map(|rec| {
+                let (id, art) = build_emitted_artifact(self, ctx.node_id, &session_id, rec);
+                (id, art)
+            })
+            .collect();
+        Ok(ExecutorOutputs {
+            artifacts,
+            declared_empty: None,
+        })
     }
 }
 
@@ -350,6 +429,100 @@ fn render_user_prompt(ctx: &ExecutorContext) -> String {
     out
 }
 
+/// Build one DAG `Artifact` from a manifest-emitted record (spec #520
+/// §4c). The agent-supplied `content_ref` lands on an
+/// [`ArtifactVersion`]; provenance is stamped
+/// `Provenance::Uncertain { source: Agent }` here — never trusted from
+/// the manifest.
+fn build_emitted_artifact(
+    exec: &AgentExecutor,
+    node_id: onsager_artifact::NodeId,
+    session_id: &str,
+    rec: &EmittedArtifact,
+) -> (onsager_artifact::ArtifactId, Artifact) {
+    let name = if rec.summary.is_empty() {
+        "agent-output".to_string()
+    } else {
+        rec.summary.clone()
+    };
+    let mut artifact = Artifact::new(
+        kind_from_str(&rec.kind),
+        name,
+        "agent",
+        node_id.to_string(),
+        Vec::new(),
+    );
+    // Stamped HERE, not read from the manifest (spec #520 §4c, ADR 0010
+    // / ADR 0018 invariant 2). If this were ever sourced from the
+    // agent-controlled record, the agent could self-certify
+    // `Deterministic` — the mutation test guards against exactly that.
+    artifact.provenance = Executor::declared_provenance(exec, &[]);
+    artifact.produced_by_node = Some(node_id);
+    // Carry the agent-supplied content pointer on a first version.
+    artifact.versions.push(ArtifactVersion {
+        version: 1,
+        created_at: Utc::now(),
+        created_by_session: session_id.to_string(),
+        content_ref: rec.content_ref.clone(),
+        change_summary: rec.summary.clone(),
+        parent_version: None,
+    });
+    artifact.current_version = 1;
+    let id = artifact.artifact_id.clone();
+    (id, artifact)
+}
+
+/// Map a manifest `kind` tag onto the [`Kind`] enum, mirroring
+/// [`Kind`]'s `Display`. Unknown tags become [`Kind::Custom`] — the
+/// kind set is typed but open.
+fn kind_from_str(kind: &str) -> Kind {
+    match kind {
+        "code" => Kind::Code,
+        "document" => Kind::Document,
+        "pull_request" => Kind::PullRequest,
+        "github_issue" => Kind::GithubIssue,
+        other => Kind::Custom(other.to_string()),
+    }
+}
+
+/// Cross-check the runner's optimization-channel `emitted` refs (spec
+/// #520 §4b) against the authoritative manifest. The manifest always
+/// wins; a divergence means the runner's fast-path view drifted from
+/// the recorded truth — log it so the drift is visible without
+/// stalling the run. A runner that reports nothing (the common case —
+/// emits flow out-of-band through MCP) is silently fine.
+fn cross_check_response(
+    ctx: &ExecutorContext,
+    response: &AgentResponse,
+    manifest: &SessionManifest,
+) {
+    if response.emitted.is_empty() {
+        return;
+    }
+    let mut from_response: Vec<&str> = response
+        .emitted
+        .iter()
+        .map(|e| e.content_ref.uri.as_str())
+        .collect();
+    let mut from_manifest: Vec<&str> = manifest
+        .emitted
+        .iter()
+        .map(|e| e.content_ref.uri.as_str())
+        .collect();
+    from_response.sort_unstable();
+    from_manifest.sort_unstable();
+    if from_response != from_manifest {
+        tracing::warn!(
+            plan = %ctx.plan_id,
+            node = %ctx.node_id,
+            response_emits = from_response.len(),
+            manifest_emits = from_manifest.len(),
+            "agent runner response.emitted diverged from the authoritative manifest; \
+             using the manifest",
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -359,14 +532,53 @@ mod tests {
     use super::*;
     use crate::registry::ExecutorRegistry;
     use crate::spine::test_support::MockSpine;
-    use onsager_artifact::{ArtifactId, NodeId};
+    use onsager_artifact::{ArtifactId, ContentRef, NodeId};
 
     fn agent_with_stub(output: &str) -> AgentExecutor {
         AgentExecutor::new("claude-sonnet-4-6", "you are helpful")
             .with_runner(Arc::new(StubAgentRunner::new(output)))
     }
 
+    /// A manifest carrying a single emitted output — the "agent
+    /// delivered" case for the liveness gate.
+    fn manifest_one_emit() -> SessionManifest {
+        SessionManifest {
+            emitted: vec![EmittedArtifact {
+                artifact_id: "art_emit_1".into(),
+                content_ref: ContentRef {
+                    uri: "inline:base64,aGVsbG8=".into(),
+                    checksum: Some("abc123".into()),
+                },
+                kind: "document".into(),
+                summary: "the agent said hello".into(),
+            }],
+            declared_empty: false,
+        }
+    }
+
+    /// A context whose spine serves `manifest` from
+    /// `read_session_manifest`. Returns the concrete [`MockSpine`] too so
+    /// tests can read back the lifecycle events the executor emitted.
+    fn ctx_with_manifest(
+        node_id: NodeId,
+        manifest: SessionManifest,
+    ) -> (ExecutorContext, Arc<MockSpine>) {
+        let mock = Arc::new(MockSpine::with_manifest(manifest));
+        let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
+            node_id,
+            inputs: Vec::new(),
+            spine: Arc::clone(&mock) as Arc<dyn crate::SpineClient>,
+            subworkflow_ref: None,
+        };
+        (ctx, mock)
+    }
+
     fn empty_ctx() -> ExecutorContext {
+        // Default MockSpine serves an empty (no-emit, not-declared)
+        // manifest — the liveness-gate trip condition. Tests that
+        // expect `execute` to reach the gate use the manifest-aware
+        // constructors above instead.
         ExecutorContext {
             plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
@@ -425,21 +637,27 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Authoritative liveness gate (spec #520 §4c).
+    // -----------------------------------------------------------------
+
     #[tokio::test]
-    async fn execute_returns_uncertain_agent_artifact() {
-        let exec = agent_with_stub("the agent said hello");
+    async fn execute_packages_emitted_manifest_record_as_uncertain_agent_artifact() {
+        // Stub runner reports "session over"; the manifest carries one
+        // emitted output. The gate packages it onto the DAG.
+        let exec = agent_with_stub("final assistant text");
         let node_id = NodeId::generate();
-        let ctx = ExecutorContext {
-            plan_id: crate::scheduler::PlanId::generate(),
-            node_id,
-            inputs: Vec::new(),
-            spine: Arc::new(MockSpine::default()),
-            subworkflow_ref: None,
-        };
+        let (ctx, _spine) = ctx_with_manifest(node_id, manifest_one_emit());
 
         let outputs = exec.execute(ctx).await.unwrap();
+        // node.completed.output_artifact_ids will be non-empty.
         assert_eq!(outputs.artifacts.len(), 1);
+        assert_eq!(outputs.declared_empty, None);
         let (_id, art) = &outputs.artifacts[0];
+        // Mutation guard: provenance is STAMPED here as
+        // Uncertain { Agent }, never read from the manifest. Forcing
+        // this to `Deterministic` in `build_emitted_artifact` fails
+        // this assertion (spec #520 §4c).
         assert_eq!(
             art.provenance,
             Provenance::Uncertain {
@@ -447,8 +665,65 @@ mod tests {
             }
         );
         assert_eq!(art.produced_by_node, Some(node_id));
-        // Stubbed runner output flows through.
-        assert_eq!(art.name, "the agent said hello");
+        // The agent-supplied content_ref rides on a first version.
+        assert_eq!(art.current_version, 1);
+        assert_eq!(art.versions.len(), 1);
+        assert_eq!(art.versions[0].content_ref.uri, "inline:base64,aGVsbG8=");
+        assert_eq!(art.kind, Kind::Document);
+    }
+
+    #[tokio::test]
+    async fn execute_escalates_when_empty_and_not_declared() {
+        // No emits, no declaration → emit node.awaiting_human + return
+        // the Escalate path.
+        let exec = agent_with_stub("i did some thinking but never emitted");
+        let node_id = NodeId::generate();
+        let (ctx, spine) = ctx_with_manifest(node_id, SessionManifest::default());
+
+        let err = exec.execute(ctx).await.unwrap_err();
+        match err {
+            ExecutorError::Failed(msg) => {
+                assert!(msg.contains("escalating"), "{msg}");
+                assert!(msg.contains("no emitted output"), "{msg}");
+            }
+            other => panic!("expected ExecutorError::Failed, got {other:?}"),
+        }
+
+        // node.awaiting_human was emitted on the existing escalation
+        // channel.
+        let emitted = spine.emitted.lock().unwrap();
+        assert!(
+            emitted
+                .iter()
+                .any(|(k, _)| k == se::KIND_NODE_AWAITING_HUMAN),
+            "expected node.awaiting_human emit, got: {emitted:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_finishes_clean_when_declared_empty() {
+        // No emits but an explicit declaration → clean finish, no
+        // artifacts, no escalation, declared_empty signal set.
+        let exec = agent_with_stub("nothing to deliver this time");
+        let node_id = NodeId::generate();
+        let manifest = SessionManifest {
+            emitted: Vec::new(),
+            declared_empty: true,
+        };
+        let (ctx, spine) = ctx_with_manifest(node_id, manifest);
+
+        let outputs = exec.execute(ctx).await.unwrap();
+        assert!(outputs.artifacts.is_empty());
+        // Surfaces as node.completed.declared_empty = Some(true) (§4e).
+        assert_eq!(outputs.declared_empty, Some(true));
+        // No escalation.
+        let emitted = spine.emitted.lock().unwrap();
+        assert!(
+            !emitted
+                .iter()
+                .any(|(k, _)| k == se::KIND_NODE_AWAITING_HUMAN),
+            "declared-empty must not escalate, got: {emitted:?}"
+        );
     }
 
     #[tokio::test]
@@ -465,6 +740,7 @@ mod tests {
                 *self.request.lock().unwrap() = Some(request);
                 Ok(AgentResponse {
                     output: "ok".into(),
+                    emitted: Vec::new(),
                 })
             }
         }
@@ -477,11 +753,17 @@ mod tests {
 
         let input_id = ArtifactId::new("art_input_1");
         let input_art = Artifact::new(Kind::Document, "upstream", "owner", "test", Vec::new());
+        // Declared-empty manifest so the gate lets `execute` return Ok;
+        // this test only asserts the assembled request.
+        let mock = Arc::new(MockSpine::with_manifest(SessionManifest {
+            emitted: Vec::new(),
+            declared_empty: true,
+        }));
         let ctx = ExecutorContext {
             plan_id: crate::scheduler::PlanId::generate(),
             node_id: NodeId::generate(),
             inputs: vec![(input_id.clone(), input_art)],
-            spine: Arc::new(MockSpine::default()),
+            spine: mock as Arc<dyn crate::SpineClient>,
             subworkflow_ref: None,
         };
 
@@ -496,6 +778,11 @@ mod tests {
             request.user_prompt.contains(input_id.as_str()),
             "user prompt should reference the upstream artifact id, got: {}",
             request.user_prompt
+        );
+        // The executor minted a session id and threaded it to the runner.
+        assert!(
+            !request.session_id.is_empty(),
+            "session_id must be threaded to the runner (spec #520 §4b)"
         );
     }
 
@@ -642,18 +929,55 @@ mod tests {
         assert_eq!(exec.executor_kind(), "agent");
 
         let node_id = NodeId::generate();
-        let ctx = ExecutorContext {
-            plan_id: crate::scheduler::PlanId::generate(),
-            node_id,
-            inputs: Vec::new(),
-            spine: Arc::new(MockSpine::default()),
-            subworkflow_ref: None,
-        };
+        let (ctx, _spine) = ctx_with_manifest(node_id, manifest_one_emit());
         let outputs = exec.execute(ctx).await.unwrap();
         let (_id, art) = &outputs.artifacts[0];
         assert!(art.provenance.is_uncertain());
         assert_eq!(art.provenance.source(), SourceTag::Agent);
         assert_eq!(art.produced_by_node, Some(node_id));
+    }
+
+    // -----------------------------------------------------------------
+    // §4b — widened response is an optimization, manifest is authority.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn manifest_is_authoritative_regardless_of_response_emitted() {
+        // A runner that surfaces emitted refs on the response.
+        #[derive(Debug)]
+        struct EmittingRunner(Vec<EmittedArtifact>);
+        #[async_trait]
+        impl AgentRunner for EmittingRunner {
+            async fn run(&self, _r: AgentRequest) -> Result<AgentResponse, AgentRunError> {
+                Ok(AgentResponse {
+                    output: "done".into(),
+                    emitted: self.0.clone(),
+                })
+            }
+        }
+
+        let manifest = manifest_one_emit();
+        let node_id = NodeId::generate();
+
+        // Run A: runner reports the same emit the manifest has.
+        let exec_a = AgentExecutor::new("m", "p")
+            .with_runner(Arc::new(EmittingRunner(manifest.emitted.clone())));
+        let (ctx_a, _) = ctx_with_manifest(node_id, manifest.clone());
+        let out_a = exec_a.execute(ctx_a).await.unwrap();
+
+        // Run B: runner reports NOTHING on the response, but the
+        // manifest still carries the emit. Behavior must be identical —
+        // the executor reads the manifest, not the response.
+        let exec_b = AgentExecutor::new("m", "p").with_runner(Arc::new(EmittingRunner(Vec::new())));
+        let (ctx_b, _) = ctx_with_manifest(node_id, manifest.clone());
+        let out_b = exec_b.execute(ctx_b).await.unwrap();
+
+        assert_eq!(out_a.artifacts.len(), out_b.artifacts.len());
+        assert_eq!(out_a.artifacts.len(), 1);
+        assert_eq!(
+            out_a.artifacts[0].1.versions[0].content_ref,
+            out_b.artifacts[0].1.versions[0].content_ref,
+        );
     }
 
     /// Compile-time check: the runtime trait is still object-safe

--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -452,6 +452,14 @@ fn build_emitted_artifact(
         node_id.to_string(),
         Vec::new(),
     );
+    // Preserve the identity minted at emit time (spec #520 §4a) rather
+    // than the throwaway id `Artifact::new` generated, so the packaged
+    // artifact matches the manifest record downstream can reference.
+    // (The scheduler still re-keys this to the edge's namespaced
+    // ArtifactId on persist — single-writer-per-edge — but the
+    // executor's own output stays faithful to the manifest, which is
+    // what direct (non-scheduler) callers and the unit tests observe.)
+    artifact.artifact_id = onsager_artifact::ArtifactId::new(rec.artifact_id.clone());
     // Stamped HERE, not read from the manifest (spec #520 §4c, ADR 0010
     // / ADR 0018 invariant 2). If this were ever sourced from the
     // agent-controlled record, the agent could self-certify
@@ -665,6 +673,8 @@ mod tests {
             }
         );
         assert_eq!(art.produced_by_node, Some(node_id));
+        // The minted manifest id is preserved (not a throwaway ULID).
+        assert_eq!(art.artifact_id.as_str(), "art_emit_1");
         // The agent-supplied content_ref rides on a first version.
         assert_eq!(art.current_version, 1);
         assert_eq!(art.versions.len(), 1);

--- a/crates/onsager-nodes/src/context.rs
+++ b/crates/onsager-nodes/src/context.rs
@@ -65,6 +65,13 @@ pub struct ExecutorContext {
 #[derive(Debug, Default)]
 pub struct ExecutorOutputs {
     pub artifacts: Vec<(ArtifactId, Artifact)>,
+    /// `Some(true)` when the executor produced no artifacts **on
+    /// purpose** — an explicit empty delivery, distinguishing it from
+    /// "delivered nothing" (`artifacts` empty, field `None`). The
+    /// scheduler threads this onto `node.completed.declared_empty`
+    /// (spec #520 §4c/§4e). `None` for every executor that doesn't
+    /// have a no-output concept.
+    pub declared_empty: Option<bool>,
 }
 
 impl ExecutorOutputs {
@@ -78,6 +85,17 @@ impl ExecutorOutputs {
     pub fn single(id: ArtifactId, artifact: Artifact) -> Self {
         Self {
             artifacts: vec![(id, artifact)],
+            declared_empty: None,
+        }
+    }
+
+    /// An empty outputs value that records the executor declared it
+    /// produced nothing on purpose (spec #520 §4c). Surfaces as
+    /// `node.completed.declared_empty = Some(true)`.
+    pub fn declared_empty() -> Self {
+        Self {
+            artifacts: Vec::new(),
+            declared_empty: Some(true),
         }
     }
 }

--- a/crates/onsager-nodes/src/lib.rs
+++ b/crates/onsager-nodes/src/lib.rs
@@ -53,6 +53,7 @@ pub use scheduler::{
     PlanId, PlanStore, PlanStoreError, Scheduler, SchedulerError,
 };
 pub use script::{INLINE_URI_PREFIX, ScriptExecutor, decode_inline_body};
+pub use spine::{EmittedArtifact, SessionManifest};
 pub use spine::{SpineClient, SpineError};
 pub use subworkflow::{
     SUBWORKFLOW_KIND, SchedulerSubWorkflowRunner, StubSubWorkflowRunner, SubWorkflowExecutor,

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -455,6 +455,11 @@ impl Scheduler {
         };
         match dispatch(&self.registry, node, ctx).await {
             Ok(outputs) => {
+                // Capture the no-output declaration before the outputs
+                // are consumed by persistence — the authoritative
+                // liveness gate (spec #520 §4c) sets it on the
+                // `AgentExecutor`'s empty-but-declared path.
+                let declared_empty = outputs.declared_empty;
                 let output_artifact_ids =
                     self.persist_outputs(plan_id, plan, node, outputs).await?;
                 state.insert(node.id, NodeState::Completed);
@@ -462,7 +467,7 @@ impl Scheduler {
                     .set_node_state(plan_id, node.id, NodeState::Completed)
                     .await
                     .map_err(|e| SchedulerError::Store(e.0))?;
-                self.emit_completed(plan_id, node.id, output_artifact_ids)
+                self.emit_completed(plan_id, node.id, output_artifact_ids, declared_empty)
                     .await;
                 Ok(())
             }
@@ -496,14 +501,16 @@ impl Scheduler {
         plan_id: &PlanId,
         node_id: NodeId,
         output_artifact_ids: Vec<ArtifactId>,
+        declared_empty: Option<bool>,
     ) {
         let payload = se::NodeCompleted {
             plan_id: plan_id.as_str().to_string(),
             node_id,
             output_artifact_ids,
-            // Populated by the authoritative gate (§4c, #520); `None`
-            // here keeps behavior unchanged.
-            declared_empty: None,
+            // Set by the authoritative liveness gate (§4c, #520) on the
+            // `AgentExecutor`'s empty-but-declared path; `None` for
+            // every other executor.
+            declared_empty,
         };
         self.emit(plan_id, node_id, EVENT_NODE_COMPLETED, &payload)
             .await;
@@ -865,6 +872,78 @@ mod tests {
         assert!(
             seen.contains(&external_input),
             "entry node executor should have received its declared input artifact, saw: {seen:?}",
+        );
+    }
+
+    /// Executor that declares it produced nothing on purpose — the
+    /// `AgentExecutor`'s declared-empty path (spec #520 §4c). Registers
+    /// under `noop` to override the default.
+    #[derive(Debug)]
+    struct DeclaredEmptyExecutor;
+
+    #[async_trait]
+    impl crate::Executor for DeclaredEmptyExecutor {
+        fn executor_kind(&self) -> &'static str {
+            "noop"
+        }
+        fn declared_provenance(
+            &self,
+            _: &[onsager_artifact::Provenance],
+        ) -> onsager_artifact::Provenance {
+            onsager_artifact::Provenance::external_deterministic()
+        }
+        async fn execute(
+            &self,
+            _: ExecutorContext,
+        ) -> Result<crate::context::ExecutorOutputs, ExecutorError> {
+            Ok(crate::context::ExecutorOutputs::declared_empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn declared_empty_outputs_thread_onto_node_completed() {
+        // Single-node plan whose executor declares empty. The emitted
+        // node.completed must carry declared_empty = true (§4c/§4e).
+        let edge_out = EdgeId::generate();
+        let node_id = NodeId::generate();
+        let node = SubstrateNode {
+            id: node_id,
+            executor: Box::new(onsager_substrate::executor::NoOpExecutor),
+            inputs: vec![],
+            outputs: vec![EdgeRef::new(edge_out)],
+        };
+        let plan = ExecutionPlan {
+            nodes: vec![node],
+            edges: vec![Edge {
+                id: edge_out,
+                artifact_id: ArtifactId::new("out"),
+                requires_deterministic: false,
+            }],
+            spec_index: HashMap::new(),
+            entry_inputs: HashMap::new(),
+            node_spec_index: HashMap::new(),
+        };
+
+        let mut registry = ExecutorRegistry::new();
+        registry.register(Arc::new(DeclaredEmptyExecutor));
+        let store = Arc::new(InMemoryPlanStore::new());
+        let spine = Arc::new(MockSpine::default());
+        let scheduler = Scheduler::new(
+            Arc::new(registry),
+            Arc::clone(&store) as Arc<dyn PlanStore>,
+            Arc::clone(&spine) as Arc<dyn SpineClient>,
+        );
+        let plan_id = PlanId::generate();
+        scheduler.run(&plan_id, &plan).await.unwrap();
+
+        let emitted = spine.emitted.lock().unwrap();
+        let (_, payload) = emitted
+            .iter()
+            .find(|(k, _)| k == EVENT_NODE_COMPLETED)
+            .expect("node.completed emit");
+        assert_eq!(
+            payload["declared_empty"], true,
+            "declared_empty must thread onto node.completed, got {payload}"
         );
     }
 

--- a/crates/onsager-nodes/src/spine.rs
+++ b/crates/onsager-nodes/src/spine.rs
@@ -15,7 +15,7 @@
 //! introducing parallel ports.
 
 use async_trait::async_trait;
-use onsager_artifact::{Artifact, ArtifactId};
+use onsager_artifact::{Artifact, ArtifactId, ContentRef};
 use thiserror::Error;
 
 /// Error returned by a [`SpineClient`] call.
@@ -36,6 +36,36 @@ impl SpineError {
     }
 }
 
+/// One output an agent session emitted, read back from its
+/// `events_ext` manifest (spec #520 §4a). Carries identity + content
+/// pointer + agent-supplied metadata — **never** provenance. The
+/// `AgentExecutor` stamps `Provenance::Uncertain { source: Agent }`
+/// when it packages these onto the typed DAG (spec #520 §4c); the agent
+/// must not be able to self-declare a stronger provenance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmittedArtifact {
+    /// Stable id minted at emit time (`art_<ulid>`).
+    pub artifact_id: String,
+    /// Pointer to the addressable content the session produced.
+    pub content_ref: ContentRef,
+    /// Artifact kind tag (`code` / `document` / `pull_request` / …).
+    pub kind: String,
+    /// Human-readable summary of what was emitted.
+    pub summary: String,
+}
+
+/// An agent session's output manifest: the outputs it emitted plus
+/// whether it explicitly declared it produced nothing.
+///
+/// `emitted.is_empty() && !declared_empty` is the liveness-gate trip
+/// condition (spec #520 §4c) — the session ended having neither
+/// delivered nor declared empty.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionManifest {
+    pub emitted: Vec<EmittedArtifact>,
+    pub declared_empty: bool,
+}
+
 /// Async port over the spine event store, scoped to the surface an
 /// executor needs while it runs.
 ///
@@ -52,6 +82,20 @@ pub trait SpineClient: Send + Sync + std::fmt::Debug {
     /// `Ok(None)` for a missing id is not an error — executors decide
     /// whether absence is a failure condition.
     async fn read_artifact(&self, id: &ArtifactId) -> Result<Option<Artifact>, SpineError>;
+
+    /// Read an agent session's output manifest (spec #520 §4a / §4c).
+    ///
+    /// The default returns an empty manifest so adapters that never
+    /// serve agent sessions (most test stubs) don't have to override
+    /// it. The deployed substrate scheduler's adapter overrides this to
+    /// query the `events_ext` `session:<id>` stream — that read is what
+    /// the `AgentExecutor`'s authoritative liveness gate keys off.
+    async fn read_session_manifest(
+        &self,
+        _session_id: &str,
+    ) -> Result<SessionManifest, SpineError> {
+        Ok(SessionManifest::default())
+    }
 }
 
 #[cfg(test)]
@@ -61,10 +105,24 @@ pub(crate) mod test_support {
     use std::sync::Mutex;
 
     /// In-memory mock used by this crate's tests. Captures every
-    /// `emit` call and looks up artifacts in a fixed table.
+    /// `emit` call, looks up artifacts in a fixed table, and serves a
+    /// canned [`SessionManifest`] so the `AgentExecutor` liveness gate
+    /// (spec #520 §4c) is unit-testable without a database.
     #[derive(Debug, Default)]
     pub struct MockSpine {
         pub emitted: Mutex<Vec<(String, serde_json::Value)>>,
+        pub manifest: Mutex<SessionManifest>,
+    }
+
+    impl MockSpine {
+        /// Build a mock that serves `manifest` from
+        /// `read_session_manifest`.
+        pub fn with_manifest(manifest: SessionManifest) -> Self {
+            Self {
+                emitted: Mutex::new(Vec::new()),
+                manifest: Mutex::new(manifest),
+            }
+        }
     }
 
     #[async_trait]
@@ -79,6 +137,13 @@ pub(crate) mod test_support {
 
         async fn read_artifact(&self, _id: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
             Ok(None)
+        }
+
+        async fn read_session_manifest(
+            &self,
+            _session_id: &str,
+        ) -> Result<SessionManifest, SpineError> {
+            Ok(self.manifest.lock().unwrap().clone())
         }
     }
 

--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -444,7 +444,10 @@ impl RuntimeExecutor for SubWorkflowExecutor {
             .run(workflow_ref, inputs)
             .await
             .map_err(|e| ExecutorError::failed(e.to_string()))?;
-        Ok(ExecutorOutputs { artifacts: outputs })
+        Ok(ExecutorOutputs {
+            artifacts: outputs,
+            declared_empty: None,
+        })
     }
 }
 

--- a/crates/onsager-nodes/tests/crawlab_fixture.rs
+++ b/crates/onsager-nodes/tests/crawlab_fixture.rs
@@ -32,10 +32,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use onsager_artifact::{Artifact, ArtifactId, Provenance, SourceTag};
+use onsager_artifact::{Artifact, ArtifactId, ContentRef, Provenance, SourceTag};
 use onsager_nodes::{
-    AgentExecutor, ExecutorRegistry, InMemoryPlanStore, NodeState, PlanId, PlanStore, Scheduler,
-    ScriptExecutor, SpineClient, SpineError, StubAgentRunner, VerifyExecutor,
+    AgentExecutor, EmittedArtifact, ExecutorRegistry, InMemoryPlanStore, NodeState, PlanId,
+    PlanStore, Scheduler, ScriptExecutor, SessionManifest, SpineClient, SpineError,
+    StubAgentRunner, VerifyExecutor,
 };
 use onsager_nodes::{Check, FailPolicy};
 use onsager_substrate::NodeId;
@@ -193,6 +194,27 @@ impl SpineClient for ObservingSpine {
 
     async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
         Ok(None)
+    }
+
+    /// Serve a single-emit manifest for every session: the fixture's
+    /// agent "delivered" its analysis via `emit_artifact`, so the
+    /// authoritative liveness gate (spec #520 §4c) packages that one
+    /// output onto the agent node's single output edge. (Without an
+    /// emit the gate would correctly escalate — exercised by the
+    /// `AgentExecutor` unit tests, not this end-to-end pipeline.)
+    async fn read_session_manifest(&self, session_id: &str) -> Result<SessionManifest, SpineError> {
+        Ok(SessionManifest {
+            emitted: vec![EmittedArtifact {
+                artifact_id: format!("art_{session_id}"),
+                content_ref: ContentRef {
+                    uri: "inline:base64,YW5hbHlzaXM=".into(),
+                    checksum: None,
+                },
+                kind: "document".into(),
+                summary: "crawlab analysis".into(),
+            }],
+            declared_empty: false,
+        })
     }
 }
 

--- a/crates/onsager-nodes/tests/scheduler_event_contract.rs
+++ b/crates/onsager-nodes/tests/scheduler_event_contract.rs
@@ -29,11 +29,11 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use onsager_artifact::{Artifact, ArtifactId, NodeId};
+use onsager_artifact::{Artifact, ArtifactId, ContentRef, NodeId};
 use onsager_nodes::{
-    AgentExecutor, EVENT_NODE_COMPLETED, EVENT_NODE_FAILED, EVENT_NODE_STARTED, ExecutorRegistry,
-    InMemoryPlanStore, PlanId, PlanStore, Scheduler, SpineClient, SpineError, StubAgentRunner,
-    VerifyExecutor,
+    AgentExecutor, EVENT_NODE_COMPLETED, EVENT_NODE_FAILED, EVENT_NODE_STARTED, EmittedArtifact,
+    ExecutorRegistry, InMemoryPlanStore, PlanId, PlanStore, Scheduler, SessionManifest,
+    SpineClient, SpineError, StubAgentRunner, VerifyExecutor,
     verify::{Check, FailPolicy},
 };
 use onsager_substrate::compiler::ExecutionPlan;
@@ -59,6 +59,24 @@ impl SpineClient for CapturingSpine {
     }
     async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
         Ok(None)
+    }
+    /// The agent in this plan delivers one output; serve a single-emit
+    /// manifest so the liveness gate (spec #520 §4c) packages it rather
+    /// than escalating. (The empty / declared-empty branches are
+    /// covered by the `AgentExecutor` unit tests.)
+    async fn read_session_manifest(&self, session_id: &str) -> Result<SessionManifest, SpineError> {
+        Ok(SessionManifest {
+            emitted: vec![EmittedArtifact {
+                artifact_id: format!("art_{session_id}"),
+                content_ref: ContentRef {
+                    uri: "inline:base64,aGk=".into(),
+                    checksum: None,
+                },
+                kind: "document".into(),
+                summary: "agent output".into(),
+            }],
+            declared_empty: false,
+        })
     }
 }
 

--- a/crates/onsager-portal/src/mcp/tools/session_manifest.rs
+++ b/crates/onsager-portal/src/mcp/tools/session_manifest.rs
@@ -7,37 +7,23 @@
 //! holding portal MCP server is the only thing that touches the
 //! database, exactly like every other tool in this directory.
 //!
-//! Storage is `events_ext` (not a new table, not a new
-//! `FactoryEventKind`) via [`EventStore::append_ext`] /
-//! [`EventStore::query_ext_stream`]. Those rows are already on the
-//! `onsager_events` pg_notify stream, so a future Observer (OBS-01,
-//! #361) can subscribe to the same manifest with no extra plumbing.
-//! The conventions below are locked in spec #520 §3 — do not
-//! re-litigate:
-//!
-//! - `namespace = "stiglab"` (the emit happens inside a stiglab-
-//!   orchestrated session; reuse the existing validated namespace).
-//! - `stream_id = "session:<session_id>"`.
-//! - `event_type = "artifact.emitted"` for a real output;
-//!   `"output.declared_empty"` for an explicit no-output declaration.
-//!
-//! **Provenance never goes into the manifest.** Records carry
-//! `content_ref / kind / summary` (plus the minted `artifact_id`
-//! identity) only — the agent must not be able to self-declare
-//! `Deterministic`. `AgentExecutor` stamps `Provenance::Uncertain`
-//! when it reads records back (spec #520 §4c, a later layer).
+//! The manifest wire contract — the `events_ext` namespace / stream /
+//! event-type / data-field conventions, the parser, and the store-level
+//! append/read helpers — is the **single source of truth** in
+//! [`onsager_spine::session_manifest`]. It lives there (a crate both
+//! sides of the seam already depend on) because the substrate scheduler
+//! reads the same manifest from the other side of the seam to run the
+//! authoritative liveness gate (spec #520 §4c). These tools own only the
+//! MCP surface on top of it: argument schemas, workspace-scoped auth,
+//! and the inline content-storage path the agent's `emit_artifact` runs
+//! before recording a row.
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use ring::digest;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
-
-use onsager_artifact::ArtifactId;
-use onsager_spine::EventMetadata;
-use onsager_spine::EventStore;
-use onsager_spine::extension_event::ExtensionEventRecord;
 
 use crate::auth::AuthUser;
 use crate::state::AppState;
@@ -45,12 +31,12 @@ use crate::state::AppState;
 use super::super::{ToolError, ToolResult};
 use super::require_workspace_access;
 
-/// Namespace the manifest rows live under (spec #520 §3).
-const MANIFEST_NAMESPACE: &str = "stiglab";
-/// `events_ext.event_type` for a real emitted output.
-const EVENT_ARTIFACT_EMITTED: &str = "artifact.emitted";
-/// `events_ext.event_type` for an explicit "I produced nothing".
-const EVENT_OUTPUT_DECLARED_EMPTY: &str = "output.declared_empty";
+// Re-export the shared store-level helpers + types so existing callers
+// (the integration test, the tool wrappers below) keep one import path.
+// The contract itself is owned by `onsager-spine`.
+pub use onsager_spine::session_manifest::{
+    EmitStatus, append_declared_empty, append_emit, read_status,
+};
 
 /// Inline content-storage URI scheme. First cut matches the Script
 /// executor's convention (`crates/onsager-nodes/src/script.rs`):
@@ -58,17 +44,6 @@ const EVENT_OUTPUT_DECLARED_EMPTY: &str = "output.declared_empty";
 /// backed scheme replaces this once content storage is formalized
 /// (RUN-01 #359 — the same gap the Script executor flags).
 const INLINE_URI_PREFIX: &str = "inline:base64,";
-
-/// Build the manifest stream key for a session.
-fn session_stream_id(session_id: &str) -> String {
-    format!("session:{session_id}")
-}
-
-/// The actor stamp on every manifest write — the session itself, never
-/// a human or another subsystem.
-fn session_actor(session_id: &str) -> String {
-    format!("session:{session_id}")
-}
 
 // ---------------------------------------------------------------------------
 // emit_artifact
@@ -100,48 +75,6 @@ fn store_content(content: &str) -> Value {
     let uri = format!("{INLINE_URI_PREFIX}{}", BASE64.encode(bytes));
     let checksum = hex::encode(digest::digest(&digest::SHA256, bytes).as_ref());
     serde_json::json!({ "uri": uri, "checksum": checksum })
-}
-
-/// Append an `artifact.emitted` row to the session manifest. Returns
-/// the minted `artifact_id`. Store-level helper so the integration
-/// test can exercise the round-trip without standing up auth.
-pub async fn append_emit(
-    store: &EventStore,
-    workspace_id: &str,
-    session_id: &str,
-    content_ref: Value,
-    kind: &str,
-    summary: &str,
-) -> Result<String, sqlx::Error> {
-    // Mint a stable id so the authoritative gate (spec #520 §4c) can
-    // reference this output when it packages it onto the typed DAG.
-    // Use the canonical `art_<ulid>` shape (`ArtifactId::generate`) so
-    // manifest rows match every other id that flows through the
-    // artifact model — downstream `art_`-prefix matching stays uniform.
-    let artifact_id = ArtifactId::generate().as_str().to_string();
-    let data = serde_json::json!({
-        "artifact_id": artifact_id,
-        "content_ref": content_ref,
-        "kind": kind,
-        "summary": summary,
-    });
-    let metadata = EventMetadata {
-        correlation_id: None,
-        causation_id: None,
-        actor: session_actor(session_id),
-    };
-    store
-        .append_ext(
-            workspace_id,
-            &session_stream_id(session_id),
-            MANIFEST_NAMESPACE,
-            EVENT_ARTIFACT_EMITTED,
-            data,
-            &metadata,
-            None,
-        )
-        .await?;
-    Ok(artifact_id)
 }
 
 pub async fn emit_artifact(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
@@ -186,34 +119,6 @@ pub struct DeclareNoOutputArgs {
     pub reason: String,
 }
 
-/// Append an `output.declared_empty` row to the session manifest.
-/// Store-level helper, mirroring [`append_emit`].
-pub async fn append_declared_empty(
-    store: &EventStore,
-    workspace_id: &str,
-    session_id: &str,
-    reason: &str,
-) -> Result<(), sqlx::Error> {
-    let data = serde_json::json!({ "reason": reason });
-    let metadata = EventMetadata {
-        correlation_id: None,
-        causation_id: None,
-        actor: session_actor(session_id),
-    };
-    store
-        .append_ext(
-            workspace_id,
-            &session_stream_id(session_id),
-            MANIFEST_NAMESPACE,
-            EVENT_OUTPUT_DECLARED_EMPTY,
-            data,
-            &metadata,
-            None,
-        )
-        .await?;
-    Ok(())
-}
-
 pub async fn declare_no_output(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
     let args: DeclareNoOutputArgs = serde_json::from_value(args)
         .map_err(|e| ToolError::InvalidParams(format!("invalid declare_no_output args: {e}")))?;
@@ -248,53 +153,6 @@ pub struct ReadEmitStatusArgs {
     pub session_id: String,
 }
 
-/// Pure tally of a session's manifest records, scoped to a workspace.
-/// Counts `artifact.emitted` rows and detects any
-/// `output.declared_empty`. Separated from the DB read so it is
-/// unit-testable without Postgres.
-pub fn tally_status(records: &[ExtensionEventRecord], workspace_id: &str) -> EmitStatus {
-    let mut emit_count: u64 = 0;
-    let mut declared_empty = false;
-    for r in records {
-        // Defensive: the session stream is workspace-private by
-        // construction, but never count a row that names a different
-        // workspace.
-        if r.workspace_id != workspace_id {
-            continue;
-        }
-        match r.event_type.as_str() {
-            EVENT_ARTIFACT_EMITTED => emit_count += 1,
-            EVENT_OUTPUT_DECLARED_EMPTY => declared_empty = true,
-            _ => {}
-        }
-    }
-    EmitStatus {
-        emit_count,
-        declared_empty,
-    }
-}
-
-/// The manifest summary `read_emit_status` returns.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct EmitStatus {
-    pub emit_count: u64,
-    pub declared_empty: bool,
-}
-
-/// Read + tally a session's manifest. Store-level helper so the
-/// integration test can call it directly. Pure read — safe to call
-/// repeatedly.
-pub async fn read_status(
-    store: &EventStore,
-    workspace_id: &str,
-    session_id: &str,
-) -> Result<EmitStatus, sqlx::Error> {
-    let records = store
-        .query_ext_stream(&session_stream_id(session_id))
-        .await?;
-    Ok(tally_status(&records, workspace_id))
-}
-
 pub async fn read_emit_status(state: &AppState, auth_user: &AuthUser, args: Value) -> ToolResult {
     let args: ReadEmitStatusArgs = serde_json::from_value(args)
         .map_err(|e| ToolError::InvalidParams(format!("invalid read_emit_status args: {e}")))?;
@@ -314,52 +172,6 @@ pub async fn read_emit_status(state: &AppState, auth_user: &AuthUser, args: Valu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-
-    fn record(workspace_id: &str, event_type: &str) -> ExtensionEventRecord {
-        ExtensionEventRecord {
-            id: 0,
-            stream_id: session_stream_id("s1"),
-            namespace: MANIFEST_NAMESPACE.to_string(),
-            event_type: event_type.to_string(),
-            data: serde_json::json!({}),
-            metadata: serde_json::json!({}),
-            ref_event_id: None,
-            created_at: Utc::now(),
-            correlation_id: None,
-            workspace_id: workspace_id.to_string(),
-        }
-    }
-
-    #[test]
-    fn tally_counts_emits_and_detects_declared_empty() {
-        let recs = vec![
-            record("ws1", EVENT_ARTIFACT_EMITTED),
-            record("ws1", EVENT_ARTIFACT_EMITTED),
-            record("ws1", EVENT_OUTPUT_DECLARED_EMPTY),
-        ];
-        let status = tally_status(&recs, "ws1");
-        assert_eq!(status.emit_count, 2);
-        assert!(status.declared_empty);
-    }
-
-    #[test]
-    fn tally_untouched_session_is_zero_and_not_declared() {
-        let status = tally_status(&[], "ws1");
-        assert_eq!(status.emit_count, 0);
-        assert!(!status.declared_empty);
-    }
-
-    #[test]
-    fn tally_ignores_rows_from_a_different_workspace() {
-        let recs = vec![
-            record("other", EVENT_ARTIFACT_EMITTED),
-            record("other", EVENT_OUTPUT_DECLARED_EMPTY),
-        ];
-        let status = tally_status(&recs, "ws1");
-        assert_eq!(status.emit_count, 0);
-        assert!(!status.declared_empty);
-    }
 
     #[test]
     fn store_content_round_trips_via_inline_scheme() {

--- a/crates/onsager-scheduler/src/spine_client.rs
+++ b/crates/onsager-scheduler/src/spine_client.rs
@@ -25,7 +25,7 @@
 
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, ArtifactId};
-use onsager_nodes::{SpineClient, SpineError};
+use onsager_nodes::{EmittedArtifact, SessionManifest, SpineClient, SpineError};
 use onsager_spine::{EventMetadata, EventStore};
 
 /// Substrate-scheduler [`SpineClient`] backed by the real spine event
@@ -110,5 +110,38 @@ impl SpineClient for SpineEventStoreClient {
         // See module docs — v1 returns None; executors gather inputs
         // through PlanStore, not through cross-plan spine reads.
         Ok(None)
+    }
+
+    /// Read an agent session's output manifest for the
+    /// `AgentExecutor`'s authoritative liveness gate (spec #520 §4c).
+    ///
+    /// Delegates to the shared manifest contract in
+    /// [`onsager_spine::session_manifest`] — the same code path portal's
+    /// MCP tools (§4a) write through — and scopes the read to this
+    /// client's `workspace_id` so a session-id collision across tenants
+    /// can't leak outputs. Maps the spine-side records onto the
+    /// executor-port `SessionManifest` (the two structs live on opposite
+    /// sides of the seam; this is the adapter that bridges them).
+    async fn read_session_manifest(&self, session_id: &str) -> Result<SessionManifest, SpineError> {
+        let manifest = onsager_spine::session_manifest::read_manifest(
+            &self.store,
+            &self.workspace_id,
+            session_id,
+        )
+        .await
+        .map_err(|e| SpineError::new(format!("read_session_manifest failed: {e}")))?;
+        Ok(SessionManifest {
+            emitted: manifest
+                .emitted
+                .into_iter()
+                .map(|r| EmittedArtifact {
+                    artifact_id: r.artifact_id,
+                    content_ref: r.content_ref,
+                    kind: r.kind,
+                    summary: r.summary,
+                })
+                .collect(),
+            declared_empty: manifest.declared_empty,
+        })
     }
 }

--- a/crates/onsager-spine/src/lib.rs
+++ b/crates/onsager-spine/src/lib.rs
@@ -37,6 +37,7 @@ pub mod factory_event;
 pub mod listener;
 pub mod namespace;
 pub mod protocol;
+pub mod session_manifest;
 pub mod store;
 pub mod trigger;
 pub mod webhook_routing;

--- a/crates/onsager-spine/src/session_manifest.rs
+++ b/crates/onsager-spine/src/session_manifest.rs
@@ -85,11 +85,13 @@ pub struct EmittedRecord {
 }
 
 /// The deserialization shape of an `artifact.emitted` row's `data`
-/// field. `content_ref` is required; everything else defaults so a
-/// partially-written row is still salvageable.
+/// field. `artifact_id` and `content_ref` are required — the contract
+/// relies on the minted id as a stable identity and on the ref as the
+/// content pointer, so a row missing either is malformed and dropped
+/// (see [`parse_manifest`]). `kind` / `summary` default so a row that
+/// only omits the soft metadata is still salvageable.
 #[derive(Debug, Deserialize)]
 struct EmitData {
-    #[serde(default)]
     artifact_id: String,
     content_ref: ContentRef,
     #[serde(default)]
@@ -140,17 +142,22 @@ pub struct EmitStatus {
 /// Parse a session's raw `events_ext` rows into a typed
 /// [`SessionManifest`], scoped to a workspace.
 ///
-/// The session stream is workspace-private by construction, but rows
-/// from a different workspace are defensively skipped so a session-id
-/// collision across workspaces can never leak outputs. An
-/// `artifact.emitted` row whose `data` fails to parse (e.g. missing
-/// `content_ref`) is dropped with a warning rather than failing the
-/// whole read — a malformed row must not strand a live session.
+/// Two defensive filters guard the read. The session stream is
+/// workspace-private by construction, but rows from a different
+/// workspace are skipped so a session-id collision across workspaces
+/// can never leak outputs. `query_ext_stream` also returns every
+/// extension row on the stream regardless of namespace, so rows outside
+/// the manifest namespace (`stiglab`) are skipped too — another
+/// subsystem reusing the same `event_type` on the same stream must not
+/// be miscounted as a manifest record. An `artifact.emitted` row whose
+/// `data` fails to parse (missing `artifact_id` / `content_ref`) is
+/// dropped with a warning rather than failing the whole read — a
+/// malformed row must not strand a live session.
 pub fn parse_manifest(records: &[ExtensionEventRecord], workspace_id: &str) -> SessionManifest {
     let mut emitted = Vec::new();
     let mut declared_empty = false;
     for r in records {
-        if r.workspace_id != workspace_id {
+        if r.workspace_id != workspace_id || r.namespace != MANIFEST_NAMESPACE {
             continue;
         }
         match r.event_type.as_str() {
@@ -379,5 +386,38 @@ mod tests {
         let m = parse_manifest(&recs, "ws1");
         assert_eq!(m.emit_count(), 1);
         assert_eq!(m.emitted[0].content_ref.uri, "inline:ok");
+    }
+
+    #[test]
+    fn parse_drops_emit_row_missing_artifact_id() {
+        // `artifact_id` is required — a row carrying a valid content_ref
+        // but no minted id is malformed (the contract relies on the id
+        // as stable identity for downstream packaging) and is dropped.
+        let recs = vec![record(
+            "ws1",
+            EVENT_ARTIFACT_EMITTED,
+            serde_json::json!({
+                "content_ref": { "uri": "inline:x", "checksum": "z" },
+                "kind": "code",
+                "summary": "no id",
+            }),
+        )];
+        let m = parse_manifest(&recs, "ws1");
+        assert_eq!(m.emit_count(), 0, "row missing artifact_id must be dropped");
+    }
+
+    #[test]
+    fn parse_ignores_rows_outside_the_manifest_namespace() {
+        // `query_ext_stream` returns every extension row on the stream
+        // regardless of namespace; a row reusing `artifact.emitted`
+        // under a different namespace must not be miscounted.
+        let mut foreign = record(
+            "ws1",
+            EVENT_ARTIFACT_EMITTED,
+            emit_data("inline:a", "code", "one"),
+        );
+        foreign.namespace = "synodic".to_string();
+        let m = parse_manifest(&[foreign], "ws1");
+        assert_eq!(m.emit_count(), 0, "foreign-namespace row must be ignored");
     }
 }

--- a/crates/onsager-spine/src/session_manifest.rs
+++ b/crates/onsager-spine/src/session_manifest.rs
@@ -1,0 +1,383 @@
+//! Session output manifest — the `events_ext`-backed record of what an
+//! agent session produced (spec #520).
+//!
+//! This module is the **single source of truth** for the manifest wire
+//! contract: the namespace / stream / event-type / data-field
+//! conventions locked in spec #520 §3, the parse from raw
+//! [`ExtensionEventRecord`] rows into a typed [`SessionManifest`], and
+//! the store-level append/read helpers. Two callers sit on opposite
+//! sides of the seam and share it from here rather than each carrying
+//! their own copy:
+//!
+//! - **portal's MCP tools** (`crates/onsager-portal/src/mcp/tools/
+//!   session_manifest.rs`, spec #520 §4a / #521) — the agent's only
+//!   path to *write* the manifest (the execution environment holds no
+//!   DB credentials).
+//! - **the substrate scheduler's [`SpineClient`]** (`onsager-scheduler`,
+//!   spec #520 §4c / #523) — the authoritative liveness gate *reads* the
+//!   manifest after the agent session ends.
+//!
+//! Keeping the contract here (a crate both sides already depend on)
+//! avoids the parallel-schema drift the seam rule forbids: one set of
+//! constants, one parser, one data shape.
+//!
+//! Conventions (locked in spec #520 §3 — do not re-litigate):
+//!
+//! - `namespace = "stiglab"` (the emit happens inside a stiglab-
+//!   orchestrated session; reuse the existing validated namespace).
+//! - `stream_id = "session:<session_id>"`.
+//! - `event_type = "artifact.emitted"` for a real output;
+//!   `"output.declared_empty"` for an explicit no-output declaration.
+//!
+//! **Provenance never goes into the manifest.** Records carry
+//! `content_ref / kind / summary` (plus the minted `artifact_id`
+//! identity) only — the agent must not be able to self-declare
+//! `Deterministic`. The `AgentExecutor` stamps
+//! `Provenance::Uncertain { source: Agent }` when it reads records back
+//! (spec #520 §4c).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use onsager_artifact::ContentRef;
+
+use crate::extension_event::ExtensionEventRecord;
+use crate::store::{EventMetadata, EventStore};
+
+/// Namespace the manifest rows live under (spec #520 §3).
+pub const MANIFEST_NAMESPACE: &str = "stiglab";
+/// `events_ext.event_type` for a real emitted output.
+pub const EVENT_ARTIFACT_EMITTED: &str = "artifact.emitted";
+/// `events_ext.event_type` for an explicit "I produced nothing".
+pub const EVENT_OUTPUT_DECLARED_EMPTY: &str = "output.declared_empty";
+
+/// Build the manifest stream key for a session.
+pub fn session_stream_id(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+/// The actor stamp on every manifest write — the session itself, never
+/// a human or another subsystem.
+pub fn session_actor(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+// ---------------------------------------------------------------------------
+// Typed manifest shapes
+// ---------------------------------------------------------------------------
+
+/// One output a session emitted, as recorded on an `artifact.emitted`
+/// row. Carries identity + content pointer + agent-supplied metadata —
+/// never provenance (see module docs).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmittedRecord {
+    /// Stable id minted at emit time (`art_<ulid>`), so the
+    /// authoritative gate can reference this output when packaging it
+    /// onto the typed DAG.
+    pub artifact_id: String,
+    /// Pointer to the addressable content the session produced.
+    pub content_ref: ContentRef,
+    /// Artifact kind tag (`code` / `document` / `pull_request` /
+    /// `github_issue` / a custom string). Stored verbatim.
+    pub kind: String,
+    /// Human-readable summary of what was emitted.
+    pub summary: String,
+}
+
+/// The deserialization shape of an `artifact.emitted` row's `data`
+/// field. `content_ref` is required; everything else defaults so a
+/// partially-written row is still salvageable.
+#[derive(Debug, Deserialize)]
+struct EmitData {
+    #[serde(default)]
+    artifact_id: String,
+    content_ref: ContentRef,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    summary: String,
+}
+
+/// A session's full output manifest: every emitted output plus whether
+/// the session explicitly declared it produced nothing.
+///
+/// `emitted.is_empty() && !declared_empty` is the liveness-gate trip
+/// condition (spec #520 §4c) — the session ended having neither
+/// delivered nor declared empty.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionManifest {
+    pub emitted: Vec<EmittedRecord>,
+    pub declared_empty: bool,
+}
+
+impl SessionManifest {
+    /// Count of real emitted outputs.
+    pub fn emit_count(&self) -> u64 {
+        self.emitted.len() as u64
+    }
+
+    /// The narrow count-only summary `read_emit_status` returns.
+    pub fn status(&self) -> EmitStatus {
+        EmitStatus {
+            emit_count: self.emit_count(),
+            declared_empty: self.declared_empty,
+        }
+    }
+}
+
+/// The narrow manifest summary the `read_emit_status` MCP tool returns —
+/// counts only, no content. Pure projection of [`SessionManifest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EmitStatus {
+    pub emit_count: u64,
+    pub declared_empty: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+/// Parse a session's raw `events_ext` rows into a typed
+/// [`SessionManifest`], scoped to a workspace.
+///
+/// The session stream is workspace-private by construction, but rows
+/// from a different workspace are defensively skipped so a session-id
+/// collision across workspaces can never leak outputs. An
+/// `artifact.emitted` row whose `data` fails to parse (e.g. missing
+/// `content_ref`) is dropped with a warning rather than failing the
+/// whole read — a malformed row must not strand a live session.
+pub fn parse_manifest(records: &[ExtensionEventRecord], workspace_id: &str) -> SessionManifest {
+    let mut emitted = Vec::new();
+    let mut declared_empty = false;
+    for r in records {
+        if r.workspace_id != workspace_id {
+            continue;
+        }
+        match r.event_type.as_str() {
+            EVENT_ARTIFACT_EMITTED => match serde_json::from_value::<EmitData>(r.data.clone()) {
+                Ok(d) => emitted.push(EmittedRecord {
+                    artifact_id: d.artifact_id,
+                    content_ref: d.content_ref,
+                    kind: d.kind,
+                    summary: d.summary,
+                }),
+                Err(e) => tracing::warn!(
+                    stream = %r.stream_id,
+                    "skipping malformed artifact.emitted manifest row: {e}"
+                ),
+            },
+            EVENT_OUTPUT_DECLARED_EMPTY => declared_empty = true,
+            _ => {}
+        }
+    }
+    SessionManifest {
+        emitted,
+        declared_empty,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store helpers (write / read)
+// ---------------------------------------------------------------------------
+
+/// Append an `artifact.emitted` row to the session manifest, recording a
+/// pre-stored `content_ref`. Returns the minted `artifact_id`.
+///
+/// Content persistence is the caller's concern (portal's MCP tool runs
+/// the inline/object-store path before calling this); this helper owns
+/// only the manifest row.
+pub async fn append_emit(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+    content_ref: Value,
+    kind: &str,
+    summary: &str,
+) -> Result<String, sqlx::Error> {
+    // Mint a stable id so the authoritative gate (spec #520 §4c) can
+    // reference this output when it packages it onto the typed DAG. Use
+    // the canonical `art_<ulid>` shape so manifest rows match every
+    // other id that flows through the artifact model.
+    let artifact_id = onsager_artifact::ArtifactId::generate()
+        .as_str()
+        .to_string();
+    let data = serde_json::json!({
+        "artifact_id": artifact_id,
+        "content_ref": content_ref,
+        "kind": kind,
+        "summary": summary,
+    });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: session_actor(session_id),
+    };
+    store
+        .append_ext(
+            workspace_id,
+            &session_stream_id(session_id),
+            MANIFEST_NAMESPACE,
+            EVENT_ARTIFACT_EMITTED,
+            data,
+            &metadata,
+            None,
+        )
+        .await?;
+    Ok(artifact_id)
+}
+
+/// Append an `output.declared_empty` row to the session manifest.
+pub async fn append_declared_empty(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+    reason: &str,
+) -> Result<(), sqlx::Error> {
+    let data = serde_json::json!({ "reason": reason });
+    let metadata = EventMetadata {
+        correlation_id: None,
+        causation_id: None,
+        actor: session_actor(session_id),
+    };
+    store
+        .append_ext(
+            workspace_id,
+            &session_stream_id(session_id),
+            MANIFEST_NAMESPACE,
+            EVENT_OUTPUT_DECLARED_EMPTY,
+            data,
+            &metadata,
+            None,
+        )
+        .await?;
+    Ok(())
+}
+
+/// Read + parse a session's full manifest. Pure read — safe to call
+/// repeatedly.
+pub async fn read_manifest(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+) -> Result<SessionManifest, sqlx::Error> {
+    let records = store
+        .query_ext_stream(&session_stream_id(session_id))
+        .await?;
+    Ok(parse_manifest(&records, workspace_id))
+}
+
+/// Read a session's narrow status summary (counts only). Pure read.
+pub async fn read_status(
+    store: &EventStore,
+    workspace_id: &str,
+    session_id: &str,
+) -> Result<EmitStatus, sqlx::Error> {
+    Ok(read_manifest(store, workspace_id, session_id)
+        .await?
+        .status())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn record(workspace_id: &str, event_type: &str, data: Value) -> ExtensionEventRecord {
+        ExtensionEventRecord {
+            id: 0,
+            stream_id: session_stream_id("s1"),
+            namespace: MANIFEST_NAMESPACE.to_string(),
+            event_type: event_type.to_string(),
+            data,
+            metadata: serde_json::json!({}),
+            ref_event_id: None,
+            created_at: Utc::now(),
+            correlation_id: None,
+            workspace_id: workspace_id.to_string(),
+        }
+    }
+
+    fn emit_data(uri: &str, kind: &str, summary: &str) -> Value {
+        serde_json::json!({
+            "artifact_id": "art_abc",
+            "content_ref": { "uri": uri, "checksum": "deadbeef" },
+            "kind": kind,
+            "summary": summary,
+        })
+    }
+
+    #[test]
+    fn parse_counts_emits_and_detects_declared_empty() {
+        let recs = vec![
+            record(
+                "ws1",
+                EVENT_ARTIFACT_EMITTED,
+                emit_data("inline:a", "code", "one"),
+            ),
+            record(
+                "ws1",
+                EVENT_ARTIFACT_EMITTED,
+                emit_data("inline:b", "document", "two"),
+            ),
+            record(
+                "ws1",
+                EVENT_OUTPUT_DECLARED_EMPTY,
+                serde_json::json!({"reason": "x"}),
+            ),
+        ];
+        let m = parse_manifest(&recs, "ws1");
+        assert_eq!(m.emit_count(), 2);
+        assert!(m.declared_empty);
+        assert_eq!(m.emitted[0].kind, "code");
+        assert_eq!(m.emitted[0].content_ref.uri, "inline:a");
+        assert_eq!(m.emitted[1].summary, "two");
+        assert_eq!(m.status().emit_count, 2);
+    }
+
+    #[test]
+    fn parse_untouched_session_is_zero_and_not_declared() {
+        let m = parse_manifest(&[], "ws1");
+        assert_eq!(m.emit_count(), 0);
+        assert!(!m.declared_empty);
+    }
+
+    #[test]
+    fn parse_ignores_rows_from_a_different_workspace() {
+        let recs = vec![
+            record(
+                "other",
+                EVENT_ARTIFACT_EMITTED,
+                emit_data("inline:a", "code", "one"),
+            ),
+            record(
+                "other",
+                EVENT_OUTPUT_DECLARED_EMPTY,
+                serde_json::json!({"reason": "x"}),
+            ),
+        ];
+        let m = parse_manifest(&recs, "ws1");
+        assert_eq!(m.emit_count(), 0);
+        assert!(!m.declared_empty);
+    }
+
+    #[test]
+    fn parse_drops_malformed_emit_row_without_failing_read() {
+        // Missing `content_ref` — the row is dropped, the declared-empty
+        // row still registers, and the read does not error.
+        let recs = vec![
+            record(
+                "ws1",
+                EVENT_ARTIFACT_EMITTED,
+                serde_json::json!({"kind": "code"}),
+            ),
+            record(
+                "ws1",
+                EVENT_ARTIFACT_EMITTED,
+                emit_data("inline:ok", "code", "good"),
+            ),
+        ];
+        let m = parse_manifest(&recs, "ws1");
+        assert_eq!(m.emit_count(), 1);
+        assert_eq!(m.emitted[0].content_ref.uri, "inline:ok");
+    }
+}

--- a/crates/stiglab/src/agent/session/process.rs
+++ b/crates/stiglab/src/agent/session/process.rs
@@ -66,6 +66,21 @@ struct ContentBlock {
 // Completion result forwarded from the stdout parser to the manager
 // ---------------------------------------------------------------------------
 
+/// Completion signal parsed off the `claude` CLI's NDJSON stdout
+/// stream.
+///
+/// Per spec #520 §4b this stays a "session over" signal — it carries
+/// only the final assistant `output`, **not** the artifacts the session
+/// emitted. The agent records outputs out-of-band by calling the portal
+/// MCP `emit_artifact` / `declare_no_output` tools (§4a), which write
+/// the `events_ext` `session:<id>` manifest. That manifest is the
+/// authoritative source of "what came out": the substrate
+/// `AgentExecutor` reads it back directly to run the liveness gate (§4c)
+/// rather than trusting anything parsed from this stdout stream. The
+/// optimization channel for surfacing emitted refs lives on
+/// `onsager_nodes::AgentResponse.emitted` — populated by a runner that
+/// can cheaply observe them, left empty here because the NDJSON stream
+/// genuinely does not see MCP tool side effects.
 pub enum NdjsonResult {
     Success { output: String },
     Error { error: String },


### PR DESCRIPTION
Closes #523. Closes #524. Work items **§4c** + **§4b** of #520. Builds on the merged §4a (#521) and §4e (#522).

## §4c — `AgentExecutor` authoritative liveness gate + DAG packaging

After the runner returns, `AgentExecutor::execute` reads the session output manifest over the spine port and judges liveness from **the manifest**, not the runner's response:

- **empty + not declared-empty** → emit `node.awaiting_human` on the existing escalation channel and return the Escalate-flavored `ExecutorError::Failed` (parks the run), consistent with `VerifyExecutor`'s `FailPolicy::Escalate`.
- **declared-empty** → clean finish, no artifacts, `declared_empty` signal threaded onto `node.completed` (§4e).
- **non-empty** → one `Artifact` per emitted record; `content_ref` rides on a first `ArtifactVersion`; `provenance = Uncertain { source: Agent }` **stamped here**, never read from the agent-controlled manifest (only a Verify node may upgrade provenance — ADR 0010 / ADR 0018 invariant 2); `produced_by_node = Some(ctx.node_id)`.

Liveness is **not** a Verify node — it's a post-condition inside `AgentExecutor` and does not touch provenance, and does not depend on the §4d Stop hook firing.

## §4b — widened runner/response contract

- `AgentResponse.emitted` surfaces the outputs a runner observed — an **optimization channel only**.
- `AgentRequest.session_id` threads the executor-minted session id to the runner so the agent's MCP `emit_artifact` / `declare_no_output` calls attribute to the same `session:<id>` manifest stream.
- The manifest read stays authoritative: the executor cross-checks `response.emitted` against it and `warn!`s on divergence (so the field has a real consumer — no dangling wire).
- On the stiglab side, `NdjsonResult` is **documented** to stay "session over": emits flow out-of-band through the MCP manifest, which the stdout NDJSON stream genuinely cannot observe, so the manifest remains the sole source of truth. (This is the spec's explicitly-sanctioned "or document" branch for the stiglab port.)

## Seam: one manifest contract, not two

The manifest wire contract (namespace / stream / event-type / data-field constants, the parser, and the append/read store helpers) moves **down** to a new shared `onsager-spine::session_manifest` module as the single source of truth. Portal's §4a MCP tools now delegate to it (keeping only content-storage + arg schemas + auth), and the substrate scheduler's `SpineClient` reads through the same path. This collapses what would otherwise be a parallel-schema bridge across the seam — the scheduler depends on `onsager-spine`, not portal, so the contract can't live in portal.

- `SpineClient` gains `read_session_manifest` (default returns an empty manifest, so non-agent adapters need no change).
- `ExecutorOutputs` gains `declared_empty: Option<bool>`, threaded onto `node.completed` by the scheduler.

## Test

- `AgentExecutor` unit tests for all three gate branches (package / escalate + `node.awaiting_human` / declared-empty), plus the §4b manifest-vs-response authority test (behavior identical whether the response carries refs or not).
- Scheduler test asserts `declared_empty` threads onto the `node.completed` payload.
- **Mutation-checked** (not theater): forcing provenance to `Deterministic` in the packaging path fails the Uncertain-Agent assertion.
- Existing end-to-end fixtures (`crawlab_fixture`, `scheduler_event_contract`) updated to serve a one-emit manifest so their agent nodes deliver.
- `cargo build --workspace`, `clippy -D warnings`, `fmt --check`, and `check-events` / `lint-seams` / `check-api-contract` / `check-file-budget` / occam lints all pass.

## Not in scope

§4d (liveness Stop hook + claude spawn wiring) remains open as #525.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhWywQvhacGwYAgYjm1smb)_