### PR TITLE
L1 follow-up — provision MCP config + workspace-scoped session token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,18 @@ ONSAGER_DATABASE_URL=postgres://onsager:onsager@localhost:5432/onsager
 # authoritative gate in AgentExecutor still covers liveness). Point it at
 # portal's route (Caddy proxies /api/* → portal).
 # ONSAGER_LIVENESS_HOOK_URL=https://app.example.com/api/internal/session-liveness
-# Workspace-scoped bearer token the Stop hook sends as Authorization.
-# Interpolated from the session env at hook time (kept out of on-disk
-# settings). Until per-session token provisioning lands (a sibling of
-# #520's deferred MCP-config wiring) this is unset and the hook fails
-# open (401 → session continues).
-# ONSAGER_SESSION_TOKEN=
+# Portal MCP endpoint (spec #531). When set on the agent node AND a session
+# token is present, workspace-scoped sessions are spawned with --mcp-config
+# registering portal's MCP server so the agent can call emit_artifact /
+# declare_no_output / read_emit_status. Point it at portal's /mcp/messages
+# (Caddy proxies /mcp/* → portal). Unset → no MCP server registered.
+# ONSAGER_MCP_URL=https://app.example.com/mcp/messages
+# NOTE: ONSAGER_SESSION_TOKEN is NOT set by hand. Spec #531 provisions a
+# per-session workspace-scoped token automatically: portal mints it at
+# session creation, encrypts it into the portal.session_requested event,
+# and stiglab decrypts + injects it (with ONSAGER_SESSION_ID /
+# ONSAGER_WORKSPACE_ID) into the agent env. The Stop hook and the MCP
+# config both read it from there.
 #
 # GitHub OAuth (issue #193) lives on portal post-#222 Slice 5 — see
 # the `Portal` block below. Set `GITHUB_CLIENT_ID` /

--- a/crates/onsager-portal/src/handlers/tasks.rs
+++ b/crates/onsager-portal/src/handlers/tasks.rs
@@ -50,6 +50,13 @@ pub struct TaskDispatchPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
     pub user_id: String,
+    /// Workspace-scoped session token (spec #531), **encrypted** with the
+    /// shared credential key. Stiglab decrypts it at dispatch and injects
+    /// it as `ONSAGER_SESSION_TOKEN` so the agent can reach portal's MCP
+    /// surface + the liveness Stop hook. `None` when the session is
+    /// unscoped or no credential key is configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_session_token: Option<String>,
 }
 
 /// POST /api/tasks — create a task and its initial session.
@@ -191,6 +198,33 @@ pub async fn create_task(
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
 
+    // Mint a workspace-scoped session token (spec #531) so the agent can
+    // reach portal's MCP surface + the liveness Stop hook. Requires both a
+    // workspace scope and a configured credential key; absent either, the
+    // session runs without a token (the authoritative gate still applies).
+    let encrypted_session_token = match (
+        workspace_id.as_deref(),
+        state.config.credential_key.as_deref(),
+    ) {
+        (Some(ws), Some(key)) => {
+            match crate::session_token::mint_for_session(&state.pool, key, user_id, ws, &session.id)
+                .await
+            {
+                Ok(token) => Some(token),
+                Err(e) => {
+                    // Non-fatal: the session can still run; it just can't
+                    // emit via MCP and the Stop hook will fail open.
+                    tracing::error!(
+                        session_id = %session.id,
+                        "failed to mint session token: {e}"
+                    );
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+
     // Emit portal.session_requested so stiglab's listener can pick up the
     // session, fetch credentials, and dispatch to the agent WebSocket.
     let dispatch = TaskDispatchPayload {
@@ -206,6 +240,7 @@ pub async fn create_task(
         permission_mode: task.permission_mode.clone(),
         workspace_id: workspace_id.clone(),
         user_id: user_id.to_string(),
+        encrypted_session_token,
     };
 
     let ws_id = workspace_id.as_deref().unwrap_or("default");

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -54,6 +54,7 @@ pub mod remediation_db;
 pub mod runtime;
 pub mod server;
 pub mod session_db;
+pub mod session_token;
 pub mod spec_plan_db;
 pub mod sso;
 pub mod state;

--- a/crates/onsager-portal/src/listeners/mod.rs
+++ b/crates/onsager-portal/src/listeners/mod.rs
@@ -1,2 +1,3 @@
 pub mod session_completed;
+pub mod session_token_revoke;
 pub mod workflow_activated;

--- a/crates/onsager-portal/src/listeners/session_token_revoke.rs
+++ b/crates/onsager-portal/src/listeners/session_token_revoke.rs
@@ -1,0 +1,64 @@
+//! Spine listener: revoke a session's workspace-scoped token when the
+//! session ends (spec #531).
+//!
+//! Portal mints a per-session PAT at session creation
+//! (`session_token::mint_for_session`); the token carries a short expiry as
+//! a backstop. This listener tightens the window — on any terminal session
+//! event it soft-revokes the token immediately, so a finished session can
+//! no longer authenticate to portal's MCP surface or the liveness hook.
+//!
+//! Portal is the only writer of `user_pats` (seam rule), so revocation
+//! lives here and is driven by the spine, not an HTTP call. Sibling of the
+//! `session_completed` PR-opener listener; same `events_ext` source.
+//!
+//! The terminal events all use the `session_id` as their `events_ext`
+//! `stream_id` (see `FactoryEventKind::stream_id`), so the id is read
+//! straight off the notification with no row fetch.
+
+use async_trait::async_trait;
+use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
+use sqlx::postgres::PgPool;
+
+use crate::session_token;
+
+/// Terminal session event types whose arrival revokes the session token.
+const TERMINAL_EVENTS: &[&str] = &[
+    "stiglab.session_completed",
+    "stiglab.session_failed",
+    "stiglab.session_aborted",
+];
+
+/// Run the revoke-on-end listener forever. Returns only when the pg_notify
+/// channel closes.
+pub async fn run(pool: PgPool, store: EventStore) -> anyhow::Result<()> {
+    Listener::new(store).run(Revoker { pool }).await
+}
+
+struct Revoker {
+    pool: PgPool,
+}
+
+#[async_trait]
+impl EventHandler for Revoker {
+    async fn handle(&self, event: EventNotification) -> anyhow::Result<()> {
+        // Session lifecycle events are stiglab-namespaced `events_ext` rows
+        // (see stiglab's `SpineEmitter::emit`), keyed by session_id as the
+        // stream.
+        if event.table != "events_ext" || !TERMINAL_EVENTS.contains(&event.event_type.as_str()) {
+            return Ok(());
+        }
+        let session_id = &event.stream_id;
+        match session_token::revoke_for_session(&self.pool, session_id).await {
+            Ok(n) if n > 0 => {
+                tracing::info!(session_id = %session_id, "revoked session token on session end");
+            }
+            // No live token (unscoped session, already revoked, or never
+            // minted) — nothing to do.
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!(session_id = %session_id, "failed to revoke session token: {e}");
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/onsager-portal/src/pat_db.rs
+++ b/crates/onsager-portal/src/pat_db.rs
@@ -180,6 +180,23 @@ pub async fn revoke_user_pat(pool: &PgPool, user_id: &str, pat_id: &str) -> anyh
     Ok(res.rows_affected() > 0)
 }
 
+/// Revoke (soft) every live PAT carrying the given `name`. Used to revoke
+/// a session-scoped token when its session ends (spec #531): the terminal
+/// spine event carries only `session_id`, so we match on the
+/// `session:<session_id>` name rather than `(user_id, pat_id)`. Session
+/// ids are unique, so the name is effectively unique. Idempotent —
+/// `revoked_at IS NULL` guards a double-revoke; returns the row count.
+pub async fn revoke_pats_by_name(pool: &PgPool, name: &str) -> anyhow::Result<u64> {
+    let now = Utc::now().to_rfc3339();
+    let res =
+        sqlx::query("UPDATE user_pats SET revoked_at = $1 WHERE name = $2 AND revoked_at IS NULL")
+            .bind(&now)
+            .bind(name)
+            .execute(pool)
+            .await?;
+    Ok(res.rows_affected())
+}
+
 pub async fn touch_user_pat(
     pool: &PgPool,
     pat_id: &str,

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -479,6 +479,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let activation_spine = state.spine.clone();
     let reconciliation_pool = state.pool.clone();
     let reconciliation_spine = state.spine.clone();
+    let revoke_pool = state.pool.clone();
+    let revoke_spine = state.spine.clone();
     let activation_is_oss = !state
         .config
         .deployment
@@ -495,6 +497,16 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             crate::listeners::session_completed::run(listener_pool, listener_spine).await
         {
             tracing::error!("portal: session_completed listener exited: {e}");
+        }
+    });
+
+    // Spawn the revoke-session-token-on-end listener (spec #531). Soft-
+    // revokes a session's workspace-scoped PAT the moment its session
+    // reaches a terminal state, tightening the expiry backstop.
+    tokio::spawn(async move {
+        if let Err(e) = crate::listeners::session_token_revoke::run(revoke_pool, revoke_spine).await
+        {
+            tracing::error!("portal: session_token_revoke listener exited: {e}");
         }
     });
 

--- a/crates/onsager-portal/src/session_token.rs
+++ b/crates/onsager-portal/src/session_token.rs
@@ -1,0 +1,85 @@
+//! Per-session workspace-scoped tokens (spec #531).
+//!
+//! An agent session runs in an untrusted execution environment that holds
+//! no DB credentials. To let it reach portal's MCP surface (the
+//! `emit_artifact` / `declare_no_output` / `read_emit_status` tools, spec
+//! #520 §4a) and the liveness Stop hook (#525), the session is provisioned
+//! a narrow, **workspace-pinned PAT** minted here.
+//!
+//! Lifecycle (locked design, spec #531):
+//!
+//! - **Mint** at session creation ([`mint_for_session`]): a PAT pinned to
+//!   the session's workspace, named `session:<session_id>`, with a short
+//!   `expires_at`. Only the hash is persisted (reusing the existing PAT
+//!   machinery); the raw token is **encrypted** with the shared credential
+//!   key and travels inside the `portal.session_requested` event so no
+//!   usable secret is persisted in `events_ext` at rest. Stiglab decrypts
+//!   it at dispatch and injects it as `ONSAGER_SESSION_TOKEN`.
+//! - **Revoke** when the session ends ([`session_pat_name`] + the
+//!   session-lifecycle listener): the token is soft-revoked on
+//!   `stiglab.session_completed` / `_failed` / `_aborted` so the window
+//!   closes immediately rather than waiting for expiry.
+//!
+//! Portal is the only writer of `user_pats` (seam rule), so both mint and
+//! revoke live on the portal side.
+
+use chrono::{Duration, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::auth::{encrypt_credential, generate_pat_token};
+use crate::pat_db;
+
+/// How long a session token is valid before it expires on its own. The
+/// session-lifecycle listener revokes it earlier on a terminal event; this
+/// is the backstop for sessions whose terminal event is missed.
+pub const SESSION_TOKEN_TTL: Duration = Duration::hours(6);
+
+/// The `user_pats.name` for a session-scoped token. Session ids are unique,
+/// so this is effectively a unique handle the revocation path matches on.
+pub fn session_pat_name(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+/// Mint a workspace-pinned PAT for `session_id` and return the raw token
+/// **encrypted** with `key_hex` (ready to embed in the dispatch event).
+/// Only the hash is persisted to `user_pats`.
+pub async fn mint_for_session(
+    pool: &PgPool,
+    key_hex: &str,
+    user_id: &str,
+    workspace_id: &str,
+    session_id: &str,
+) -> anyhow::Result<String> {
+    let pat = generate_pat_token();
+    let expires_at = Utc::now() + SESSION_TOKEN_TTL;
+    pat_db::insert_user_pat(
+        pool,
+        &Uuid::new_v4().to_string(),
+        user_id,
+        workspace_id,
+        &session_pat_name(session_id),
+        &pat.prefix,
+        &pat.hash,
+        Some(expires_at),
+    )
+    .await?;
+    let encrypted = encrypt_credential(key_hex, &pat.token)?;
+    Ok(encrypted)
+}
+
+/// Revoke the session-scoped PAT for `session_id` (idempotent). Returns the
+/// number of rows revoked (0 if already revoked / never minted).
+pub async fn revoke_for_session(pool: &PgPool, session_id: &str) -> anyhow::Result<u64> {
+    pat_db::revoke_pats_by_name(pool, &session_pat_name(session_id)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_pat_name_is_prefixed() {
+        assert_eq!(session_pat_name("abc-123"), "session:abc-123");
+    }
+}

--- a/crates/onsager-portal/tests/session_token.rs
+++ b/crates/onsager-portal/tests/session_token.rs
@@ -1,0 +1,90 @@
+//! Integration test for spec #531 — per-session workspace-scoped tokens.
+//!
+//! Exercises the full mint → encrypt → decrypt → verify → revoke
+//! round-trip against `user_pats`:
+//!
+//! - `mint_for_session` returns the raw token **encrypted** with the
+//!   credential key and persists only the hash.
+//! - The ciphertext decrypts to a live `ons_pat_` token that `verify_pat`
+//!   accepts, pinned to the session's workspace.
+//! - `revoke_for_session` flips the row to revoked so `verify_pat` then
+//!   reports `Revoked` — the revoke-on-end path the session-lifecycle
+//!   listener drives.
+//!
+//! Skipped when `DATABASE_URL` is unset — `user_pats` is a portal table
+//! only the Postgres-backed harness exercises.
+
+use onsager_portal::auth::{
+    PatVerifyOutcome, decrypt_credential, generate_credential_key, verify_pat,
+};
+use onsager_portal::session_token::{mint_for_session, revoke_for_session, session_pat_name};
+use sqlx::PgPool;
+
+async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    Some(PgPool::connect(&url).await.expect("db connect"))
+}
+
+async fn cleanup(pool: &PgPool, session_id: &str) {
+    let _ = sqlx::query("DELETE FROM user_pats WHERE name = $1")
+        .bind(session_pat_name(session_id))
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn mint_encrypts_a_verifiable_token_then_revoke_invalidates_it() {
+    let Some(pool) = try_pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let key = generate_credential_key();
+    let user_id = format!("u_{}", ulid::Ulid::new());
+    let workspace_id = format!("ws_{}", ulid::Ulid::new());
+    let session_id = ulid::Ulid::new().to_string();
+    cleanup(&pool, &session_id).await;
+
+    // Mint: returns the raw token encrypted with the credential key.
+    let encrypted = mint_for_session(&pool, &key, &user_id, &workspace_id, &session_id)
+        .await
+        .expect("mint");
+
+    // The ciphertext is not the token itself, but decrypts to a real PAT.
+    assert!(
+        !encrypted.starts_with("ons_pat_"),
+        "token must travel encrypted"
+    );
+    let raw = decrypt_credential(&key, &encrypted).expect("decrypt");
+    assert!(raw.starts_with("ons_pat_"), "decrypts to a PAT");
+
+    // The decrypted token verifies and is pinned to the session workspace.
+    match verify_pat(&pool, &raw).await.expect("verify") {
+        PatVerifyOutcome::Ok(pat) => {
+            assert_eq!(pat.workspace_id, workspace_id);
+            assert_eq!(pat.user_id, user_id);
+            assert_eq!(pat.name, session_pat_name(&session_id));
+            assert!(pat.expires_at.is_some(), "session token carries an expiry");
+        }
+        other => panic!("expected Ok, got {other:?}"),
+    }
+
+    // Revoke-on-end: the token is invalidated immediately.
+    let revoked = revoke_for_session(&pool, &session_id)
+        .await
+        .expect("revoke");
+    assert_eq!(revoked, 1, "exactly one live token revoked");
+
+    match verify_pat(&pool, &raw).await.expect("verify after revoke") {
+        PatVerifyOutcome::Revoked => {}
+        other => panic!("expected Revoked, got {other:?}"),
+    }
+
+    // Idempotent: a second revoke affects no rows.
+    let again = revoke_for_session(&pool, &session_id)
+        .await
+        .expect("revoke again");
+    assert_eq!(again, 0, "second revoke is a no-op");
+
+    cleanup(&pool, &session_id).await;
+}

--- a/crates/stiglab/src/agent/session/process.rs
+++ b/crates/stiglab/src/agent/session/process.rs
@@ -23,11 +23,19 @@ const LIVENESS_HOOK_URL_ENV: &str = "ONSAGER_LIVENESS_HOOK_URL";
 /// Env var holding the session's workspace-scoped bearer token. The
 /// Stop hook interpolates it into the `Authorization` header at call
 /// time (kept out of the on-disk settings via Claude Code's
-/// `allowedEnvVars`). Provisioning this token into the session env is a
-/// sibling of #520's deferred MCP-config wiring; until it lands the
-/// hook's request is unauthorized → `401` → the hook fails open, which
-/// is the desired degrade-to-authoritative-gate behavior.
+/// `allowedEnvVars`); the MCP server config (spec #531) interpolates the
+/// same var into its `Authorization` header. Provisioned into the session
+/// env by stiglab's dispatch path (decrypted from the
+/// `portal.session_requested` event); when absent the Stop hook's request
+/// is unauthorized → `401` → it fails open (the authoritative gate #523
+/// still applies) and no MCP server is registered.
 const SESSION_TOKEN_ENV: &str = "ONSAGER_SESSION_TOKEN";
+
+/// Env var (read on the agent node) holding portal's MCP endpoint URL,
+/// e.g. `https://app.example.com/mcp/messages`. Unset → no MCP server is
+/// registered (the agent can't emit via MCP, but the session still runs).
+/// Spec #531.
+const MCP_URL_ENV: &str = "ONSAGER_MCP_URL";
 
 /// Build the inline `--settings` JSON that registers the liveness Stop
 /// hook. Pure (no env, no IO) so the wire shape is unit-testable.
@@ -96,6 +104,30 @@ fn urlencode(s: &str) -> String {
         }
     }
     out
+}
+
+/// Build the inline `--mcp-config` JSON registering portal's MCP server
+/// (spec #531) so the agent can call `emit_artifact` / `declare_no_output`
+/// / `read_emit_status`. Pure so the wire shape is unit-testable.
+///
+/// The bearer token is interpolated from `$ONSAGER_SESSION_TOKEN` at
+/// startup (Claude Code expands `${VAR}` in MCP `headers`). This is only
+/// wired when the token is actually present in the env — Claude Code
+/// **fails to parse** an MCP config whose `${VAR}` is unset, so registering
+/// it tokenless would break the whole session rather than degrade.
+fn mcp_config_json(mcp_url: &str) -> String {
+    serde_json::json!({
+        "mcpServers": {
+            "onsager": {
+                "type": "http",
+                "url": mcp_url,
+                "headers": {
+                    "Authorization": format!("Bearer ${{{SESSION_TOKEN_ENV}}}"),
+                },
+            }
+        }
+    })
+    .to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +265,21 @@ impl SessionProcess {
         {
             let settings = stop_hook_settings_json(&hook_url_base, workspace_id, session_id);
             cmd.args(["--settings", &settings]);
+        }
+
+        // Portal MCP server (spec #531). Registered only when the MCP URL
+        // is configured AND the session token is present in the env —
+        // Claude Code fails to parse an MCP config whose `${VAR}` is unset,
+        // so a tokenless registration would break the session rather than
+        // degrade. Absent either, the agent runs without MCP (no emit
+        // path); the authoritative gate (#523) still covers liveness.
+        let has_session_token = credentials.is_some_and(|c| c.contains_key(SESSION_TOKEN_ENV));
+        if let Ok(mcp_url) = std::env::var(MCP_URL_ENV)
+            && !mcp_url.is_empty()
+            && has_session_token
+        {
+            let mcp_config = mcp_config_json(&mcp_url);
+            cmd.args(["--mcp-config", &mcp_config]);
         }
 
         // Separator + prompt
@@ -491,6 +538,20 @@ mod tests {
         );
         // Exactly one `?` in the final URL.
         assert_eq!(url.matches('?').count(), 1);
+    }
+
+    #[test]
+    fn mcp_config_registers_http_server_with_interpolated_token() {
+        let json = mcp_config_json("https://app.example.com/mcp/messages");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let server = &v["mcpServers"]["onsager"];
+        assert_eq!(server["type"], "http");
+        assert_eq!(server["url"], "https://app.example.com/mcp/messages");
+        // Token interpolated from env at startup, never inlined.
+        assert_eq!(
+            server["headers"]["Authorization"],
+            "Bearer ${ONSAGER_SESSION_TOKEN}"
+        );
     }
 
     #[test]

--- a/crates/stiglab/src/server/session_requested_listener.rs
+++ b/crates/stiglab/src/server/session_requested_listener.rs
@@ -38,6 +38,11 @@ struct TaskDispatchPayload {
     #[serde(default)]
     workspace_id: Option<String>,
     user_id: String,
+    /// Workspace-scoped session token (spec #531), encrypted with the
+    /// shared credential key. Decrypted here and injected into the agent
+    /// env as `ONSAGER_SESSION_TOKEN`.
+    #[serde(default)]
+    encrypted_session_token: Option<String>,
 }
 
 pub async fn run(store: EventStore, app_state: AppState, since: Option<i64>) -> anyhow::Result<()> {
@@ -109,10 +114,39 @@ impl Dispatcher {
             return Ok(());
         }
 
-        let credentials = match payload.workspace_id.as_deref() {
+        let mut credentials = match payload.workspace_id.as_deref() {
             Some(ws) => fetch_workspace_credentials(state, ws, &payload.user_id).await,
             None => None,
         };
+
+        // Inject the workspace-scoped session token + the session's own
+        // identity (spec #531) so the agent can authenticate to portal's
+        // MCP surface and the liveness Stop hook, and pass its
+        // `(workspace_id, session_id)` to the emit tools. The token rides
+        // the event encrypted; decrypt it with the shared credential key.
+        if let (Some(enc), Some(ws), Some(key)) = (
+            payload.encrypted_session_token.as_deref(),
+            payload.workspace_id.as_deref(),
+            state.config.credential_key.as_deref(),
+        ) {
+            match crate::server::auth::decrypt_credential(key, enc) {
+                Ok(token) => {
+                    let creds = credentials.get_or_insert_with(std::collections::HashMap::new);
+                    creds.insert("ONSAGER_SESSION_TOKEN".to_string(), token);
+                    creds.insert("ONSAGER_SESSION_ID".to_string(), payload.session_id.clone());
+                    creds.insert("ONSAGER_WORKSPACE_ID".to_string(), ws.to_string());
+                }
+                Err(e) => {
+                    // Non-fatal: session proceeds without MCP auth; the
+                    // Stop hook then fails open and the authoritative gate
+                    // (#523) still applies.
+                    tracing::error!(
+                        session_id = %payload.session_id,
+                        "failed to decrypt session token: {e}"
+                    );
+                }
+            }
+        }
 
         let task = Task {
             id: payload.task_id.clone(),


### PR DESCRIPTION
Closes #531. Part of #520.

Provisions a per-session workspace-scoped token + portal MCP-server config into the `claude` spawn — the wire that makes #521 (emit tools), #530 (liveness Stop hook), and the §4c authoritative gate compose into a live in-session loop. Until this, the #530 hook was dormant (401 → fail-open) and the emit tools were unreachable.

## Design (confirmed with maintainer)

**PAT, encrypted-in-event + expiry + revoke-on-end.**

- **Mint (portal).** `create_task` mints a workspace-pinned PAT named `session:<id>` with a short expiry (6h backstop), persists only the hash, `encrypt_credential`s the raw token with the shared credential key, and embeds the **ciphertext** in the `portal.session_requested` event — no usable secret at rest in `events_ext`. Seam-correct: portal is the only writer of `user_pats`.
- **Inject (stiglab).** The dispatch listener decrypts the token and injects `ONSAGER_SESSION_TOKEN` + `ONSAGER_SESSION_ID` + `ONSAGER_WORKSPACE_ID` into the agent env (the last two let the agent pass its ids to the emit tools).
- **MCP config (stiglab spawn).** `--mcp-config` registers portal's `/mcp/messages` with `Authorization: Bearer ${ONSAGER_SESSION_TOKEN}` (interpolated at startup; `bypassPermissions` auto-approves the tools). Gated on the token being present — Claude Code *fails to parse* an MCP config whose `${VAR}` is unset, so a tokenless registration would break the session rather than degrade. The same env var activates the #530 Stop hook.
- **Revoke-on-end (portal).** A new `listeners/session_token_revoke` consumer (sibling of the existing `session_completed` PR-opener) soft-revokes the token on `stiglab.session_{completed,failed,aborted}`, tightening the expiry backstop.

## Version confirmation (version-sensitive per #520)

Against `@anthropic-ai/claude-code` v2.1.158: `--mcp-config` accepts inline JSON; remote HTTP MCP servers use `{ "mcpServers": { "<name>": { "type": "http", "url", "headers" } } }`; `${VAR}` interpolation is supported in `headers`/`url` (no allowlist); unset `${VAR}` is a parse error; `bypassPermissions` auto-approves MCP tools (namespaced `mcp__onsager__*`).

## Scope note

Minting lives in `create_task`, the path that emits `portal.session_requested`. The scheduler / `PlanRunner` → `AgentExecutor` path (#520's typed-DAG loop) provisions its token when its own dispatch wiring lands (#363) — out of scope here.

## Tests

- Portal lib: `session_pat_name` shape; MCP-config builder shape (`type: http`, interpolated bearer, not inlined).
- Portal integration (`tests/session_token.rs`, DB-gated): full mint → decrypt → `verify_pat` (Ok, workspace-pinned, has expiry) → `revoke_for_session` → `verify_pat` (Revoked) → idempotent second revoke (no-op).
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`, and `check-events` / `lint-seams` / `check-deferred-todos` / `check-file-budget` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qp2euR5UcXJ7Pvf4Npdeq)_