### PR TITLE
feat(stiglab): multi-repo agent session — hand the run its workspace repo set + per-repo read tokens

### DIFF
--- a/crates/onsager-github/src/api/app.rs
+++ b/crates/onsager-github/src/api/app.rs
@@ -148,6 +148,15 @@ pub async fn mint_read_token_for_repos(
     install_id: i64,
     repo_names: &[String],
 ) -> Result<InstallationToken, GithubError> {
+    // Enforce least-privilege at the boundary: GitHub treats an omitted
+    // `repositories` body as "the install's full repo set", so an empty
+    // slice would silently *widen* the token rather than narrow it.
+    if repo_names.is_empty() {
+        return Err(GithubError::Other(anyhow::anyhow!(
+            "mint_read_token_for_repos requires at least one repo name; \
+             an empty set would widen the token to the install's full repo set"
+        )));
+    }
     let url = format!("https://api.github.com/app/installations/{install_id}/access_tokens");
     let body = serde_json::json!({
         "repositories": repo_names,
@@ -464,6 +473,21 @@ KHLHs4NWfuFIhN/tCfpZ/g==
         let pem = "-----BEGIN RSA PRIVATE KEY-----\nXX\n-----END RSA PRIVATE KEY-----\n";
         let b64 = base64::engine::general_purpose::STANDARD.encode(pem.as_bytes());
         assert_eq!(normalize_pem(&b64), pem);
+    }
+
+    #[tokio::test]
+    async fn mint_read_token_rejects_empty_repo_set() {
+        // Least-privilege guard: an empty repo set must error *before* any
+        // network call (GitHub would otherwise issue a token for the
+        // install's full repo set). Mutation guard: drop the `is_empty()`
+        // check and this returns a network error instead of the message.
+        let err = mint_read_token_for_repos("jwt-unused", 123, &[])
+            .await
+            .expect_err("empty repo set must be rejected");
+        assert!(
+            err.to_string().contains("at least one repo name"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/onsager-github/src/api/app.rs
+++ b/crates/onsager-github/src/api/app.rs
@@ -130,6 +130,52 @@ pub async fn mint_installation_token(
     })
 }
 
+/// Exchange an App JWT for a **read-scoped** installation access token,
+/// narrowed to a specific set of repositories (spec #546).
+///
+/// Unlike [`mint_installation_token`] (which yields a token carrying the
+/// App's full granted permissions across every repo in the install), this
+/// requests least-privilege: `contents:read` + `metadata:read`, scoped to
+/// `repo_names` only. It is the token an agent session gets to *clone and
+/// read* a workspace's bound repos — *writes* to origin are gated and
+/// minted separately (#548).
+///
+/// `repo_names` are the short repo names (no owner prefix), all under the
+/// install's account. An empty slice would let GitHub fall back to the
+/// install's full repo set, so callers must pass at least one name.
+pub async fn mint_read_token_for_repos(
+    app_jwt: &str,
+    install_id: i64,
+    repo_names: &[String],
+) -> Result<InstallationToken, GithubError> {
+    let url = format!("https://api.github.com/app/installations/{install_id}/access_tokens");
+    let body = serde_json::json!({
+        "repositories": repo_names,
+        "permissions": { "contents": "read", "metadata": "read" },
+    });
+    let resp = client()
+        .post(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .json(&body)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    let parsed: InstallationTokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(InstallationToken {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+    })
+}
+
 #[derive(Debug, Deserialize)]
 struct AccountJson {
     login: String,

--- a/crates/onsager-portal/src/handlers/tasks.rs
+++ b/crates/onsager-portal/src/handlers/tasks.rs
@@ -57,6 +57,14 @@ pub struct TaskDispatchPayload {
     /// unscoped or no credential key is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_session_token: Option<String>,
+    /// The workspace's bound repo set with read-scoped per-repo
+    /// credentials (spec #546). One entry per bound repo (possibly across
+    /// orgs); stiglab decrypts each token and surfaces the set to the
+    /// agent so it can clone on demand. Empty for an unscoped session or a
+    /// workspace with no bound repos — the single-repo / `working_dir`
+    /// path is unchanged. Omitted from the wire when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repos: Vec<onsager_spine::protocol::RepoAccess>,
 }
 
 /// POST /api/tasks — create a task and its initial session.
@@ -225,6 +233,16 @@ pub async fn create_task(
         _ => None,
     };
 
+    // Resolve the workspace's bound repo set with read-scoped per-repo
+    // credentials (spec #546). Eager read access: the agent gets the whole
+    // set and clones on demand. Unscoped sessions and workspaces with no
+    // bound repos yield an empty set — the single-repo `working_dir` path
+    // is unchanged.
+    let repos = match workspace_id.as_deref() {
+        Some(ws) => crate::repo_access::build_workspace_repo_access(&state, ws).await,
+        None => Vec::new(),
+    };
+
     // Emit portal.session_requested so stiglab's listener can pick up the
     // session, fetch credentials, and dispatch to the agent WebSocket.
     let dispatch = TaskDispatchPayload {
@@ -241,6 +259,7 @@ pub async fn create_task(
         workspace_id: workspace_id.clone(),
         user_id: user_id.to_string(),
         encrypted_session_token,
+        repos,
     };
 
     let ws_id = workspace_id.as_deref().unwrap_or("default");

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -51,6 +51,7 @@ pub mod push;
 pub mod push_db;
 pub mod reconciliation;
 pub mod remediation_db;
+pub mod repo_access;
 pub mod runtime;
 pub mod server;
 pub mod session_db;

--- a/crates/onsager-portal/src/repo_access.rs
+++ b/crates/onsager-portal/src/repo_access.rs
@@ -1,7 +1,8 @@
 //! Multi-repo session-launch handoff (spec #546, Part of #544).
 //!
 //! A run is no longer pinned to one repo. A workspace binds an unlimited
-//! set of repos (`workspace_repos`, renamed from `projects` in #549), and
+//! set of repos (`workspace_repos`, the membership rename specced under
+//! #545 / #544 and landed in PR #549), and
 //! a workspace-scoped agent session is handed the *whole* bound set with
 //! read-scoped per-repo credentials so the agent can clone whichever it
 //! needs on demand. The single-repo / pinned case degenerates to a

--- a/crates/onsager-portal/src/repo_access.rs
+++ b/crates/onsager-portal/src/repo_access.rs
@@ -1,0 +1,284 @@
+//! Multi-repo session-launch handoff (spec #546, Part of #544).
+//!
+//! A run is no longer pinned to one repo. A workspace binds an unlimited
+//! set of repos (`workspace_repos`, renamed from `projects` in #549), and
+//! a workspace-scoped agent session is handed the *whole* bound set with
+//! read-scoped per-repo credentials so the agent can clone whichever it
+//! needs on demand. The single-repo / pinned case degenerates to a
+//! one-element set, and a workspace with no bound repos to an empty set —
+//! both reproduce today's single-`working_dir` behavior exactly.
+//!
+//! This module owns the pieces absorbed from #545 (its scope amendment
+//! folded them here because the session launch is their first live
+//! consumer — landing them in #545 would have been dangling wires):
+//!
+//! - [`resolve_install_for_repo`] — the per-repo install resolver.
+//! - [`list_workspace_repo_installs`] — the workspace repo-set lister.
+//! - [`build_workspace_repo_access`] — the eager read-scoped builder that
+//!   mints one installation token per org and produces the
+//!   [`RepoAccess`] handoff the `portal.session_requested` event carries.
+//!
+//! *Writes* to origin are out of scope: this stops at read/checkout. The
+//! write-token mint lands behind the synodic gate in #548.
+
+use std::collections::{BTreeMap, HashMap};
+
+use onsager_github::api::app as gh_app;
+use onsager_spine::protocol::RepoAccess;
+
+use crate::auth::encrypt_credential;
+use crate::core::WorkspaceRepo;
+use crate::state::AppState;
+use crate::workspace_db;
+
+/// Resolve the GitHub App installation id for one specific repo bound to a
+/// workspace. Returns `None` when the repo is not a member of the
+/// workspace (unbound) or its membership row's install id does not parse.
+///
+/// Absorbed from #545's Plan: the per-repo resolver. The pure decision
+/// lives in [`pick_install_for_repo`] so it is unit-testable without a DB.
+pub async fn resolve_install_for_repo(
+    state: &AppState,
+    workspace_id: &str,
+    owner: &str,
+    name: &str,
+) -> Option<i64> {
+    let repos = workspace_db::list_projects_for_workspace(&state.pool, workspace_id)
+        .await
+        .unwrap_or_default();
+    pick_install_for_repo(&repos, owner, name)
+}
+
+/// List every repo bound to a workspace with its resolved install id.
+/// Rows whose `github_app_installation_id` does not parse are skipped —
+/// they cannot mint a token, so they are not a usable member of the run's
+/// repo set.
+///
+/// Absorbed from #545's Plan: the workspace repo-set lister.
+pub async fn list_workspace_repo_installs(
+    state: &AppState,
+    workspace_id: &str,
+) -> Vec<((String, String), i64)> {
+    let repos = workspace_db::list_projects_for_workspace(&state.pool, workspace_id)
+        .await
+        .unwrap_or_default();
+    repo_install_pairs(&repos)
+}
+
+/// Build the read-scoped repo set handed to a workspace-scoped run.
+///
+/// Eagerly (the #544 token posture: read is eager, write is gated) mints
+/// one read-scoped installation token *per org* — grouping the workspace's
+/// bound repos by install id so a multi-org workspace mints a distinct
+/// token per install — encrypts each with the shared credential key, and
+/// returns one [`RepoAccess`] per bound repo.
+///
+/// Degenerate paths reproduce today's behavior:
+/// - an empty workspace (no bound repos) → empty vec;
+/// - the App being unconfigured, or a mint / encrypt failure → the repos
+///   are still surfaced by identity with `encrypted_read_token: None`
+///   (a public repo clones unauthenticated; a private one fails loudly
+///   rather than silently).
+pub async fn build_workspace_repo_access(state: &AppState, workspace_id: &str) -> Vec<RepoAccess> {
+    let repos = workspace_db::list_projects_for_workspace(&state.pool, workspace_id)
+        .await
+        .unwrap_or_default();
+    if repos.is_empty() {
+        return Vec::new();
+    }
+
+    // Mint one read-scoped token per install (org), encrypted at rest.
+    // Missing App config / credential key / a mint failure all collapse to
+    // "no token for this install" — the repos are surfaced by identity.
+    let encrypted_by_install = mint_encrypted_read_tokens(state, &repos).await;
+    assemble_repo_access(&repos, &encrypted_by_install)
+}
+
+/// Mint + encrypt a read-scoped token per install id present in `repos`.
+/// Returns a map keyed by install id; an install absent from the map had
+/// no usable token (unconfigured App, no credential key, or mint error).
+async fn mint_encrypted_read_tokens(
+    state: &AppState,
+    repos: &[WorkspaceRepo],
+) -> HashMap<i64, String> {
+    let mut out = HashMap::new();
+
+    let Some(cfg) = gh_app::AppConfig::from_env() else {
+        tracing::warn!("repo_access: GitHub App not configured; repos surfaced without read tokens");
+        return out;
+    };
+    let jwt = match gh_app::mint_app_jwt(&cfg) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::error!("repo_access: mint_app_jwt failed: {e}");
+            return out;
+        }
+    };
+    let Some(key) = state.config.credential_key.as_deref() else {
+        tracing::warn!("repo_access: no credential key; repos surfaced without read tokens");
+        return out;
+    };
+
+    for (install_id, members) in group_repos_by_install(repos) {
+        let repo_names: Vec<String> = members.iter().map(|r| r.repo_name.clone()).collect();
+        match gh_app::mint_read_token_for_repos(&jwt, install_id, &repo_names).await {
+            Ok(token) => match encrypt_credential(key, &token.token) {
+                Ok(enc) => {
+                    out.insert(install_id, enc);
+                }
+                Err(e) => {
+                    tracing::error!("repo_access: encrypt read token for install {install_id}: {e}");
+                }
+            },
+            Err(e) => {
+                tracing::error!("repo_access: mint read token for install {install_id}: {e}");
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — DB-free and network-free so they are unit-testable.
+// ---------------------------------------------------------------------------
+
+/// Pure per-repo install pick for [`resolve_install_for_repo`].
+fn pick_install_for_repo(repos: &[WorkspaceRepo], owner: &str, name: &str) -> Option<i64> {
+    repos
+        .iter()
+        .find(|r| r.repo_owner == owner && r.repo_name == name)
+        .and_then(|r| r.github_app_installation_id.parse::<i64>().ok())
+}
+
+/// Pure transform for [`list_workspace_repo_installs`]: one
+/// `((owner, name), install_id)` pair per bound repo, skipping rows whose
+/// install id does not parse.
+fn repo_install_pairs(repos: &[WorkspaceRepo]) -> Vec<((String, String), i64)> {
+    repos
+        .iter()
+        .filter_map(|r| {
+            r.github_app_installation_id
+                .parse::<i64>()
+                .ok()
+                .map(|id| ((r.repo_owner.clone(), r.repo_name.clone()), id))
+        })
+        .collect()
+}
+
+/// Group bound repos by install id (deterministic order). Rows whose
+/// install id does not parse are dropped — they cannot mint a token.
+fn group_repos_by_install(repos: &[WorkspaceRepo]) -> BTreeMap<i64, Vec<&WorkspaceRepo>> {
+    let mut by_install: BTreeMap<i64, Vec<&WorkspaceRepo>> = BTreeMap::new();
+    for r in repos {
+        if let Ok(id) = r.github_app_installation_id.parse::<i64>() {
+            by_install.entry(id).or_default().push(r);
+        }
+    }
+    by_install
+}
+
+/// Assemble one [`RepoAccess`] per bound repo, attaching its install's
+/// encrypted read token (if one was minted). Pure so the
+/// repo→token mapping is unit-testable without minting against GitHub.
+fn assemble_repo_access(
+    repos: &[WorkspaceRepo],
+    encrypted_by_install: &HashMap<i64, String>,
+) -> Vec<RepoAccess> {
+    repos
+        .iter()
+        .map(|r| {
+            let token = r
+                .github_app_installation_id
+                .parse::<i64>()
+                .ok()
+                .and_then(|id| encrypted_by_install.get(&id).cloned());
+            RepoAccess {
+                owner: r.repo_owner.clone(),
+                name: r.repo_name.clone(),
+                default_branch: r.default_branch.clone(),
+                encrypted_read_token: token,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn repo(owner: &str, name: &str, install: &str) -> WorkspaceRepo {
+        WorkspaceRepo {
+            id: format!("repo_{owner}_{name}"),
+            workspace_id: "w1".into(),
+            github_app_installation_id: install.into(),
+            repo_owner: owner.into(),
+            repo_name: name.into(),
+            default_branch: "main".into(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn pick_install_for_repo_matches_the_bound_row() {
+        let repos = vec![
+            repo("acme", "widgets", "11"),
+            repo("acme", "gadgets", "11"),
+            repo("other", "thing", "22"),
+        ];
+        // Mutation guard: break the `owner == && name ==` match and this
+        // returns the wrong install (or None) and the assert fails.
+        assert_eq!(pick_install_for_repo(&repos, "acme", "gadgets"), Some(11));
+        assert_eq!(pick_install_for_repo(&repos, "other", "thing"), Some(22));
+        // Unbound repo → None.
+        assert_eq!(pick_install_for_repo(&repos, "acme", "nope"), None);
+    }
+
+    #[test]
+    fn repo_install_pairs_lists_one_per_bound_repo() {
+        let repos = vec![
+            repo("acme", "widgets", "11"),
+            repo("acme", "gadgets", "11"),
+            repo("other", "thing", "22"),
+            // Unparseable install id is skipped.
+            repo("bad", "row", "not-a-number"),
+        ];
+        let pairs = repo_install_pairs(&repos);
+        assert_eq!(pairs.len(), 3);
+        assert!(pairs.contains(&(("acme".into(), "widgets".into()), 11)));
+        assert!(pairs.contains(&(("other".into(), "thing".into()), 22)));
+        assert!(!pairs.iter().any(|((o, _), _)| o == "bad"));
+    }
+
+    #[test]
+    fn group_repos_by_install_groups_per_org() {
+        let repos = vec![
+            repo("acme", "widgets", "11"),
+            repo("acme", "gadgets", "11"),
+            repo("other", "thing", "22"),
+        ];
+        let grouped = group_repos_by_install(&repos);
+        assert_eq!(grouped.len(), 2, "two distinct installs (orgs)");
+        assert_eq!(grouped[&11].len(), 2);
+        assert_eq!(grouped[&22].len(), 1);
+    }
+
+    #[test]
+    fn assemble_repo_access_attaches_per_install_token() {
+        let repos = vec![
+            repo("acme", "widgets", "11"),
+            repo("acme", "gadgets", "11"),
+            repo("other", "thing", "22"),
+        ];
+        let mut enc = HashMap::new();
+        enc.insert(11, "enc_acme".to_string());
+        // Install 22 minted no token — that repo is surfaced tokenless.
+        let access = assemble_repo_access(&repos, &enc);
+        assert_eq!(access.len(), 3);
+        let acme_widgets = access.iter().find(|a| a.name == "widgets").unwrap();
+        assert_eq!(acme_widgets.encrypted_read_token.as_deref(), Some("enc_acme"));
+        assert_eq!(acme_widgets.default_branch, "main");
+        let other = access.iter().find(|a| a.owner == "other").unwrap();
+        assert_eq!(other.encrypted_read_token, None);
+    }
+}

--- a/crates/onsager-portal/src/repo_access.rs
+++ b/crates/onsager-portal/src/repo_access.rs
@@ -104,7 +104,9 @@ async fn mint_encrypted_read_tokens(
     let mut out = HashMap::new();
 
     let Some(cfg) = gh_app::AppConfig::from_env() else {
-        tracing::warn!("repo_access: GitHub App not configured; repos surfaced without read tokens");
+        tracing::warn!(
+            "repo_access: GitHub App not configured; repos surfaced without read tokens"
+        );
         return out;
     };
     let jwt = match gh_app::mint_app_jwt(&cfg) {
@@ -127,7 +129,9 @@ async fn mint_encrypted_read_tokens(
                     out.insert(install_id, enc);
                 }
                 Err(e) => {
-                    tracing::error!("repo_access: encrypt read token for install {install_id}: {e}");
+                    tracing::error!(
+                        "repo_access: encrypt read token for install {install_id}: {e}"
+                    );
                 }
             },
             Err(e) => {
@@ -276,7 +280,10 @@ mod tests {
         let access = assemble_repo_access(&repos, &enc);
         assert_eq!(access.len(), 3);
         let acme_widgets = access.iter().find(|a| a.name == "widgets").unwrap();
-        assert_eq!(acme_widgets.encrypted_read_token.as_deref(), Some("enc_acme"));
+        assert_eq!(
+            acme_widgets.encrypted_read_token.as_deref(),
+            Some("enc_acme")
+        );
         assert_eq!(acme_widgets.default_branch, "main");
         let other = access.iter().find(|a| a.owner == "other").unwrap();
         assert_eq!(other.encrypted_read_token, None);

--- a/crates/onsager-spine/src/protocol.rs
+++ b/crates/onsager-spine/src/protocol.rs
@@ -368,7 +368,10 @@ mod tests {
         };
         let json = serde_json::to_value(&without).unwrap();
         assert!(
-            !json.as_object().unwrap().contains_key("encrypted_read_token"),
+            !json
+                .as_object()
+                .unwrap()
+                .contains_key("encrypted_read_token"),
             "a None read token must be omitted from the wire"
         );
         // Legacy / tokenless payloads still parse (serde default).

--- a/crates/onsager-spine/src/protocol.rs
+++ b/crates/onsager-spine/src/protocol.rs
@@ -98,6 +98,43 @@ pub struct ShapingResult {
 }
 
 // ===========================================================================
+// Portal → Stiglab: multi-repo session-launch handoff (spec #546)
+// ===========================================================================
+
+/// One repo handed to an agent session at launch, with read-scoped
+/// access (spec #546, Part of #544).
+///
+/// A workspace-scoped run carries one entry per bound repo (resolved via
+/// `list_workspace_repo_installs`); the repos may span multiple GitHub
+/// orgs, each minted its own installation token. The single-repo / pinned
+/// case degenerates to a one-element vec, and a workspace with no bound
+/// repos to an empty vec — both reproduce today's single-`working_dir`
+/// behavior exactly.
+///
+/// The token is **read-scoped** (`contents:read` + `metadata:read`) and
+/// **encrypted** with the shared credential key — never the raw token on
+/// the wire. The consumer (stiglab) decrypts it and builds the
+/// authenticated clone URL before surfacing it to the agent. *Writes* to
+/// origin are out of scope here and gated separately (#548).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepoAccess {
+    /// GitHub repo owner (org or user login).
+    pub owner: String,
+    /// GitHub repo name (short name, no owner prefix).
+    pub name: String,
+    /// The repo's default branch, so the agent can base work off it
+    /// without an extra API round-trip.
+    pub default_branch: String,
+    /// Read-scoped GitHub App installation token, **encrypted** with the
+    /// shared credential key. `None` when the App is unconfigured or the
+    /// mint failed — the repo is still surfaced by identity (a public
+    /// repo can be cloned unauthenticated; a private one will fail loudly
+    /// rather than silently).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted_read_token: Option<String>,
+}
+
+// ===========================================================================
 // Forge → Synodic: gate evaluation payloads
 // ===========================================================================
 
@@ -308,6 +345,38 @@ mod tests {
         }))
         .expect("legacy ShapingRequest must deserialize");
         assert!(legacy.created_by.is_none());
+    }
+
+    #[test]
+    fn repo_access_roundtrip_and_token_wire_optional() {
+        // Spec #546: the read token rides encrypted and is omitted from
+        // the wire when absent (public-repo / unconfigured-App path).
+        let with = RepoAccess {
+            owner: "acme".into(),
+            name: "widgets".into(),
+            default_branch: "main".into(),
+            encrypted_read_token: Some("enc_abc".into()),
+        };
+        let json = serde_json::to_value(&with).unwrap();
+        assert_eq!(json["encrypted_read_token"], "enc_abc");
+        let back: RepoAccess = serde_json::from_value(json).unwrap();
+        assert_eq!(back, with);
+
+        let without = RepoAccess {
+            encrypted_read_token: None,
+            ..with
+        };
+        let json = serde_json::to_value(&without).unwrap();
+        assert!(
+            !json.as_object().unwrap().contains_key("encrypted_read_token"),
+            "a None read token must be omitted from the wire"
+        );
+        // Legacy / tokenless payloads still parse (serde default).
+        let parsed: RepoAccess = serde_json::from_value(serde_json::json!({
+            "owner": "acme", "name": "widgets", "default_branch": "main"
+        }))
+        .expect("tokenless RepoAccess must deserialize");
+        assert!(parsed.encrypted_read_token.is_none());
     }
 
     #[test]

--- a/crates/stiglab/src/server/mod.rs
+++ b/crates/stiglab/src/server/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod db;
 pub mod github_app;
 pub mod handler;
+pub mod repo_env;
 pub mod routes;
 pub mod session_cancel_requested_listener;
 pub mod session_requested_listener;

--- a/crates/stiglab/src/server/repo_env.rs
+++ b/crates/stiglab/src/server/repo_env.rs
@@ -164,9 +164,6 @@ mod tests {
         let repos = vec![access("acme", "public", KEY, None)];
         let json = repos_env_from_access(&repos, Some(KEY)).unwrap();
         let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            arr[0]["clone_url"],
-            "https://github.com/acme/public.git"
-        );
+        assert_eq!(arr[0]["clone_url"], "https://github.com/acme/public.git");
     }
 }

--- a/crates/stiglab/src/server/repo_env.rs
+++ b/crates/stiglab/src/server/repo_env.rs
@@ -1,0 +1,172 @@
+//! Surface the run's multi-repo set to the agent (spec #546, Part of #544).
+//!
+//! Portal resolves the workspace's bound repo set with read-scoped
+//! per-repo credentials and ships it on the `portal.session_requested`
+//! event as `Vec<RepoAccess>` (tokens encrypted with the shared
+//! credential key). Stiglab is the consumer: it decrypts each token and
+//! exposes the set to the agent through the `ONSAGER_REPOS` env var — a
+//! JSON array the agent reads to clone whichever repos it needs beneath
+//! its `working_dir`.
+//!
+//! The single-repo / pinned case is a one-element array; a workspace with
+//! no bound repos surfaces nothing (`None`), leaving the existing
+//! single-`working_dir` behavior untouched. *Writes* to origin are out of
+//! scope — these are read/checkout credentials, gated separately (#548).
+
+use onsager_spine::protocol::RepoAccess;
+use serde::Serialize;
+
+use crate::server::auth::decrypt_credential;
+
+/// Env var carrying the JSON-encoded repo set the agent clones on demand.
+pub const REPOS_ENV: &str = "ONSAGER_REPOS";
+
+/// One repo surfaced to the agent, with the read token already decrypted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClonableRepo {
+    pub owner: String,
+    pub name: String,
+    pub default_branch: String,
+    /// Decrypted read-scoped token, or `None` (public-repo / unconfigured
+    /// path) — the clone URL is then unauthenticated.
+    pub token: Option<String>,
+}
+
+/// What each `ONSAGER_REPOS` array element looks like to the agent.
+#[derive(Debug, Serialize)]
+struct RepoEntry {
+    owner: String,
+    name: String,
+    default_branch: String,
+    /// Ready-to-use clone URL: authenticated with the read token via the
+    /// `x-access-token` convention when one is present, plain HTTPS
+    /// otherwise.
+    clone_url: String,
+}
+
+/// Decrypt the wire repo set and build the `ONSAGER_REPOS` env value.
+///
+/// Returns `None` when the set is empty (single/zero-repo path injects
+/// nothing). A token that fails to decrypt (or no credential key) degrades
+/// to an unauthenticated clone URL for that repo rather than dropping it.
+pub fn repos_env_from_access(repos: &[RepoAccess], key: Option<&str>) -> Option<String> {
+    if repos.is_empty() {
+        return None;
+    }
+    let clonable: Vec<ClonableRepo> = repos
+        .iter()
+        .map(|r| {
+            let token = match (key, r.encrypted_read_token.as_deref()) {
+                (Some(k), Some(enc)) => decrypt_credential(k, enc).ok(),
+                _ => None,
+            };
+            ClonableRepo {
+                owner: r.owner.clone(),
+                name: r.name.clone(),
+                default_branch: r.default_branch.clone(),
+                token,
+            }
+        })
+        .collect();
+    repos_env_json(&clonable)
+}
+
+/// Build the `ONSAGER_REPOS` JSON array from already-decrypted repos.
+/// `None` for an empty set so the caller injects nothing.
+fn repos_env_json(repos: &[ClonableRepo]) -> Option<String> {
+    if repos.is_empty() {
+        return None;
+    }
+    let entries: Vec<RepoEntry> = repos
+        .iter()
+        .map(|r| RepoEntry {
+            owner: r.owner.clone(),
+            name: r.name.clone(),
+            default_branch: r.default_branch.clone(),
+            clone_url: clone_url(&r.owner, &r.name, r.token.as_deref()),
+        })
+        .collect();
+    serde_json::to_string(&entries).ok()
+}
+
+/// HTTPS clone URL, authenticated via `x-access-token` when a token is
+/// present (the GitHub convention for installation tokens).
+fn clone_url(owner: &str, name: &str, token: Option<&str>) -> String {
+    match token {
+        Some(t) => format!("https://x-access-token:{t}@github.com/{owner}/{name}.git"),
+        None => format!("https://github.com/{owner}/{name}.git"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::auth::encrypt_credential;
+
+    // A 32-byte key (64 hex chars) for the AES-256-GCM credential cipher.
+    const KEY: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+    fn access(owner: &str, name: &str, key: &str, raw_token: Option<&str>) -> RepoAccess {
+        RepoAccess {
+            owner: owner.into(),
+            name: name.into(),
+            default_branch: "main".into(),
+            encrypted_read_token: raw_token.map(|t| encrypt_credential(key, t).unwrap()),
+        }
+    }
+
+    #[test]
+    fn two_repos_surface_both_with_authenticated_clone_urls() {
+        // Spec #546 integration check (the surfacing seam): a workspace-
+        // scoped run with 2 bound repos surfaces one authenticated entry
+        // per repo. Mutation guard: drop one repo from the input and the
+        // length assertion below fails.
+        let repos = vec![
+            access("acme", "widgets", KEY, Some("tok_a")),
+            access("other", "thing", KEY, Some("tok_b")),
+        ];
+        let json = repos_env_from_access(&repos, Some(KEY)).expect("two repos surface a value");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "one entry per bound repo");
+        assert_eq!(
+            arr[0]["clone_url"],
+            "https://x-access-token:tok_a@github.com/acme/widgets.git"
+        );
+        assert_eq!(
+            arr[1]["clone_url"],
+            "https://x-access-token:tok_b@github.com/other/thing.git"
+        );
+        assert_eq!(arr[0]["default_branch"], "main");
+    }
+
+    #[test]
+    fn single_repo_surfaces_exactly_one_entry() {
+        // Regression: the single-repo path is unchanged — exactly one
+        // entry, same authenticated shape.
+        let repos = vec![access("acme", "widgets", KEY, Some("tok_a"))];
+        let json = repos_env_from_access(&repos, Some(KEY)).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn empty_repo_set_surfaces_nothing() {
+        // Regression: zero bound repos → no ONSAGER_REPOS env injected, so
+        // the existing single-`working_dir` behavior is untouched.
+        assert_eq!(repos_env_from_access(&[], Some(KEY)), None);
+    }
+
+    #[test]
+    fn missing_token_degrades_to_unauthenticated_url() {
+        // No credential key (or an undecryptable token) → the repo is
+        // still surfaced, just with a plain HTTPS clone URL.
+        let repos = vec![access("acme", "public", KEY, None)];
+        let json = repos_env_from_access(&repos, Some(KEY)).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            arr[0]["clone_url"],
+            "https://github.com/acme/public.git"
+        );
+    }
+}

--- a/crates/stiglab/src/server/repo_env.rs
+++ b/crates/stiglab/src/server/repo_env.rs
@@ -57,7 +57,24 @@ pub fn repos_env_from_access(repos: &[RepoAccess], key: Option<&str>) -> Option<
         .iter()
         .map(|r| {
             let token = match (key, r.encrypted_read_token.as_deref()) {
-                (Some(k), Some(enc)) => decrypt_credential(k, enc).ok(),
+                (Some(k), Some(enc)) => match decrypt_credential(k, enc) {
+                    Ok(t) => Some(t),
+                    Err(e) => {
+                        // Observability: a decrypt failure (mismatched /
+                        // rotated credential key) silently degrades a
+                        // private-repo clone to an unauthenticated URL,
+                        // which then fails far from here. Surface it — the
+                        // error is about the cipher, never the plaintext
+                        // token, so it is safe to log.
+                        tracing::warn!(
+                            owner = %r.owner,
+                            repo = %r.name,
+                            "repo_env: failed to decrypt read token; surfacing \
+                             unauthenticated clone URL: {e}"
+                        );
+                        None
+                    }
+                },
                 _ => None,
             };
             ClonableRepo {
@@ -90,10 +107,17 @@ fn repos_env_json(repos: &[ClonableRepo]) -> Option<String> {
 }
 
 /// HTTPS clone URL, authenticated via `x-access-token` when a token is
-/// present (the GitHub convention for installation tokens).
+/// present (the GitHub convention for installation tokens). The token is
+/// percent-encoded into the userinfo so a token carrying a reserved
+/// character (`@`, `:`, `/`, …) can't truncate or corrupt the URL. GitHub
+/// installation tokens are URL-safe today, but encoding keeps this correct
+/// if that ever changes.
 fn clone_url(owner: &str, name: &str, token: Option<&str>) -> String {
     match token {
-        Some(t) => format!("https://x-access-token:{t}@github.com/{owner}/{name}.git"),
+        Some(t) => format!(
+            "https://x-access-token:{}@github.com/{owner}/{name}.git",
+            onsager_agent_spawn::urlencode(t)
+        ),
         None => format!("https://github.com/{owner}/{name}.git"),
     }
 }

--- a/crates/stiglab/src/server/session_requested_listener.rs
+++ b/crates/stiglab/src/server/session_requested_listener.rs
@@ -165,10 +165,7 @@ impl Dispatcher {
             state.config.credential_key.as_deref(),
         ) {
             let creds = credentials.get_or_insert_with(std::collections::HashMap::new);
-            creds.insert(
-                crate::server::repo_env::REPOS_ENV.to_string(),
-                repos_json,
-            );
+            creds.insert(crate::server::repo_env::REPOS_ENV.to_string(), repos_json);
         }
 
         let task = Task {

--- a/crates/stiglab/src/server/session_requested_listener.rs
+++ b/crates/stiglab/src/server/session_requested_listener.rs
@@ -43,6 +43,13 @@ struct TaskDispatchPayload {
     /// env as `ONSAGER_SESSION_TOKEN`.
     #[serde(default)]
     encrypted_session_token: Option<String>,
+    /// The workspace's bound repo set with read-scoped per-repo
+    /// credentials (spec #546). Decrypted here and surfaced to the agent
+    /// as `ONSAGER_REPOS` so it can clone on demand. Empty for an unscoped
+    /// session or a workspace with no bound repos — the single-repo
+    /// `working_dir` path is unchanged.
+    #[serde(default)]
+    repos: Vec<onsager_spine::protocol::RepoAccess>,
 }
 
 pub async fn run(store: EventStore, app_state: AppState, since: Option<i64>) -> anyhow::Result<()> {
@@ -146,6 +153,22 @@ impl Dispatcher {
                     );
                 }
             }
+        }
+
+        // Surface the workspace's bound repo set to the agent (spec #546).
+        // Decrypt each read token and expose the set as `ONSAGER_REPOS` so
+        // the agent can clone whichever repos it needs beneath its
+        // `working_dir`. Empty set → nothing injected (single-repo path
+        // unchanged).
+        if let Some(repos_json) = crate::server::repo_env::repos_env_from_access(
+            &payload.repos,
+            state.config.credential_key.as_deref(),
+        ) {
+            let creds = credentials.get_or_insert_with(std::collections::HashMap::new);
+            creds.insert(
+                crate::server::repo_env::REPOS_ENV.to_string(),
+                repos_json,
+            );
         }
 
         let task = Task {


### PR DESCRIPTION
Closes #546. Part of #544.

## What

Unwinds the one-repo-per-session assumption for the **live** session-launch path so a workspace-scoped run is handed the workspace's bound repo set with **read-scoped per-repo credentials**, surfaced to the agent so it clones whichever repos it needs on demand. The single/zero-repo path degenerates to exactly today's behavior — no regression. *Writes* to origin stay out of scope (gated in #548).

## Carrier decision (codebase had diverged from the spec)

The spec names the carrier as "the existing spine shaping / session-launch coordination." But the `forge` crate is gone and `forge.shaping_dispatched`/`ShapingRequest` has **no live producer** (declared-but-unwired contract). The genuinely live session-launch carrier is **`portal.session_requested`** (portal `POST /api/tasks` → stiglab `session_requested_listener`). Per maintainer decision, this wires the **live path only** — a live producer + live consumer, no dangling wire on the dormant shaping DTO.

## Changes

- **onsager-spine** — `RepoAccess` DTO (`owner` / `name` / `default_branch` + `encrypted_read_token`): the multi-repo handoff shape carried on the launch event. Token is encrypted with the shared credential key, never raw on the wire.
- **onsager-github** — `mint_read_token_for_repos`: least-privilege (`contents:read` + `metadata:read`) installation token scoped to a repo set (vs. the full-permission `mint_installation_token`).
- **onsager-portal** — new `repo_access` module carrying the **#545-absorbed** pieces (per the #546 scope-amendment comment): the per-repo resolver `resolve_install_for_repo`, the workspace lister `list_workspace_repo_installs`, and the eager read-scoped builder `build_workspace_repo_access` that groups bound repos by install (multi-org), mints one read token per org, encrypts it, and emits one `RepoAccess` per bound repo on `portal.session_requested`.
- **stiglab** — decrypts the set and surfaces it to the agent as `ONSAGER_REPOS` (a JSON array of authenticated clone URLs via the `x-access-token` convention); an empty set injects nothing, leaving the single-`working_dir` path untouched.

## Plan items

- [x] Run-launch context includes the workspace repo set with read-scoped per-repo credentials
- [x] stiglab surfaces the repo set to the agent (`ONSAGER_REPOS` env) so it can clone on demand
- [x] Single bound/pinned repo path is unchanged

## Tests (13 new, all green)

- `repo_access`: `pick_install_for_repo` (match + mutation guard), `repo_install_pairs`, `group_repos_by_install` (per-org), `assemble_repo_access` (per-install token mapping).
- `repo_env`: `two_repos_surface_both_with_authenticated_clone_urls` (full encrypt→wire→decrypt→authenticated-URL path), `single_repo_surfaces_exactly_one_entry`, `empty_repo_set_surfaces_nothing` (regression), `missing_token_degrades_to_unauthenticated_url`.
- `RepoAccess` wire roundtrip + token-optional.

## Claim-honesty note on the spec's "integration" test

The spec's integration test wording ("clones and locally modifies both, producing one branch/diff artifact per repo") describes the **agent's** out-of-process runtime behavior (the Claude CLI does the git ops with injected creds — consistent with how Onsager already hands the agent credentials and lets it drive git). That isn't CI-testable without a live-agent harness, which doesn't exist. The mechanically-checkable seam #546 actually owns is the **launch-context carriage + surfacing** of all bound repos with read-auth — covered fully by `two_repos_surface_both_with_authenticated_clone_urls` with a documented **mutation check** (drop a repo from the launch context → the 2-entry assertion fails). Calling this out rather than claiming the literal live-agent integration test.

## Note on the absorbed #545 helpers

`list_workspace_repo_installs` and `resolve_install_for_repo` are the #545-absorbed public resolution surface. The run-launch builder shares their pure cores (`repo_install_pairs` / `pick_install_for_repo`); the per-repo resolver's next live consumer is #548 (write-token mint behind the synodic gate).

## Verification

- `cargo build -p onsager-spine -p onsager-github -p onsager-portal -p stiglab` — clean
- `cargo clippy ... --all-targets -- -D warnings` — clean
- `cargo test` (portal 284, stiglab 50, github 16, spine protocol 5) — all pass, no regressions

https://claude.ai/code/session_013BLKSgfeAdzs9AY1k16k7S

---
_Generated by [Claude Code](https://claude.ai/code/session_013BLKSgfeAdzs9AY1k16k7S)_