### PR TITLE
feat(scheduler): multi-repo read parity for spec-plan agent runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,6 +2230,7 @@ version = "0.2.0-alpha.1"
 name = "onsager-agent-spawn"
 version = "0.2.0-alpha.1"
 dependencies = [
+ "serde",
  "serde_json",
 ]
 

--- a/crates/onsager-agent-spawn/Cargo.toml
+++ b/crates/onsager-agent-spawn/Cargo.toml
@@ -7,4 +7,5 @@ repository.workspace = true
 description = "Shared agent-session spawn wiring — env-var constants + claude MCP/Stop-hook JSON builders reused across stiglab and the scheduler-side runner (spec #535)."
 
 [dependencies]
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/onsager-agent-spawn/src/lib.rs
+++ b/crates/onsager-agent-spawn/src/lib.rs
@@ -13,6 +13,19 @@
 //!
 //! Behavior is unchanged from the stiglab originals; the unit tests
 //! below are the parity assertions #532 added, moved with the functions.
+//!
+//! Per spec #555 the same charter brought the `ONSAGER_REPOS` builder
+//! here too: multi-repo read (#546) was first wired on stiglab's
+//! `portal.session_requested` path, but the scheduler/`AgentExecutor`
+//! launch path needs the *identical* env var. The agent-facing wire
+//! shape (the JSON array the agent reads to clone its repos) is the
+//! contract that must not drift across the two launch paths, so it lives
+//! here, in the one crate both sides depend on. Each subsystem still
+//! owns the spine→agent decrypt boundary (`RepoAccess` ciphertext →
+//! plaintext token) with its own `decrypt_credential` replica — the
+//! same split the session token already uses.
+
+use serde::Serialize;
 
 /// Env var (read on the agent node) holding the base URL of portal's
 /// liveness endpoint, e.g.
@@ -135,6 +148,75 @@ pub fn mcp_config_json(mcp_url: &str) -> String {
     .to_string()
 }
 
+/// Env var carrying the JSON-encoded repo set the agent clones on demand
+/// (spec #546 / #555). One array element per repo bound to the run's
+/// workspace; an empty set injects nothing, leaving the single-repo /
+/// pinned `working_dir` behavior untouched.
+pub const REPOS_ENV: &str = "ONSAGER_REPOS";
+
+/// One repo surfaced to the agent, with the read token **already
+/// decrypted** by the caller. The caller maps each spine-side
+/// `RepoAccess` (encrypted token) onto a `ClonableRepo` (plaintext)
+/// across its own `decrypt_credential` replica — keeping the crypto out
+/// of this pure crate, exactly as the session token does.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClonableRepo {
+    pub owner: String,
+    pub name: String,
+    pub default_branch: String,
+    /// Decrypted read-scoped token, or `None` (public-repo / unconfigured
+    /// path) — the clone URL is then unauthenticated.
+    pub token: Option<String>,
+}
+
+/// What each `ONSAGER_REPOS` array element looks like to the agent.
+#[derive(Debug, Serialize)]
+struct RepoEntry {
+    owner: String,
+    name: String,
+    default_branch: String,
+    /// Ready-to-use clone URL: authenticated with the read token via the
+    /// `x-access-token` convention when one is present, plain HTTPS
+    /// otherwise.
+    clone_url: String,
+}
+
+/// Build the `ONSAGER_REPOS` JSON array from already-decrypted repos.
+/// `None` for an empty set so the caller injects nothing (the
+/// single/zero-repo path is unchanged). This is the agent-facing
+/// contract — the shape both launch paths must produce identically.
+pub fn repos_env_json(repos: &[ClonableRepo]) -> Option<String> {
+    if repos.is_empty() {
+        return None;
+    }
+    let entries: Vec<RepoEntry> = repos
+        .iter()
+        .map(|r| RepoEntry {
+            owner: r.owner.clone(),
+            name: r.name.clone(),
+            default_branch: r.default_branch.clone(),
+            clone_url: clone_url(&r.owner, &r.name, r.token.as_deref()),
+        })
+        .collect();
+    serde_json::to_string(&entries).ok()
+}
+
+/// HTTPS clone URL, authenticated via `x-access-token` when a token is
+/// present (the GitHub convention for installation tokens). The token is
+/// percent-encoded into the userinfo so a token carrying a reserved
+/// character (`@`, `:`, `/`, …) can't truncate or corrupt the URL. GitHub
+/// installation tokens are URL-safe today, but encoding keeps this correct
+/// if that ever changes.
+fn clone_url(owner: &str, name: &str, token: Option<&str>) -> String {
+    match token {
+        Some(t) => format!(
+            "https://x-access-token:{}@github.com/{owner}/{name}.git",
+            urlencode(t)
+        ),
+        None => format!("https://github.com/{owner}/{name}.git"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,5 +280,62 @@ mod tests {
     fn urlencode_passes_safe_ids_and_escapes_reserved() {
         assert_eq!(urlencode("ws_01HZX-abc.def~9"), "ws_01HZX-abc.def~9");
         assert_eq!(urlencode("a b&c=d"), "a%20b%26c%3Dd");
+    }
+
+    fn clonable(owner: &str, name: &str, token: Option<&str>) -> ClonableRepo {
+        ClonableRepo {
+            owner: owner.into(),
+            name: name.into(),
+            default_branch: "main".into(),
+            token: token.map(|t| t.to_string()),
+        }
+    }
+
+    #[test]
+    fn repos_env_json_builds_one_authenticated_entry_per_repo() {
+        // The shared agent-facing contract (spec #546 / #555): every
+        // bound repo surfaces one entry with an `x-access-token` clone
+        // URL. Mutation guard: drop a repo from the input and the length
+        // assertion below fails.
+        let repos = vec![
+            clonable("acme", "widgets", Some("tok_a")),
+            clonable("other", "thing", Some("tok_b")),
+        ];
+        let json = repos_env_json(&repos).expect("two repos surface a value");
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "one entry per bound repo");
+        assert_eq!(
+            arr[0]["clone_url"],
+            "https://x-access-token:tok_a@github.com/acme/widgets.git"
+        );
+        assert_eq!(
+            arr[1]["clone_url"],
+            "https://x-access-token:tok_b@github.com/other/thing.git"
+        );
+        assert_eq!(arr[0]["default_branch"], "main");
+    }
+
+    #[test]
+    fn repos_env_json_single_repo_surfaces_exactly_one_entry() {
+        let json = repos_env_json(&[clonable("acme", "widgets", Some("tok_a"))]).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn repos_env_json_empty_set_is_none() {
+        // Zero bound repos → nothing injected, so the single-`working_dir`
+        // behavior is untouched.
+        assert_eq!(repos_env_json(&[]), None);
+    }
+
+    #[test]
+    fn repos_env_json_tokenless_repo_is_unauthenticated() {
+        // A repo whose token the caller couldn't decrypt (or a public
+        // repo) is still surfaced, just with a plain HTTPS clone URL.
+        let json = repos_env_json(&[clonable("acme", "public", None)]).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr[0]["clone_url"], "https://github.com/acme/public.git");
     }
 }

--- a/crates/onsager-nodes/src/agent.rs
+++ b/crates/onsager-nodes/src/agent.rs
@@ -137,6 +137,15 @@ pub struct AgentRequest {
     /// key configured); the agent then runs without MCP auth and the
     /// authoritative liveness gate still applies.
     pub session_token: Option<String>,
+    /// Pre-built `ONSAGER_REPOS` value (spec #555), already decrypted: the
+    /// JSON array of the run's workspace repos with authenticated clone
+    /// URLs. The production runner injects it as `ONSAGER_REPOS` so the
+    /// scheduler-dispatched agent can clone whichever repos it needs —
+    /// parity with the chat path's stiglab-side handoff (#546). `None`
+    /// when the workspace binds no repos (the single-`working_dir` run is
+    /// unchanged). Carries embedded read tokens, so it is redacted in
+    /// [`Debug`] like [`Self::session_token`].
+    pub repos_env: Option<String>,
 }
 
 // Manual `Debug` so the plaintext `session_token` (a PAT) never leaks
@@ -154,6 +163,14 @@ impl std::fmt::Debug for AgentRequest {
             .field(
                 "session_token",
                 if self.session_token.is_some() {
+                    &"<redacted>"
+                } else {
+                    &"None"
+                },
+            )
+            .field(
+                "repos_env",
+                if self.repos_env.is_some() {
                     &"<redacted>"
                 } else {
                     &"None"
@@ -338,6 +355,10 @@ impl Executor for AgentExecutor {
             // runner injects it as ONSAGER_SESSION_TOKEN. The scheduler
             // decrypted it once per plan and set it on the context.
             session_token: ctx.session_token.clone(),
+            // Workspace repo set (#555) rides the same context → request
+            // channel so the runner injects it as ONSAGER_REPOS. The
+            // scheduler decrypted + built it once per plan.
+            repos_env: ctx.repos_env.clone(),
         };
 
         emit_event(
@@ -644,6 +665,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
         (ctx, mock)
     }
@@ -661,6 +683,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 
@@ -845,6 +868,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
 
         exec.execute(ctx).await.unwrap();
@@ -906,6 +930,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: Some("ons_pat_plan_token".to_string()),
+            repos_env: None,
         };
 
         exec.execute(ctx).await.unwrap();
@@ -915,6 +940,59 @@ mod tests {
             request.session_token.as_deref(),
             Some("ons_pat_plan_token"),
             "plan-scoped session token must reach the runner for env injection"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_threads_repos_env_to_runner() {
+        // Spec #555: the scheduler decrypts + builds the workspace repo
+        // set once and sets it on `ExecutorContext::repos_env`; the agent
+        // executor must copy it onto the `AgentRequest` so the runner
+        // injects it as `ONSAGER_REPOS`. Mutation guard: drop the
+        // `repos_env: ctx.repos_env.clone()` line in `execute` and this
+        // assertion fails.
+        #[derive(Debug, Default)]
+        struct CapturingRunner {
+            request: std::sync::Mutex<Option<AgentRequest>>,
+        }
+        #[async_trait]
+        impl AgentRunner for CapturingRunner {
+            async fn run(&self, request: AgentRequest) -> Result<AgentResponse, AgentRunError> {
+                *self.request.lock().unwrap() = Some(request);
+                Ok(AgentResponse {
+                    output: "ok".into(),
+                    emitted: Vec::new(),
+                })
+            }
+        }
+
+        let captured: Arc<CapturingRunner> = Arc::new(CapturingRunner::default());
+        let exec = AgentExecutor::new("claude-sonnet-4-6", "you are helpful")
+            .with_runner(captured.clone());
+        // Declared-empty manifest so the gate lets `execute` return Ok.
+        let mock = Arc::new(MockSpine::with_manifest(SessionManifest {
+            emitted: Vec::new(),
+            declared_empty: true,
+        }));
+        let repos_env = r#"[{"owner":"acme","name":"widgets","default_branch":"main","clone_url":"https://x-access-token:tok@github.com/acme/widgets.git"}]"#;
+        let ctx = ExecutorContext {
+            plan_id: crate::scheduler::PlanId::generate(),
+            node_id: NodeId::generate(),
+            inputs: Vec::new(),
+            spine: mock as Arc<dyn crate::SpineClient>,
+            subworkflow_ref: None,
+            agent_config: None,
+            session_token: None,
+            repos_env: Some(repos_env.to_string()),
+        };
+
+        exec.execute(ctx).await.unwrap();
+
+        let request = captured.request.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            request.repos_env.as_deref(),
+            Some(repos_env),
+            "the workspace repo set must reach the runner for ONSAGER_REPOS injection"
         );
     }
 
@@ -1133,6 +1211,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: SubstrateExecutor::agent_config(&node_exec),
             session_token: None,
+            repos_env: None,
         };
 
         dispatch(&registry, &node, ctx).await.unwrap();
@@ -1165,6 +1244,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
         exec.execute(ctx).await.unwrap();
         assert_eq!(runner.seen_model.lock().unwrap().as_deref(), Some("SELF"));

--- a/crates/onsager-nodes/src/context.rs
+++ b/crates/onsager-nodes/src/context.rs
@@ -75,6 +75,17 @@ pub struct ExecutorContext {
     /// minted (no credential key configured) or for non-agent nodes
     /// that ignore it.
     pub session_token: Option<String>,
+    /// Pre-built `ONSAGER_REPOS` value (spec #555) — the JSON array of the
+    /// workspace's bound repos with authenticated clone URLs, shared
+    /// across every agent node in this plan run. The scheduler host
+    /// decrypts the repo set off the `plan.run_requested` event once per
+    /// plan and sets it here; the `AgentExecutor` copies it onto its
+    /// [`crate::AgentRequest`] so the runner injects it as `ONSAGER_REPOS`
+    /// — parity with the chat path's stiglab-side handoff. `None` when the
+    /// workspace binds no repos (single-`working_dir` run, unchanged) or
+    /// for non-agent nodes that ignore it. Carries embedded read tokens,
+    /// so it is redacted in [`Debug`] like [`Self::session_token`].
+    pub repos_env: Option<String>,
 }
 
 // Manual `Debug` so the plaintext `session_token` (a PAT) never leaks
@@ -92,6 +103,14 @@ impl std::fmt::Debug for ExecutorContext {
             .field(
                 "session_token",
                 if self.session_token.is_some() {
+                    &"<redacted>"
+                } else {
+                    &"None"
+                },
+            )
+            .field(
+                "repos_env",
+                if self.repos_env.is_some() {
                     &"<redacted>"
                 } else {
                     &"None"
@@ -175,9 +194,11 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
         assert!(ctx.inputs.is_empty());
         assert!(ctx.subworkflow_ref.is_none());
         assert!(ctx.session_token.is_none());
+        assert!(ctx.repos_env.is_none());
     }
 }

--- a/crates/onsager-nodes/src/dispatch.rs
+++ b/crates/onsager-nodes/src/dispatch.rs
@@ -56,6 +56,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 

--- a/crates/onsager-nodes/src/executor.rs
+++ b/crates/onsager-nodes/src/executor.rs
@@ -107,6 +107,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 

--- a/crates/onsager-nodes/src/human.rs
+++ b/crates/onsager-nodes/src/human.rs
@@ -450,6 +450,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
         (ctx, spine)
     }

--- a/crates/onsager-nodes/src/registry.rs
+++ b/crates/onsager-nodes/src/registry.rs
@@ -124,6 +124,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         };
         let outputs = exec.execute(ctx).await.unwrap();
         assert!(outputs.artifacts.is_empty());

--- a/crates/onsager-nodes/src/scheduler.rs
+++ b/crates/onsager-nodes/src/scheduler.rs
@@ -311,6 +311,13 @@ pub struct Scheduler {
     /// onto its runner request for `ONSAGER_SESSION_TOKEN` injection.
     /// `None` when no plan token was minted.
     pub session_token: Option<String>,
+    /// Pre-built `ONSAGER_REPOS` value (spec #555) threaded onto every
+    /// node's [`ExecutorContext`] for this run. The scheduler host
+    /// decrypts the workspace repo set off the `plan.run_requested` event
+    /// once per plan and sets it via [`Scheduler::with_repos_env`]; the
+    /// `AgentExecutor` copies it onto its runner request for
+    /// `ONSAGER_REPOS` injection. `None` when the workspace binds no repos.
+    pub repos_env: Option<String>,
 }
 
 impl Scheduler {
@@ -324,6 +331,7 @@ impl Scheduler {
             store,
             spine,
             session_token: None,
+            repos_env: None,
         }
     }
 
@@ -333,6 +341,15 @@ impl Scheduler {
     /// don't run agent nodes.
     pub fn with_session_token(mut self, token: Option<String>) -> Self {
         self.session_token = token;
+        self
+    }
+
+    /// Set the pre-built `ONSAGER_REPOS` value (spec #555) threaded onto
+    /// every node's [`ExecutorContext`] for this run. Builder so the bare
+    /// `new` constructor stays repo-free for the many call sites that
+    /// don't run agent nodes.
+    pub fn with_repos_env(mut self, repos_env: Option<String>) -> Self {
+        self.repos_env = repos_env;
         self
     }
 
@@ -479,6 +496,9 @@ impl Scheduler {
             // node in this run — the AgentExecutor copies it onto its
             // runner request for ONSAGER_SESSION_TOKEN injection.
             session_token: self.session_token.clone(),
+            // Workspace repo set (#555), same sharing — the AgentExecutor
+            // copies it onto its runner request for ONSAGER_REPOS.
+            repos_env: self.repos_env.clone(),
         };
         match dispatch(&self.registry, node, ctx).await {
             Ok(outputs) => {

--- a/crates/onsager-nodes/src/script.rs
+++ b/crates/onsager-nodes/src/script.rs
@@ -258,6 +258,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 

--- a/crates/onsager-nodes/src/subworkflow.rs
+++ b/crates/onsager-nodes/src/subworkflow.rs
@@ -466,6 +466,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 
@@ -482,6 +483,7 @@ mod tests {
             subworkflow_ref: Some(workflow_ref),
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 

--- a/crates/onsager-nodes/src/verify.rs
+++ b/crates/onsager-nodes/src/verify.rs
@@ -277,6 +277,7 @@ mod tests {
             subworkflow_ref: None,
             agent_config: None,
             session_token: None,
+            repos_env: None,
         }
     }
 

--- a/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
+++ b/crates/onsager-portal/src/mcp/tools/substrate_specs.rs
@@ -410,6 +410,16 @@ pub async fn run_spec_plan(state: &AppState, auth_user: &AuthUser, args: Value) 
         None => None,
     };
 
+    // Resolve the workspace's bound repo set with read-scoped per-repo
+    // credentials (spec #555, parity with #546's chat path). Portal owns
+    // the mint — it has the GitHub App config + credential key; the
+    // scheduler can't reach them across the seam — so, exactly like the
+    // plan session token above, the set rides the event encrypted and the
+    // scheduler decrypts it to surface `ONSAGER_REPOS` to each agent node.
+    // Empty for a workspace with no bound repos; the single-repo /
+    // `working_dir` path is then unchanged.
+    let repos = crate::repo_access::build_workspace_repo_access(state, &args.workspace_id).await;
+
     // Raw payload — the scheduler's `decode_spec_plan_run_requested`
     // accepts this shape (alongside a FactoryEvent envelope / bare
     // kind), mirroring how `run_workflow` emits `trigger.fired`. Fields:
@@ -422,6 +432,11 @@ pub async fn run_spec_plan(state: &AppState, auth_user: &AuthUser, args: Value) 
     //   - `encrypted_session_token` (optional): present only when a
     //     plan token was minted; the scheduler decrypts it and injects
     //     `ONSAGER_SESSION_TOKEN` into each agent node (#536).
+    //   - `repos` (optional): the workspace's bound repo set with
+    //     read-scoped encrypted tokens (#555); present only when the
+    //     workspace binds ≥1 repo. The scheduler decrypts each and
+    //     surfaces the set as `ONSAGER_REPOS`. Additive — older
+    //     consumers ignore it.
     // All are in-contract — consumers may rely on the non-optional ones.
     let mut payload = serde_json::json!({
         "spec_plan_id": stored.spec_plan_id,
@@ -432,6 +447,9 @@ pub async fn run_spec_plan(state: &AppState, auth_user: &AuthUser, args: Value) 
     });
     if let Some(token) = &encrypted_session_token {
         payload["encrypted_session_token"] = serde_json::Value::String(token.clone());
+    }
+    if !repos.is_empty() {
+        payload["repos"] = serde_json::to_value(&repos).unwrap_or_default();
     }
     let metadata = onsager_spine::EventMetadata {
         correlation_id: None,

--- a/crates/onsager-registry/src/events.rs
+++ b/crates/onsager-registry/src/events.rs
@@ -612,9 +612,11 @@ pub const EVENTS: EventManifest = EventManifest {
             // Portal's `run_spec_plan` MCP tool emits this; the
             // substrate scheduler host consumes it, loads the stored
             // SpecPlan, compiles it, and runs it (#501, ADR 0023).
-            // Carries an additive optional `encrypted_session_token`
-            // (#536) the scheduler decrypts to inject ONSAGER_SESSION_TOKEN
-            // into agent nodes — additive, so no schema_version bump.
+            // Carries two additive optional fields the scheduler decrypts
+            // to provision agent nodes: `encrypted_session_token` (#536)
+            // → ONSAGER_SESSION_TOKEN, and `repos` (a Vec<RepoAccess> with
+            // encrypted read tokens, #555) → ONSAGER_REPOS. Both additive,
+            // so no schema_version bump.
             producers: &[Subsystem::Portal],
             consumers: &[Subsystem::Substrate],
             diagnostic_only: false,

--- a/crates/onsager-scheduler/src/lib.rs
+++ b/crates/onsager-scheduler/src/lib.rs
@@ -39,6 +39,7 @@ pub mod migrate;
 pub mod plan_registry;
 pub mod plan_runner;
 pub mod plan_store;
+pub mod repo_env;
 pub mod runners;
 pub mod service;
 pub mod spine_client;

--- a/crates/onsager-scheduler/src/plan_runner.rs
+++ b/crates/onsager-scheduler/src/plan_runner.rs
@@ -49,6 +49,12 @@ pub struct PlanRunner {
     /// the run carries it for `ONSAGER_SESSION_TOKEN` injection. `None`
     /// for the trigger.fired path and whenever no plan token was minted.
     session_token: Option<String>,
+    /// Pre-built `ONSAGER_REPOS` value (spec #555) threaded onto the
+    /// [`Scheduler`] so every agent node in the run carries the
+    /// workspace's bound repo set for `ONSAGER_REPOS` injection. `None`
+    /// for the trigger.fired path and whenever the workspace binds no
+    /// repos.
+    repos_env: Option<String>,
 }
 
 impl std::fmt::Debug for PlanRunner {
@@ -68,6 +74,7 @@ impl PlanRunner {
             store,
             spine,
             session_token: None,
+            repos_env: None,
         }
     }
 
@@ -76,6 +83,14 @@ impl PlanRunner {
     /// Builder so the trigger.fired path keeps the token-free `new`.
     pub fn with_session_token(mut self, token: Option<String>) -> Self {
         self.session_token = token;
+        self
+    }
+
+    /// Attach the pre-built `ONSAGER_REPOS` value (spec #555) threaded
+    /// onto the scheduler so agent nodes inject it as `ONSAGER_REPOS`.
+    /// Builder so the trigger.fired path keeps the repo-free `new`.
+    pub fn with_repos_env(mut self, repos_env: Option<String>) -> Self {
+        self.repos_env = repos_env;
         self
     }
 
@@ -101,7 +116,8 @@ impl PlanRunner {
             Arc::clone(&self.store),
             Arc::clone(&self.spine),
         )
-        .with_session_token(self.session_token.clone());
+        .with_session_token(self.session_token.clone())
+        .with_repos_env(self.repos_env.clone());
         scheduler.run(plan_id, &exec_plan).await?;
         Ok(())
     }

--- a/crates/onsager-scheduler/src/repo_env.rs
+++ b/crates/onsager-scheduler/src/repo_env.rs
@@ -1,0 +1,165 @@
+//! Surface the run's multi-repo set to the scheduler-launched agent
+//! (spec #555, parity with #546).
+//!
+//! Multi-repo read (#546 / PR #552) was first wired on stiglab's
+//! `portal.session_requested` path. The scheduler/`AgentExecutor` launch
+//! path — where spec-plan and automated workflow runs execute — had no
+//! repo-set wiring at all. This module closes that gap: portal attaches
+//! the workspace's bound repo set (`Vec<RepoAccess>`, tokens encrypted
+//! with the shared credential key) onto the `plan.run_requested` event,
+//! exactly as it already attaches the plan-scoped session token (#536);
+//! the scheduler decrypts each token and exposes the set to the agent
+//! through `ONSAGER_REPOS`.
+//!
+//! This is the scheduler's spine→agent decrypt boundary — the direct
+//! counterpart of stiglab's [`crate`](../../stiglab/src/server/repo_env.rs).
+//! The agent-facing JSON shape lives in
+//! [`onsager_agent_spawn::repos_env_json`] so the two launch paths cannot
+//! drift; the decrypt uses this crate's own [`crate::crypto`] replica,
+//! the same split the session token already uses (the seam rule forbids
+//! depending on portal/stiglab). *Writes* to origin remain out of scope —
+//! these are read/checkout credentials, gated separately (#548).
+
+use onsager_agent_spawn::ClonableRepo;
+use onsager_spine::protocol::RepoAccess;
+
+use crate::crypto::decrypt_credential;
+
+/// Decrypt the wire repo set and build the `ONSAGER_REPOS` env value.
+///
+/// Returns `None` when the set is empty (single/zero-repo scheduler runs
+/// inject nothing, so they are unchanged). A token that fails to decrypt
+/// (or an absent credential key) degrades to an unauthenticated clone URL
+/// for that repo rather than dropping it — matching stiglab's behavior.
+pub fn repos_env_from_access(repos: &[RepoAccess], key: Option<&str>) -> Option<String> {
+    if repos.is_empty() {
+        return None;
+    }
+    let clonable: Vec<ClonableRepo> = repos
+        .iter()
+        .map(|r| {
+            let token = match (key, r.encrypted_read_token.as_deref()) {
+                (Some(k), Some(enc)) => match decrypt_credential(k, enc) {
+                    Ok(t) => Some(t),
+                    Err(e) => {
+                        // A decrypt failure (mismatched / rotated key)
+                        // silently degrades a private-repo clone to an
+                        // unauthenticated URL, which then fails far from
+                        // here. Surface it — the error is about the
+                        // cipher, never the plaintext, so it is safe to
+                        // log.
+                        tracing::warn!(
+                            owner = %r.owner,
+                            repo = %r.name,
+                            "repo_env: failed to decrypt read token; surfacing \
+                             unauthenticated clone URL: {e}"
+                        );
+                        None
+                    }
+                },
+                _ => None,
+            };
+            ClonableRepo {
+                owner: r.owner.clone(),
+                name: r.name.clone(),
+                default_branch: r.default_branch.clone(),
+                token,
+            }
+        })
+        .collect();
+    onsager_agent_spawn::repos_env_json(&clonable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::aead;
+    use ring::rand::{SecureRandom, SystemRandom};
+
+    // A 32-byte key (64 hex chars) for the AES-256-GCM credential cipher.
+    const KEY: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+    /// Encrypt mirroring portal's `encrypt_credential` so the decrypt
+    /// round-trip is provable without depending on portal. Production
+    /// ciphertext always comes from portal (which mints the read token);
+    /// this only exercises that the scheduler reads that exact wire
+    /// format.
+    fn encrypt(key_hex: &str, plaintext: &str) -> String {
+        let key_bytes = hex::decode(key_hex).unwrap();
+        let unbound = aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes).unwrap();
+        let sealing = aead::LessSafeKey::new(unbound);
+        let rng = SystemRandom::new();
+        let mut nonce_bytes = [0u8; 12];
+        rng.fill(&mut nonce_bytes).unwrap();
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+        let mut in_out = plaintext.as_bytes().to_vec();
+        sealing
+            .seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut in_out)
+            .unwrap();
+        let mut result = nonce_bytes.to_vec();
+        result.extend_from_slice(&in_out);
+        hex::encode(result)
+    }
+
+    fn access(owner: &str, name: &str, raw_token: Option<&str>) -> RepoAccess {
+        RepoAccess {
+            owner: owner.into(),
+            name: name.into(),
+            default_branch: "main".into(),
+            encrypted_read_token: raw_token.map(|t| encrypt(KEY, t)),
+        }
+    }
+
+    #[test]
+    fn two_repos_surface_both_with_authenticated_clone_urls() {
+        // Spec #555 integration check (the scheduler-path surfacing seam):
+        // a scheduler-launched run for a workspace with 2 bound repos
+        // surfaces one authenticated entry per repo, decrypted off the
+        // wire token. Mutation guard: drop one repo from the input and the
+        // length assertion below fails.
+        let repos = vec![
+            access("acme", "widgets", Some("tok_a")),
+            access("other", "thing", Some("tok_b")),
+        ];
+        let json = repos_env_from_access(&repos, Some(KEY)).expect("two repos surface a value");
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "one entry per bound repo");
+        assert_eq!(
+            arr[0]["clone_url"],
+            "https://x-access-token:tok_a@github.com/acme/widgets.git"
+        );
+        assert_eq!(
+            arr[1]["clone_url"],
+            "https://x-access-token:tok_b@github.com/other/thing.git"
+        );
+        assert_eq!(arr[0]["default_branch"], "main");
+    }
+
+    #[test]
+    fn single_repo_scheduler_run_is_unchanged() {
+        // Regression: the single-repo path surfaces exactly one entry,
+        // same authenticated shape.
+        let repos = vec![access("acme", "widgets", Some("tok_a"))];
+        let json = repos_env_from_access(&repos, Some(KEY)).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn empty_repo_set_surfaces_nothing() {
+        // Regression: zero bound repos → no ONSAGER_REPOS injected, so a
+        // single-`working_dir` scheduler run is untouched.
+        assert_eq!(repos_env_from_access(&[], Some(KEY)), None);
+    }
+
+    #[test]
+    fn missing_token_degrades_to_unauthenticated_url() {
+        // No credential key (or an undecryptable token) → the repo is
+        // still surfaced, just with a plain HTTPS clone URL.
+        let repos = vec![access("acme", "public", None)];
+        let json = repos_env_from_access(&repos, Some(KEY)).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr[0]["clone_url"], "https://github.com/acme/public.git");
+    }
+}

--- a/crates/onsager-scheduler/src/runners.rs
+++ b/crates/onsager-scheduler/src/runners.rs
@@ -40,7 +40,8 @@ use std::process::Stdio;
 
 use async_trait::async_trait;
 use onsager_agent_spawn::{
-    LIVENESS_HOOK_URL_ENV, MCP_URL_ENV, SESSION_TOKEN_ENV, mcp_config_json, stop_hook_settings_json,
+    LIVENESS_HOOK_URL_ENV, MCP_URL_ENV, REPOS_ENV, SESSION_TOKEN_ENV, mcp_config_json,
+    stop_hook_settings_json,
 };
 use onsager_nodes::{AgentRequest, AgentResponse, AgentRunError, AgentRunner};
 use serde::Deserialize;
@@ -184,6 +185,18 @@ impl AgentRunner for ClaudeCliRunner {
         // (and the MCP config above was not registered).
         if let Some(token) = request.session_token.as_deref().filter(|t| !t.is_empty()) {
             cmd.env(SESSION_TOKEN_ENV, token);
+        }
+
+        // Surface the run's workspace repo set (spec #555) as
+        // `ONSAGER_REPOS` so the scheduler-dispatched agent can clone
+        // whichever repos it needs — parity with the chat path, where
+        // stiglab injects the same var off the `portal.session_requested`
+        // event. The scheduler decrypted + built this value once per plan
+        // (`repo_env::repos_env_from_access`); empty/absent means the
+        // workspace binds no repos and the single-`working_dir` behavior
+        // is unchanged.
+        if let Some(repos) = request.repos_env.as_deref().filter(|s| !s.is_empty()) {
+            cmd.env(REPOS_ENV, repos);
         }
 
         // stderr is discarded, not piped: this runner has no consumer
@@ -349,6 +362,7 @@ mod tests {
                echo \"ARGS: $*\"\n\
                echo \"SESSION_ID: ${{ONSAGER_SESSION_ID:-}}\"\n\
                echo \"SESSION_TOKEN: ${{ONSAGER_SESSION_TOKEN:-}}\"\n\
+               echo \"REPOS: ${{ONSAGER_REPOS:-}}\"\n\
              }} >> \"{capture}\"\n\
              cat <<'NDJSON'\n{body}\nNDJSON\n",
             capture = capture_path.display(),
@@ -378,6 +392,14 @@ mod tests {
             user_prompt: prompt.into(),
             session_id: session_id.into(),
             session_token: session_token.map(Into::into),
+            repos_env: None,
+        }
+    }
+
+    fn request_with_repos(prompt: &str, session_id: &str, repos_env: Option<&str>) -> AgentRequest {
+        AgentRequest {
+            repos_env: repos_env.map(Into::into),
+            ..request(prompt, session_id)
         }
     }
 
@@ -589,6 +611,55 @@ mod tests {
         assert!(
             recorded.contains("SESSION_TOKEN: \n"),
             "ONSAGER_SESSION_TOKEN must be empty when the request has no token, got: {recorded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repos_injected_as_onsager_repos_when_present() {
+        // Spec #555 consumption seam: a request carrying the pre-built
+        // repo set is injected into the child env as ONSAGER_REPOS so the
+        // scheduler-dispatched agent can clone its workspace's repos.
+        // Mutation guard: dropping the `cmd.env(REPOS_ENV ..)` line makes
+        // this assertion fail.
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let repos_env = r#"[{"owner":"acme","name":"widgets","default_branch":"main","clone_url":"https://x-access-token:tok@github.com/acme/widgets.git"}]"#;
+        let runner = ClaudeCliRunner::with_command(script);
+        runner
+            .run(request_with_repos("p", "sess_repos", Some(repos_env)))
+            .await
+            .unwrap();
+
+        let recorded = std::fs::read_to_string(&cap_file).unwrap();
+        assert!(
+            recorded.contains("REPOS: ")
+                && recorded.contains("x-access-token:tok@github.com/acme/widgets.git"),
+            "ONSAGER_REPOS must be injected from the request, got: {recorded}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repos_env_empty_when_request_has_none() {
+        // Regression: a no-repo run injects nothing, so the child sees an
+        // empty ONSAGER_REPOS (the single-`working_dir` behavior is
+        // unchanged). Mirrors `mcp_config_omitted_when_token_absent`.
+        let _guard = ENV_LOCK.lock().await;
+        let capture = tempfile::tempdir().unwrap();
+        let cap_file = capture.path().join("argv.txt");
+        let body = r#"{"type":"result","subtype":"success","result":"ok"}"#;
+        let (_dir, script) = fake_claude(body, &cap_file);
+
+        let runner = ClaudeCliRunner::with_command(script);
+        runner.run(request("p", "sess_no_repos")).await.unwrap();
+
+        let recorded = std::fs::read_to_string(&cap_file).unwrap();
+        assert!(
+            recorded.contains("REPOS: \n"),
+            "ONSAGER_REPOS must be empty when the request has no repo set, got: {recorded}"
         );
     }
 }

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -464,11 +464,15 @@ impl TriggerHandler {
         // session token is resolved: portal attached it (read tokens
         // encrypted) to the event, the scheduler decrypts each and builds
         // the `ONSAGER_REPOS` value once per plan, then threads it to the
-        // runner; the AgentExecutor injects it into every agent node. An
-        // empty set (no bound repos, or no credential key) injects
-        // nothing — single-`working_dir` runs are unchanged. This is the
-        // scheduler-path parity #555 closes: spec-plan runs now span the
-        // workspace's repos, not just the one the chat path got.
+        // runner; the AgentExecutor injects it into every agent node. Only
+        // an empty set (no bound repos) injects nothing, leaving
+        // single-`working_dir` runs unchanged. A missing/rotated
+        // credential key does NOT drop the set — each repo degrades to an
+        // unauthenticated clone URL (still surfaced), so a private repo
+        // fails loudly at clone time rather than vanishing silently
+        // (matches `repo_env::repos_env_from_access` + stiglab). This is
+        // the scheduler-path parity #555 closes: spec-plan runs now span
+        // the workspace's repos, not just the one the chat path got.
         let repos_env = crate::repo_env::repos_env_from_access(
             &decode_plan_repos(&data),
             self.credential_key.as_deref(),

--- a/crates/onsager-scheduler/src/service.rs
+++ b/crates/onsager-scheduler/src/service.rs
@@ -460,6 +460,20 @@ impl TriggerHandler {
                 },
             );
 
+        // Resolve the workspace's bound repo set (#555) the same way the
+        // session token is resolved: portal attached it (read tokens
+        // encrypted) to the event, the scheduler decrypts each and builds
+        // the `ONSAGER_REPOS` value once per plan, then threads it to the
+        // runner; the AgentExecutor injects it into every agent node. An
+        // empty set (no bound repos, or no credential key) injects
+        // nothing — single-`working_dir` runs are unchanged. This is the
+        // scheduler-path parity #555 closes: spec-plan runs now span the
+        // workspace's repos, not just the one the chat path got.
+        let repos_env = crate::repo_env::repos_env_from_access(
+            &decode_plan_repos(&data),
+            self.credential_key.as_deref(),
+        );
+
         // Pin the workflow-library versions this run compiles against so
         // a later recovery recompiles against the same versions, not
         // whatever is latest then (#511). Resolved once and shared with
@@ -489,7 +503,8 @@ impl TriggerHandler {
             Arc::clone(&self.plan_store),
             scoped_spine,
         )
-        .with_session_token(session_token);
+        .with_session_token(session_token)
+        .with_repos_env(repos_env);
         match runner.run(&plan_id, &spec_plan, &snapshot).await {
             Ok(()) => {
                 let _ = plan_registry::set_status(self.store.pool(), &plan_id, "completed").await;
@@ -574,6 +589,20 @@ fn decode_plan_session_token(data: &serde_json::Value) -> Option<String> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
+}
+
+/// Pull the workspace's bound repo set (#555) off a `plan.run_requested`
+/// body. Portal's `run_spec_plan` MCP tool attaches it as an additive
+/// top-level `repos` array — one [`onsager_spine::protocol::RepoAccess`]
+/// per bound repo, read tokens encrypted with the shared credential key,
+/// alongside `encrypted_session_token`. Empty when the field is absent
+/// (older producers, or the workspace binds no repos) or does not parse,
+/// so the single-`working_dir` path stays unchanged.
+fn decode_plan_repos(data: &serde_json::Value) -> Vec<onsager_spine::protocol::RepoAccess> {
+    data.get("repos")
+        .cloned()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
 }
 
 /// Extract `FactoryEventKind::TriggerFired` from an `events_ext.data`
@@ -831,6 +860,42 @@ mod tests {
             decode_plan_session_token(&serde_json::json!({ "encrypted_session_token": "" }))
                 .is_none()
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Spec #555 — workspace repo set decode (the transport layer of the
+    // scheduler-path ONSAGER_REPOS parity).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn decode_plan_repos_reads_top_level_array() {
+        // Portal attaches the workspace repo set as a top-level `repos`
+        // array, decoded here alongside the session token. Mutation
+        // guard: drop the `repos` key and the length assertion fails.
+        let data = serde_json::json!({
+            "spec_plan_id": "github:42",
+            "workspace_id": "ws-7",
+            "repos": [
+                { "owner": "acme", "name": "widgets", "default_branch": "main",
+                  "encrypted_read_token": "deadbeef" },
+                { "owner": "acme", "name": "gadgets", "default_branch": "trunk" },
+            ],
+        });
+        let repos = decode_plan_repos(&data);
+        assert_eq!(repos.len(), 2);
+        assert_eq!(repos[0].name, "widgets");
+        assert_eq!(repos[0].encrypted_read_token.as_deref(), Some("deadbeef"));
+        // A tokenless entry (public repo) survives — surfaced by identity.
+        assert_eq!(repos[1].encrypted_read_token, None);
+    }
+
+    #[test]
+    fn decode_plan_repos_empty_when_absent_or_malformed() {
+        // Absent `repos` (older producer / no bound repos) → empty set,
+        // so the single-`working_dir` path is unchanged.
+        assert!(decode_plan_repos(&serde_json::json!({ "spec_plan_id": "x" })).is_empty());
+        // A non-array `repos` does not parse → empty, never a panic.
+        assert!(decode_plan_repos(&serde_json::json!({ "repos": "nope" })).is_empty());
     }
 
     /// End-to-end of the inject seam #536 wires up: portal's

--- a/crates/onsager-scheduler/tests/agent_loop.rs
+++ b/crates/onsager-scheduler/tests/agent_loop.rs
@@ -10,7 +10,7 @@
 //! the session manifest back → a packaged `Artifact`
 //! (`Uncertain { source: Agent }`) on the node's output edge.
 //!
-//! Three tests:
+//! Four tests:
 //!
 //! 1. `agent_node_runs_to_terminal_with_uncertain_agent_artifact` — the
 //!    §520 acceptance bullet, now on the scheduler path, against the
@@ -26,13 +26,17 @@
 //!    the spawned agent carries `ONSAGER_SESSION_TOKEN`, `--mcp-config`,
 //!    and `--settings` (Stop hook). The token's presence is exactly what
 //!    lets the §4d hook authenticate instead of 401→fail-open.
+//! 4. `scheduler_path_surfaces_repos_to_agent_spawn` — the #555
+//!    multi-repo read parity: a run for a workspace with two bound repos
+//!    threads `ONSAGER_REPOS` through `PlanRunner` to the spawned agent,
+//!    which sees both authenticated clone URLs.
 
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use onsager_agent_spawn::{LIVENESS_HOOK_URL_ENV, MCP_URL_ENV};
+use onsager_agent_spawn::{ClonableRepo, LIVENESS_HOOK_URL_ENV, MCP_URL_ENV, repos_env_json};
 use onsager_artifact::{Artifact, ArtifactId, ContentRef, NodeId, Provenance, SourceTag};
 use onsager_nodes::{
     AgentExecutor, EmittedArtifact, ExecutorRegistry, InMemoryPlanStore, NoOpExecutor, PlanId,
@@ -166,6 +170,7 @@ fn fake_claude(capture_path: &std::path::Path) -> (tempfile::TempDir, String) {
          {{\n\
            echo \"ARGS: $*\"\n\
            echo \"SESSION_TOKEN: ${{ONSAGER_SESSION_TOKEN:-}}\"\n\
+           echo \"REPOS: ${{ONSAGER_REPOS:-}}\"\n\
          }} >> \"{capture}\"\n\
          echo '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"analysis done\"}}'\n",
         capture = capture_path.display(),
@@ -342,5 +347,81 @@ async fn scheduler_path_injects_session_token_and_mcp_into_agent_spawn() {
     assert!(
         recorded.contains("--settings"),
         "the §4d Stop hook (--settings) must be wired on the scheduler path, got: {recorded}",
+    );
+}
+
+#[tokio::test]
+async fn scheduler_path_surfaces_repos_to_agent_spawn() {
+    // §555: a scheduler-launched run for a workspace with ≥2 bound repos
+    // must surface BOTH in ONSAGER_REPOS with authenticated clone URLs —
+    // the multi-repo read parity the chat path already had. The set is
+    // built once per plan and threaded PlanRunner → Scheduler →
+    // ExecutorContext → AgentExecutor → AgentRequest → ClaudeCliRunner →
+    // the spawned agent's env. Mutation guard: drop a repo from
+    // `repos_env` (or the `with_repos_env` thread) and an assertion below
+    // fails. (The decrypt-off-the-event half is unit-tested in
+    // `onsager_scheduler::repo_env`.)
+    let _guard = ENV_LOCK.lock().await;
+    let cap = tempfile::tempdir().unwrap();
+    let cap_file = cap.path().join("argv.txt");
+    let (_dir, script) = fake_claude(&cap_file);
+
+    // SAFETY: serialized by ENV_LOCK; removed before the guard drops.
+    unsafe {
+        std::env::set_var(CLAUDE_BIN_ENV, &script);
+    }
+
+    // The agent-facing shape the scheduler builds from the decrypted repo
+    // set — two bound repos, each with a read token.
+    let repos_env = repos_env_json(&[
+        ClonableRepo {
+            owner: "acme".into(),
+            name: "widgets".into(),
+            default_branch: "main".into(),
+            token: Some("tok_a".into()),
+        },
+        ClonableRepo {
+            owner: "other".into(),
+            name: "thing".into(),
+            default_branch: "main".into(),
+            token: Some("tok_b".into()),
+        },
+    ])
+    .expect("two repos build a value");
+
+    let spine = Arc::new(ManifestSpine::default());
+    let runner = PlanRunner::new(
+        Arc::new(default_executor_registry()),
+        Arc::new(InMemoryPlanStore::new()) as Arc<dyn PlanStore>,
+        Arc::clone(&spine) as Arc<dyn SpineClient>,
+    )
+    .with_repos_env(Some(repos_env));
+
+    let plan_id = PlanId::generate();
+    let result = runner
+        .run(
+            &plan_id,
+            &one_agent_spec_plan(),
+            &AgentLibrary {
+                workflow: agent_workflow(),
+            },
+        )
+        .await;
+
+    unsafe {
+        std::env::remove_var(CLAUDE_BIN_ENV);
+    }
+    result.expect("agent-node plan runs to terminal");
+
+    let recorded = std::fs::read_to_string(&cap_file).unwrap();
+    // Both repos surface, each with an authenticated (x-access-token)
+    // clone URL — "surfaces both with read-auth", on the scheduler path.
+    assert!(
+        recorded.contains("https://x-access-token:tok_a@github.com/acme/widgets.git"),
+        "the first bound repo must reach the agent env via ONSAGER_REPOS, got: {recorded}",
+    );
+    assert!(
+        recorded.contains("https://x-access-token:tok_b@github.com/other/thing.git"),
+        "the second bound repo must reach the agent env via ONSAGER_REPOS, got: {recorded}",
     );
 }

--- a/crates/stiglab/src/server/repo_env.rs
+++ b/crates/stiglab/src/server/repo_env.rs
@@ -12,37 +12,23 @@
 //! no bound repos surfaces nothing (`None`), leaving the existing
 //! single-`working_dir` behavior untouched. *Writes* to origin are out of
 //! scope — these are read/checkout credentials, gated separately (#548).
+//!
+//! Spec #555 extended the same env var to the scheduler/`AgentExecutor`
+//! launch path. The agent-facing JSON shape is the contract both paths
+//! must produce identically, so it moved to `onsager-agent-spawn`
+//! ([`onsager_agent_spawn::repos_env_json`]); this module keeps only
+//! stiglab's spine→agent decrypt boundary.
 
 use onsager_spine::protocol::RepoAccess;
-use serde::Serialize;
 
 use crate::server::auth::decrypt_credential;
 
-/// Env var carrying the JSON-encoded repo set the agent clones on demand.
-pub const REPOS_ENV: &str = "ONSAGER_REPOS";
-
-/// One repo surfaced to the agent, with the read token already decrypted.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ClonableRepo {
-    pub owner: String,
-    pub name: String,
-    pub default_branch: String,
-    /// Decrypted read-scoped token, or `None` (public-repo / unconfigured
-    /// path) — the clone URL is then unauthenticated.
-    pub token: Option<String>,
-}
-
-/// What each `ONSAGER_REPOS` array element looks like to the agent.
-#[derive(Debug, Serialize)]
-struct RepoEntry {
-    owner: String,
-    name: String,
-    default_branch: String,
-    /// Ready-to-use clone URL: authenticated with the read token via the
-    /// `x-access-token` convention when one is present, plain HTTPS
-    /// otherwise.
-    clone_url: String,
-}
+// The agent-facing wire shape (`ClonableRepo` → `ONSAGER_REPOS` JSON) is
+// the contract shared with the scheduler launch path, so it lives in
+// `onsager-agent-spawn` (spec #555). Stiglab keeps only the spine→agent
+// decrypt boundary below — mapping each encrypted `RepoAccess` onto a
+// plaintext `ClonableRepo` across its own `decrypt_credential`.
+pub use onsager_agent_spawn::{ClonableRepo, REPOS_ENV};
 
 /// Decrypt the wire repo set and build the `ONSAGER_REPOS` env value.
 ///
@@ -85,41 +71,7 @@ pub fn repos_env_from_access(repos: &[RepoAccess], key: Option<&str>) -> Option<
             }
         })
         .collect();
-    repos_env_json(&clonable)
-}
-
-/// Build the `ONSAGER_REPOS` JSON array from already-decrypted repos.
-/// `None` for an empty set so the caller injects nothing.
-fn repos_env_json(repos: &[ClonableRepo]) -> Option<String> {
-    if repos.is_empty() {
-        return None;
-    }
-    let entries: Vec<RepoEntry> = repos
-        .iter()
-        .map(|r| RepoEntry {
-            owner: r.owner.clone(),
-            name: r.name.clone(),
-            default_branch: r.default_branch.clone(),
-            clone_url: clone_url(&r.owner, &r.name, r.token.as_deref()),
-        })
-        .collect();
-    serde_json::to_string(&entries).ok()
-}
-
-/// HTTPS clone URL, authenticated via `x-access-token` when a token is
-/// present (the GitHub convention for installation tokens). The token is
-/// percent-encoded into the userinfo so a token carrying a reserved
-/// character (`@`, `:`, `/`, …) can't truncate or corrupt the URL. GitHub
-/// installation tokens are URL-safe today, but encoding keeps this correct
-/// if that ever changes.
-fn clone_url(owner: &str, name: &str, token: Option<&str>) -> String {
-    match token {
-        Some(t) => format!(
-            "https://x-access-token:{}@github.com/{owner}/{name}.git",
-            onsager_agent_spawn::urlencode(t)
-        ),
-        None => format!("https://github.com/{owner}/{name}.git"),
-    }
+    onsager_agent_spawn::repos_env_json(&clonable)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #555.

## What

Multi-repo read (#546 / PR #552) was wired on only **one** of the two live session-launch paths — portal's `POST /api/tasks` → `portal.session_requested` → stiglab. The scheduler / `AgentExecutor` path (where **spec-plan runs** execute) injected `ONSAGER_SESSION_TOKEN` but never `ONSAGER_REPOS`, so spec-plan runs were effectively single-repo. This wires the same read-scoped repo-set handoff onto the scheduler path, surfacing `ONSAGER_REPOS` to the agent.

## Open question — resolved with candidate (c)

The issue asked where the provisioning lives, given `build_workspace_repo_access` + the token mint are in `onsager-portal` (edge) and the scheduler can't import portal (seam rule). I took **(c): the edge attaches `RepoAccess` onto the scheduler's launch event.**

Portal's `run_spec_plan` MCP tool already mints + attaches the plan-scoped session token (#539) onto `plan.run_requested`. It now **also** calls the existing `build_workspace_repo_access` and attaches `repos: Vec<RepoAccess>` (read tokens encrypted) — a byte-for-byte mirror of the session-token handoff. The scheduler decrypts each token and builds `ONSAGER_REPOS`, then threads it `PlanRunner → Scheduler → ExecutorContext → AgentRequest → ClaudeCliRunner`, mirroring the session-token thread exactly.

Why (c) over (a)/(b):
- **(a)** would re-route scheduler launches through stiglab, undoing the #538–541 agent loop.
- **(b)** would drag portal's DB reads + GitHub-App JWT minting across the seam and force the scheduler to hold App config — asymmetric with how the session token is already handled.
- **(c)** respects the seam (portal mints, scheduler decrypts — *identical* to the session token), reuses `build_workspace_repo_access` / `RepoAccess` / `mint_read_token_for_repos` with no relocation, and adds no new wire format (additive optional `repos` field, no `schema_version` bump).

## Internal-symmetry note

The agent-facing `ONSAGER_REPOS` wire shape (the JSON array the agent reads) is the one thing the two launch paths must produce **identically**, so it moved into `onsager-agent-spawn` (`repos_env_json` + `ClonableRepo`) — the same cross-seam move #535 made for the MCP / Stop-hook builders, now that a second consumer (the scheduler) exists. Each subsystem keeps its own spine→agent decrypt boundary (`RepoAccess` ciphertext → plaintext) using its existing `decrypt_credential` replica — the same split the session token already uses. stiglab's `repo_env.rs` shrinks to that boundary; no behavior change there.

## Scope

Wired on `plan.run_requested` — **exact parity** with where the plan-scoped session token (#539) is provisioned. The `trigger.fired` automated-workflow path provisions neither a session token **nor** repos today (pre-existing — the token gap predates this change); the consumption machinery here is path-agnostic, so extending `trigger.fired` later is just provisioning `repos_env` once it also gets a token. Flagging rather than silently expanding scope — a possible follow-up.

## Tests

- **integration** (`scheduler_path_surfaces_repos_to_agent_spawn`): a scheduler-launched run with two bound repos threads `ONSAGER_REPOS` through `PlanRunner` to the spawned (fake) `claude`, which sees both authenticated clone URLs.
- **regression**: `single_repo_scheduler_run_is_unchanged`, `repos_env_empty_when_request_has_none`, `empty_repo_set_surfaces_nothing` — single/zero-repo runs inject nothing, so `working_dir`-only behavior is untouched.
- **mutation checks** (verified locally, not just asserted): dropping the `runners.rs` injection fails the runner test; dropping the `agent.rs` context→request thread fails both the unit and integration tests. `two_repos_surface_both_with_authenticated_clone_urls` fails if a repo is dropped from the set.
- transport decode (`decode_plan_repos_*`) + shared-builder wire-shape tests (`repos_env_json_*`).

`cargo test` green for the touched crates; `cargo fmt`/`clippy -D warnings` clean; `lint-seams`, `check-events`, `check-api-contract`, `check-file-budget`, `gen-event-docs --check`, `check-generated-types`, `check-orphan-crates` all clean.

https://claude.ai/code/session_01SBrWKjTQfgTLcBb8rU3qQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBrWKjTQfgTLcBb8rU3qQw)_