### PR TITLE
Thread per-node agent config through scheduler dispatch (RUN-02)

### DIFF
--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use onsager_artifact::{Artifact, ArtifactVersion, Kind, Provenance, SourceTag};
 use onsager_substrate::events as se;
-use onsager_substrate::executor::Executor as SubstrateExecutor;
+use onsager_substrate::executor::{AgentConfig, Executor as SubstrateExecutor};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
@@ -241,6 +241,19 @@ impl SubstrateExecutor for AgentExecutor {
             source: SourceTag::Agent,
         }
     }
+
+    /// Expose this node's per-instance config so the scheduler can
+    /// thread it through [`ExecutorContext`] to the registered runtime
+    /// singleton (issue #534). The `runner` is intentionally excluded —
+    /// it's runtime wiring on the singleton, not node-level config.
+    fn agent_config(&self) -> Option<AgentConfig> {
+        Some(AgentConfig {
+            model: self.model.clone(),
+            system_prompt: self.system_prompt.clone(),
+            tools: self.tools.clone(),
+            credential_ref: self.credential_ref.clone(),
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -267,11 +280,25 @@ impl Executor for AgentExecutor {
         let plan_id = ctx.plan_id.as_str().to_string();
         let session_id = Uuid::new_v4().to_string();
 
-        let request = AgentRequest {
+        // The registered runtime instance is shared across every agent
+        // node — its own `model` / `system_prompt` / `tools` /
+        // `credential_ref` are placeholders. The scheduler reads the
+        // per-node config off the substrate executor and threads it
+        // through the context; prefer that. Fall back to `self`'s own
+        // fields for the direct-execute path (tests, and any caller
+        // that bypasses the scheduler). Issue #534.
+        let effective = ctx.agent_config.clone().unwrap_or_else(|| AgentConfig {
             model: self.model.clone(),
             system_prompt: self.system_prompt.clone(),
             tools: self.tools.clone(),
             credential_ref: self.credential_ref.clone(),
+        });
+
+        let request = AgentRequest {
+            model: effective.model.clone(),
+            system_prompt: effective.system_prompt.clone(),
+            tools: effective.tools.clone(),
+            credential_ref: effective.credential_ref.clone(),
             user_prompt: render_user_prompt(&ctx),
             session_id: session_id.clone(),
         };
@@ -283,7 +310,7 @@ impl Executor for AgentExecutor {
                 plan_id: plan_id.clone(),
                 node_id: ctx.node_id,
                 session_id: session_id.clone(),
-                model: self.model.clone(),
+                model: effective.model.clone(),
             },
         )
         .await;
@@ -578,6 +605,7 @@ mod tests {
             inputs: Vec::new(),
             spine: Arc::clone(&mock) as Arc<dyn crate::SpineClient>,
             subworkflow_ref: None,
+            agent_config: None,
         };
         (ctx, mock)
     }
@@ -593,6 +621,7 @@ mod tests {
             inputs: Vec::new(),
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 
@@ -775,6 +804,7 @@ mod tests {
             inputs: vec![(input_id.clone(), input_art)],
             spine: mock as Arc<dyn crate::SpineClient>,
             subworkflow_ref: None,
+            agent_config: None,
         };
 
         exec.execute(ctx).await.unwrap();
@@ -945,6 +975,118 @@ mod tests {
         assert!(art.provenance.is_uncertain());
         assert_eq!(art.provenance.source(), SourceTag::Agent);
         assert_eq!(art.produced_by_node, Some(node_id));
+    }
+
+    // -----------------------------------------------------------------
+    // Per-node agent config threading (issue #534).
+    //
+    // A registered singleton AgentExecutor dispatches every agent node;
+    // the per-node model / prompt / tools / credential must reach it
+    // via ExecutorContext::agent_config, threaded off the substrate
+    // executor — not the singleton's own placeholder fields.
+    // -----------------------------------------------------------------
+
+    /// Runner that records the model it was dispatched with, so a test
+    /// can prove which config the executor actually used.
+    #[derive(Debug, Default)]
+    struct ModelCapturingRunner {
+        seen_model: std::sync::Mutex<Option<String>>,
+    }
+    #[async_trait]
+    impl AgentRunner for ModelCapturingRunner {
+        async fn run(&self, request: AgentRequest) -> Result<AgentResponse, AgentRunError> {
+            *self.seen_model.lock().unwrap() = Some(request.model.clone());
+            Ok(AgentResponse {
+                output: "ok".into(),
+                emitted: Vec::new(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_threads_per_node_agent_config_over_singleton() {
+        use crate::dispatch;
+        use onsager_substrate::executor::Executor as SubstrateExecutor;
+        use onsager_substrate::workflow::Node;
+
+        // Register a singleton AgentExecutor with model "SINGLETON" and
+        // a capturing runner.
+        let runner: Arc<ModelCapturingRunner> = Arc::new(ModelCapturingRunner::default());
+        let singleton = AgentExecutor::new("SINGLETON", "singleton prompt")
+            .with_runner(Arc::clone(&runner) as Arc<dyn AgentRunner>);
+        let mut registry = ExecutorRegistry::new();
+        registry.register(Arc::new(singleton));
+
+        // Build a node whose *own* AgentExecutor carries model "NODE".
+        let node_exec = AgentExecutor::new("NODE", "node prompt");
+        let node = Node {
+            id: NodeId::generate(),
+            executor: Box::new(node_exec.clone()),
+            inputs: vec![],
+            outputs: vec![],
+        };
+
+        // The scheduler reads `node.executor.agent_config()` into the
+        // context. Replicate that exactly. Declared-empty manifest so
+        // the liveness gate lets execute return Ok.
+        let mock = Arc::new(MockSpine::with_manifest(SessionManifest {
+            emitted: Vec::new(),
+            declared_empty: true,
+        }));
+        let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
+            node_id: node.id,
+            inputs: Vec::new(),
+            spine: mock as Arc<dyn crate::SpineClient>,
+            subworkflow_ref: None,
+            agent_config: SubstrateExecutor::agent_config(&node_exec),
+        };
+
+        dispatch(&registry, &node, ctx).await.unwrap();
+
+        // The runner saw the NODE's model, not the SINGLETON's. With the
+        // threading removed (agent_config: None) the runner would see
+        // "SINGLETON" and this assertion fails — proving the threading
+        // is load-bearing (the spec's mutation check).
+        assert_eq!(runner.seen_model.lock().unwrap().as_deref(), Some("NODE"),);
+    }
+
+    #[tokio::test]
+    async fn execute_falls_back_to_self_config_when_context_is_none() {
+        // Direct-execute path (no scheduler): agent_config is None, so
+        // the executor uses its own fields. The existing unit tests all
+        // run this way; this asserts the fallback explicitly.
+        let runner: Arc<ModelCapturingRunner> = Arc::new(ModelCapturingRunner::default());
+        let exec = AgentExecutor::new("SELF", "self prompt")
+            .with_runner(Arc::clone(&runner) as Arc<dyn AgentRunner>);
+
+        let mock = Arc::new(MockSpine::with_manifest(SessionManifest {
+            emitted: Vec::new(),
+            declared_empty: true,
+        }));
+        let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
+            node_id: NodeId::generate(),
+            inputs: Vec::new(),
+            spine: mock as Arc<dyn crate::SpineClient>,
+            subworkflow_ref: None,
+            agent_config: None,
+        };
+        exec.execute(ctx).await.unwrap();
+        assert_eq!(runner.seen_model.lock().unwrap().as_deref(), Some("SELF"));
+    }
+
+    #[test]
+    fn substrate_agent_config_reflects_executor_fields() {
+        use onsager_substrate::executor::Executor as SubstrateExecutor;
+        let exec = AgentExecutor::new("claude-sonnet-4-6", "be helpful")
+            .with_tools(vec!["edit".into(), "read".into()])
+            .with_credential_ref("creds_42");
+        let cfg = SubstrateExecutor::agent_config(&exec).expect("agent exposes config");
+        assert_eq!(cfg.model, "claude-sonnet-4-6");
+        assert_eq!(cfg.system_prompt, "be helpful");
+        assert_eq!(cfg.tools, vec!["edit".to_string(), "read".to_string()]);
+        assert_eq!(cfg.credential_ref.as_deref(), Some("creds_42"));
     }
 
     // -----------------------------------------------------------------

--- a/crates/onsager-nodes/src/context.rs
+++ b/crates/onsager-nodes/src/context.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use onsager_artifact::{Artifact, ArtifactId, NodeId};
+use onsager_substrate::executor::AgentConfig;
 use onsager_substrate::ids::WorkflowId;
 
 use crate::SpineClient;
@@ -54,6 +55,18 @@ pub struct ExecutorContext {
     /// scheduler reads it off the substrate executor and threads it
     /// through here. Other executors ignore the field.
     pub subworkflow_ref: Option<WorkflowId>,
+    /// `Some(config)` if the node's substrate-side executor is an Agent
+    /// (its [`onsager_substrate::executor::Executor::agent_config`]
+    /// returned `Some`); `None` otherwise.
+    ///
+    /// The agent-config sibling of [`Self::subworkflow_ref`], for the
+    /// same reason: dispatch shares one registered `AgentExecutor`
+    /// across every agent node, so its per-instance config is invisible
+    /// to the runtime instance. The scheduler reads the per-node config
+    /// off the substrate executor and threads it through here; the
+    /// runtime `AgentExecutor` prefers it over its own fields. Other
+    /// executors ignore the field. Issue #534.
+    pub agent_config: Option<AgentConfig>,
 }
 
 /// What an executor returns to the runtime.
@@ -128,6 +141,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         };
         assert!(ctx.inputs.is_empty());
         assert!(ctx.subworkflow_ref.is_none());

--- a/crates/onsager-nodes/src/dispatch.rs
+++ b/crates/onsager-nodes/src/dispatch.rs
@@ -54,6 +54,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 

--- a/crates/onsager-nodes/src/executor.rs
+++ b/crates/onsager-nodes/src/executor.rs
@@ -105,6 +105,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 

--- a/crates/onsager-nodes/src/human.rs
+++ b/crates/onsager-nodes/src/human.rs
@@ -448,6 +448,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::clone(&spine) as Arc<dyn crate::SpineClient>,
             subworkflow_ref: None,
+            agent_config: None,
         };
         (ctx, spine)
     }

--- a/crates/onsager-nodes/src/registry.rs
+++ b/crates/onsager-nodes/src/registry.rs
@@ -122,6 +122,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         };
         let outputs = exec.execute(ctx).await.unwrap();
         assert!(outputs.artifacts.is_empty());

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -452,6 +452,11 @@ impl Scheduler {
             // SubWorkflow runtime (#357) learns which workflow to
             // run for *this* node.
             subworkflow_ref: node.executor.subworkflow_ref(),
+            // Same mechanism for the per-node agent config — the
+            // registered singleton `AgentExecutor` reads its model /
+            // prompt / tools / credential off the context rather than
+            // its own placeholder fields (issue #534).
+            agent_config: node.executor.agent_config(),
         };
         match dispatch(&self.registry, node, ctx).await {
             Ok(outputs) => {

--- a/crates/onsager-nodes/src/script.rs
+++ b/crates/onsager-nodes/src/script.rs
@@ -256,6 +256,7 @@ mod tests {
             inputs: vec![],
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 

--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -464,6 +464,7 @@ mod tests {
             inputs,
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 
@@ -478,6 +479,7 @@ mod tests {
             inputs,
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: Some(workflow_ref),
+            agent_config: None,
         }
     }
 

--- a/crates/onsager-nodes/src/verify.rs
+++ b/crates/onsager-nodes/src/verify.rs
@@ -275,6 +275,7 @@ mod tests {
             inputs,
             spine: Arc::new(MockSpine::default()),
             subworkflow_ref: None,
+            agent_config: None,
         }
     }
 

--- a/crates/onsager-nodes/tests/crawlab_fixture.rs
+++ b/crates/onsager-nodes/tests/crawlab_fixture.rs
@@ -458,11 +458,13 @@ async fn crawlab_brownfield_pipeline_runs_end_to_end() {
     // node-level command / prompt / checks would still let the
     // registry-dispatch path produce green output — silently passing.
     //
-    // Today (RUN-01 / #381), the scheduler dispatches by `executor_kind`
-    // and runs the *registry* instance instead of the node's; threading
-    // per-node config through dispatch is RUN-02 (#360). Until then,
-    // the compile-side guarantee that node config round-trips is the
-    // best mechanical assertion we can make.
+    // The scheduler dispatches by `executor_kind` and runs the
+    // *registry* instance. For Agent nodes, per-node config now reaches
+    // that instance via `ExecutorContext::agent_config`, threaded off
+    // the substrate executor (RUN-02 / #534). Script / Verify per-node
+    // config is not yet threaded, so for those kinds the compile-side
+    // guarantee that node config round-trips is still the best
+    // mechanical assertion we can make.
     let kinds: Vec<&str> = exec_plan
         .nodes
         .iter()
@@ -520,13 +522,16 @@ async fn crawlab_brownfield_pipeline_runs_end_to_end() {
     );
 
     // ---- act -------------------------------------------------------------
-    // Today's `dispatch` (RUN-01) resolves a node to *the registry's*
-    // instance for that kind — not to the node's own boxed executor
-    // (see `crates/onsager-nodes/src/dispatch.rs`). Threading per-node
-    // configuration through dispatch is RUN-02 (#360). The compile-
-    // side assertions above prove the node-level config survives
-    // instantiation; here we register one canonical handler per kind
-    // that the scheduler actually invokes during this run.
+    // `dispatch` resolves a node to *the registry's* instance for that
+    // kind — not to the node's own boxed executor (see
+    // `crates/onsager-nodes/src/dispatch.rs`). For Agent nodes the
+    // registry instance now reads per-node config off
+    // `ExecutorContext::agent_config`, threaded by the scheduler off
+    // the substrate executor (RUN-02 / #534); Script / Verify per-node
+    // config is not yet threaded. The compile-side assertions above
+    // prove the node-level config survives instantiation; here we
+    // register one canonical handler per kind that the scheduler
+    // actually invokes during this run.
     let mut registry = ExecutorRegistry::new();
     registry.register(Arc::new(ScriptExecutor::new([
         "sh",

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -230,16 +230,22 @@ async fn events_ext_max_id(store: &EventStore) -> anyhow::Result<Option<i64>> {
 /// Build the default registry the deployed binary uses.
 ///
 /// v1 registers only [`NoOpExecutor`]. Script / Verify / Agent /
-/// SubWorkflow are wired through the registry by `executor_kind`,
-/// but the dispatch path (`onsager_nodes::dispatch`) runs the
-/// *registered* instance — not the node's per-instance config (see
-/// dispatch.rs and the RUN-02 follow-up note in `crawlab_fixture.rs`).
-/// Until per-node config threading lands, registering a singleton
-/// ScriptExecutor with no command would dispatch every script node
-/// through that empty config — silently wrong. Registering only NoOp
-/// means non-NoOp nodes fail with [`ExecutorError::UnknownKind`],
-/// which is the correct loud failure; tests inject a richer registry
-/// via [`SchedulerService::with_registry`].
+/// SubWorkflow are wired through the registry by `executor_kind`, and
+/// the dispatch path (`onsager_nodes::dispatch`) runs the *registered*
+/// instance. Per-node config reaches that instance through the
+/// `ExecutorContext` escape hatch the scheduler threads off each
+/// substrate executor: `subworkflow_ref` for SubWorkflow (#357) and
+/// `agent_config` for Agent (#534). A registered singleton
+/// `AgentExecutor` therefore dispatches each agent node with *its*
+/// model / prompt / tools / credential.
+///
+/// Script / Verify per-node config is *not* yet threaded (those keep
+/// only the compile-side round-trip assertion), so registering a
+/// singleton `ScriptExecutor` with no command would still dispatch
+/// every script node through that empty config — silently wrong.
+/// Registering only NoOp means non-NoOp nodes fail with
+/// [`ExecutorError::UnknownKind`], which is the correct loud failure;
+/// tests inject a richer registry via [`SchedulerService::with_registry`].
 pub fn default_executor_registry() -> ExecutorRegistry {
     let mut r = ExecutorRegistry::new();
     r.register(Arc::new(NoOpExecutor));

--- a/crates/onsager-substrate/src/executor.rs
+++ b/crates/onsager-substrate/src/executor.rs
@@ -81,6 +81,42 @@ pub trait Executor: std::fmt::Debug + Send + Sync {
     fn subworkflow_ref(&self) -> Option<WorkflowId> {
         None
     }
+
+    /// If this executor is an Agent, the per-node [`AgentConfig`] it
+    /// carries. Default `None` covers every non-agent executor — they
+    /// inherit it untouched, so no impl churn.
+    ///
+    /// This is the agent-config sibling of [`Self::subworkflow_ref`]:
+    /// dispatch resolves a node to the *registered singleton* runtime
+    /// executor by `executor_kind()` string, so per-instance config on
+    /// the node's own boxed executor is invisible to the runtime
+    /// instance. The scheduler reads this off the substrate executor
+    /// and threads it through `ExecutorContext` so the registered
+    /// `AgentExecutor` runs each node with *its* model / prompt /
+    /// tools / credential rather than the singleton's (issue #534).
+    fn agent_config(&self) -> Option<AgentConfig> {
+        None
+    }
+}
+
+/// Per-node configuration an Agent executor carries — the slice of an
+/// agent node's state the runtime needs to dispatch a session with the
+/// *node's* parameters rather than the registered singleton's.
+///
+/// Mirrors the fields stiglab's `Task` carries (`model`,
+/// `system_prompt`, allowed `tools`, a credential bundle reference);
+/// the runtime wiring (the session runner) stays on the singleton and
+/// is deliberately *not* part of this serializable shape. Lives in the
+/// substrate because [`Executor::agent_config`] must return a
+/// substrate-visible type (issue #534).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentConfig {
+    pub model: String,
+    pub system_prompt: String,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    #[serde(default)]
+    pub credential_ref: Option<String>,
 }
 
 /// A no-op executor — declares deterministic output, performs nothing.


### PR DESCRIPTION
## What

`onsager-nodes::dispatch` resolves a node to the **registered singleton** runtime executor by `executor_kind()` string and runs that instance — it never consults the node's own `Box<dyn Executor>` config. A registered singleton `AgentExecutor` would therefore dispatch *every* agent node with one `model` / `system_prompt` / `tools` / `credential_ref`, ignoring each node's per-instance config. This is the blocker spec #533 names for registering `AgentExecutor`.

## How

Mirrors the existing `subworkflow_ref` escape hatch exactly:

- **`onsager-substrate`** — new serializable `AgentConfig { model, system_prompt, tools, credential_ref }` struct + a defaulted `fn agent_config(&self) -> Option<AgentConfig> { None }` on the `Executor` trait. Every non-agent executor inherits `None` — no impl churn.
- **`onsager-nodes` `agent.rs`** — the substrate `AgentExecutor` overrides `agent_config()` to expose its config (the `runner` stays off it — runtime wiring, not node config). The runtime `execute()` resolves effective config from `ctx.agent_config`, falling back to `self`'s own fields when `None` (direct/non-scheduler callers and existing unit tests). `AgentRequest` and the `agent.session_started` `model` are built from the effective config; the runner stays `self.runner`.
- **`onsager-nodes` `context.rs`** — `agent_config: Option<AgentConfig>` on `ExecutorContext`, sibling of `subworkflow_ref`; all ~21 construction sites updated.
- **`onsager-nodes` `scheduler.rs`** — `execute_node` sets `agent_config: node.executor.agent_config()` when building the context.
- Stale RUN-02 notes in `service.rs` and `crawlab_fixture.rs` updated to reflect that agent threading now works (script/verify per-node config stays out of scope and keeps its compile-side round-trip assertion).

## Test

- New dispatch-level test: register a singleton `AgentExecutor` (model `"SINGLETON"`) with a capturing runner; build a node whose `AgentExecutor` has model `"NODE"`; dispatch with `agent_config` threaded; assert the runner saw `"NODE"`. **Mutation-checked**: with the threading removed (`agent_config: None`) the runner sees `"SINGLETON"` and the test fails — verified locally, so the coverage is load-bearing, not theater.
- A self-fallback test (`agent_config: None` → runner sees `self`'s model) and a substrate `agent_config()` reflection test.
- Existing `agent.rs` unit tests and the `crawlab_fixture` end-to-end test pass via the `self` fallback.
- `cargo test -p onsager-substrate -p onsager-nodes`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, and `xtask check-file-budget` all clean.

Closes #534

> **Note for reviewers:** an earlier revision of this PR/branch contained unrelated dashboard-Markdown changes pushed against the wrong issue (my error — I acted on a misread of #534, which is this substrate task). That has been fully reverted; the branch now contains only the work above. The earlier Copilot review comments and the `build` CI failure were against that reverted revision.

https://claude.ai/code/session_01Ed5iiWSymjyaNtHVPvZ397