### PR TITLE
feat(dashboard): guided "Create Plan" authoring surface

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -35,6 +35,11 @@ const RunDetailPage = lazy(() =>
 const SpecPlansPage = lazy(() =>
   import("@/pages/SpecPlansPage").then((m) => ({ default: m.SpecPlansPage })),
 )
+const CreateSpecPlanPage = lazy(() =>
+  import("@/pages/CreateSpecPlanPage").then((m) => ({
+    default: m.CreateSpecPlanPage,
+  })),
+)
 const RunsPage = lazy(() =>
   import("@/pages/RunsPage").then((m) => ({ default: m.RunsPage })),
 )
@@ -356,6 +361,13 @@ function AppRoutes() {
                         <Route
                           path="spec-plans"
                           element={<LazyRoute variant="list"><SpecPlansPage /></LazyRoute>}
+                        />
+                        {/* Guided "Create Plan" authoring surface
+                            (spec #542) — sub-route, not a modal, for
+                            the DAG preview + clean back-nav. */}
+                        <Route
+                          path="spec-plans/new"
+                          element={<LazyRoute><CreateSpecPlanPage /></LazyRoute>}
                         />
                         {/* Spine event stream at operator grain
                             (#454 / ADR 0019). */}

--- a/apps/dashboard/src/components/layout/CommandPalette.tsx
+++ b/apps/dashboard/src/components/layout/CommandPalette.tsx
@@ -218,6 +218,13 @@ function CommandPaletteDialog() {
                 New workflow
               </CommandItem>
               <CommandItem
+                keywords={["new", "spec", "plan", "dag"]}
+                onSelect={() => go(scoped("spec-plans/new"))}
+              >
+                <Rocket className="mr-2 h-4 w-4" />
+                New plan
+              </CommandItem>
+              <CommandItem
                 keywords={["new"]}
                 onSelect={() => run(() => setSessionOpen(true))}
               >

--- a/apps/dashboard/src/components/specplans/SpecKindCombobox.tsx
+++ b/apps/dashboard/src/components/specplans/SpecKindCombobox.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Check, ChevronsUpDown, Layers } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { mcpCallTool } from "@/lib/mcp-client"
+
+// The `kind` picker for a spec node (spec #542). A spec's `kind` must be
+// an *active* entry in the workspace's workflow library — the same set
+// `compile_dry_run` resolves against. Rather than free-typing a kind
+// (and learning it's wrong only at compile time), this reads the library
+// over the existing `list_workflows_v2` MCP tool and offers it as a
+// searchable combobox, per the dashboard-ui "avoid manual input" rule.
+// No new REST endpoint, no parallel kind list: the library is the one
+// source of truth, reached through the same MCP client the chat uses.
+
+interface WorkflowLibraryCard {
+  spec_kind: string
+  version: number
+  retired_at: string | null
+}
+
+/** Read active library kinds (retired entries filtered out), de-duplicated
+ *  and sorted. Returns `[]` while loading or on error so the picker stays
+ *  mountable; the caller surfaces the load failure. */
+function useSpecKinds(workspaceId: string) {
+  const query = useQuery({
+    queryKey: ["workflow-library-kinds", workspaceId],
+    queryFn: async () => {
+      const res = await mcpCallTool("list_workflows_v2", {
+        workspace_id: workspaceId,
+      })
+      if (res.isError) {
+        throw new Error(res.content[0]?.text ?? "Failed to list workflow kinds")
+      }
+      const parsed = JSON.parse(res.content[0]?.text ?? "{}") as {
+        workflows?: WorkflowLibraryCard[]
+      }
+      const active = (parsed.workflows ?? []).filter((c) => c.retired_at == null)
+      return [...new Set(active.map((c) => c.spec_kind))].sort()
+    },
+    enabled: !!workspaceId,
+    staleTime: 60_000,
+  })
+  return {
+    kinds: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+  }
+}
+
+export interface SpecKindComboboxProps {
+  workspaceId: string
+  value: string
+  onChange: (kind: string) => void
+  /** Accessible name for the trigger (each row's picker is distinct). */
+  ariaLabel?: string
+}
+
+export function SpecKindCombobox({
+  workspaceId,
+  value,
+  onChange,
+  ariaLabel,
+}: SpecKindComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const { kinds, isLoading, isError } = useSpecKinds(workspaceId)
+
+  const empty = useMemo(() => {
+    if (isLoading) return "Loading kinds…"
+    if (isError) return "Couldn't load the workflow library."
+    return "No matching kinds. Register one in the library first."
+  }, [isLoading, isError])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label={ariaLabel ?? "Spec kind"}
+            className="w-full justify-between"
+          >
+            <span className="flex min-w-0 items-center gap-2 truncate">
+              <Layers className="h-4 w-4 shrink-0 text-muted-foreground" />
+              {value ? (
+                <span className="truncate">{value}</span>
+              ) : (
+                <span className="truncate text-muted-foreground">Pick a kind</span>
+              )}
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        }
+      />
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] min-w-56 p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search kinds…" />
+          <CommandList>
+            <CommandEmpty>{empty}</CommandEmpty>
+            <CommandGroup>
+              {kinds.map((kind) => (
+                <CommandItem
+                  key={kind}
+                  value={kind}
+                  onSelect={() => {
+                    onChange(kind)
+                    setOpen(false)
+                  }}
+                >
+                  <Layers className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{kind}</span>
+                  {value === kind && <Check className="ml-auto h-4 w-4" />}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/lib/spec-plan-draft.ts
+++ b/apps/dashboard/src/lib/spec-plan-draft.ts
@@ -1,0 +1,83 @@
+// Authoring helpers for the guided "Create Plan" surface (spec #542).
+//
+// The create page (`CreateSpecPlanPage`) assembles a `SpecPlan`
+// (`{ specs, deps }`, see `spec-plan.ts`) from form rows, then validates
+// it through the `compile_dry_run` MCP tool before committing via
+// `submit_spec_plan`. These pure helpers turn the in-progress draft into
+// the plan body the tools consume and turn the compiler's structured
+// error payload into one human line — kept out of the `.tsx` so they can
+// be unit-tested and so the page stays inside the file budget.
+
+import type { SpecPlan, SpecRef, SpecDep } from "@/lib/spec-plan"
+
+/** A spec row in the create form. `id` / `kind` may be blank while editing. */
+export interface DraftSpec {
+  id: string
+  kind: string
+}
+
+/** Shape of `compile_dry_run`'s structured result (see
+ *  `crates/onsager-portal/src/mcp/tools/substrate_specs.rs`). */
+export type CompileResult =
+  | { ok: true; execution_plan: { node_count: number; edge_count: number } }
+  | { ok: false; error: CompileError }
+
+export interface CompileError {
+  kind: string
+  message: string
+  spec_id?: string
+  spec_kind?: string
+  violations?: { message: string }[]
+}
+
+/** A spec row is "complete" once both id and kind are non-blank. */
+export function isComplete(spec: DraftSpec): boolean {
+  return spec.id.trim().length > 0 && spec.kind.trim().length > 0
+}
+
+/**
+ * Build the `SpecPlan` body from the draft. Only complete spec rows are
+ * included; deps are kept only when both endpoints reference an included
+ * spec id (a dep dangling off a half-typed row would otherwise make every
+ * keystroke a compile error). Trims ids so trailing whitespace doesn't
+ * fork identity between the node and its edges.
+ */
+export function draftToPlan(specs: DraftSpec[], deps: SpecDep[]): SpecPlan {
+  const complete = specs.filter(isComplete)
+  const ids = new Set(complete.map((s) => s.id.trim()))
+  const planSpecs: SpecRef[] = complete.map((s) => ({
+    id: s.id.trim(),
+    kind: s.kind.trim(),
+  }))
+  const planDeps = deps.filter(
+    (d) => d.from && d.to && ids.has(d.from) && ids.has(d.to),
+  )
+  return { specs: planSpecs, deps: planDeps }
+}
+
+/** De-duplicate specs by id (last wins) so a transient duplicate-id draft
+ *  doesn't hand React Flow colliding node keys while the compiler flags it. */
+export function dedupeById(plan: SpecPlan): SpecPlan {
+  const byId = new Map<string, SpecRef>()
+  for (const s of plan.specs) byId.set(s.id, s)
+  return { specs: [...byId.values()], deps: plan.deps }
+}
+
+/** Parse a `compile_dry_run` result envelope; `null` if it isn't JSON. */
+export function parseCompileResult(text: string | undefined): CompileResult | null {
+  if (!text) return null
+  try {
+    return JSON.parse(text) as CompileResult
+  } catch {
+    return null
+  }
+}
+
+/** One human-readable line for a compile failure, suitable for an inline
+ *  error banner. Invariant batches list each violation. */
+export function compileErrorMessage(err: CompileError): string {
+  if (err.kind === "invariant" && err.violations?.length) {
+    return err.violations.map((v) => v.message).join("; ")
+  }
+  return err.message || `Compile failed (${err.kind}).`
+}

--- a/apps/dashboard/src/lib/spec-plan-draft.ts
+++ b/apps/dashboard/src/lib/spec-plan-draft.ts
@@ -49,9 +49,11 @@ export function draftToPlan(specs: DraftSpec[], deps: SpecDep[]): SpecPlan {
     id: s.id.trim(),
     kind: s.kind.trim(),
   }))
-  const planDeps = deps.filter(
-    (d) => d.from && d.to && ids.has(d.from) && ids.has(d.to),
-  )
+  const planDeps: SpecDep[] = deps
+    .filter((d) => d.from && d.to && ids.has(d.from) && ids.has(d.to))
+    // Map to a clean `{ from, to }` so any per-row UI metadata (e.g. a
+    // stable row id) can never leak into the submitted plan body.
+    .map((d) => ({ from: d.from, to: d.to }))
   return { specs: planSpecs, deps: planDeps }
 }
 

--- a/apps/dashboard/src/pages/CreateSpecPlanPage.tsx
+++ b/apps/dashboard/src/pages/CreateSpecPlanPage.tsx
@@ -54,6 +54,20 @@ function useDebounced<T>(value: T, ms: number): T {
   return debounced
 }
 
+// Stable per-row identity so React keys don't track array position —
+// removing a row must not make a sibling input/combobox reuse the wrong
+// internal state or focus. Monotonic across the session; never submitted
+// (stripped by `draftToPlan`).
+let ROW_SEQ = 0
+const nextRowId = () => `row-${ROW_SEQ++}`
+
+interface SpecRow extends DraftSpec {
+  rowId: string
+}
+interface DepRow extends SpecDep {
+  rowId: string
+}
+
 export function CreateSpecPlanPage() {
   const workspace = useActiveWorkspace()
   const navigate = useNavigate()
@@ -61,17 +75,22 @@ export function CreateSpecPlanPage() {
   usePageHeader({ title: "Create Plan", backTo: plansPath })
 
   const [planId, setPlanId] = useState("")
-  const [specs, setSpecs] = useState<DraftSpec[]>([{ id: "", kind: "" }])
-  const [deps, setDeps] = useState<SpecDep[]>([])
+  const [specs, setSpecs] = useState<SpecRow[]>(() => [
+    { rowId: nextRowId(), id: "", kind: "" },
+  ])
+  const [deps, setDeps] = useState<DepRow[]>([])
 
   const plan = useMemo(() => draftToPlan(specs, deps), [specs, deps])
   const completeSpecs = specs.filter(isComplete)
-  const completeIds = completeSpecs.map((s) => s.id.trim())
+  // De-duplicate: two rows can transiently share an id (the compiler
+  // flags it), but the dep selects must not render duplicate keys/values.
+  const completeIds = [...new Set(completeSpecs.map((s) => s.id.trim()))]
 
   // Live lint: recompile the candidate plan (debounced) whenever it has
   // at least one complete spec. The compiler is the source of truth for
   // unknown kinds / cycles / dangling edges — we don't re-implement it.
-  const planKey = useDebounced(JSON.stringify(plan), 400)
+  const liveKey = JSON.stringify(plan)
+  const planKey = useDebounced(liveKey, 400)
   const compileQuery = useQuery({
     queryKey: ["compile-dry-run", workspace.id, planKey],
     queryFn: async () => {
@@ -87,8 +106,15 @@ export function CreateSpecPlanPage() {
     enabled: plan.specs.length > 0,
   })
 
-  const compileResult = plan.specs.length > 0 ? compileQuery.data : null
-  const compiling = plan.specs.length > 0 && compileQuery.isFetching
+  // The submit button sends the *current* plan, so the gate must reflect
+  // the current plan — not a stale debounced compile. While the debounce
+  // hasn't caught up (`dirty`) or the query is in flight, treat the plan
+  // as still compiling so commit stays disabled until the live plan is
+  // the one that compiled clean.
+  const dirty = liveKey !== planKey
+  const compileResult = plan.specs.length > 0 && !dirty ? compileQuery.data : null
+  const compiling =
+    plan.specs.length > 0 && (dirty || compileQuery.isFetching)
   const canSubmit =
     planId.trim().length > 0 &&
     completeSpecs.length > 0 &&
@@ -97,7 +123,8 @@ export function CreateSpecPlanPage() {
 
   const setSpec = (i: number, patch: Partial<DraftSpec>) =>
     setSpecs((prev) => prev.map((s, j) => (j === i ? { ...s, ...patch } : s)))
-  const addSpec = () => setSpecs((prev) => [...prev, { id: "", kind: "" }])
+  const addSpec = () =>
+    setSpecs((prev) => [...prev, { rowId: nextRowId(), id: "", kind: "" }])
   const removeSpec = (i: number) => {
     const removedId = specs[i]?.id.trim()
     setSpecs((prev) => prev.filter((_, j) => j !== i))
@@ -107,7 +134,8 @@ export function CreateSpecPlanPage() {
       )
     }
   }
-  const addDep = () => setDeps((prev) => [...prev, { from: "", to: "" }])
+  const addDep = () =>
+    setDeps((prev) => [...prev, { rowId: nextRowId(), from: "", to: "" }])
   const setDep = (i: number, patch: Partial<SpecDep>) =>
     setDeps((prev) => prev.map((d, j) => (j === i ? { ...d, ...patch } : d)))
   const removeDep = (i: number) =>
@@ -150,7 +178,7 @@ export function CreateSpecPlanPage() {
         </CardHeader>
         <CardContent className="space-y-3">
           {specs.map((spec, i) => (
-            <div key={i} className="flex items-center gap-2">
+            <div key={spec.rowId} className="flex items-center gap-2">
               <Input
                 aria-label={`Spec ${i + 1} id`}
                 value={spec.id}
@@ -197,7 +225,7 @@ export function CreateSpecPlanPage() {
             </p>
           ) : (
             deps.map((dep, i) => (
-              <div key={i} className="flex items-center gap-2">
+              <div key={dep.rowId} className="flex items-center gap-2">
                 <DepEndpointSelect
                   ariaLabel={`Dependency ${i + 1} from`}
                   value={dep.from}
@@ -345,7 +373,19 @@ function CompileStatus({
       </div>
     )
   }
-  if (!result) return null
+  if (!result) {
+    // Query resolved but the payload wasn't the expected JSON envelope —
+    // don't leave the author staring at a blank preview with no signal.
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-sm text-destructive"
+      >
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>Couldn&apos;t read the compiler response.</span>
+      </div>
+    )
+  }
   if (result.ok) {
     return (
       <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">

--- a/apps/dashboard/src/pages/CreateSpecPlanPage.tsx
+++ b/apps/dashboard/src/pages/CreateSpecPlanPage.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Loader2,
+  Plus,
+  Rocket,
+  Trash2,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { HitlActionButton } from "@/components/chat/HitlActionButton"
+import { SpecPlanDAG } from "@/components/chat/SpecPlanDAG"
+import { SpecKindCombobox } from "@/components/specplans/SpecKindCombobox"
+import { usePageHeader } from "@/components/layout/PageHeader"
+import { mcpCallTool } from "@/lib/mcp-client"
+import {
+  type DraftSpec,
+  compileErrorMessage,
+  dedupeById,
+  draftToPlan,
+  isComplete,
+  parseCompileResult,
+} from "@/lib/spec-plan-draft"
+import type { SpecDep } from "@/lib/spec-plan"
+import { useActiveWorkspace } from "@/lib/workspace"
+
+// Guided "Create Plan" surface (spec #542). The authoring third of the
+// Spec Plans surface (#514 built list + Run): assemble a `SpecPlan`
+// (`{ specs, deps }`) from form rows — never raw JSON — validate it live
+// through `compile_dry_run`, preview the resulting DAG, then commit
+// through `submit_spec_plan` routed via a HitlCard. No new business
+// logic and no new REST endpoint: the dashboard is already an MCP client
+// (seam rule), and chat stays the conversational authoring path — this
+// is the deterministic path for a known plan (ADR 0025, complement).
+
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms)
+    return () => clearTimeout(t)
+  }, [value, ms])
+  return debounced
+}
+
+export function CreateSpecPlanPage() {
+  const workspace = useActiveWorkspace()
+  const navigate = useNavigate()
+  const plansPath = `/workspaces/${workspace.slug}/spec-plans`
+  usePageHeader({ title: "Create Plan", backTo: plansPath })
+
+  const [planId, setPlanId] = useState("")
+  const [specs, setSpecs] = useState<DraftSpec[]>([{ id: "", kind: "" }])
+  const [deps, setDeps] = useState<SpecDep[]>([])
+
+  const plan = useMemo(() => draftToPlan(specs, deps), [specs, deps])
+  const completeSpecs = specs.filter(isComplete)
+  const completeIds = completeSpecs.map((s) => s.id.trim())
+
+  // Live lint: recompile the candidate plan (debounced) whenever it has
+  // at least one complete spec. The compiler is the source of truth for
+  // unknown kinds / cycles / dangling edges — we don't re-implement it.
+  const planKey = useDebounced(JSON.stringify(plan), 400)
+  const compileQuery = useQuery({
+    queryKey: ["compile-dry-run", workspace.id, planKey],
+    queryFn: async () => {
+      const res = await mcpCallTool("compile_dry_run", {
+        workspace_id: workspace.id,
+        spec_plan: JSON.parse(planKey),
+      })
+      if (res.isError) {
+        throw new Error(res.content[0]?.text ?? "compile_dry_run failed")
+      }
+      return parseCompileResult(res.content[0]?.text)
+    },
+    enabled: plan.specs.length > 0,
+  })
+
+  const compileResult = plan.specs.length > 0 ? compileQuery.data : null
+  const compiling = plan.specs.length > 0 && compileQuery.isFetching
+  const canSubmit =
+    planId.trim().length > 0 &&
+    completeSpecs.length > 0 &&
+    !compiling &&
+    compileResult?.ok === true
+
+  const setSpec = (i: number, patch: Partial<DraftSpec>) =>
+    setSpecs((prev) => prev.map((s, j) => (j === i ? { ...s, ...patch } : s)))
+  const addSpec = () => setSpecs((prev) => [...prev, { id: "", kind: "" }])
+  const removeSpec = (i: number) => {
+    const removedId = specs[i]?.id.trim()
+    setSpecs((prev) => prev.filter((_, j) => j !== i))
+    if (removedId) {
+      setDeps((prev) =>
+        prev.filter((d) => d.from !== removedId && d.to !== removedId),
+      )
+    }
+  }
+  const addDep = () => setDeps((prev) => [...prev, { from: "", to: "" }])
+  const setDep = (i: number, patch: Partial<SpecDep>) =>
+    setDeps((prev) => prev.map((d, j) => (j === i ? { ...d, ...patch } : d)))
+  const removeDep = (i: number) =>
+    setDeps((prev) => prev.filter((_, j) => j !== i))
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="hidden space-y-1 md:block">
+        <h1 className="text-2xl font-bold tracking-tight">Create Plan</h1>
+        <p className="text-sm text-muted-foreground">
+          Add specs and their dependencies, preview the execution graph,
+          then submit. The plan runs each spec in dependency order.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Plan</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <label htmlFor="plan-id" className="text-sm font-medium">
+            Plan ID
+          </label>
+          <Input
+            id="plan-id"
+            value={planId}
+            onChange={(e) => setPlanId(e.target.value)}
+            placeholder="e.g. github:42 or release-2026-06"
+          />
+          <p className="text-xs text-muted-foreground">
+            A stable identifier for this plan. Reuse a GitHub issue
+            reference or any memorable slug.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Specs</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {specs.map((spec, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Input
+                aria-label={`Spec ${i + 1} id`}
+                value={spec.id}
+                onChange={(e) => setSpec(i, { id: e.target.value })}
+                placeholder="spec id (e.g. github:42)"
+                className="flex-1"
+              />
+              <div className="w-44 shrink-0">
+                <SpecKindCombobox
+                  workspaceId={workspace.id}
+                  value={spec.kind}
+                  onChange={(kind) => setSpec(i, { kind })}
+                  ariaLabel={`Spec ${i + 1} kind`}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove spec ${i + 1}`}
+                onClick={() => removeSpec(i)}
+                disabled={specs.length === 1}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button type="button" variant="outline" size="sm" onClick={addSpec}>
+            <Plus className="h-4 w-4" />
+            Add spec
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Dependencies</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {deps.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No dependencies — every spec runs independently. Add one to
+              order a spec after another.
+            </p>
+          ) : (
+            deps.map((dep, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <DepEndpointSelect
+                  ariaLabel={`Dependency ${i + 1} from`}
+                  value={dep.from}
+                  options={completeIds}
+                  onChange={(from) => setDep(i, { from })}
+                />
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <DepEndpointSelect
+                  ariaLabel={`Dependency ${i + 1} to`}
+                  value={dep.to}
+                  options={completeIds}
+                  onChange={(to) => setDep(i, { to })}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove dependency ${i + 1}`}
+                  onClick={() => removeDep(i)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addDep}
+            disabled={completeIds.length < 2}
+          >
+            <Plus className="h-4 w-4" />
+            Add dependency
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Preview</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <CompileStatus
+            hasSpecs={completeSpecs.length > 0}
+            compiling={compiling}
+            result={compileResult ?? null}
+            error={compileQuery.error as Error | null}
+          />
+          {completeSpecs.length > 0 ? (
+            <div className="rounded-md border">
+              <SpecPlanDAG plan={dedupeById(plan)} />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Add a spec to preview the execution graph.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-end gap-3">
+        <Button type="button" variant="ghost" onClick={() => navigate(plansPath)}>
+          Cancel
+        </Button>
+        <HitlActionButton
+          toolName="submit_spec_plan"
+          args={{
+            workspace_id: workspace.id,
+            spec_plan_id: planId.trim(),
+            spec_plan: plan,
+          }}
+          onCommitted={() => navigate(plansPath)}
+          disabled={!canSubmit}
+        >
+          <Rocket className="h-4 w-4" />
+          Submit plan
+        </HitlActionButton>
+      </div>
+    </div>
+  )
+}
+
+function DepEndpointSelect({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+}: {
+  ariaLabel: string
+  value: string
+  options: string[]
+  onChange: (id: string) => void
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => {
+        if (typeof v === "string") onChange(v)
+      }}
+      items={options.map((id) => ({ value: id, label: id }))}
+    >
+      <SelectTrigger aria-label={ariaLabel} className="flex-1">
+        <SelectValue placeholder="select spec" />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((id) => (
+          <SelectItem key={id} value={id}>
+            {id}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function CompileStatus({
+  hasSpecs,
+  compiling,
+  result,
+  error,
+}: {
+  hasSpecs: boolean
+  compiling: boolean
+  result: ReturnType<typeof parseCompileResult> | null
+  error: Error | null
+}) {
+  if (!hasSpecs) return null
+  if (compiling) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Compiling…
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-sm text-destructive"
+      >
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>Couldn&apos;t compile — {error.message}</span>
+      </div>
+    )
+  }
+  if (!result) return null
+  if (result.ok) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="h-4 w-4" />
+        Compiles — {result.execution_plan.node_count} node
+        {result.execution_plan.node_count === 1 ? "" : "s"},{" "}
+        {result.execution_plan.edge_count} edge
+        {result.execution_plan.edge_count === 1 ? "" : "s"}.
+      </div>
+    )
+  }
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-sm text-destructive"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <span>{compileErrorMessage(result.error)}</span>
+    </div>
+  )
+}

--- a/apps/dashboard/src/pages/SpecPlansPage.tsx
+++ b/apps/dashboard/src/pages/SpecPlansPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react"
+import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
-import { AlertTriangle, ChevronDown, ChevronRight, Rocket } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronRight, Plus, Rocket } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { HitlActionButton } from "@/components/chat/HitlActionButton"
@@ -49,9 +50,28 @@ function planShape(plan: SpecPlan): string {
 
 export function SpecPlansPage() {
   const workspace = useActiveWorkspace()
+  const newPlanPath = `/workspaces/${workspace.slug}/spec-plans/new`
+  // Single primary action → inline icon button in the mobile bar
+  // (dashboard-ui chrome rule). Memoized so the header effect doesn't
+  // re-set on every render.
+  const headerActions = useMemo(
+    () => (
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Create plan"
+        title="Create plan"
+        render={<Link to={newPlanPath} />}
+      >
+        <Plus className="h-5 w-5" />
+      </Button>
+    ),
+    [newPlanPath],
+  )
   usePageHeader({
     title: "Spec Plans",
     backTo: `/workspaces/${workspace.slug}/workflows`,
+    actions: headerActions,
   })
 
   const plansQuery = useQuery({
@@ -71,12 +91,18 @@ export function SpecPlansPage() {
 
   return (
     <div className="space-y-6">
-      <div className="hidden space-y-1 md:block">
-        <h1 className="text-2xl font-bold tracking-tight">Spec Plans</h1>
-        <p className="text-sm text-muted-foreground">
-          Authored in chat, runnable here. Each plan compiles to a DAG of
-          specs and runs them in dependency order.
-        </p>
+      <div className="hidden items-start justify-between gap-3 md:flex">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold tracking-tight">Spec Plans</h1>
+          <p className="text-sm text-muted-foreground">
+            Author in chat or here, runnable here. Each plan compiles to a
+            DAG of specs and runs them in dependency order.
+          </p>
+        </div>
+        <Button className="shrink-0" render={<Link to={newPlanPath} />}>
+          <Plus className="h-4 w-4" />
+          Create plan
+        </Button>
       </div>
 
       {plansQuery.isLoading ? (
@@ -84,7 +110,7 @@ export function SpecPlansPage() {
       ) : plansQuery.isError ? (
         <ErrorState message={(plansQuery.error as Error).message} />
       ) : plans.length === 0 ? (
-        <EmptyState />
+        <EmptyState newPlanPath={newPlanPath} />
       ) : (
         <ul className="space-y-3">
           {plans.map((p) => (
@@ -190,17 +216,21 @@ function ErrorState({ message }: { message: string }) {
   )
 }
 
-function EmptyState() {
+function EmptyState({ newPlanPath }: { newPlanPath: string }) {
   return (
     <Card>
-      <CardContent className="flex flex-col items-center gap-2 py-10 text-center text-sm text-muted-foreground">
+      <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-sm text-muted-foreground">
         <Rocket className="h-8 w-8 text-muted-foreground/50" />
         <div>No spec plans yet.</div>
         <div className="max-w-sm text-xs text-muted-foreground/80">
-          Spec plans are authored in chat — open the chat and describe the
-          batch of specs you want to run. Submitted plans show up here,
-          ready to launch.
+          Create a plan here — add specs and their dependencies and submit
+          — or describe one in chat. Either way it shows up here, ready to
+          launch.
         </div>
+        <Button size="sm" className="mt-1" render={<Link to={newPlanPath} />}>
+          <Plus className="h-4 w-4" />
+          Create plan
+        </Button>
       </CardContent>
     </Card>
   )

--- a/apps/dashboard/tests/smoke/create-spec-plan.test.tsx
+++ b/apps/dashboard/tests/smoke/create-spec-plan.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  within,
+} from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom"
+
+import { CreateSpecPlanPage } from "@/pages/CreateSpecPlanPage"
+import { WorkspaceScope } from "@/lib/workspace"
+
+// Guided "Create Plan" surface (spec #542). Asserts the authoring loop:
+// form rows → live `compile_dry_run` gate → `submit_spec_plan` via a
+// HitlCard. The compile gate is mutation-checked — a kind the library
+// rejects keeps the commit button disabled, and the exact submit call is
+// asserted so dropping the gate fails the suite.
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u1" }, authEnabled: false }),
+}))
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [
+        {
+          id: "w1",
+          slug: "acme",
+          name: "Acme",
+          account: "acme",
+          account_type: "organization" as const,
+        },
+      ],
+    }),
+  },
+}))
+
+const mcpMock = vi.hoisted(() => ({ mcpCallTool: vi.fn() }))
+vi.mock("@/lib/mcp-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/mcp-client")>("@/lib/mcp-client")
+  return { ...actual, mcpCallTool: mcpMock.mcpCallTool }
+})
+
+function ok(payload: unknown) {
+  return Promise.resolve({
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    isError: false,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mcpMock.mcpCallTool.mockImplementation(
+    (name: string, args: Record<string, unknown>) => {
+      if (name === "list_workflows_v2") {
+        return ok({
+          workflows: [
+            { spec_kind: "Issue", version: 1, retired_at: null },
+            { spec_kind: "PR", version: 1, retired_at: null },
+            { spec_kind: "broken", version: 1, retired_at: null },
+          ],
+        })
+      }
+      if (name === "compile_dry_run") {
+        const plan = args.spec_plan as { specs: { kind: string }[] }
+        const bad = plan.specs.some((s) => s.kind === "broken")
+        return bad
+          ? ok({
+              ok: false,
+              error: {
+                kind: "missing_kind",
+                message: "unknown spec kind `broken`",
+                spec_kind: "broken",
+              },
+            })
+          : ok({ ok: true, execution_plan: { node_count: 1, edge_count: 0 } })
+      }
+      if (name === "submit_spec_plan") {
+        return ok({ spec_plan: { spec_plan_id: args.spec_plan_id } })
+      }
+      return Promise.resolve({ content: [], isError: false })
+    },
+  )
+})
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location">{loc.pathname}</div>
+}
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/workspaces/acme/spec-plans/new"]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspace/*"
+            element={
+              <WorkspaceScope>
+                <Routes>
+                  <Route path="spec-plans/new" element={<CreateSpecPlanPage />} />
+                  <Route path="spec-plans" element={<div>plans list</div>} />
+                </Routes>
+                <LocationProbe />
+              </WorkspaceScope>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+async function fillPlan(specId: string, kind: string) {
+  fireEvent.change(await screen.findByLabelText("Plan ID"), {
+    target: { value: "p1" },
+  })
+  fireEvent.change(screen.getByLabelText("Spec 1 id"), {
+    target: { value: specId },
+  })
+  // Kind is a library-backed combobox, never a typed string.
+  fireEvent.click(screen.getByRole("combobox", { name: "Spec 1 kind" }))
+  fireEvent.click(await screen.findByText(kind))
+}
+
+function trigger() {
+  return document.querySelector(
+    '[data-slot="hitl-action-button"][data-tool="submit_spec_plan"]',
+  ) as HTMLButtonElement
+}
+
+describe("CreateSpecPlanPage (spec #542)", () => {
+  it("compiles a valid plan and commits via submit_spec_plan", async () => {
+    mount()
+    await act(async () => {
+      await fillPlan("github:1", "Issue")
+    })
+
+    // Live compile lands ok → the commit button enables.
+    await waitFor(() => expect(trigger()).not.toBeDisabled())
+
+    await act(async () => {
+      fireEvent.click(trigger())
+    })
+    const dialog = await screen.findByRole("dialog")
+    await act(async () => {
+      fireEvent.click(
+        within(dialog).getByRole("button", { name: /submit plan/i }),
+      )
+    })
+
+    await waitFor(() =>
+      expect(mcpMock.mcpCallTool).toHaveBeenCalledWith("submit_spec_plan", {
+        workspace_id: "w1",
+        spec_plan_id: "p1",
+        spec_plan: { specs: [{ id: "github:1", kind: "Issue" }], deps: [] },
+      }),
+    )
+    // On success the surface routes back to the plans list.
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/acme/spec-plans",
+      ),
+    )
+  })
+
+  it("disables commit when the compiler rejects the plan", async () => {
+    mount()
+    await act(async () => {
+      await fillPlan("github:1", "broken")
+    })
+
+    // The compile error surfaces and the gate stays closed.
+    await screen.findByText(/unknown spec kind `broken`/i)
+    expect(trigger()).toBeDisabled()
+  })
+})

--- a/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
+++ b/docs/adr/0023-spec-plan-run-orchestration-and-dashboard-placement.md
@@ -9,6 +9,10 @@
   ADR 0015 (Spec Plan as DAG external contract), and ADR 0017 (plan
   compiler).
 - **Superseded by**: none
+- **Amended by**: ADR 0025 (chat is no longer the sole launch+monitor
+  surface for spec-plan runs) and #542 (the noun surface gains a guided
+  authoring form, so F1's in-chat `SpecPlanDAG` authoring is complemented
+  by a structured "Create Plan" surface, not replaced).
 
 ## Context
 

--- a/docs/adr/0025-chat-as-design-and-maintenance-surface.md
+++ b/docs/adr/0025-chat-as-design-and-maintenance-surface.md
@@ -7,6 +7,7 @@
 - **Tracking issues**: #506 (umbrella spec). Amends ADR 0020 (chat as portable global component); reconciles ADR 0023 (spec-plan run orchestration).
 - **Supersedes**: none. Amends ADR 0020 — see the note below; the responsive-mount + auto-scope decisions of 0020 stand.
 - **Superseded by**: none
+- **Amended by**: #542 — the noun surface (Spec Plans) gains a guided *authoring* affordance (a "Create Plan" form), so chat is no longer the sole spec-plan **authoring** path, just as it is no longer the sole *launch* path. This is a complement, not a reversal: chat stays the conversational/design authoring surface; the form is the deterministic path for a known plan. See § "Routine actions move to the noun surfaces".
 
 ## Context
 
@@ -35,6 +36,7 @@ This amends ADR 0020's "chat is one interchangeable frontend, not privileged" to
 ### Routine actions move to the noun surfaces
 
 - A **"run a batch" button** lands on `ready` workflows (ADR 0024) and on persisted spec plans, reusing `run_spec_plan` / `run_workflow`. Starting a routine run no longer requires opening chat. Chat is no longer the *sole* launch path for spec-plan runs — this is the reconciliation with ADR 0023 Decision 2.
+- A guided **"Create Plan" form** lands on the Spec Plans surface (#542), reusing `compile_dry_run` (live lint + DAG preview) and `submit_spec_plan` (routed through a HitlCard). Authoring a known plan no longer requires describing it in chat. This extends the same reasoning from *launch* to *authoring*: a deterministic, structured action belongs on the noun surface; chat remains the conversational/design path for plans that are still being shaped.
 
 ### Desktop gains a labeled chat entry
 


### PR DESCRIPTION
## What

Adds the missing **authoring** third of the Spec Plans surface (#514 built list + Run). Creating a spec plan was chat/MCP-only; this adds a guided form so a known plan can be assembled on the noun surface without dropping into chat or knowing the JSON shape.

The flow reuses existing backend — **no new business logic, no new REST endpoint** (the dashboard is already an MCP client, per the seam rule):

- **`/spec-plans/new` sub-route** (`CreateSpecPlanPage`) — Plan ID field, add/remove spec rows (spec `id` text field + library-backed `kind` combobox), add/remove `deps` rows as `Select` pairs. No raw JSON input.
- **Live lint + preview** — debounced `compile_dry_run` on each change; renders the DAG via the shared `SpecPlanDAG` and surfaces compile errors (unknown kind, cycle, dangling edge) inline. Commit is gated on a clean compile.
- **Commit** — `submit_spec_plan` routed through a `HitlCard` (constructive), consistent with the chat path; on success routes back to the plans list.
- **`kind` picker** reads the active workflow library over the existing **`list_workflows_v2`** MCP tool (filters `retired_at`) — no parallel kind list, no hand-maintained source of truth.
- **Reach** — `SpecPlansPage` gains a desktop "Create plan" button, a mobile `usePageHeader` action, and an empty-state CTA; `CommandPalette` gains a "New plan" Create entry.

## Decisions (resolved on the spec)

- **Complement, not reversal** — chat stays the conversational/design authoring path; the form is the deterministic path for a known plan. ADR 0025 and ADR 0023 carry `Amended by #542` notes recording this.
- Spec `id` = constrained text field (picker is a follow-up); dep auto-inference deferred; sub-route over modal.

## Tests

- `tests/smoke/create-spec-plan.test.tsx` — valid plan compiles → commit fires `submit_spec_plan` with the assembled body → routes back; a library-rejected kind surfaces the compile error and **keeps the commit button disabled** (mutation-checked: dropping the compile gate fails this test).
- Full dashboard suite green (250 tests). `tsc -b`, eslint, and `check-hitl-coverage` / `check-generated-types` / `check-api-contract` / `check-file-budget` all clean.

Closes #542

---
_Generated by [Claude Code](https://claude.ai/code/session_017QU9MJD3XQYcZAcoSU2PKn)_