### PR TITLE
Production ClaudeCliRunner + shared agent-spawn crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,13 @@ name = "onsager"
 version = "0.2.0-alpha.1"
 
 [[package]]
+name = "onsager-agent-spawn"
+version = "0.2.0-alpha.1"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "onsager-artifact"
 version = "0.2.0-alpha.1"
 dependencies = [
@@ -2359,6 +2366,7 @@ dependencies = [
  "chrono",
  "clap",
  "hex",
+ "onsager-agent-spawn",
  "onsager-artifact",
  "onsager-nodes",
  "onsager-spine",
@@ -2367,6 +2375,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3586,6 +3595,7 @@ dependencies = [
  "hex",
  "hostname",
  "jsonwebtoken",
+ "onsager-agent-spawn",
  "onsager-artifact",
  "onsager-github",
  "onsager-spine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/onsager-substrate",
     "crates/onsager-nodes",
     "crates/onsager-observers",
+    "crates/onsager-agent-spawn",
     "crates/onsager",
     "crates/onsager-github",
     "crates/onsager-portal",

--- a/crates/onsager-agent-spawn/Cargo.toml
+++ b/crates/onsager-agent-spawn/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "onsager-agent-spawn"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared agent-session spawn wiring — env-var constants + claude MCP/Stop-hook JSON builders reused across stiglab and the scheduler-side runner (spec #535)."
+
+[dependencies]
+serde_json = { workspace = true }

--- a/crates/onsager-agent-spawn/src/lib.rs
+++ b/crates/onsager-agent-spawn/src/lib.rs
@@ -1,0 +1,202 @@
+//! Shared agent-session spawn wiring (spec #535, Part of #533).
+//!
+//! The constants and JSON builders below were authored inline in
+//! stiglab's `agent/session/process.rs` by spec #530/#532. Per #533 the
+//! production scheduler-side runner (`ClaudeCliRunner`) must spawn the
+//! same `claude` CLI with the same MCP-server / liveness-Stop-hook
+//! wiring — but stiglab and the scheduler live on opposite sides of the
+//! subsystem seam and cannot import each other. This crate is the pure
+//! utility both depend on instead: extracted **verbatim** from stiglab,
+//! it carries no IO, no env reads, and no subsystem knowledge, so
+//! sharing it across the seam is seam-correct (a utility crate is not a
+//! subsystem).
+//!
+//! Behavior is unchanged from the stiglab originals; the unit tests
+//! below are the parity assertions #532 added, moved with the functions.
+
+/// Env var (read on the agent node) holding the base URL of portal's
+/// liveness endpoint, e.g.
+/// `https://app.example.com/api/internal/session-liveness`. Unset → no
+/// Stop hook is configured (fail-safe default for local dev and tests);
+/// the authoritative gate (#523) alone then covers liveness.
+pub const LIVENESS_HOOK_URL_ENV: &str = "ONSAGER_LIVENESS_HOOK_URL";
+
+/// Env var holding the session's workspace-scoped bearer token. The
+/// Stop hook interpolates it into the `Authorization` header at call
+/// time (kept out of the on-disk settings via Claude Code's
+/// `allowedEnvVars`); the MCP server config (spec #531) interpolates the
+/// same var into its `Authorization` header. Provisioned into the session
+/// env by stiglab's dispatch path (decrypted from the
+/// `portal.session_requested` event); when absent the Stop hook's request
+/// is unauthorized → `401` → it fails open (the authoritative gate #523
+/// still applies) and no MCP server is registered.
+pub const SESSION_TOKEN_ENV: &str = "ONSAGER_SESSION_TOKEN";
+
+/// Env var (read on the agent node) holding portal's MCP endpoint URL,
+/// e.g. `https://app.example.com/mcp/messages`. Unset → no MCP server is
+/// registered (the agent can't emit via MCP, but the session still runs).
+/// Spec #531.
+pub const MCP_URL_ENV: &str = "ONSAGER_MCP_URL";
+
+/// Build the inline `--settings` JSON that registers the liveness Stop
+/// hook. Pure (no env, no IO) so the wire shape is unit-testable.
+///
+/// The hook is an **HTTP** hook (Claude Code `>= 2.1.x`): on every stop
+/// attempt it POSTs to the manifest evaluator, which returns allow
+/// (empty 2xx) or `{ "decision": "block", "reason": ... }`. Claude Code
+/// fails the hook open on any non-2xx / timeout. Consecutive blocks are
+/// capped by `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default 8); the decision
+/// is recomputed from the manifest on every call, so a session that is
+/// still empty stays blocked until the cap — we never short-circuit on
+/// a `stop_hook_active`-style flag.
+///
+/// Our stiglab `session_id` + `workspace_id` are baked into the URL
+/// query string (the POST body carries Claude Code's *own* session id,
+/// which is unrelated to our manifest stream key).
+pub fn stop_hook_settings_json(
+    hook_url_base: &str,
+    workspace_id: &str,
+    session_id: &str,
+) -> String {
+    // Choose `?` vs `&` so a base URL that already carries a query
+    // string (or a trailing `?`) stays a valid URL rather than
+    // producing a double `?`.
+    let sep = if hook_url_base.contains('?') {
+        '&'
+    } else {
+        '?'
+    };
+    let url = format!(
+        "{hook_url_base}{sep}workspace_id={}&session_id={}",
+        urlencode(workspace_id),
+        urlencode(session_id),
+    );
+    let token_ref = format!("Bearer ${SESSION_TOKEN_ENV}");
+    serde_json::json!({
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        {
+                            "type": "http",
+                            "url": url,
+                            // Short timeout: a network blip should fail
+                            // the hook open promptly, not stall the stop
+                            // for the 600s HTTP-hook default.
+                            "timeout": 10,
+                            "headers": { "Authorization": token_ref },
+                            "allowedEnvVars": [SESSION_TOKEN_ENV],
+                        }
+                    ]
+                }
+            ]
+        }
+    })
+    .to_string()
+}
+
+/// Minimal percent-encoding for query-string values. Server-minted ids
+/// (`ws_<ulid>`, ULID/UUID session ids) are already URL-safe; this is
+/// defensive against any reserved character sneaking in.
+pub fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Build the inline `--mcp-config` JSON registering portal's MCP server
+/// (spec #531) so the agent can call `emit_artifact` / `declare_no_output`
+/// / `read_emit_status`. Pure so the wire shape is unit-testable.
+///
+/// The bearer token is interpolated from `$ONSAGER_SESSION_TOKEN` at
+/// startup (Claude Code expands `${VAR}` in MCP `headers`). This is only
+/// wired when the token is actually present in the env — Claude Code
+/// **fails to parse** an MCP config whose `${VAR}` is unset, so registering
+/// it tokenless would break the whole session rather than degrade.
+pub fn mcp_config_json(mcp_url: &str) -> String {
+    serde_json::json!({
+        "mcpServers": {
+            "onsager": {
+                "type": "http",
+                "url": mcp_url,
+                "headers": {
+                    "Authorization": format!("Bearer ${{{SESSION_TOKEN_ENV}}}"),
+                },
+            }
+        }
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_hook_settings_have_http_hook_shape() {
+        let json = stop_hook_settings_json(
+            "https://app.example.com/api/internal/session-liveness",
+            "ws_123",
+            "sess_abc",
+        );
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let hook = &v["hooks"]["Stop"][0]["hooks"][0];
+        assert_eq!(hook["type"], "http");
+        // Identity rides on the URL query string, not the POST body
+        // (the body carries Claude Code's own session id).
+        let url = hook["url"].as_str().unwrap();
+        assert!(url.starts_with("https://app.example.com/api/internal/session-liveness?"));
+        assert!(url.contains("workspace_id=ws_123"));
+        assert!(url.contains("session_id=sess_abc"));
+        // Token is interpolated from env at call time, never inlined.
+        assert_eq!(
+            hook["headers"]["Authorization"],
+            "Bearer $ONSAGER_SESSION_TOKEN"
+        );
+        assert_eq!(hook["allowedEnvVars"][0], "ONSAGER_SESSION_TOKEN");
+        // Short timeout so a blip fails open promptly.
+        assert_eq!(hook["timeout"], 10);
+    }
+
+    #[test]
+    fn stop_hook_url_uses_amp_when_base_already_has_query() {
+        // A base URL carrying its own query string must stay valid —
+        // append with `&`, not a second `?`.
+        let json = stop_hook_settings_json("https://h.example/live?env=prod", "ws_1", "s_1");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let url = v["hooks"]["Stop"][0]["hooks"][0]["url"].as_str().unwrap();
+        assert_eq!(
+            url,
+            "https://h.example/live?env=prod&workspace_id=ws_1&session_id=s_1"
+        );
+        // Exactly one `?` in the final URL.
+        assert_eq!(url.matches('?').count(), 1);
+    }
+
+    #[test]
+    fn mcp_config_registers_http_server_with_interpolated_token() {
+        let json = mcp_config_json("https://app.example.com/mcp/messages");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let server = &v["mcpServers"]["onsager"];
+        assert_eq!(server["type"], "http");
+        assert_eq!(server["url"], "https://app.example.com/mcp/messages");
+        // Token interpolated from env at startup, never inlined.
+        assert_eq!(
+            server["headers"]["Authorization"],
+            "Bearer ${ONSAGER_SESSION_TOKEN}"
+        );
+    }
+
+    #[test]
+    fn urlencode_passes_safe_ids_and_escapes_reserved() {
+        assert_eq!(urlencode("ws_01HZX-abc.def~9"), "ws_01HZX-abc.def~9");
+        assert_eq!(urlencode("a b&c=d"), "a%20b%26c%3Dd");
+    }
+}

--- a/crates/onsager-scheduler/Cargo.toml
+++ b/crates/onsager-scheduler/Cargo.toml
@@ -17,6 +17,7 @@ onsager-artifact = { path = "../onsager-artifact" }
 onsager-nodes    = { path = "../onsager-nodes" }
 onsager-spine    = { path = "../onsager-spine" }
 onsager-substrate = { path = "../onsager-substrate" }
+onsager-agent-spawn = { path = "../onsager-agent-spawn" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -39,3 +40,4 @@ uuid = { workspace = true }
 [dev-dependencies]
 chrono = { workspace = true }
 tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -39,11 +39,18 @@ pub mod migrate;
 pub mod plan_registry;
 pub mod plan_runner;
 pub mod plan_store;
+pub mod runners;
 pub mod service;
 pub mod spine_client;
 
 pub use bridge::{TriggerBridge, TriggerBridgeError};
 pub use plan_runner::{PlanRunError, PlanRunner, SchedulerLibrarySnapshot, resolve_kind_versions};
 pub use plan_store::SqlxPlanStore;
+// The production agent runner (spec #535). Threading it into
+// `default_executor_registry` requires per-node `AgentExecutor` config
+// (model / prompt / runner), which lands with registration in #533.4 —
+// registering a singleton today would dispatch every agent node through
+// one config (see the note on `service::default_executor_registry`).
+pub use runners::ClaudeCliRunner;
 pub use service::{SchedulerService, ServiceConfig};
 pub use spine_client::SpineEventStoreClient;

--- a/crates/onsager-scheduler/src/runners.rs
+++ b/crates/onsager-scheduler/src/runners.rs
@@ -17,11 +17,13 @@
 //! `claude --output-format stream-json --verbose --include-partial-messages
 //! --permission-mode bypassPermissions [--model M] [--system-prompt P]
 //! [--mcp-config …] [--settings …] -- <prompt>` with `ONSAGER_SESSION_ID`
-//! threaded into the child env from [`AgentRequest::session_id`]. The MCP
-//! config (spec #531) and liveness Stop hook (spec #520 §4d) are wired
-//! only when their env is present, mirroring stiglab's gating exactly:
-//! Claude Code fails to parse an MCP config whose `${VAR}` is unset, so a
-//! tokenless registration would break the session rather than degrade.
+//! threaded into the child env from [`AgentRequest::session_id`] and the
+//! plan-scoped token (#536) injected as `ONSAGER_SESSION_TOKEN` from
+//! [`AgentRequest::session_token`]. The MCP config (spec #531) and
+//! liveness Stop hook (spec #520 §4d) are wired only when their inputs
+//! are present, mirroring stiglab's gating exactly: Claude Code fails to
+//! parse an MCP config whose `${VAR}` is unset, so a tokenless
+//! registration would break the session rather than degrade.
 //!
 //! ## What it returns
 //!
@@ -136,13 +138,18 @@ impl AgentRunner for ClaudeCliRunner {
         }
 
         // Portal MCP server (spec #531). Registered only when the MCP
-        // URL is configured AND the session token is present in the env —
-        // Claude Code fails to parse an MCP config whose `${VAR}` is
-        // unset, so a tokenless registration would break the session
-        // rather than degrade. Absent either → the agent runs without
-        // MCP (no emit path); the authoritative gate (#523) still covers
-        // liveness. Same gating stiglab applies.
-        let has_session_token = std::env::var(SESSION_TOKEN_ENV).is_ok_and(|t| !t.is_empty());
+        // URL is configured AND the plan-scoped session token (#536) is
+        // present on the request — Claude Code fails to parse an MCP
+        // config whose `${VAR}` is unset, so a tokenless registration
+        // would break the session rather than degrade. Absent either →
+        // the agent runs without MCP (no emit path); the authoritative
+        // gate (#523) still covers liveness. The token rides the request
+        // (decrypted once per plan by the scheduler, #538/#539), not the
+        // process env — each plan run carries its own.
+        let has_session_token = request
+            .session_token
+            .as_ref()
+            .is_some_and(|t| !t.is_empty());
         if let Ok(mcp_url) = std::env::var(MCP_URL_ENV)
             && !mcp_url.is_empty()
             && has_session_token
@@ -158,6 +165,15 @@ impl AgentRunner for ClaudeCliRunner {
         // its MCP emits to the same `session:<id>` manifest stream the
         // executor reads back authoritatively (spec #520 §4b/§4c).
         cmd.env(SESSION_ID_ENV, &request.session_id);
+
+        // Inject the plan-scoped session token (#536) as
+        // `ONSAGER_SESSION_TOKEN` so the `${VAR}` interpolation in the MCP
+        // config + Stop-hook `Authorization` headers resolves at startup.
+        // Only set when present; an empty/absent token means no MCP auth
+        // (and the MCP config above was not registered).
+        if let Some(token) = request.session_token.as_deref().filter(|t| !t.is_empty()) {
+            cmd.env(SESSION_TOKEN_ENV, token);
+        }
 
         // stderr is discarded, not piped: this runner has no consumer
         // for it (unlike stiglab, which forwards stderr as UI chunks),
@@ -321,6 +337,7 @@ mod tests {
              {{\n\
                echo \"ARGS: $*\"\n\
                echo \"SESSION_ID: ${{ONSAGER_SESSION_ID:-}}\"\n\
+               echo \"SESSION_TOKEN: ${{ONSAGER_SESSION_TOKEN:-}}\"\n\
              }} >> \"{capture}\"\n\
              cat <<'NDJSON'\n{body}\nNDJSON\n",
             capture = capture_path.display(),
@@ -334,6 +351,14 @@ mod tests {
     }
 
     fn request(prompt: &str, session_id: &str) -> AgentRequest {
+        request_with_token(prompt, session_id, None)
+    }
+
+    fn request_with_token(
+        prompt: &str,
+        session_id: &str,
+        session_token: Option<&str>,
+    ) -> AgentRequest {
         AgentRequest {
             model: "claude-sonnet-4-6".into(),
             system_prompt: "you are helpful".into(),
@@ -341,6 +366,7 @@ mod tests {
             credential_ref: None,
             user_prompt: prompt.into(),
             session_id: session_id.into(),
+            session_token: session_token.map(Into::into),
         }
     }
 
@@ -455,26 +481,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mcp_config_wired_when_url_and_token_present() {
+    async fn mcp_config_wired_and_token_injected_when_url_and_token_present() {
         let _guard = ENV_LOCK.lock().await;
         let capture = tempfile::tempdir().unwrap();
         let cap_file = capture.path().join("argv.txt");
         let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
         let (_dir, script) = fake_claude(body, &cap_file);
 
-        // SAFETY: env mutation is serialized by ENV_LOCK; vars are
-        // cleared before the guard drops so no other test observes them.
+        // The MCP endpoint URL is deployment config (process env); the
+        // session token is plan-scoped and rides the request (#536/#538).
+        // SAFETY: env mutation is serialized by ENV_LOCK and cleared
+        // before the guard drops, so no other test observes it.
         unsafe {
             std::env::set_var(MCP_URL_ENV, "https://app.example.com/mcp/messages");
-            std::env::set_var(SESSION_TOKEN_ENV, "tok_secret");
         }
 
         let runner = ClaudeCliRunner::with_command(script);
-        runner.run(request("p", "sess_mcp")).await.unwrap();
+        runner
+            .run(request_with_token("p", "sess_mcp", Some("tok_secret")))
+            .await
+            .unwrap();
 
         unsafe {
             std::env::remove_var(MCP_URL_ENV);
-            std::env::remove_var(SESSION_TOKEN_ENV);
         }
 
         let recorded = std::fs::read_to_string(&cap_file).unwrap();
@@ -487,6 +516,14 @@ mod tests {
             recorded.contains("https://app.example.com/mcp/messages"),
             "the MCP config JSON should carry the portal URL, got: {recorded}"
         );
+        // The plan-scoped token is injected into the child env as
+        // ONSAGER_SESSION_TOKEN so the `${VAR}` headers resolve at
+        // startup. Mutation guard: dropping the `cmd.env(SESSION_TOKEN_ENV
+        // ..)` line makes this assertion fail.
+        assert!(
+            recorded.contains("SESSION_TOKEN: tok_secret"),
+            "ONSAGER_SESSION_TOKEN must be injected from the request, got: {recorded}"
+        );
     }
 
     #[tokio::test]
@@ -497,13 +534,12 @@ mod tests {
         let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
         let (_dir, script) = fake_claude(body, &cap_file);
 
-        // MCP URL set but NO session token → Claude Code would fail to
-        // parse a tokenless config, so the runner must omit it (mirrors
-        // stiglab's gating). Mutation guard: dropping the
-        // `has_session_token` check here makes this assertion fail.
+        // MCP URL set but the request carries NO session token → Claude
+        // Code would fail to parse a tokenless config, so the runner must
+        // omit it (mirrors stiglab's gating). Mutation guard: dropping the
+        // `has_session_token` check makes this assertion fail.
         unsafe {
             std::env::set_var(MCP_URL_ENV, "https://app.example.com/mcp/messages");
-            std::env::remove_var(SESSION_TOKEN_ENV);
         }
 
         let runner = ClaudeCliRunner::with_command(script);
@@ -517,6 +553,11 @@ mod tests {
         assert!(
             !recorded.contains("--mcp-config"),
             "argv must omit --mcp-config when the session token is absent, got: {recorded}"
+        );
+        // The token env stays empty in the child when the request has none.
+        assert!(
+            recorded.contains("SESSION_TOKEN: \n"),
+            "ONSAGER_SESSION_TOKEN must be empty when the request has no token, got: {recorded}"
         );
     }
 }

--- a/crates/onsager-scheduler/src/runners.rs
+++ b/crates/onsager-scheduler/src/runners.rs
@@ -1,0 +1,515 @@
+//! [`ClaudeCliRunner`] — the production [`AgentRunner`] (spec #535,
+//! Plan item 1 of #533).
+//!
+//! [`onsager_nodes::AgentExecutor`] dispatches its session through an
+//! `Arc<dyn AgentRunner>`; the only workspace impls before this were
+//! `UnconfiguredRunner` (errors) and `StubAgentRunner` (tests). This is
+//! the first runner that actually runs an agent. Per #533 the backend
+//! is the subprocess `claude` CLI — maximal parity with stiglab, whose
+//! `SessionProcess::spawn` (`crates/stiglab/src/agent/session/process.rs`)
+//! this mirrors. It lives host-side in the scheduler binary's crate so
+//! `onsager-nodes` stays free of a process-spawn dependency, and reuses
+//! — never forks — the spawn-wiring constants and JSON builders through
+//! the shared `onsager-agent-spawn` crate.
+//!
+//! ## What the runner spawns
+//!
+//! `claude --output-format stream-json --verbose --include-partial-messages
+//! --permission-mode bypassPermissions [--model M] [--system-prompt P]
+//! [--mcp-config …] [--settings …] -- <prompt>` with `ONSAGER_SESSION_ID`
+//! threaded into the child env from [`AgentRequest::session_id`]. The MCP
+//! config (spec #531) and liveness Stop hook (spec #520 §4d) are wired
+//! only when their env is present, mirroring stiglab's gating exactly:
+//! Claude Code fails to parse an MCP config whose `${VAR}` is unset, so a
+//! tokenless registration would break the session rather than degrade.
+//!
+//! ## What it returns
+//!
+//! It parses the NDJSON stdout to the terminal `Result` event and
+//! returns [`AgentResponse`] `{ output, emitted: vec![] }`. `emitted`
+//! stays empty by design (§4c): the agent records outputs out-of-band
+//! through portal's MCP `emit_artifact` / `declare_no_output` tools,
+//! which write the authoritative `events_ext` manifest the executor
+//! reads back. The NDJSON stream genuinely does not see those MCP side
+//! effects, so the runner reports "session over" only and the manifest
+//! remains the single source of truth for "what came out".
+
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use onsager_agent_spawn::{
+    LIVENESS_HOOK_URL_ENV, MCP_URL_ENV, SESSION_TOKEN_ENV, mcp_config_json, stop_hook_settings_json,
+};
+use onsager_nodes::{AgentRequest, AgentResponse, AgentRunError, AgentRunner};
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+/// Env var holding the session's workspace id. Threaded into the child
+/// env so the liveness Stop hook (#520 §4d) can address the manifest by
+/// `(workspace_id, session_id)`. Unset → no Stop hook is wired, the same
+/// fail-safe stiglab uses when a session is not workspace-scoped.
+const WORKSPACE_ID_ENV: &str = "ONSAGER_WORKSPACE_ID";
+
+/// Env var the agent's execution environment reads to attribute its MCP
+/// `emit_artifact` / `declare_no_output` calls to the right manifest
+/// stream. The executor mints the id and the runner threads it here
+/// (spec #520 §4b), mirroring stiglab's `session_requested_listener`.
+const SESSION_ID_ENV: &str = "ONSAGER_SESSION_ID";
+
+/// Production [`AgentRunner`] backed by the subprocess `claude` CLI.
+///
+/// Holds only the binary name/path to invoke (default `claude`, on
+/// PATH). Everything else comes off the per-call [`AgentRequest`] and
+/// the process env, matching the host-side configuration model:
+/// `AgentExecutor` carries the workflow template's config (model,
+/// prompt, tools), the runner carries the runtime backend.
+#[derive(Debug, Clone)]
+pub struct ClaudeCliRunner {
+    /// The `claude` binary to spawn. Defaults to `"claude"` (resolved on
+    /// PATH); overridable for tests (a fixture script) and for pinning a
+    /// specific install in production.
+    command: String,
+}
+
+impl Default for ClaudeCliRunner {
+    fn default() -> Self {
+        Self {
+            command: "claude".to_string(),
+        }
+    }
+}
+
+impl ClaudeCliRunner {
+    /// Runner spawning the default `claude` binary on PATH.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Runner spawning a specific binary path / name. Used by tests to
+    /// point at a fixture script and by deployments pinning an install.
+    pub fn with_command(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentRunner for ClaudeCliRunner {
+    async fn run(&self, request: AgentRequest) -> Result<AgentResponse, AgentRunError> {
+        let mut cmd = Command::new(&self.command);
+
+        // Stream-JSON flags — identical to stiglab's SessionProcess.
+        cmd.args([
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]);
+
+        // Non-interactive execution: bypass permission prompts. The
+        // scheduler runs agents headlessly with no human at the TTY.
+        cmd.args(["--permission-mode", "bypassPermissions"]);
+
+        if !request.model.is_empty() {
+            cmd.args(["--model", &request.model]);
+        }
+        if !request.system_prompt.is_empty() {
+            cmd.args(["--system-prompt", &request.system_prompt]);
+        }
+
+        // Liveness Stop hook (spec #520 §4d). Wired only when both the
+        // hook endpoint URL and the session's workspace id are present
+        // (the manifest is addressed by `(workspace_id, session_id)`).
+        // Absent either → no hook; the authoritative gate (#523) alone
+        // covers liveness. Same gating stiglab applies.
+        if let (Ok(hook_url_base), Ok(workspace_id)) = (
+            std::env::var(LIVENESS_HOOK_URL_ENV),
+            std::env::var(WORKSPACE_ID_ENV),
+        ) && !hook_url_base.is_empty()
+            && !workspace_id.is_empty()
+        {
+            let settings =
+                stop_hook_settings_json(&hook_url_base, &workspace_id, &request.session_id);
+            cmd.args(["--settings", &settings]);
+        }
+
+        // Portal MCP server (spec #531). Registered only when the MCP
+        // URL is configured AND the session token is present in the env —
+        // Claude Code fails to parse an MCP config whose `${VAR}` is
+        // unset, so a tokenless registration would break the session
+        // rather than degrade. Absent either → the agent runs without
+        // MCP (no emit path); the authoritative gate (#523) still covers
+        // liveness. Same gating stiglab applies.
+        let has_session_token = std::env::var(SESSION_TOKEN_ENV).is_ok_and(|t| !t.is_empty());
+        if let Ok(mcp_url) = std::env::var(MCP_URL_ENV)
+            && !mcp_url.is_empty()
+            && has_session_token
+        {
+            let mcp_config = mcp_config_json(&mcp_url);
+            cmd.args(["--mcp-config", &mcp_config]);
+        }
+
+        // Separator + prompt body assembled by the executor.
+        cmd.arg("--").arg(&request.user_prompt);
+
+        // Thread the executor-minted session id so the agent attributes
+        // its MCP emits to the same `session:<id>` manifest stream the
+        // executor reads back authoritatively (spec #520 §4b/§4c).
+        cmd.env(SESSION_ID_ENV, &request.session_id);
+
+        cmd.stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::null());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| AgentRunError::new(format!("spawning `{}`: {e}", self.command)))?;
+
+        // Drain stdout, parsing NDJSON to the terminal `Result` event.
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AgentRunError::new("child process produced no stdout pipe"))?;
+        let mut lines = BufReader::new(stdout).lines();
+
+        let mut accumulated = String::new();
+        let mut result: Option<Result<String, String>> = None;
+
+        loop {
+            let line = match lines.next_line().await {
+                Ok(Some(line)) => line,
+                Ok(None) => break, // EOF
+                Err(e) => {
+                    let _ = child.kill().await;
+                    return Err(AgentRunError::new(format!("reading agent stdout: {e}")));
+                }
+            };
+            let event: ClaudeEvent = match serde_json::from_str(&line) {
+                Ok(e) => e,
+                // Non-JSON line — defensively accumulate as raw output so
+                // a session whose final text leaks outside the Result
+                // event is not silently dropped.
+                Err(_) => {
+                    accumulated.push_str(&line);
+                    accumulated.push('\n');
+                    continue;
+                }
+            };
+            match event {
+                ClaudeEvent::StreamEvent { event: inner } => {
+                    if inner.event_type == "content_block_delta"
+                        && let Some(delta) = inner.delta
+                        && delta.delta_type == "text_delta"
+                        && let Some(text) = delta.text
+                    {
+                        accumulated.push_str(&text);
+                    }
+                }
+                ClaudeEvent::Result {
+                    subtype,
+                    result: text,
+                    error,
+                } => {
+                    result = Some(match subtype.as_str() {
+                        "success" => Ok(text.unwrap_or_else(|| accumulated.clone())),
+                        _ => Err(error
+                            .unwrap_or_else(|| format!("claude exited with subtype: {subtype}"))),
+                    });
+                }
+                ClaudeEvent::Unknown => {}
+            }
+        }
+
+        // Reap the child so we don't leak a zombie. A non-zero exit with
+        // a parsed success Result still counts as success (the CLI can
+        // exit non-zero on a Stop-hook block cap, for instance); a
+        // missing Result is the real failure surfaced below.
+        let _ = child.wait().await;
+
+        match result {
+            Some(Ok(output)) => Ok(AgentResponse {
+                output,
+                // Empty by design: emits flow out-of-band through MCP and
+                // are read back from the authoritative manifest (§4c).
+                emitted: Vec::new(),
+            }),
+            Some(Err(error)) => Err(AgentRunError::new(error)),
+            None => Err(AgentRunError::new(
+                "agent stdout closed without a result event",
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON event types emitted by `claude --output-format stream-json`.
+//
+// A focused subset of stiglab's `ClaudeEvent` — the runner only needs
+// the final-text deltas and the terminal `Result`. System / tool_use
+// events stiglab forwards as UI chunks have no consumer here (the agent
+// runs headlessly under the scheduler), so they fold into `Unknown`.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClaudeEvent {
+    #[serde(rename = "stream_event")]
+    StreamEvent { event: StreamEventInner },
+    Result {
+        subtype: String,
+        #[serde(default)]
+        result: Option<String>,
+        #[serde(default)]
+        error: Option<String>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamEventInner {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    delta: Option<DeltaPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeltaPayload {
+    #[serde(rename = "type", default)]
+    delta_type: String,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Serializes every test that spawns the runner. `Command::spawn`
+    /// reads the process-global env, and the env-mutating tests below
+    /// call `set_var` / `remove_var`; without this lock those mutations
+    /// would race a concurrent spawn (a genuine data race, not just a
+    /// logical one). Every spawning test holds it across its `run`. A
+    /// `tokio::sync::Mutex` (not `std`) so the guard can be held across
+    /// the `.await` without tripping `clippy::await_holding_lock`.
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Write an executable fake `claude` script that records its argv +
+    /// env to `capture_path` and emits `body` on stdout. Returns the
+    /// temp dir (kept alive) and the script path.
+    fn fake_claude(body: &str, capture_path: &std::path::Path) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake-claude.sh");
+        let mut f = std::fs::File::create(&script).unwrap();
+        // Record the full argv and the env vars the assertions care
+        // about, then print the canned NDJSON body.
+        write!(
+            f,
+            "#!/usr/bin/env bash\n\
+             {{\n\
+               echo \"ARGS: $*\"\n\
+               echo \"SESSION_ID: ${{ONSAGER_SESSION_ID:-}}\"\n\
+             }} >> \"{capture}\"\n\
+             cat <<'NDJSON'\n{body}\nNDJSON\n",
+            capture = capture_path.display(),
+            body = body,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        (dir, script.to_string_lossy().into_owned())
+    }
+
+    fn request(prompt: &str, session_id: &str) -> AgentRequest {
+        AgentRequest {
+            model: "claude-sonnet-4-6".into(),
+            system_prompt: "you are helpful".into(),
+            tools: Vec::new(),
+            credential_ref: None,
+            user_prompt: prompt.into(),
+            session_id: session_id.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn parses_success_result_into_output() {
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"final answer"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let runner = ClaudeCliRunner::with_command(script);
+        let resp = runner.run(request("do the thing", "sess_1")).await.unwrap();
+        assert_eq!(resp.output, "final answer");
+        // emitted is always empty — manifest is authoritative (§4c).
+        assert!(resp.emitted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn spawned_argv_and_env_carry_model_and_session_id() {
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        // No MCP URL / session token / workspace id in env → no
+        // --mcp-config, no --settings; we assert the always-on flags.
+        let runner = ClaudeCliRunner::with_command(script);
+        runner.run(request("the prompt", "sess_xyz")).await.unwrap();
+
+        let recorded = std::fs::read_to_string(&cap_file).unwrap();
+        assert!(
+            recorded.contains("--model claude-sonnet-4-6"),
+            "argv should carry --model, got: {recorded}"
+        );
+        assert!(
+            recorded.contains("--output-format stream-json"),
+            "argv should carry stream-json flags, got: {recorded}"
+        );
+        assert!(
+            recorded.contains("--permission-mode bypassPermissions"),
+            "argv should bypass permissions, got: {recorded}"
+        );
+        assert!(
+            recorded.contains("SESSION_ID: sess_xyz"),
+            "ONSAGER_SESSION_ID must be threaded into the child env, got: {recorded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accumulates_text_deltas_when_result_lacks_result_field() {
+        let _guard = ENV_LOCK.lock().await;
+        // A Result event with no `result` field falls back to the
+        // accumulated content_block_delta text.
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = concat!(
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}}"#,
+            "\n",
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"world"}}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success"}"#,
+        );
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let runner = ClaudeCliRunner::with_command(script);
+        let resp = runner.run(request("p", "s")).await.unwrap();
+        assert_eq!(resp.output, "Hello world");
+    }
+
+    #[tokio::test]
+    async fn error_result_surfaces_as_run_error() {
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body =
+            r#"{"type":"result","subtype":"error_during_execution","error":"model refused"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let runner = ClaudeCliRunner::with_command(script);
+        let err = runner.run(request("p", "s")).await.unwrap_err();
+        assert!(
+            err.to_string().contains("model refused"),
+            "runner should surface the CLI error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_result_event_is_an_error() {
+        let _guard = ENV_LOCK.lock().await;
+        // stdout closes with only deltas, no terminal Result.
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let runner = ClaudeCliRunner::with_command(script);
+        let err = runner.run(request("p", "s")).await.unwrap_err();
+        assert!(
+            err.to_string().contains("without a result event"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_failure_for_missing_binary_is_an_error() {
+        let _guard = ENV_LOCK.lock().await;
+        let runner = ClaudeCliRunner::with_command("/nonexistent/definitely-not-claude");
+        let err = runner.run(request("p", "s")).await.unwrap_err();
+        assert!(err.to_string().contains("spawning"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn mcp_config_wired_when_url_and_token_present() {
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        // SAFETY: env mutation is serialized by ENV_LOCK; vars are
+        // cleared before the guard drops so no other test observes them.
+        unsafe {
+            std::env::set_var(MCP_URL_ENV, "https://app.example.com/mcp/messages");
+            std::env::set_var(SESSION_TOKEN_ENV, "tok_secret");
+        }
+
+        let runner = ClaudeCliRunner::with_command(script);
+        runner.run(request("p", "sess_mcp")).await.unwrap();
+
+        unsafe {
+            std::env::remove_var(MCP_URL_ENV);
+            std::env::remove_var(SESSION_TOKEN_ENV);
+        }
+
+        let recorded = std::fs::read_to_string(&cap_file).unwrap();
+        assert!(
+            recorded.contains("--mcp-config"),
+            "argv should carry --mcp-config when MCP URL + token are set, got: {recorded}"
+        );
+        // The portal MCP server URL rides inside the inline JSON config.
+        assert!(
+            recorded.contains("https://app.example.com/mcp/messages"),
+            "the MCP config JSON should carry the portal URL, got: {recorded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_config_omitted_when_token_absent() {
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        // MCP URL set but NO session token → Claude Code would fail to
+        // parse a tokenless config, so the runner must omit it (mirrors
+        // stiglab's gating). Mutation guard: dropping the
+        // `has_session_token` check here makes this assertion fail.
+        unsafe {
+            std::env::set_var(MCP_URL_ENV, "https://app.example.com/mcp/messages");
+            std::env::remove_var(SESSION_TOKEN_ENV);
+        }
+
+        let runner = ClaudeCliRunner::with_command(script);
+        runner.run(request("p", "sess_no_tok")).await.unwrap();
+
+        unsafe {
+            std::env::remove_var(MCP_URL_ENV);
+        }
+
+        let recorded = std::fs::read_to_string(&cap_file).unwrap();
+        assert!(
+            !recorded.contains("--mcp-config"),
+            "argv must omit --mcp-config when the session token is absent, got: {recorded}"
+        );
+    }
+}

--- a/crates/onsager-scheduler/src/runners.rs
+++ b/crates/onsager-scheduler/src/runners.rs
@@ -159,8 +159,15 @@ impl AgentRunner for ClaudeCliRunner {
         // executor reads back authoritatively (spec #520 §4b/§4c).
         cmd.env(SESSION_ID_ENV, &request.session_id);
 
+        // stderr is discarded, not piped: this runner has no consumer
+        // for it (unlike stiglab, which forwards stderr as UI chunks),
+        // and an unread pipe would deadlock — if `claude` writes enough
+        // diagnostics to fill the OS pipe buffer, the child blocks on the
+        // stderr write before closing stdout and the NDJSON read loop
+        // below waits forever. `Stdio::null()` lets the child write
+        // freely with nowhere to block.
         cmd.stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::null())
             .stdin(Stdio::null());
 
         let mut child = cmd

--- a/crates/stiglab/Cargo.toml
+++ b/crates/stiglab/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 onsager-artifact = { path = "../onsager-artifact" }
 onsager-github = { path = "../onsager-github" }
 onsager-spine = { path = "../onsager-spine" }
+onsager-agent-spawn = { path = "../onsager-agent-spawn" }
 
 # From stiglab-core
 serde = { workspace = true }

--- a/crates/stiglab/src/agent/session/process.rs
+++ b/crates/stiglab/src/agent/session/process.rs
@@ -10,125 +10,18 @@ use tokio::sync::{mpsc, oneshot};
 use crate::core::{AgentMessage, SessionState, Task};
 
 // ---------------------------------------------------------------------------
-// Liveness Stop hook (spec #520 §4d / #525)
+// Liveness Stop hook + MCP spawn wiring (spec #520 §4d / #525, #531)
 // ---------------------------------------------------------------------------
-
-/// Env var (read on the agent node) holding the base URL of portal's
-/// liveness endpoint, e.g.
-/// `https://app.example.com/api/internal/session-liveness`. Unset → no
-/// Stop hook is configured (fail-safe default for local dev and tests);
-/// the authoritative gate (#523) alone then covers liveness.
-const LIVENESS_HOOK_URL_ENV: &str = "ONSAGER_LIVENESS_HOOK_URL";
-
-/// Env var holding the session's workspace-scoped bearer token. The
-/// Stop hook interpolates it into the `Authorization` header at call
-/// time (kept out of the on-disk settings via Claude Code's
-/// `allowedEnvVars`); the MCP server config (spec #531) interpolates the
-/// same var into its `Authorization` header. Provisioned into the session
-/// env by stiglab's dispatch path (decrypted from the
-/// `portal.session_requested` event); when absent the Stop hook's request
-/// is unauthorized → `401` → it fails open (the authoritative gate #523
-/// still applies) and no MCP server is registered.
-const SESSION_TOKEN_ENV: &str = "ONSAGER_SESSION_TOKEN";
-
-/// Env var (read on the agent node) holding portal's MCP endpoint URL,
-/// e.g. `https://app.example.com/mcp/messages`. Unset → no MCP server is
-/// registered (the agent can't emit via MCP, but the session still runs).
-/// Spec #531.
-const MCP_URL_ENV: &str = "ONSAGER_MCP_URL";
-
-/// Build the inline `--settings` JSON that registers the liveness Stop
-/// hook. Pure (no env, no IO) so the wire shape is unit-testable.
-///
-/// The hook is an **HTTP** hook (Claude Code `>= 2.1.x`): on every stop
-/// attempt it POSTs to the manifest evaluator, which returns allow
-/// (empty 2xx) or `{ "decision": "block", "reason": ... }`. Claude Code
-/// fails the hook open on any non-2xx / timeout. Consecutive blocks are
-/// capped by `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default 8); the decision
-/// is recomputed from the manifest on every call, so a session that is
-/// still empty stays blocked until the cap — we never short-circuit on
-/// a `stop_hook_active`-style flag.
-///
-/// Our stiglab `session_id` + `workspace_id` are baked into the URL
-/// query string (the POST body carries Claude Code's *own* session id,
-/// which is unrelated to our manifest stream key).
-fn stop_hook_settings_json(hook_url_base: &str, workspace_id: &str, session_id: &str) -> String {
-    // Choose `?` vs `&` so a base URL that already carries a query
-    // string (or a trailing `?`) stays a valid URL rather than
-    // producing a double `?`.
-    let sep = if hook_url_base.contains('?') {
-        '&'
-    } else {
-        '?'
-    };
-    let url = format!(
-        "{hook_url_base}{sep}workspace_id={}&session_id={}",
-        urlencode(workspace_id),
-        urlencode(session_id),
-    );
-    let token_ref = format!("Bearer ${SESSION_TOKEN_ENV}");
-    serde_json::json!({
-        "hooks": {
-            "Stop": [
-                {
-                    "hooks": [
-                        {
-                            "type": "http",
-                            "url": url,
-                            // Short timeout: a network blip should fail
-                            // the hook open promptly, not stall the stop
-                            // for the 600s HTTP-hook default.
-                            "timeout": 10,
-                            "headers": { "Authorization": token_ref },
-                            "allowedEnvVars": [SESSION_TOKEN_ENV],
-                        }
-                    ]
-                }
-            ]
-        }
-    })
-    .to_string()
-}
-
-/// Minimal percent-encoding for query-string values. Server-minted ids
-/// (`ws_<ulid>`, ULID/UUID session ids) are already URL-safe; this is
-/// defensive against any reserved character sneaking in.
-fn urlencode(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char)
-            }
-            _ => out.push_str(&format!("%{b:02X}")),
-        }
-    }
-    out
-}
-
-/// Build the inline `--mcp-config` JSON registering portal's MCP server
-/// (spec #531) so the agent can call `emit_artifact` / `declare_no_output`
-/// / `read_emit_status`. Pure so the wire shape is unit-testable.
-///
-/// The bearer token is interpolated from `$ONSAGER_SESSION_TOKEN` at
-/// startup (Claude Code expands `${VAR}` in MCP `headers`). This is only
-/// wired when the token is actually present in the env — Claude Code
-/// **fails to parse** an MCP config whose `${VAR}` is unset, so registering
-/// it tokenless would break the whole session rather than degrade.
-fn mcp_config_json(mcp_url: &str) -> String {
-    serde_json::json!({
-        "mcpServers": {
-            "onsager": {
-                "type": "http",
-                "url": mcp_url,
-                "headers": {
-                    "Authorization": format!("Bearer ${{{SESSION_TOKEN_ENV}}}"),
-                },
-            }
-        }
-    })
-    .to_string()
-}
+//
+// The env-var constants and JSON builders that register the liveness
+// Stop hook and portal's MCP server were authored here inline (#530/
+// #532) and were extracted to the shared `onsager-agent-spawn` crate
+// (spec #535) so the scheduler-side production runner can reuse the
+// exact same wiring across the subsystem seam. Stiglab now consumes
+// them rather than owning a private copy.
+use onsager_agent_spawn::{
+    LIVENESS_HOOK_URL_ENV, MCP_URL_ENV, SESSION_TOKEN_ENV, mcp_config_json, stop_hook_settings_json,
+};
 
 // ---------------------------------------------------------------------------
 // NDJSON event types emitted by `claude --output-format stream-json`
@@ -495,68 +388,7 @@ impl SessionProcess {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn stop_hook_settings_have_http_hook_shape() {
-        let json = stop_hook_settings_json(
-            "https://app.example.com/api/internal/session-liveness",
-            "ws_123",
-            "sess_abc",
-        );
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let hook = &v["hooks"]["Stop"][0]["hooks"][0];
-        assert_eq!(hook["type"], "http");
-        // Identity rides on the URL query string, not the POST body
-        // (the body carries Claude Code's own session id).
-        let url = hook["url"].as_str().unwrap();
-        assert!(url.starts_with("https://app.example.com/api/internal/session-liveness?"));
-        assert!(url.contains("workspace_id=ws_123"));
-        assert!(url.contains("session_id=sess_abc"));
-        // Token is interpolated from env at call time, never inlined.
-        assert_eq!(
-            hook["headers"]["Authorization"],
-            "Bearer $ONSAGER_SESSION_TOKEN"
-        );
-        assert_eq!(hook["allowedEnvVars"][0], "ONSAGER_SESSION_TOKEN");
-        // Short timeout so a blip fails open promptly.
-        assert_eq!(hook["timeout"], 10);
-    }
-
-    #[test]
-    fn stop_hook_url_uses_amp_when_base_already_has_query() {
-        // A base URL carrying its own query string must stay valid —
-        // append with `&`, not a second `?`.
-        let json = stop_hook_settings_json("https://h.example/live?env=prod", "ws_1", "s_1");
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let url = v["hooks"]["Stop"][0]["hooks"][0]["url"].as_str().unwrap();
-        assert_eq!(
-            url,
-            "https://h.example/live?env=prod&workspace_id=ws_1&session_id=s_1"
-        );
-        // Exactly one `?` in the final URL.
-        assert_eq!(url.matches('?').count(), 1);
-    }
-
-    #[test]
-    fn mcp_config_registers_http_server_with_interpolated_token() {
-        let json = mcp_config_json("https://app.example.com/mcp/messages");
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let server = &v["mcpServers"]["onsager"];
-        assert_eq!(server["type"], "http");
-        assert_eq!(server["url"], "https://app.example.com/mcp/messages");
-        // Token interpolated from env at startup, never inlined.
-        assert_eq!(
-            server["headers"]["Authorization"],
-            "Bearer ${ONSAGER_SESSION_TOKEN}"
-        );
-    }
-
-    #[test]
-    fn urlencode_passes_safe_ids_and_escapes_reserved() {
-        assert_eq!(urlencode("ws_01HZX-abc.def~9"), "ws_01HZX-abc.def~9");
-        assert_eq!(urlencode("a b&c=d"), "a%20b%26c%3Dd");
-    }
-}
+// The Stop-hook / MCP-config builder unit tests moved with their
+// functions to `onsager-agent-spawn` (spec #535). Stiglab's own session
+// tests live alongside the session lifecycle code; the spawn-wiring
+// shape is asserted once, in the crate that owns it.


### PR DESCRIPTION
## Summary

Lands Plan item 1 of #533: a production `AgentRunner` so an agent node compiled into an `ExecutionPlan` can actually run an agent. The chosen backend is the subprocess `claude` CLI (max parity with stiglab), living host-side so `onsager-nodes` stays free of a process-spawn dependency.

### 1. New shared crate `onsager-agent-spawn`

A pure utility crate (deps: `serde_json` only) holding the spawn-wiring `#530`/`#532` added inline to `crates/stiglab/src/agent/session/process.rs`:

- the three env-var constants `LIVENESS_HOOK_URL_ENV` / `SESSION_TOKEN_ENV` / `MCP_URL_ENV`
- the `mcp_config_json` / `stop_hook_settings_json` / `urlencode` builders

Extracted **verbatim**, with the parity unit tests `#532` added moved alongside. Because neither stiglab nor the scheduler may import the other across the subsystem seam, the shared crate is the seam-correct home (a utility crate is not a subsystem).

### 2. stiglab consumes the crate

`process.rs` deletes its local copies and `use`s the shared crate instead — same PR, no compat window (per "no dangling wires"). The spawn logic is byte-identical (the only added non-comment line is the import); stiglab's session tests stay green.

### 3. `ClaudeCliRunner` in `onsager-scheduler`

The first production `onsager_nodes::AgentRunner`. Spawns `claude` via `tokio::process` mirroring `SessionProcess::spawn`: `--output-format stream-json --verbose --include-partial-messages`, `--permission-mode bypassPermissions`, `--model`/`--system-prompt` from `AgentRequest`, `--mcp-config` + `--settings` from the shared builders (same gating stiglab uses), threads `AgentRequest.session_id` → `ONSAGER_SESSION_ID`, parses NDJSON stdout to the `Result` event, and returns `AgentResponse { output, emitted: vec[] }`. `emitted` is empty by design — the manifest stays authoritative (spec #520 §4c). stderr is `Stdio::null()` (this runner has no consumer for it; an unread pipe would deadlock).

**Plan-scoped token (integration with #538/#539, landed on main while this PR was open):** those PRs added `AgentRequest.session_token`, and the field's contract names the production runner as the injector. The runner reads the token off the request (decrypted once per plan by the scheduler) — **not** the process env — gates the MCP config on it, and injects it into the child as `ONSAGER_SESSION_TOKEN` so the `${VAR}` interpolation in the MCP + Stop-hook `Authorization` headers resolves at startup. Only deployment-wide config (MCP URL, liveness-hook URL, workspace id) still comes from the process env.

**Location decision:** collapsed into `onsager-scheduler` rather than a sibling `onsager-agent-host` crate. The scheduler binary is the only consumer; a separate library crate would be a single-consumer speculative seam the Occam's-razor lints (`check-orphan-crates` / `check-single-impl-traits`) warn against. Registration into `default_executor_registry` lands with #533.4; the runner is exported now (`pub use runners::ClaudeCliRunner`) so the wire is connected at both ends.

## Test

- `onsager-agent-spawn`: the 4 JSON-builder parity tests (moved from stiglab).
- `ClaudeCliRunner`: 8 tests against a sandboxed fake `claude` fixture script — success-result parsing, argv/env carry `--model` + `ONSAGER_SESSION_ID`, `--mcp-config` wired **and** `ONSAGER_SESSION_TOKEN` injected when URL + request token present, `--mcp-config` **omitted** when the request carries no token, text-delta accumulation fallback, error-result surfacing, missing-result error, and spawn-failure error. Env-mutating tests serialized via a `tokio::sync::Mutex` (env is process-global; `Command::spawn` reads it).
- stiglab session tests unchanged and green after the extraction.
- `cargo build --workspace`, `clippy --workspace -D warnings`, `fmt`, `lint-seams`, `check-orphan-crates` (8 lib crates, clean — the new crate has its stiglab + scheduler reverse-deps), `check-file-budget` all clean.

### Claim-honesty
Mutation-checked the new paths locally: forcing `has_session_token = true` fails `mcp_config_omitted_when_token_absent`; mis-threading the session id fails the argv/env test; skipping the token injection fails the inject assertion. All confirm the tests exercise real logic, not theater.

Rebased onto `main` (resolved against #538/#539); branch is 3 clean commits.

Closes #535