### PR TITLE
refactor: rename projects table/type to workspace_repos

### DIFF
--- a/apps/dashboard/src/components/chat/BindDraftDialog.tsx
+++ b/apps/dashboard/src/components/chat/BindDraftDialog.tsx
@@ -27,7 +27,7 @@ import {
   api,
   ApiError,
   type GitHubAppInstallation,
-  type Project,
+  type WorkspaceRepo,
   type Workspace,
 } from "@/lib/api"
 import { markDraftBound } from "@/lib/drafts"
@@ -364,7 +364,7 @@ function ProjectStep({
     queryFn: () => api.listWorkspaceProjects(workspace.id),
     staleTime: 30_000,
   })
-  const projects: Project[] = projectsQuery.data?.projects ?? []
+  const projects: WorkspaceRepo[] = projectsQuery.data?.projects ?? []
 
   // The user has picked a repo via RepoCombobox once these three are set.
   const repoChosen = !!installId && !!repoOwner && !!repoName

--- a/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/workspaces/WorkspaceCard.tsx
@@ -13,7 +13,7 @@ import {
   type AccessibleRepo,
   type Workspace,
   type GitHubAppInstallation,
-  type Project,
+  type WorkspaceRepo,
   type WorkspaceMember,
 } from "@/lib/api"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -490,7 +490,7 @@ export interface ProjectsSectionHandle {
 interface ProjectsSectionProps {
   workspaceId: string
   installations: GitHubAppInstallation[]
-  projects: Project[]
+  projects: WorkspaceRepo[]
 }
 
 const ProjectsSection = forwardRef<ProjectsSectionHandle, ProjectsSectionProps>(

--- a/apps/dashboard/src/lib/api/generated/WorkspaceRepo.ts
+++ b/apps/dashboard/src/lib/api/generated/WorkspaceRepo.ts
@@ -5,4 +5,4 @@
  * installation. Opt-in per repo: installing the App on an org does not
  * auto-mirror all of that org's repos; the user explicitly adds each one.
  */
-export type Project = { id: string, workspace_id: string, github_app_installation_id: string, repo_owner: string, repo_name: string, default_branch: string, created_at: string, };
+export type WorkspaceRepo = { id: string, workspace_id: string, github_app_installation_id: string, repo_owner: string, repo_name: string, default_branch: string, created_at: string, };

--- a/apps/dashboard/src/lib/api/index.ts
+++ b/apps/dashboard/src/lib/api/index.ts
@@ -17,7 +17,7 @@ export type {
   WorkspaceMember,
   GitHubAccountType,
   GitHubAppInstallation,
-  Project,
+  WorkspaceRepo,
   AccessibleRepo,
   GovernanceEvent,
   TokenUsage,

--- a/apps/dashboard/src/lib/api/types.ts
+++ b/apps/dashboard/src/lib/api/types.ts
@@ -26,7 +26,6 @@ export type { MeVia } from "./generated/MeVia";
 export type { Node } from "./generated/Node";
 export type { NodeStatus } from "./generated/NodeStatus";
 export type { Pat } from "./generated/Pat";
-export type { Project } from "./generated/Project";
 export type { ProjectIssueDetail } from "./generated/ProjectIssueDetail";
 export type { ProjectIssueDetailResponse } from "./generated/ProjectIssueDetailResponse";
 export type { ProjectPullRow } from "./generated/ProjectPullRow";
@@ -44,6 +43,7 @@ export type { WorkflowGateKind } from "./generated/WorkflowGateKind";
 export type { Workspace } from "./generated/Workspace";
 export type { WorkspaceDeliveryHealthResponse } from "./generated/WorkspaceDeliveryHealthResponse";
 export type { WorkspaceMember } from "./generated/WorkspaceMember";
+export type { WorkspaceRepo } from "./generated/WorkspaceRepo";
 
 // ── Hand-written (pending derive) ────────────────────────────────────────
 

--- a/apps/dashboard/src/lib/api/workspaces.ts
+++ b/apps/dashboard/src/lib/api/workspaces.ts
@@ -4,7 +4,7 @@ import type {
   WorkspaceMember,
   GitHubAppInstallation,
   GitHubAccountType,
-  Project,
+  WorkspaceRepo,
   AccessibleRepo,
   GitHubLabel,
   WorkspaceDeliveryHealthResponse,
@@ -49,7 +49,7 @@ export const workspaces = {
       { method: 'DELETE' },
     ),
   listWorkspaceProjects: (id: string) =>
-    request<{ projects: Project[] }>(
+    request<{ projects: WorkspaceRepo[] }>(
       `/workspaces/${encodeURIComponent(id)}/projects`,
     ),
   addWorkspaceProject: (
@@ -61,11 +61,11 @@ export const workspaces = {
       default_branch?: string;
     },
   ) =>
-    request<{ project: Project }>(
+    request<{ project: WorkspaceRepo }>(
       `/workspaces/${encodeURIComponent(id)}/projects`,
       { method: 'POST', body: JSON.stringify(body) },
     ),
-  listAllProjects: () => request<{ projects: Project[] }>('/projects'),
+  listAllProjects: () => request<{ projects: WorkspaceRepo[] }>('/projects'),
   deleteProject: (id: string) =>
     request<{ ok: boolean }>(`/projects/${encodeURIComponent(id)}`, {
       method: 'DELETE',

--- a/crates/onsager-portal/src/core.rs
+++ b/crates/onsager-portal/src/core.rs
@@ -56,7 +56,7 @@ pub struct WorkspaceMemberWithUser {
 /// auto-mirror all of that org's repos; the user explicitly adds each one.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
-pub struct Project {
+pub struct WorkspaceRepo {
     pub id: String,
     pub workspace_id: String,
     pub github_app_installation_id: String,

--- a/crates/onsager-portal/src/db.rs
+++ b/crates/onsager-portal/src/db.rs
@@ -99,7 +99,7 @@ pub async fn find_active_github_workflows_for_label(
 
 /// A project row resolved from `(installation, repo_owner, repo_name)`.
 #[derive(Debug, Clone)]
-pub struct ProjectRecord {
+pub struct WorkspaceRepoRecord {
     pub id: String,
     pub tenant_id: String,
     pub github_app_installation_id: String,
@@ -116,10 +116,10 @@ pub async fn find_project_for_repo(
     installation_id: &str,
     owner: &str,
     name: &str,
-) -> anyhow::Result<Option<ProjectRecord>> {
+) -> anyhow::Result<Option<WorkspaceRepoRecord>> {
     let row: Option<(String, String, String, String, String, String)> = sqlx::query_as(
         "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch \
-         FROM projects \
+         FROM workspace_repos \
          WHERE github_app_installation_id = $1 AND repo_owner = $2 AND repo_name = $3",
     )
     .bind(installation_id)
@@ -129,7 +129,7 @@ pub async fn find_project_for_repo(
     .await?;
     Ok(row.map(
         |(id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch)| {
-            ProjectRecord {
+            WorkspaceRepoRecord {
                 id,
                 tenant_id,
                 github_app_installation_id,
@@ -141,17 +141,20 @@ pub async fn find_project_for_repo(
     ))
 }
 
-pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Option<ProjectRecord>> {
+pub async fn get_project(
+    pool: &PgPool,
+    project_id: &str,
+) -> anyhow::Result<Option<WorkspaceRepoRecord>> {
     let row: Option<(String, String, String, String, String, String)> = sqlx::query_as(
         "SELECT id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch \
-         FROM projects WHERE id = $1",
+         FROM workspace_repos WHERE id = $1",
     )
     .bind(project_id)
     .fetch_optional(pool)
     .await?;
     Ok(row.map(
         |(id, tenant_id, github_app_installation_id, repo_owner, repo_name, default_branch)| {
-            ProjectRecord {
+            WorkspaceRepoRecord {
                 id,
                 tenant_id,
                 github_app_installation_id,

--- a/crates/onsager-portal/src/handlers/live_data.rs
+++ b/crates/onsager-portal/src/handlers/live_data.rs
@@ -40,7 +40,7 @@ use onsager_spine::webhook_routing::{
 
 use crate::auth::AuthUser;
 use crate::backfill::Strategy;
-use crate::core::Project;
+use crate::core::WorkspaceRepo;
 use crate::handlers::projects::installation_token_for;
 use crate::handlers::workspaces::require_workspace_access;
 use crate::state::AppState;
@@ -65,7 +65,7 @@ async fn require_project_for_user(
     state: &AppState,
     auth_user: &AuthUser,
     project_id: &str,
-) -> Result<Project, Response> {
+) -> Result<WorkspaceRepo, Response> {
     let project = match workspace_db::get_project(&state.pool, project_id).await {
         Ok(Some(p)) => p,
         Ok(None) => return Err(not_found("project not found")),

--- a/crates/onsager-portal/src/handlers/projects.rs
+++ b/crates/onsager-portal/src/handlers/projects.rs
@@ -18,7 +18,7 @@ use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
 use crate::auth::AuthUser;
-use crate::core::Project;
+use crate::core::WorkspaceRepo;
 use crate::handlers::workspaces::require_workspace_access;
 use crate::state::AppState;
 use crate::workspace_db;
@@ -126,7 +126,7 @@ pub async fn add_project(
         },
     };
 
-    let project = Project {
+    let project = WorkspaceRepo {
         id: Uuid::new_v4().to_string(),
         workspace_id: workspace_id.clone(),
         github_app_installation_id: body.github_app_installation_id.clone(),

--- a/crates/onsager-portal/src/installation_db.rs
+++ b/crates/onsager-portal/src/installation_db.rs
@@ -151,11 +151,12 @@ pub async fn count_projects_for_installation(
     pool: &PgPool,
     install_row_id: &str,
 ) -> anyhow::Result<i64> {
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM projects WHERE github_app_installation_id = $1")
-            .bind(install_row_id)
-            .fetch_one(pool)
-            .await?;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM workspace_repos WHERE github_app_installation_id = $1",
+    )
+    .bind(install_row_id)
+    .fetch_one(pool)
+    .await?;
     Ok(count)
 }
 

--- a/crates/onsager-portal/src/reconciliation/scheduler.rs
+++ b/crates/onsager-portal/src/reconciliation/scheduler.rs
@@ -41,9 +41,9 @@ use super::state::{load_state, touch_polled_at, upsert_state};
 use super::translator::{translate_issue, translate_pull_request};
 
 /// Project row shape the scheduler needs. A narrow projection over
-/// `projects` — we don't want the full row coupling.
+/// `workspace_repos` — we don't want the full row coupling.
 #[derive(Debug, Clone)]
-struct ProjectRow {
+struct WorkspaceRepoRow {
     id: String,
     workspace_id: String,
     repo_owner: String,
@@ -105,11 +105,11 @@ pub fn spawn_all(pool: PgPool, spine: EventStore) {
     });
 }
 
-async fn load_polling_projects(pool: &PgPool) -> Result<Vec<ProjectRow>, sqlx::Error> {
+async fn load_polling_projects(pool: &PgPool) -> Result<Vec<WorkspaceRepoRow>, sqlx::Error> {
     let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
         r#"
         SELECT id, workspace_id, repo_owner, repo_name, ingestion_mode
-        FROM projects
+        FROM workspace_repos
         "#,
     )
     .fetch_all(pool)
@@ -117,7 +117,7 @@ async fn load_polling_projects(pool: &PgPool) -> Result<Vec<ProjectRow>, sqlx::E
     Ok(rows
         .into_iter()
         .map(
-            |(id, workspace_id, repo_owner, repo_name, ingestion_mode)| ProjectRow {
+            |(id, workspace_id, repo_owner, repo_name, ingestion_mode)| WorkspaceRepoRow {
                 id,
                 workspace_id,
                 repo_owner,
@@ -146,7 +146,7 @@ fn project_offset(project_id: &str, interval: Duration) -> Duration {
 async fn run_project_loop(
     pool: PgPool,
     spine: EventStore,
-    project: ProjectRow,
+    project: WorkspaceRepoRow,
     mode: IngestionMode,
 ) {
     let interval = mode.poll_interval();
@@ -182,7 +182,7 @@ async fn run_project_loop(
 async fn tick_project(
     pool: &PgPool,
     spine: &EventStore,
-    project: &ProjectRow,
+    project: &WorkspaceRepoRow,
 ) -> anyhow::Result<()> {
     // v1: unauthenticated reads. Per-installation credential
     // resolution is a deferred follow-up listed on spec #430 (open
@@ -289,7 +289,7 @@ async fn tick_project(
 async fn emit_normalized(
     pool: &PgPool,
     spine: &EventStore,
-    project: &ProjectRow,
+    project: &WorkspaceRepoRow,
     resource_kind: &str,
     events: &[NormalizedEvent],
 ) -> anyhow::Result<EmitOutcome> {
@@ -390,7 +390,7 @@ async fn emit_normalized(
 /// the issue), so we query per-label. Empty map → nothing to fire.
 async fn collect_label_workflows(
     pool: &PgPool,
-    project: &ProjectRow,
+    project: &WorkspaceRepoRow,
     issue: &Issue,
 ) -> anyhow::Result<HashMap<String, Vec<WorkflowMatch>>> {
     let mut by_label: HashMap<String, Vec<WorkflowMatch>> = HashMap::new();

--- a/crates/onsager-portal/src/workflow_install.rs
+++ b/crates/onsager-portal/src/workflow_install.rs
@@ -10,7 +10,7 @@
 //! project).
 
 use crate::auth::decrypt_credential;
-use crate::core::Project;
+use crate::core::WorkspaceRepo;
 use crate::installation_db;
 use crate::state::AppState;
 use crate::workflow::Workflow;
@@ -39,7 +39,7 @@ pub async fn resolve_workflow_install_id(state: &AppState, workflow: &Workflow) 
 /// account-level), and fall back to the workflow's cached `install_id`
 /// (mint cache) when no project matches. Kept separate so the
 /// project-match-vs-fallback choice is unit-testable without a DB.
-fn pick_install_id(workflow: &Workflow, projects: &[Project]) -> Option<i64> {
+fn pick_install_id(workflow: &Workflow, projects: &[WorkspaceRepo]) -> Option<i64> {
     if let Some((repo_owner, repo_name)) = workflow.github_repo_any()
         && let Some(project) = projects
             .iter()
@@ -90,8 +90,8 @@ mod tests {
         }
     }
 
-    fn project(repo_owner: &str, repo_name: &str, install: &str) -> Project {
-        Project {
+    fn project(repo_owner: &str, repo_name: &str, install: &str) -> WorkspaceRepo {
+        WorkspaceRepo {
             id: "p1".into(),
             workspace_id: "w1".into(),
             github_app_installation_id: install.into(),

--- a/crates/onsager-portal/src/workspace_db.rs
+++ b/crates/onsager-portal/src/workspace_db.rs
@@ -10,7 +10,7 @@
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgPool;
 
-use crate::core::{Project, Workspace, WorkspaceMember, WorkspaceMemberWithUser};
+use crate::core::{Workspace, WorkspaceMember, WorkspaceMemberWithUser, WorkspaceRepo};
 
 #[derive(sqlx::FromRow)]
 struct WorkspaceRow {
@@ -61,7 +61,7 @@ impl TryFrom<WorkspaceMemberWithUserRow> for WorkspaceMemberWithUser {
 }
 
 #[derive(sqlx::FromRow)]
-struct ProjectRow {
+struct WorkspaceRepoRow {
     id: String,
     workspace_id: String,
     github_app_installation_id: String,
@@ -71,11 +71,11 @@ struct ProjectRow {
     created_at: String,
 }
 
-impl TryFrom<ProjectRow> for Project {
+impl TryFrom<WorkspaceRepoRow> for WorkspaceRepo {
     type Error = anyhow::Error;
 
-    fn try_from(row: ProjectRow) -> anyhow::Result<Self> {
-        Ok(Project {
+    fn try_from(row: WorkspaceRepoRow) -> anyhow::Result<Self> {
+        Ok(WorkspaceRepo {
             id: row.id,
             workspace_id: row.workspace_id,
             github_app_installation_id: row.github_app_installation_id,
@@ -206,9 +206,9 @@ pub async fn get_installation_lookup(
     }))
 }
 
-pub async fn insert_project(pool: &PgPool, project: &Project) -> anyhow::Result<()> {
+pub async fn insert_project(pool: &PgPool, project: &WorkspaceRepo) -> anyhow::Result<()> {
     sqlx::query(
-        "INSERT INTO projects (id, workspace_id, github_app_installation_id, repo_owner, \
+        "INSERT INTO workspace_repos (id, workspace_id, github_app_installation_id, repo_owner, \
                                repo_name, default_branch, created_at) \
          VALUES ($1, $2, $3, $4, $5, $6, $7)",
     )
@@ -224,11 +224,11 @@ pub async fn insert_project(pool: &PgPool, project: &Project) -> anyhow::Result<
     Ok(())
 }
 
-pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Option<Project>> {
-    let row = sqlx::query_as::<_, ProjectRow>(
+pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Option<WorkspaceRepo>> {
+    let row = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
                 default_branch, created_at \
-         FROM projects WHERE id = $1",
+         FROM workspace_repos WHERE id = $1",
     )
     .bind(project_id)
     .fetch_optional(pool)
@@ -239,11 +239,11 @@ pub async fn get_project(pool: &PgPool, project_id: &str) -> anyhow::Result<Opti
 pub async fn list_projects_for_workspace(
     pool: &PgPool,
     workspace_id: &str,
-) -> anyhow::Result<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
+) -> anyhow::Result<Vec<WorkspaceRepo>> {
+    let rows = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
                 default_branch, created_at \
-         FROM projects WHERE workspace_id = $1 ORDER BY created_at ASC",
+         FROM workspace_repos WHERE workspace_id = $1 ORDER BY created_at ASC",
     )
     .bind(workspace_id)
     .fetch_all(pool)
@@ -251,11 +251,14 @@ pub async fn list_projects_for_workspace(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
-pub async fn list_projects_for_user(pool: &PgPool, user_id: &str) -> anyhow::Result<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
+pub async fn list_projects_for_user(
+    pool: &PgPool,
+    user_id: &str,
+) -> anyhow::Result<Vec<WorkspaceRepo>> {
+    let rows = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT p.id, p.workspace_id, p.github_app_installation_id, p.repo_owner, p.repo_name, \
                 p.default_branch, p.created_at \
-         FROM projects p \
+         FROM workspace_repos p \
          JOIN workspace_members m ON p.workspace_id = m.workspace_id \
          WHERE m.user_id = $1 \
          ORDER BY p.created_at ASC",
@@ -267,7 +270,7 @@ pub async fn list_projects_for_user(pool: &PgPool, user_id: &str) -> anyhow::Res
 }
 
 pub async fn delete_project(pool: &PgPool, project_id: &str) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM projects WHERE id = $1")
+    sqlx::query("DELETE FROM workspace_repos WHERE id = $1")
         .bind(project_id)
         .execute(pool)
         .await?;

--- a/crates/onsager-portal/tests/reconciliation_state.rs
+++ b/crates/onsager-portal/tests/reconciliation_state.rs
@@ -169,7 +169,7 @@ async fn ingestion_mode_check_constraint_rejects_unknown_values() {
     for mode in ["webhook+reconciler", "polling-only", "webhook-only"] {
         let project_id = format!("proj-{}", Uuid::new_v4());
         let ok = sqlx::query(
-            "INSERT INTO projects \
+            "INSERT INTO workspace_repos \
                 (id, workspace_id, github_app_installation_id, \
                  repo_owner, repo_name, default_branch, created_at, \
                  ingestion_mode) \
@@ -181,7 +181,7 @@ async fn ingestion_mode_check_constraint_rejects_unknown_values() {
         .execute(&pool)
         .await;
         assert!(ok.is_ok(), "mode {mode} should be accepted: {ok:?}");
-        sqlx::query("DELETE FROM projects WHERE id = $1")
+        sqlx::query("DELETE FROM workspace_repos WHERE id = $1")
             .bind(&project_id)
             .execute(&pool)
             .await
@@ -191,7 +191,7 @@ async fn ingestion_mode_check_constraint_rejects_unknown_values() {
     // Anything else must be rejected.
     let project_id = format!("proj-{}", Uuid::new_v4());
     let bad = sqlx::query(
-        "INSERT INTO projects \
+        "INSERT INTO workspace_repos \
             (id, workspace_id, github_app_installation_id, \
              repo_owner, repo_name, default_branch, created_at, \
              ingestion_mode) \

--- a/crates/onsager-spine/migrations/004_workflows.sql
+++ b/crates/onsager-spine/migrations/004_workflows.sql
@@ -40,7 +40,22 @@ CREATE TABLE IF NOT EXISTS workspace_members (
 
 CREATE INDEX IF NOT EXISTS idx_workspace_members_user_id ON workspace_members (user_id);
 
-CREATE TABLE IF NOT EXISTS projects (
+-- spec #545: `projects` is a workspace↔repo membership list, not a unit of
+-- work — rename it to `workspace_repos`. Idempotent + safe to re-run.
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'projects')
+     AND NOT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'workspace_repos') THEN
+    ALTER TABLE projects RENAME TO workspace_repos;
+    ALTER INDEX IF EXISTS idx_projects_workspace_id RENAME TO idx_workspace_repos_workspace_id;
+    BEGIN
+      ALTER TABLE workspace_repos RENAME CONSTRAINT projects_ingestion_mode_check TO workspace_repos_ingestion_mode_check;
+    EXCEPTION WHEN undefined_object THEN NULL;
+    END;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS workspace_repos (
     id                         TEXT NOT NULL PRIMARY KEY,
     workspace_id               TEXT NOT NULL,
     github_app_installation_id TEXT NOT NULL,
@@ -50,11 +65,11 @@ CREATE TABLE IF NOT EXISTS projects (
     created_at                 TEXT NOT NULL,
     ingestion_mode             TEXT NOT NULL DEFAULT 'webhook+reconciler',
     UNIQUE (workspace_id, repo_owner, repo_name),
-    CONSTRAINT projects_ingestion_mode_check
+    CONSTRAINT workspace_repos_ingestion_mode_check
         CHECK (ingestion_mode IN ('webhook+reconciler', 'polling-only', 'webhook-only'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_projects_workspace_id ON projects (workspace_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_repos_workspace_id ON workspace_repos (workspace_id);
 
 -- ── Workflows ────────────────────────────────────────────────────────────────
 

--- a/crates/stiglab/src/core/mod.rs
+++ b/crates/stiglab/src/core/mod.rs
@@ -16,7 +16,7 @@ pub use error::StiglabError;
 pub use event::Event;
 pub use github_app_installation::{GitHubAccountType, GitHubAppInstallation};
 pub use node::{Node, NodeInfo, NodeStatus};
-pub use project::Project;
+pub use project::WorkspaceRepo;
 pub use protocol::{AgentMessage, ServerMessage};
 pub use session::{Session, SessionState};
 pub use task::{Task, TaskRequest};

--- a/crates/stiglab/src/core/project.rs
+++ b/crates/stiglab/src/core/project.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// installation.  Opt-in per repo: installing the App on an org does not
 /// auto-mirror all of that org's repos; the user explicitly adds each one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Project {
+pub struct WorkspaceRepo {
     pub id: String,
     pub workspace_id: String,
     pub github_app_installation_id: String,

--- a/crates/stiglab/src/server/db/github_installations.rs
+++ b/crates/stiglab/src/server/db/github_installations.rs
@@ -113,11 +113,12 @@ pub async fn count_projects_for_installation(
     pool: &AnyPool,
     install_id: &str,
 ) -> anyhow::Result<i64> {
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM projects WHERE github_app_installation_id = $1")
-            .bind(install_id)
-            .fetch_one(pool)
-            .await?;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM workspace_repos WHERE github_app_installation_id = $1",
+    )
+    .bind(install_id)
+    .fetch_one(pool)
+    .await?;
     Ok(count)
 }
 

--- a/crates/stiglab/src/server/db/mod.rs
+++ b/crates/stiglab/src/server/db/mod.rs
@@ -419,8 +419,24 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // spec #545: rename legacy `projects` → `workspace_repos` on existing
+    // installs. Postgres-only `DO $$` block; SQLite tests rebuild the schema
+    // from the CREATE TABLE below, so the ignored error here is expected.
+    let _ = sqlx::query(
+        "DO $$ \
+         BEGIN \
+           IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'projects') \
+              AND NOT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'workspace_repos') THEN \
+             ALTER TABLE projects RENAME TO workspace_repos; \
+             ALTER INDEX IF EXISTS idx_projects_workspace_id RENAME TO idx_workspace_repos_workspace_id; \
+           END IF; \
+         END $$",
+    )
+    .execute(pool)
+    .await;
+
     sqlx::query(
-        "CREATE TABLE IF NOT EXISTS projects (
+        "CREATE TABLE IF NOT EXISTS workspace_repos (
             id TEXT PRIMARY KEY,
             workspace_id TEXT NOT NULL,
             github_app_installation_id TEXT NOT NULL,
@@ -434,9 +450,11 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
-    sqlx::query("CREATE INDEX IF NOT EXISTS idx_projects_workspace_id ON projects (workspace_id)")
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_workspace_repos_workspace_id ON workspace_repos (workspace_id)",
+    )
+    .execute(pool)
+    .await?;
 
     // PAT backfill: rows with NULL `workspace_id` get pinned to the user's
     // first workspace membership; rows with no membership at all are
@@ -569,7 +587,7 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     let _ = sqlx::query(
         "UPDATE sessions \
          SET workspace_id = ( \
-             SELECT p.workspace_id FROM projects p WHERE p.id = sessions.project_id \
+             SELECT p.workspace_id FROM workspace_repos p WHERE p.id = sessions.project_id \
          ) \
          WHERE workspace_id IS NULL AND project_id IS NOT NULL",
     )

--- a/crates/stiglab/src/server/db/projects.rs
+++ b/crates/stiglab/src/server/db/projects.rs
@@ -1,10 +1,10 @@
-use crate::core::Project;
+use crate::core::WorkspaceRepo;
 use chrono::Utc;
 use sqlx::AnyPool;
 
-pub async fn insert_project(pool: &AnyPool, project: &Project) -> anyhow::Result<()> {
+pub async fn insert_project(pool: &AnyPool, project: &WorkspaceRepo) -> anyhow::Result<()> {
     sqlx::query(
-        "INSERT INTO projects (id, workspace_id, github_app_installation_id, repo_owner, \
+        "INSERT INTO workspace_repos (id, workspace_id, github_app_installation_id, repo_owner, \
                                repo_name, default_branch, created_at) \
          VALUES ($1, $2, $3, $4, $5, $6, $7)",
     )
@@ -20,11 +20,14 @@ pub async fn insert_project(pool: &AnyPool, project: &Project) -> anyhow::Result
     Ok(())
 }
 
-pub async fn get_project(pool: &AnyPool, project_id: &str) -> anyhow::Result<Option<Project>> {
-    let row = sqlx::query_as::<_, ProjectRow>(
+pub async fn get_project(
+    pool: &AnyPool,
+    project_id: &str,
+) -> anyhow::Result<Option<WorkspaceRepo>> {
+    let row = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
                 default_branch, created_at \
-         FROM projects WHERE id = $1",
+         FROM workspace_repos WHERE id = $1",
     )
     .bind(project_id)
     .fetch_optional(pool)
@@ -35,11 +38,11 @@ pub async fn get_project(pool: &AnyPool, project_id: &str) -> anyhow::Result<Opt
 pub async fn list_projects_for_workspace(
     pool: &AnyPool,
     workspace_id: &str,
-) -> anyhow::Result<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
+) -> anyhow::Result<Vec<WorkspaceRepo>> {
+    let rows = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT id, workspace_id, github_app_installation_id, repo_owner, repo_name, \
                 default_branch, created_at \
-         FROM projects WHERE workspace_id = $1 ORDER BY created_at ASC",
+         FROM workspace_repos WHERE workspace_id = $1 ORDER BY created_at ASC",
     )
     .bind(workspace_id)
     .fetch_all(pool)
@@ -47,11 +50,14 @@ pub async fn list_projects_for_workspace(
     rows.into_iter().map(|r| r.try_into()).collect()
 }
 
-pub async fn list_projects_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Result<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
+pub async fn list_projects_for_user(
+    pool: &AnyPool,
+    user_id: &str,
+) -> anyhow::Result<Vec<WorkspaceRepo>> {
+    let rows = sqlx::query_as::<_, WorkspaceRepoRow>(
         "SELECT p.id, p.workspace_id, p.github_app_installation_id, p.repo_owner, p.repo_name, \
                 p.default_branch, p.created_at \
-         FROM projects p \
+         FROM workspace_repos p \
          JOIN workspace_members m ON p.workspace_id = m.workspace_id \
          WHERE m.user_id = $1 \
          ORDER BY p.created_at ASC",
@@ -63,7 +69,7 @@ pub async fn list_projects_for_user(pool: &AnyPool, user_id: &str) -> anyhow::Re
 }
 
 pub async fn delete_project(pool: &AnyPool, project_id: &str) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM projects WHERE id = $1")
+    sqlx::query("DELETE FROM workspace_repos WHERE id = $1")
         .bind(project_id)
         .execute(pool)
         .await?;
@@ -90,7 +96,7 @@ pub async fn count_live_sessions_for_project(
 // ── Row types ──
 
 #[derive(sqlx::FromRow)]
-struct ProjectRow {
+struct WorkspaceRepoRow {
     id: String,
     workspace_id: String,
     github_app_installation_id: String,
@@ -100,11 +106,11 @@ struct ProjectRow {
     created_at: String,
 }
 
-impl TryFrom<ProjectRow> for Project {
+impl TryFrom<WorkspaceRepoRow> for WorkspaceRepo {
     type Error = anyhow::Error;
 
-    fn try_from(row: ProjectRow) -> anyhow::Result<Self> {
-        Ok(Project {
+    fn try_from(row: WorkspaceRepoRow) -> anyhow::Result<Self> {
+        Ok(WorkspaceRepo {
             id: row.id,
             workspace_id: row.workspace_id,
             github_app_installation_id: row.github_app_installation_id,

--- a/crates/stiglab/src/server/db/tests.rs
+++ b/crates/stiglab/src/server/db/tests.rs
@@ -3,8 +3,8 @@
 mod tests {
     use super::super::*;
     use crate::core::{
-        GitHubAccountType, GitHubAppInstallation, Project, Session, SessionState, Workspace,
-        WorkspaceMember,
+        GitHubAccountType, GitHubAppInstallation, Session, SessionState, Workspace,
+        WorkspaceMember, WorkspaceRepo,
     };
     use chrono::Utc;
     use sqlx::AnyPool;
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(installs.len(), 1);
         assert_eq!(installs[0].install_id, 42);
 
-        let project = Project {
+        let project = WorkspaceRepo {
             id: Uuid::new_v4().to_string(),
             workspace_id: w.id.clone(),
             github_app_installation_id: install.id.clone(),
@@ -180,7 +180,7 @@ mod tests {
             .await
             .unwrap();
 
-        let project = Project {
+        let project = WorkspaceRepo {
             id: Uuid::new_v4().to_string(),
             workspace_id: w.id.clone(),
             github_app_installation_id: install.id.clone(),
@@ -287,7 +287,7 @@ mod tests {
             0
         );
 
-        let project = Project {
+        let project = WorkspaceRepo {
             id: Uuid::new_v4().to_string(),
             workspace_id: w.id.clone(),
             github_app_installation_id: install.id.clone(),
@@ -336,7 +336,7 @@ mod tests {
         insert_github_app_installation(&pool, &install, None)
             .await
             .unwrap();
-        let project = Project {
+        let project = WorkspaceRepo {
             id: Uuid::new_v4().to_string(),
             workspace_id: w1.id.clone(),
             github_app_installation_id: install.id.clone(),


### PR DESCRIPTION
Closes #545. First slice of the **workspace = project** epic (#544).

## What

The `projects` table was always a one-row-per-repo workspace↔repo **membership list** (`UNIQUE (workspace_id, repo_owner, repo_name)`, a single `github_app_installation_id`), not a unit of work. This renames it to read as what it is:

- DB table `projects` → `workspace_repos` (canonical spine migration `004_workflows.sql` + stiglab's SQLite-safe fallback DDL).
- Rust type `Project` → `WorkspaceRepo` (+ internal `WorkspaceRepoRow`/`WorkspaceRepoRecord`), and the regenerated ts-rs binding `WorkspaceRepo.ts`.
- All ~20 SQL strings and type references across portal, stiglab, spine, and the dashboard.

Existing dev DBs migrate via an idempotent, re-run-safe guarded block (no version tracking — spine migrations re-run every boot):

```sql
DO $$
BEGIN
  IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'projects')
     AND NOT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'workspace_repos') THEN
    ALTER TABLE projects RENAME TO workspace_repos;
    ALTER INDEX IF EXISTS idx_projects_workspace_id RENAME TO idx_workspace_repos_workspace_id;
    ...
  END IF;
END $$;
```

The same guarded rename, Postgres-only and ignored on SQLite, runs in stiglab's `run_migrations` — ordered *after* the legacy `tenant_id → workspace_id` column rename so existing installs migrate cleanly.

## Out of scope (deliberate)

Per the #545 scope amendment, this PR is the rename only. Left for follow-ups so this stays a tight, reviewable mechanical change:

- Function names containing "project" (`get_project`, `list_projects_for_workspace`, …) — internal naming.
- `/api/projects` route paths — an API-contract surface (touches `lint_api_contract` + dashboard client).
- The per-repo install resolver + repo-set handoff (moved to #546) and the write-token mint helper (moved to #548).
- GitHub webhook triggers stay per-repo (no `repo: Option`, no webhook fan-out) — decided on #544.

## Verification

- `cargo build --workspace` ✅, `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p onsager-portal --lib` (280) ✅ and `-p stiglab --lib` (46) ✅ — the SQLite-backed CRUD tests (`installation_and_project_crud`, `delete_project_blocks_on_live_sessions`, `list_projects_for_user_follows_membership`) exercise the renamed table/type end-to-end.
- `xtask check-generated-types` up to date ✅; dashboard `pnpm tsc --noEmit` clean ✅.

On the #545 Test item "existing rows survive the rename": this holds by construction — `ALTER TABLE … RENAME TO` is data-preserving and the guarded block is idempotent — rather than via a new seeded-Postgres migration test. Flagging that honestly; happy to add a gated integration test if preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLyLCy4L7JY7H5QJKu1wQ9)_