### PR TITLE
Register AgentExecutor + end-to-end scheduler agent-loop test

### DIFF
--- a/crates/onsager-nodes/tests/crawlab_fixture.rs
+++ b/crates/onsager-nodes/tests/crawlab_fixture.rs
@@ -34,9 +34,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use onsager_artifact::{Artifact, ArtifactId, ContentRef, Provenance, SourceTag};
 use onsager_nodes::{
-    AgentExecutor, EmittedArtifact, ExecutorRegistry, InMemoryPlanStore, NodeState, PlanId,
-    PlanStore, Scheduler, ScriptExecutor, SessionManifest, SpineClient, SpineError,
-    StubAgentRunner, VerifyExecutor,
+    AgentExecutor, AgentRequest, AgentResponse, AgentRunError, AgentRunner, EmittedArtifact,
+    ExecutorRegistry, InMemoryPlanStore, NodeState, PlanId, PlanStore, Scheduler, ScriptExecutor,
+    SessionManifest, SpineClient, SpineError, VerifyExecutor,
 };
 use onsager_nodes::{Check, FailPolicy};
 use onsager_substrate::NodeId;
@@ -275,15 +275,16 @@ fn crawlab_ingest_workflow() -> Workflow {
     };
     let analyse = Node {
         id: NodeId::generate(),
-        executor: Box::new(
-            AgentExecutor::new(
-                "claude-sonnet-4-6",
-                "you are a code-review agent — analyse the Crawlab inventory",
-            )
-            .with_runner(Arc::new(StubAgentRunner::new(
-                "analysis: README is light, web/ lacks tests, main.go has a stale TODO",
-            ))),
-        ),
+        // No `with_runner` here: dispatch runs the *registry's* singleton
+        // (#534), and compile's serde round-trip drops the node's
+        // `#[serde(skip)]` runner regardless. The node carries only the
+        // per-node config the scheduler threads via
+        // `ExecutorContext::agent_config` — the assertion below proves
+        // that config (not the singleton's placeholder) reaches the runner.
+        executor: Box::new(AgentExecutor::new(
+            "claude-sonnet-4-6",
+            "you are a code-review agent — analyse the Crawlab inventory",
+        )),
         inputs: vec![EdgeRef::new(inv_to_agent)],
         outputs: vec![EdgeRef::new(agent_to_verify)],
     };
@@ -416,6 +417,30 @@ fn build_spec_plan() -> SpecPlan {
 }
 
 // ---------------------------------------------------------------------------
+// Agent runner that records the model + system prompt it was dispatched
+// with, so the pipeline can assert the agent node's *own* config reached
+// the registered singleton via `ExecutorContext::agent_config` (#534) —
+// not the singleton's placeholder. Returns a canned analysis so the §4c
+// gate (fed by `ObservingSpine`'s one-emit manifest) packages an output.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct ConfigCapturingRunner {
+    seen: Mutex<Option<(String, String)>>,
+}
+
+#[async_trait]
+impl AgentRunner for ConfigCapturingRunner {
+    async fn run(&self, request: AgentRequest) -> Result<AgentResponse, AgentRunError> {
+        *self.seen.lock().unwrap() = Some((request.model.clone(), request.system_prompt.clone()));
+        Ok(AgentResponse {
+            output: "analysis ok".into(),
+            emitted: Vec::new(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // The acceptance test.
 // ---------------------------------------------------------------------------
 
@@ -538,9 +563,14 @@ async fn crawlab_brownfield_pipeline_runs_end_to_end() {
         "-c",
         "echo 'crawlab brownfield pipeline output'",
     ])));
+    // Register the agent singleton with a DISTINCT placeholder model so
+    // the post-run assertion is load-bearing: if per-node config did not
+    // thread (#534), the runner would observe "SINGLETON-PLACEHOLDER"
+    // instead of the analyse node's "claude-sonnet-4-6".
+    let agent_runner = Arc::new(ConfigCapturingRunner::default());
     registry.register(Arc::new(
-        AgentExecutor::new("claude-sonnet-4-6", "")
-            .with_runner(Arc::new(StubAgentRunner::new("analysis ok"))),
+        AgentExecutor::new("SINGLETON-PLACEHOLDER", "singleton prompt")
+            .with_runner(Arc::clone(&agent_runner) as Arc<dyn AgentRunner>),
     ));
     registry.register(Arc::new(VerifyExecutor::with_checks(
         vec![Check::TestRun {
@@ -568,6 +598,26 @@ async fn crawlab_brownfield_pipeline_runs_end_to_end() {
         .expect("Crawlab brownfield pipeline runs to completion");
 
     // ---- assert ----------------------------------------------------------
+    // 0) Per-node agent config reached the registered singleton (#534).
+    //    The analyse node carries model "claude-sonnet-4-6" / its own
+    //    prompt; the singleton's placeholders ("SINGLETON-PLACEHOLDER")
+    //    must NOT be what the runner saw. Mutation guard: stop threading
+    //    `agent_config` in `Scheduler::execute_node` and this fails.
+    let (seen_model, seen_prompt) = agent_runner
+        .seen
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the agent node dispatched, so the runner recorded its config");
+    assert_eq!(
+        seen_model, "claude-sonnet-4-6",
+        "the analyse node's own model must reach the runner, not the singleton placeholder",
+    );
+    assert!(
+        seen_prompt.contains("analyse the Crawlab inventory"),
+        "the analyse node's own system prompt must reach the runner, got: {seen_prompt}",
+    );
+
     // 1) All 4 nodes terminated `Completed`.
     let states = store.node_states(&plan_id).await.unwrap();
     assert_eq!(states.len(), 4, "every node should have a persisted state");

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -46,11 +46,12 @@ pub mod spine_client;
 pub use bridge::{TriggerBridge, TriggerBridgeError};
 pub use plan_runner::{PlanRunError, PlanRunner, SchedulerLibrarySnapshot, resolve_kind_versions};
 pub use plan_store::SqlxPlanStore;
-// The production agent runner (spec #535). Threading it into
-// `default_executor_registry` requires per-node `AgentExecutor` config
-// (model / prompt / runner), which lands with registration in #533.4 —
-// registering a singleton today would dispatch every agent node through
-// one config (see the note on `service::default_executor_registry`).
+// The production agent runner (spec #535), registered in
+// `default_executor_registry` (spec #537) as the runtime backend of the
+// singleton `AgentExecutor`. Per-node config reaches that singleton via
+// `ExecutorContext::agent_config` (#534), so one runner serves every
+// agent node. Re-exported for `with_command` overrides in tests and
+// deployments pinning a specific `claude` install.
 pub use runners::ClaudeCliRunner;
 pub use service::{SchedulerService, ServiceConfig};
 pub use spine_client::SpineEventStoreClient;

--- a/crates/onsager-scheduler/src/runners.rs
+++ b/crates/onsager-scheduler/src/runners.rs
@@ -74,16 +74,27 @@ pub struct ClaudeCliRunner {
     command: String,
 }
 
+/// Env var overriding the `claude` binary the default runner spawns.
+/// Empty / unset falls back to `claude` on PATH. Lets a deployment pin
+/// a specific install and lets the production `default_executor_registry`
+/// (#537) be exercised end-to-end against a fixture script without a
+/// parallel registry builder.
+const CLAUDE_BIN_ENV: &str = "ONSAGER_CLAUDE_BIN";
+
 impl Default for ClaudeCliRunner {
     fn default() -> Self {
         Self {
-            command: "claude".to_string(),
+            command: std::env::var(CLAUDE_BIN_ENV)
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "claude".to_string()),
         }
     }
 }
 
 impl ClaudeCliRunner {
-    /// Runner spawning the default `claude` binary on PATH.
+    /// Runner spawning the `claude` binary — `$ONSAGER_CLAUDE_BIN` when
+    /// set and non-empty, else `claude` on PATH.
     pub fn new() -> Self {
         Self::default()
     }
@@ -368,6 +379,26 @@ mod tests {
             session_id: session_id.into(),
             session_token: session_token.map(Into::into),
         }
+    }
+
+    #[tokio::test]
+    async fn new_honors_claude_bin_env_override() {
+        // The production `default_executor_registry` (#537) builds
+        // `ClaudeCliRunner::new()`; the env override is what lets that
+        // exact path be driven against a fixture. Mutation guard: drop
+        // the `ONSAGER_CLAUDE_BIN` read in `Default` and this fails.
+        let _guard = ENV_LOCK.lock().await;
+        // SAFETY: serialized by ENV_LOCK; cleared before the guard drops.
+        unsafe {
+            std::env::set_var(CLAUDE_BIN_ENV, "/opt/pinned/claude");
+        }
+        let runner = ClaudeCliRunner::new();
+        unsafe {
+            std::env::remove_var(CLAUDE_BIN_ENV);
+        }
+        assert_eq!(runner.command, "/opt/pinned/claude");
+        // Unset → falls back to `claude` on PATH.
+        assert_eq!(ClaudeCliRunner::new().command, "claude");
     }
 
     #[tokio::test]

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use onsager_nodes::{ExecutorRegistry, NoOpExecutor, PlanStore, SpineClient};
+use onsager_nodes::{AgentExecutor, ExecutorRegistry, NoOpExecutor, PlanStore, SpineClient};
 use onsager_spine::factory_event::{FactoryEvent, FactoryEventKind};
 use onsager_spine::{EventHandler, EventNotification, EventStore, Listener};
 use onsager_substrate::workflow_library::WorkflowLibrary as PersistedWorkflowLibrary;
@@ -32,6 +32,7 @@ use crate::bridge::{PreloadedWorkflow, TriggerBridge, WorkflowMeta};
 use crate::plan_registry::{self, derive_plan_id};
 use crate::plan_runner::{PlanRunner, SchedulerLibrarySnapshot, resolve_kind_versions};
 use crate::plan_store::SqlxPlanStore;
+use crate::runners::ClaudeCliRunner;
 use crate::spine_client::SpineEventStoreClient;
 
 /// Configuration the service reads from env / CLI.
@@ -241,26 +242,38 @@ async fn events_ext_max_id(store: &EventStore) -> anyhow::Result<Option<i64>> {
 
 /// Build the default registry the deployed binary uses.
 ///
-/// v1 registers only [`NoOpExecutor`]. Script / Verify / Agent /
-/// SubWorkflow are wired through the registry by `executor_kind`, and
-/// the dispatch path (`onsager_nodes::dispatch`) runs the *registered*
-/// instance. Per-node config reaches that instance through the
-/// `ExecutorContext` escape hatch the scheduler threads off each
+/// Registers [`NoOpExecutor`] and the production [`AgentExecutor`]
+/// backed by [`ClaudeCliRunner`] (spec #537, closing #533's headline
+/// loop). Executors are wired through the registry by `executor_kind`,
+/// and the dispatch path (`onsager_nodes::dispatch`) runs the
+/// *registered* instance. Per-node config reaches that instance through
+/// the `ExecutorContext` escape hatch the scheduler threads off each
 /// substrate executor: `subworkflow_ref` for SubWorkflow (#357) and
-/// `agent_config` for Agent (#534). A registered singleton
+/// `agent_config` for Agent (#534). The registered singleton
 /// `AgentExecutor` therefore dispatches each agent node with *its*
-/// model / prompt / tools / credential.
+/// model / prompt / tools / credential — its own placeholder fields
+/// (empty model / prompt) are never used on the scheduler path. The
+/// plan-scoped session token (#536) is threaded separately onto the
+/// runner request for `ONSAGER_SESSION_TOKEN` injection.
 ///
 /// Script / Verify per-node config is *not* yet threaded (those keep
 /// only the compile-side round-trip assertion), so registering a
 /// singleton `ScriptExecutor` with no command would still dispatch
-/// every script node through that empty config — silently wrong.
-/// Registering only NoOp means non-NoOp nodes fail with
-/// [`ExecutorError::UnknownKind`], which is the correct loud failure;
-/// tests inject a richer registry via [`SchedulerService::with_registry`].
+/// every script node through that empty config — silently wrong. They
+/// stay unregistered; a script / verify node therefore fails with
+/// [`onsager_nodes::ExecutorError::UnknownKind`], the correct loud
+/// failure, until their threading lands. Tests inject a richer or
+/// narrower registry via [`SchedulerService::with_registry`].
 pub fn default_executor_registry() -> ExecutorRegistry {
     let mut r = ExecutorRegistry::new();
     r.register(Arc::new(NoOpExecutor));
+    // Agent: one runtime singleton backed by the production
+    // `ClaudeCliRunner`. The placeholder model / prompt are overridden
+    // per node by `ExecutorContext::agent_config` (#534); the runner
+    // binary is `claude` on PATH, overridable via `ONSAGER_CLAUDE_BIN`.
+    r.register(Arc::new(
+        AgentExecutor::new("", "").with_runner(Arc::new(ClaudeCliRunner::new())),
+    ));
     r
 }
 

--- a/crates/onsager-scheduler/tests/agent_loop.rs
+++ b/crates/onsager-scheduler/tests/agent_loop.rs
@@ -1,0 +1,346 @@
+//! End-to-end scheduler agent-loop test (spec #537, closing #533's
+//! headline acceptance bullet).
+//!
+//! Proves the full wire: a [`SpecPlan`] whose compiled DAG contains one
+//! agent node runs to terminal through [`PlanRunner`] →
+//! [`onsager_nodes::Scheduler`] → `dispatch` → the *production*
+//! [`AgentExecutor`] registered by [`default_executor_registry`] →
+//! [`onsager_scheduler::ClaudeCliRunner`] spawning a sandboxed fake
+//! `claude` (no live API) → the §4c authoritative liveness gate reading
+//! the session manifest back → a packaged `Artifact`
+//! (`Uncertain { source: Agent }`) on the node's output edge.
+//!
+//! Three tests:
+//!
+//! 1. `agent_node_runs_to_terminal_with_uncertain_agent_artifact` — the
+//!    §520 acceptance bullet, now on the scheduler path, against the
+//!    real `default_executor_registry()`.
+//! 2. `agent_node_fails_unknown_kind_when_executor_unregistered` — the
+//!    mutation check: drop `AgentExecutor` from the registry and the
+//!    same plan fails `UnknownKind`, proving the registration is
+//!    load-bearing (not theater).
+//! 3. `scheduler_path_injects_session_token_and_mcp_into_agent_spawn` —
+//!    the §536 plan-scoped token + §531 MCP config + §4d Stop hook are
+//!    wired on the scheduler path: with a plan token threaded through
+//!    `PlanRunner` and the MCP / liveness-hook / workspace env present,
+//!    the spawned agent carries `ONSAGER_SESSION_TOKEN`, `--mcp-config`,
+//!    and `--settings` (Stop hook). The token's presence is exactly what
+//!    lets the §4d hook authenticate instead of 401→fail-open.
+
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use onsager_agent_spawn::{LIVENESS_HOOK_URL_ENV, MCP_URL_ENV};
+use onsager_artifact::{Artifact, ArtifactId, ContentRef, NodeId, Provenance, SourceTag};
+use onsager_nodes::{
+    AgentExecutor, EmittedArtifact, ExecutorRegistry, InMemoryPlanStore, NoOpExecutor, PlanId,
+    PlanStore, SessionManifest, SpineClient, SpineError,
+};
+use onsager_scheduler::{PlanRunner, service::default_executor_registry};
+use onsager_substrate::WorkflowLookup;
+use onsager_substrate::ids::{EdgeId, WorkflowId};
+use onsager_substrate::spec_plan::{SpecId, SpecPlan, SpecRef};
+use onsager_substrate::workflow::{Edge, EdgeRef, Node, OutputSpec, Workflow};
+
+/// Serializes the env-mutating tests. `default_executor_registry()`
+/// reads `ONSAGER_CLAUDE_BIN`, and `ClaudeCliRunner::run` reads the MCP /
+/// liveness-hook / workspace env at spawn time; both touch the
+/// process-global env. A `tokio::sync::Mutex` so the guard survives the
+/// `.await` without tripping `clippy::await_holding_lock`.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const CLAUDE_BIN_ENV: &str = "ONSAGER_CLAUDE_BIN";
+const WORKSPACE_ID_ENV: &str = "ONSAGER_WORKSPACE_ID";
+
+/// Spine that records every emit and serves a single-emit manifest for
+/// every session — the agent "delivered" via `emit_artifact`, so the
+/// §4c gate packages that one output. Mirrors the crawlab fixture's
+/// `ObservingSpine` shape.
+#[derive(Debug, Default)]
+struct ManifestSpine {
+    emitted: Mutex<Vec<(String, serde_json::Value)>>,
+}
+
+#[async_trait]
+impl SpineClient for ManifestSpine {
+    async fn emit(&self, kind: &str, payload: serde_json::Value) -> Result<(), SpineError> {
+        self.emitted
+            .lock()
+            .unwrap()
+            .push((kind.to_string(), payload));
+        Ok(())
+    }
+    async fn read_artifact(&self, _: &ArtifactId) -> Result<Option<Artifact>, SpineError> {
+        Ok(None)
+    }
+    async fn read_session_manifest(&self, session_id: &str) -> Result<SessionManifest, SpineError> {
+        Ok(SessionManifest {
+            emitted: vec![EmittedArtifact {
+                artifact_id: format!("art_{session_id}"),
+                content_ref: ContentRef {
+                    uri: "inline:base64,YW5hbHlzaXM=".into(),
+                    checksum: None,
+                },
+                kind: "document".into(),
+                summary: "scheduler-path agent analysis".into(),
+            }],
+            declared_empty: false,
+        })
+    }
+}
+
+/// One-kind library: `agent-analysis` → a workflow with a single agent
+/// node, no inputs, one (non-deterministic) output edge declaring
+/// `Uncertain { Agent }` — exactly what the agent emits.
+struct AgentLibrary {
+    workflow: Workflow,
+}
+
+impl WorkflowLookup for AgentLibrary {
+    fn get(&self, _: WorkflowId) -> Option<&Workflow> {
+        None
+    }
+    fn by_kind(&self, kind: &str) -> Option<&Workflow> {
+        (kind == "agent-analysis").then_some(&self.workflow)
+    }
+}
+
+/// Build the single-agent-node workflow. The node's own
+/// `AgentExecutor` carries the per-node model / prompt the scheduler
+/// threads to the registered singleton via `ExecutorContext::agent_config`
+/// (#534); its `runner` is irrelevant (dispatch runs the registry
+/// instance), so it keeps the default `UnconfiguredRunner`.
+fn agent_workflow() -> Workflow {
+    let exit = EdgeId::generate();
+    let agent = AgentExecutor::new(
+        "claude-sonnet-4-6",
+        "you are a code-review agent — analyse the input",
+    );
+    Workflow {
+        nodes: vec![Node {
+            id: NodeId::generate(),
+            executor: Box::new(agent),
+            inputs: vec![],
+            outputs: vec![EdgeRef::new(exit)],
+        }],
+        edges: vec![Edge {
+            id: exit,
+            artifact_id: ArtifactId::new("analysis"),
+            // Agent emits Uncertain — this edge cannot demand Deterministic.
+            requires_deterministic: false,
+        }],
+        entry_specs: vec![],
+        output_specs: vec![OutputSpec {
+            edge_id: exit,
+            provenance: Provenance::Uncertain {
+                source: SourceTag::Agent,
+            },
+        }],
+    }
+}
+
+fn one_agent_spec_plan() -> SpecPlan {
+    SpecPlan {
+        specs: vec![SpecRef {
+            id: SpecId::new("analyse"),
+            kind: "agent-analysis".into(),
+            inputs: Default::default(),
+        }],
+        deps: vec![],
+    }
+}
+
+/// Write an executable fake `claude` that records its argv + the env
+/// vars the assertions care about to `capture_path`, then emits a canned
+/// success `Result` on stdout. Returns the temp dir (kept alive) and the
+/// script path.
+fn fake_claude(capture_path: &std::path::Path) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let script = dir.path().join("fake-claude.sh");
+    let mut f = std::fs::File::create(&script).unwrap();
+    write!(
+        f,
+        "#!/usr/bin/env bash\n\
+         {{\n\
+           echo \"ARGS: $*\"\n\
+           echo \"SESSION_TOKEN: ${{ONSAGER_SESSION_TOKEN:-}}\"\n\
+         }} >> \"{capture}\"\n\
+         echo '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"analysis done\"}}'\n",
+        capture = capture_path.display(),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+    (dir, script.to_string_lossy().into_owned())
+}
+
+/// Pull the first `node.completed.output_artifact_ids[0]` off a recorded
+/// emit stream.
+fn first_output_id(emitted: &[(String, serde_json::Value)]) -> Option<String> {
+    emitted
+        .iter()
+        .find(|(k, _)| k == "node.completed")
+        .and_then(|(_, p)| p.get("output_artifact_ids"))
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+#[tokio::test]
+async fn agent_node_runs_to_terminal_with_uncertain_agent_artifact() {
+    let _guard = ENV_LOCK.lock().await;
+    let cap = tempfile::tempdir().unwrap();
+    let cap_file = cap.path().join("argv.txt");
+    let (_dir, script) = fake_claude(&cap_file);
+
+    // Point the *production* registry's ClaudeCliRunner at the fixture.
+    // SAFETY: serialized by ENV_LOCK; removed before the guard drops.
+    unsafe {
+        std::env::set_var(CLAUDE_BIN_ENV, &script);
+    }
+
+    let spine = Arc::new(ManifestSpine::default());
+    let store = Arc::new(InMemoryPlanStore::new());
+    let registry = Arc::new(default_executor_registry());
+    let runner = PlanRunner::new(
+        Arc::clone(&registry),
+        Arc::clone(&store) as Arc<dyn PlanStore>,
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    );
+
+    let plan_id = PlanId::generate();
+    let result = runner
+        .run(
+            &plan_id,
+            &one_agent_spec_plan(),
+            &AgentLibrary {
+                workflow: agent_workflow(),
+            },
+        )
+        .await;
+
+    unsafe {
+        std::env::remove_var(CLAUDE_BIN_ENV);
+    }
+    result.expect("agent-node plan runs to terminal");
+
+    // node.completed.output_artifact_ids is non-empty.
+    let emitted = spine.emitted.lock().unwrap().clone();
+    let output_id =
+        first_output_id(&emitted).expect("a node.completed with a non-empty output_artifact_ids");
+
+    // The packaged artifact is Uncertain { source: Agent } — stamped by
+    // the §4c gate, never trusted from the manifest.
+    let art = store
+        .get_artifact(&plan_id, &ArtifactId::new(&output_id))
+        .await
+        .expect("store read ok")
+        .expect("the agent output artifact is persisted on its edge");
+    assert_eq!(
+        art.provenance,
+        Provenance::Uncertain {
+            source: SourceTag::Agent,
+        },
+        "scheduler-dispatched agent output must be Uncertain {{ Agent }}",
+    );
+}
+
+#[tokio::test]
+async fn agent_node_fails_unknown_kind_when_executor_unregistered() {
+    // Mutation check (not theater): the same plan against a registry
+    // with NO AgentExecutor (the old NoOp-only default) fails
+    // `UnknownKind` — proving the #537 registration is load-bearing. No
+    // claude is spawned (dispatch fails before reaching the runner), so
+    // this needs no env.
+    let mut registry = ExecutorRegistry::new();
+    registry.register(Arc::new(NoOpExecutor));
+    let runner = PlanRunner::new(
+        Arc::new(registry),
+        Arc::new(InMemoryPlanStore::new()) as Arc<dyn PlanStore>,
+        Arc::new(ManifestSpine::default()) as Arc<dyn SpineClient>,
+    );
+
+    let plan_id = PlanId::generate();
+    let err = runner
+        .run(
+            &plan_id,
+            &one_agent_spec_plan(),
+            &AgentLibrary {
+                workflow: agent_workflow(),
+            },
+        )
+        .await
+        .expect_err("an agent node must fail when AgentExecutor is unregistered");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("agent"),
+        "the failure should name the unknown `agent` kind, got: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn scheduler_path_injects_session_token_and_mcp_into_agent_spawn() {
+    // §536 token + §531 MCP + §4d Stop hook, on the scheduler path. With
+    // a plan-scoped token threaded through PlanRunner and the MCP /
+    // liveness-hook / workspace env present, the spawned agent must carry
+    // ONSAGER_SESSION_TOKEN, --mcp-config, and --settings (the Stop
+    // hook). The token's presence is precisely what lets the §4d hook
+    // authenticate instead of 401→fail-open.
+    let _guard = ENV_LOCK.lock().await;
+    let cap = tempfile::tempdir().unwrap();
+    let cap_file = cap.path().join("argv.txt");
+    let (_dir, script) = fake_claude(&cap_file);
+
+    // SAFETY: serialized by ENV_LOCK; all removed before the guard drops.
+    unsafe {
+        std::env::set_var(CLAUDE_BIN_ENV, &script);
+        std::env::set_var(MCP_URL_ENV, "https://app.example.com/mcp/messages");
+        std::env::set_var(LIVENESS_HOOK_URL_ENV, "https://app.example.com/agent/stop");
+        std::env::set_var(WORKSPACE_ID_ENV, "ws-7");
+    }
+
+    let spine = Arc::new(ManifestSpine::default());
+    let runner = PlanRunner::new(
+        Arc::new(default_executor_registry()),
+        Arc::new(InMemoryPlanStore::new()) as Arc<dyn PlanStore>,
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    )
+    .with_session_token(Some("ons_pat_plan_scoped".to_string()));
+
+    let plan_id = PlanId::generate();
+    let result = runner
+        .run(
+            &plan_id,
+            &one_agent_spec_plan(),
+            &AgentLibrary {
+                workflow: agent_workflow(),
+            },
+        )
+        .await;
+
+    unsafe {
+        std::env::remove_var(CLAUDE_BIN_ENV);
+        std::env::remove_var(MCP_URL_ENV);
+        std::env::remove_var(LIVENESS_HOOK_URL_ENV);
+        std::env::remove_var(WORKSPACE_ID_ENV);
+    }
+    result.expect("agent-node plan runs to terminal");
+
+    let recorded = std::fs::read_to_string(&cap_file).unwrap();
+    assert!(
+        recorded.contains("SESSION_TOKEN: ons_pat_plan_scoped"),
+        "the plan-scoped token must reach the agent env as ONSAGER_SESSION_TOKEN, got: {recorded}",
+    );
+    assert!(
+        recorded.contains("--mcp-config"),
+        "the MCP server must be registered when URL + token are present, got: {recorded}",
+    );
+    assert!(
+        recorded.contains("--settings"),
+        "the §4d Stop hook (--settings) must be wired on the scheduler path, got: {recorded}",
+    );
+}


### PR DESCRIPTION
Closes #537. The integration slice of #533 — registers the production agent executor and proves the headline loop end to end: **Spec Plans "Run" → `plan.run_requested` → `PlanRunner::run` → typed DAG → agent `emit_artifact` → addressable artifact.**

The three dependencies have landed: per-node config threading (#534/#538), the `ClaudeCliRunner` + `onsager-agent-spawn` crate (#535/#540), and the scheduler-path plan-scoped session token (#536/#539). This was the last wire: `default_executor_registry()` was still NoOp-only, so an agent node dispatched to `UnknownKind`.

## Changes

- **`service.rs`** — `default_executor_registry()` now registers the `AgentExecutor` singleton backed by `ClaudeCliRunner`. Per-node `model`/`prompt`/`tools`/`credential` reach it via `ExecutorContext::agent_config` (#534); the plan-scoped token rides the runner request for `ONSAGER_SESSION_TOKEN` injection (#536). The doc comment is updated off the NoOp-only / RUN-02-blocker note (Script/Verify stay unregistered — their per-node config is not yet threaded, so they correctly fail `UnknownKind`).
- **`runners.rs`** — `ClaudeCliRunner::new()` honors `ONSAGER_CLAUDE_BIN` (empty/unset → `claude` on PATH). This lets the *production* registry be exercised against a fixture script without a parallel registry builder, and lets a deployment pin a specific install. Unit-tested.
- **`tests/agent_loop.rs`** (new) — three integration tests:
  1. `agent_node_runs_to_terminal_with_uncertain_agent_artifact` — a one-agent-node `SpecPlan` runs to terminal through `PlanRunner` against the **real** `default_executor_registry()` + a sandboxed fake `claude` (no live API); `node.completed.output_artifact_ids` is non-empty and the packaged `Artifact` is `Uncertain { source: Agent }`.
  2. `agent_node_fails_unknown_kind_when_executor_unregistered` — **mutation check (not theater):** the same plan against a NoOp-only registry fails `UnknownKind`, proving the registration is load-bearing.
  3. `scheduler_path_injects_session_token_and_mcp_into_agent_spawn` — with a plan token threaded through `PlanRunner` and the MCP / liveness-hook / workspace env present, the spawned agent carries `ONSAGER_SESSION_TOKEN`, `--mcp-config`, and `--settings` (the §4d Stop hook). The token's presence is exactly what lets the §4d hook authenticate instead of 401→fail-open.
- **`crawlab_fixture.rs`** — promotes the agent node from a `StubAgentRunner` singleton default to a `ConfigCapturingRunner` assertion: the analyse node's own `model`/`prompt` reach the runner, not the singleton placeholder (#537 Design bullet 2).

## Scope notes (claim-honesty)

- **Plan items 3 & 4** (token reaches MCP authorized; §4d Stop hook authenticates) landed mechanically in #539 (portal mint→`verify_pat` workspace-pinned+expiry→revoke, `tests/session_token.rs`) and #540 (runner wires `--mcp-config` + `--settings` with the token). This PR adds the **scheduler-path integration** that proves those pieces are wired through `PlanRunner` end to end. A *live* "agent calls `read_emit_status` against a running portal, no 401" assertion needs a live portal + DB + `claude` and is out of scope for the no-live-API integration test the spec asks for; it is covered by the composition of the unit-level pieces above.
- The crawlab "promotion" assertion is realized directly here; the dedicated `dispatch_threads_per_node_agent_config_over_singleton` test in `agent.rs` (from #534) remains as the focused unit check.

## Verification

`cargo build --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, and `lint-seams` / `check-events` / `check-api-contract` / `check-file-budget` all clean. `onsager-nodes` + `onsager-scheduler` test suites green.

https://claude.ai/code/session_01R5HbnHrCDG8H5gR2hnPH1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5HbnHrCDG8H5gR2hnPH1k)_