### PR TITLE
refactor(stiglab): dialect-aware best-effort migrations (#550)

### DIFF
--- a/crates/stiglab/src/server/db/mod.rs
+++ b/crates/stiglab/src/server/db/mod.rs
@@ -66,10 +66,22 @@ pub use workspaces::{
 
 // ── Pool initialisation ──
 
+/// Whether a database URL addresses SQLite, across every scheme form sqlx
+/// accepts: the `sqlite://<path>` file URL, the bare `sqlite:<path>` form,
+/// and `sqlite::memory:`. This drives the migration dialect (`run_pg_only`
+/// skips Postgres-only legacy statements), so it must match the broad
+/// `sqlite:` scheme — classifying a SQLite URL as Postgres would run
+/// Postgres-only statements against SQLite and fail hard (issue #550 review).
+fn is_sqlite_url(database_url: &str) -> bool {
+    database_url.starts_with("sqlite:")
+}
+
 pub async fn init_pool(database_url: &str) -> anyhow::Result<AnyPool> {
-    let is_sqlite = database_url.starts_with("sqlite://");
-    // For SQLite: ensure parent directory exists and enable create-if-missing
-    let connect_url = if is_sqlite {
+    let is_sqlite = is_sqlite_url(database_url);
+    // The parent-directory creation + `mode=rwc` handling below is specific
+    // to the file-backed `sqlite://<path>` form (a no-op for `sqlite::memory:`
+    // and for non-SQLite URLs).
+    let connect_url = if database_url.starts_with("sqlite://") {
         let path = database_url.trim_start_matches("sqlite://");
         if let Some(parent) = std::path::Path::new(path).parent()
             && !parent.as_os_str().is_empty()

--- a/crates/stiglab/src/server/db/mod.rs
+++ b/crates/stiglab/src/server/db/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use anyhow::Context;
 use sqlx::AnyPool;
 use sqlx::pool::PoolOptions;
 
@@ -66,8 +67,9 @@ pub use workspaces::{
 // ── Pool initialisation ──
 
 pub async fn init_pool(database_url: &str) -> anyhow::Result<AnyPool> {
+    let is_sqlite = database_url.starts_with("sqlite://");
     // For SQLite: ensure parent directory exists and enable create-if-missing
-    let connect_url = if database_url.starts_with("sqlite://") {
+    let connect_url = if is_sqlite {
         let path = database_url.trim_start_matches("sqlite://");
         if let Some(parent) = std::path::Path::new(path).parent()
             && !parent.as_os_str().is_empty()
@@ -95,11 +97,37 @@ pub async fn init_pool(database_url: &str) -> anyhow::Result<AnyPool> {
     )
     .await
     .map_err(|_| anyhow::anyhow!("timed out while connecting to database"))??;
-    run_migrations(&pool).await?;
+    run_migrations(&pool, is_sqlite).await?;
     Ok(pool)
 }
 
-pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
+/// Run a legacy migration statement that is meaningful only on the live
+/// Postgres install.
+///
+/// On SQLite — the unit-test backend, which rebuilds the schema fresh from
+/// the `CREATE TABLE IF NOT EXISTS` statements in `run_migrations` — the
+/// statement is skipped entirely. On Postgres it executes and **errors
+/// propagate**: a real failure (permissions, unexpected state) must surface
+/// from `run_migrations` rather than being swallowed by the old
+/// `let _ = …execute().await;` idiom, so a half-applied migration cannot
+/// silently diverge (issue #550).
+///
+/// Every statement routed here is written to be idempotent on Postgres
+/// (guarded `DO $$` blocks for renames, `IF EXISTS` for drops, `SET NOT
+/// NULL` is a no-op once applied, backfills are `WHERE … IS NULL`), so a
+/// re-run against an already-migrated database is a no-op, not an error.
+async fn run_pg_only(pool: &AnyPool, is_sqlite: bool, sql: &str) -> anyhow::Result<()> {
+    if is_sqlite {
+        return Ok(());
+    }
+    sqlx::query(sql)
+        .execute(pool)
+        .await
+        .with_context(|| format!("postgres-only migration statement failed: {sql}"))?;
+    Ok(())
+}
+
+pub async fn run_migrations(pool: &AnyPool, is_sqlite: bool) -> anyhow::Result<()> {
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS nodes (
             id TEXT PRIMARY KEY,
@@ -321,21 +349,43 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     // ── Workspace / membership / GitHub App / project tables (issue #59;
     //    renamed from "tenant" → "workspace" in issue #163).
     //
-    // The block below reuses the same swallow-on-error pattern the earlier
-    // ALTERs use.  On a fresh DB the rename statements all fail with "no
-    // such table / column" and the subsequent CREATE TABLE IF NOT EXISTS
-    // statements build the schema directly under the new names.  On an
-    // existing DB the renames run once, the CREATE TABLE IF NOT EXISTS
-    // statements are no-ops, and the column-rename ALTERs realign the
-    // surface.  See `migrations/001_rename_tenant_to_workspace.sql` for the
-    // canonical SQL; the deletion rule for `user_pats` rows with no
-    // `workspace_members` membership is documented there.
-    let _ = sqlx::query("ALTER TABLE tenants RENAME TO workspaces")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("ALTER TABLE tenant_members RENAME TO workspace_members")
-        .execute(pool)
-        .await;
+    // These statements carry a legacy "tenant"-schema installation forward.
+    // They are meaningful only on Postgres (the live install) and run via
+    // `run_pg_only`; the SQLite unit-test backend rebuilds the schema fresh
+    // from the `CREATE TABLE IF NOT EXISTS` statements below, so they are
+    // skipped there. Each rename is wrapped in a guarded `DO $$` block
+    // (mirroring the canonical spine `004_workflows.sql` shape) so it is a
+    // no-op on a fresh or already-migrated DB; a real failure (permissions,
+    // unexpected state) now propagates from `run_migrations` instead of being
+    // swallowed (issue #550). The deletion rule for `user_pats` rows with no
+    // `workspace_members` membership is enforced by the PAT backfill below.
+    //
+    // The two table renames precede the column renames deliberately: hardening
+    // only the column renames would let a failed `tenants`/`tenant_members`
+    // rename silently strand data under the old names — the same failure class
+    // this change closes — so both halves of the rename are routed here.
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'tenants') \
+              AND NOT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'workspaces') THEN \
+             ALTER TABLE tenants RENAME TO workspaces; \
+           END IF; \
+         END $$",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'tenant_members') \
+              AND NOT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'workspace_members') THEN \
+             ALTER TABLE tenant_members RENAME TO workspace_members; \
+           END IF; \
+         END $$",
+    )
+    .await?;
     // Note: pre-#163 `tenant_workflows` / `tenant_workflow_stages` are
     // not renamed here — Lever D (#149) collapses them into the spine
     // `workflows` / `workflow_stages` tables, so any stiglab DB still
@@ -343,31 +393,80 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     // migration sweeps. The remaining renames (workspaces, members,
     // installations, projects, user_pats) stay because those tables
     // remain stiglab-owned.
-    let _ = sqlx::query("ALTER TABLE workspace_members RENAME COLUMN tenant_id TO workspace_id")
-        .execute(pool)
-        .await;
-    let _ =
-        sqlx::query("ALTER TABLE github_app_installations RENAME COLUMN tenant_id TO workspace_id")
-            .execute(pool)
-            .await;
-    let _ = sqlx::query("ALTER TABLE projects RENAME COLUMN tenant_id TO workspace_id")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("ALTER TABLE user_pats RENAME COLUMN tenant_id TO workspace_id")
-        .execute(pool)
-        .await;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'workspace_members' AND column_name = 'tenant_id') \
+              AND NOT EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'workspace_members' AND column_name = 'workspace_id') THEN \
+             ALTER TABLE workspace_members RENAME COLUMN tenant_id TO workspace_id; \
+           END IF; \
+         END $$",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'github_app_installations' AND column_name = 'tenant_id') \
+              AND NOT EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'github_app_installations' AND column_name = 'workspace_id') THEN \
+             ALTER TABLE github_app_installations RENAME COLUMN tenant_id TO workspace_id; \
+           END IF; \
+         END $$",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'projects' AND column_name = 'tenant_id') \
+              AND NOT EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'projects' AND column_name = 'workspace_id') THEN \
+             ALTER TABLE projects RENAME COLUMN tenant_id TO workspace_id; \
+           END IF; \
+         END $$",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DO $$ BEGIN \
+           IF EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'user_pats' AND column_name = 'tenant_id') \
+              AND NOT EXISTS (SELECT FROM information_schema.columns \
+                      WHERE table_name = 'user_pats' AND column_name = 'workspace_id') THEN \
+             ALTER TABLE user_pats RENAME COLUMN tenant_id TO workspace_id; \
+           END IF; \
+         END $$",
+    )
+    .await?;
     // Old indexes referencing the renamed tables/columns can outlive the
     // rename on Postgres if the index name doesn't auto-update; drop the
-    // legacy ones explicitly.  All `IF EXISTS`, all idempotent.
-    let _ = sqlx::query("DROP INDEX IF EXISTS idx_tenant_members_user_id")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("DROP INDEX IF EXISTS idx_github_app_installations_tenant_id")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("DROP INDEX IF EXISTS idx_projects_tenant_id")
-        .execute(pool)
-        .await;
+    // legacy ones explicitly.  All `IF EXISTS`, all idempotent, routed
+    // through `run_pg_only` so a real failure surfaces (issue #550).
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DROP INDEX IF EXISTS idx_tenant_members_user_id",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DROP INDEX IF EXISTS idx_github_app_installations_tenant_id",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DROP INDEX IF EXISTS idx_projects_tenant_id",
+    )
+    .await?;
 
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS workspaces (
@@ -420,9 +519,13 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .await?;
 
     // spec #545: rename legacy `projects` → `workspace_repos` on existing
-    // installs. Postgres-only `DO $$` block; SQLite tests rebuild the schema
-    // from the CREATE TABLE below, so the ignored error here is expected.
-    let _ = sqlx::query(
+    // installs. Postgres-only guarded `DO $$` block routed through
+    // `run_pg_only` — skipped on SQLite (tests rebuild from the CREATE TABLE
+    // below); on Postgres a real failure propagates instead of being
+    // swallowed (issue #550).
+    run_pg_only(
+        pool,
+        is_sqlite,
         "DO $$ \
          BEGIN \
            IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'projects') \
@@ -432,8 +535,7 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
            END IF; \
          END $$",
     )
-    .execute(pool)
-    .await;
+    .await?;
 
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS workspace_repos (
@@ -460,12 +562,14 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     // first workspace membership; rows with no membership at all are
     // deleted (unusable — a workspace-less PAT can't address any
     // workspace-scoped route, and after this migration `workspace_id` is
-    // mandatory at the API layer).  Postgres-only `ALTER COLUMN ... SET
-    // NOT NULL` is gated on the live install (SQLite tests rebuild the
-    // schema each run from the new CREATE TABLE above).  See
-    // `migrations/001_rename_tenant_to_workspace.sql` for the canonical
-    // SQL.
-    let _ = sqlx::query(
+    // mandatory at the API layer).  All three statements are idempotent on
+    // Postgres (the backfill/delete are `WHERE workspace_id IS NULL`; the
+    // `SET NOT NULL` is a no-op once applied), so they run via `run_pg_only`
+    // — skipped on SQLite (tests rebuild the schema each run from the new
+    // CREATE TABLE above), errors propagated on Postgres (issue #550).
+    run_pg_only(
+        pool,
+        is_sqlite,
         "UPDATE user_pats \
          SET workspace_id = ( \
              SELECT m.workspace_id FROM workspace_members m \
@@ -475,14 +579,19 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
          ) \
          WHERE workspace_id IS NULL",
     )
-    .execute(pool)
-    .await;
-    let _ = sqlx::query("DELETE FROM user_pats WHERE workspace_id IS NULL")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("ALTER TABLE user_pats ALTER COLUMN workspace_id SET NOT NULL")
-        .execute(pool)
-        .await;
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DELETE FROM user_pats WHERE workspace_id IS NULL",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "ALTER TABLE user_pats ALTER COLUMN workspace_id SET NOT NULL",
+    )
+    .await?;
 
     // Attach sessions to projects (nullable; pre-existing sessions stay personal).
     // Same swallow-on-duplicate ALTER pattern as earlier migrations for
@@ -532,7 +641,12 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     let _ = sqlx::query("ALTER TABLE user_credentials ADD COLUMN workspace_id TEXT")
         .execute(pool)
         .await;
-    let _ = sqlx::query(
+    // Backfill + `SET NOT NULL` mirror the PAT block above: idempotent on
+    // Postgres, routed through `run_pg_only` (skipped on SQLite, errors
+    // propagated on Postgres — issue #550).
+    run_pg_only(
+        pool,
+        is_sqlite,
         "UPDATE user_credentials \
          SET workspace_id = ( \
              SELECT m.workspace_id FROM workspace_members m \
@@ -542,30 +656,41 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
          ) \
          WHERE workspace_id IS NULL",
     )
-    .execute(pool)
-    .await;
-    let _ = sqlx::query("DELETE FROM user_credentials WHERE workspace_id IS NULL")
-        .execute(pool)
-        .await;
-    // Postgres-only `SET NOT NULL`; SQLite tests rebuild the schema each
-    // run so the contract is enforced via the new unique index instead.
-    let _ = sqlx::query("ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL")
-        .execute(pool)
-        .await;
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DELETE FROM user_credentials WHERE workspace_id IS NULL",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "ALTER TABLE user_credentials ALTER COLUMN workspace_id SET NOT NULL",
+    )
+    .await?;
     // Drop the legacy `(user_id, name)` unique constraint — its modern
     // equivalent is `(workspace_id, user_id, name)`. Both names cover the
-    // index/constraint forms Postgres might have created.
-    let _ = sqlx::query("DROP INDEX IF EXISTS user_credentials_user_id_name_key")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("DROP INDEX IF EXISTS idx_user_credentials_user_name")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query(
+    // index/constraint forms Postgres might have created. All `IF EXISTS`,
+    // idempotent, routed through `run_pg_only`.
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DROP INDEX IF EXISTS user_credentials_user_id_name_key",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
+        "DROP INDEX IF EXISTS idx_user_credentials_user_name",
+    )
+    .await?;
+    run_pg_only(
+        pool,
+        is_sqlite,
         "ALTER TABLE user_credentials DROP CONSTRAINT IF EXISTS user_credentials_user_id_name_key",
     )
-    .execute(pool)
-    .await;
+    .await?;
     sqlx::query(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_workspace_user_name \
          ON user_credentials (workspace_id, user_id, name)",
@@ -580,19 +705,23 @@ pub async fn run_migrations(pool: &AnyPool) -> anyhow::Result<()> {
     .await?;
 
     // sessions.workspace_id — backfill from project; rows without a
-    // project remain NULL (legacy personal sessions).
+    // project remain NULL (legacy personal sessions). The backfill is
+    // idempotent (`WHERE workspace_id IS NULL`), so it runs via
+    // `run_pg_only` — skipped on SQLite, errors propagated on Postgres
+    // (issue #550).
     let _ = sqlx::query("ALTER TABLE sessions ADD COLUMN workspace_id TEXT")
         .execute(pool)
         .await;
-    let _ = sqlx::query(
+    run_pg_only(
+        pool,
+        is_sqlite,
         "UPDATE sessions \
          SET workspace_id = ( \
              SELECT p.workspace_id FROM workspace_repos p WHERE p.id = sessions.project_id \
          ) \
          WHERE workspace_id IS NULL AND project_id IS NOT NULL",
     )
-    .execute(pool)
-    .await;
+    .await?;
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions (workspace_id)")
         .execute(pool)
         .await?;

--- a/crates/stiglab/src/server/db/tests.rs
+++ b/crates/stiglab/src/server/db/tests.rs
@@ -18,7 +18,7 @@ mod tests {
             .connect("sqlite::memory:")
             .await
             .expect("failed to connect to sqlite in-memory");
-        run_migrations(&pool)
+        run_migrations(&pool, true)
             .await
             .expect("migrations should succeed");
         pool
@@ -352,5 +352,44 @@ mod tests {
 
         let u2_projects = list_projects_for_user(&pool, "u2").await.unwrap();
         assert!(u2_projects.is_empty());
+    }
+
+    // ── run_pg_only (issue #550) ──
+    //
+    // The legacy best-effort migration statements route through
+    // `run_pg_only`, which must skip on SQLite and propagate errors on
+    // Postgres. These two tests pin both branches without a Postgres harness
+    // by driving the `is_sqlite` flag directly.
+
+    #[tokio::test]
+    async fn run_pg_only_skips_statements_on_sqlite() {
+        // On SQLite the helper must skip the statement entirely, so even
+        // syntactically invalid SQL is a no-op. (If the helper executed the
+        // statement, SQLite would reject it and this would error.)
+        let pool = test_pool().await;
+        run_pg_only(&pool, true, "this is not valid sql at all")
+            .await
+            .expect("run_pg_only must skip every statement on SQLite");
+    }
+
+    #[tokio::test]
+    async fn run_pg_only_propagates_errors_off_sqlite() {
+        // Off SQLite the helper executes the statement and propagates any
+        // error instead of swallowing it (issue #550). We exercise the
+        // propagate branch by forcing `is_sqlite = false` and running a
+        // statement that fails on the backend (missing table). A
+        // swallow-everything helper would return Ok here — that is the
+        // mutation check.
+        let pool = test_pool().await;
+        let result = run_pg_only(
+            &pool,
+            false,
+            "ALTER TABLE missing_table_550 RENAME COLUMN a TO b",
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "run_pg_only must propagate execution errors when not on SQLite"
+        );
     }
 }

--- a/crates/stiglab/src/server/db/tests.rs
+++ b/crates/stiglab/src/server/db/tests.rs
@@ -354,6 +354,19 @@ mod tests {
         assert!(u2_projects.is_empty());
     }
 
+    #[test]
+    fn is_sqlite_url_matches_all_sqlite_schemes() {
+        // The migration dialect flag must recognise every SQLite URL form,
+        // not just the `sqlite://` file URL — a missed form (e.g.
+        // `sqlite::memory:`) would run Postgres-only statements against
+        // SQLite and fail hard (issue #550 review).
+        assert!(is_sqlite_url("sqlite://./data/stiglab.db"));
+        assert!(is_sqlite_url("sqlite::memory:"));
+        assert!(is_sqlite_url("sqlite:stiglab.db"));
+        assert!(!is_sqlite_url("postgres://localhost/onsager"));
+        assert!(!is_sqlite_url("postgresql://localhost/onsager"));
+    }
+
     // ── run_pg_only (issue #550) ──
     //
     // The legacy best-effort migration statements route through

--- a/crates/stiglab/tests/pats.rs
+++ b/crates/stiglab/tests/pats.rs
@@ -27,7 +27,7 @@ async fn test_pool() -> AnyPool {
         .connect("sqlite::memory:")
         .await
         .expect("sqlite connect");
-    db::run_migrations(&pool).await.expect("migrations");
+    db::run_migrations(&pool, true).await.expect("migrations");
     pool
 }
 


### PR DESCRIPTION
## Overview

`run_migrations` (stiglab's fallback migrator) applied legacy / Postgres-only idempotent statements with `let _ = sqlx::query(...).execute(pool).await;`, swallowing errors unconditionally. On **Postgres** a real failure (permissions, unexpected state) was also swallowed, so the migration could proceed and silently diverge — e.g. a failed `projects → workspace_repos` rename followed by `CREATE TABLE IF NOT EXISTS workspace_repos` strands data in `projects` while the app reads an empty new table.

The authoritative path (spine `migrations/*.sql` via `psql -v ON_ERROR_STOP=1`) already fails loudly, so this is defense-in-depth hardening of the fallback, not a live bug — but the swallow-everything idiom is the wrong default.

## What changed

- **One helper, `run_pg_only(pool, is_sqlite, sql)`** — skips on SQLite (the unit-test backend rebuilds the schema fresh from the `CREATE TABLE` calls) and **propagates** errors on Postgres, with `.with_context()` naming the failing statement.
- **`is_sqlite` plumbed** from the connect path in `init_pool` into `run_migrations` (the cleaner of the issue's two options — deterministic, no connection acquisition, no sqlx-internal coupling).
- **Non-idempotent renames wrapped in guarded `DO $$` blocks** (mirroring the canonical spine `004_workflows.sql` shape) so propagation is re-run-safe: on a fresh or already-migrated DB they are a no-op, and only a real failure surfaces. The already-idempotent statements (`DROP … IF EXISTS`, the guarded rename, `WHERE … IS NULL` backfills, `SET NOT NULL`) route directly.

## Scope

The issue lists four statement groups; per its symmetry note ("equivalent statements keep equivalent shape" — CLAUDE.md *internal symmetry is load-bearing*) this routes **every idempotent-on-Postgres legacy statement** through the helper, leaving a clean reviewable invariant: **every remaining `let _ =` swallow is a bare `ALTER TABLE … ADD COLUMN`** (which legitimately errors with "duplicate column" on Postgres re-run and must keep swallowing).

This deliberately extends slightly past the four named groups — flagging it explicitly rather than silently:

- the two `tenant*` → `workspace*` **table** renames (hardening only the *column* renames would let a failed table rename silently strand data — the same failure class the issue targets);
- the `user_credentials` legacy-constraint drops (same kind as the in-scope tenant index drops);
- the `sessions.workspace_id` backfill (same idempotent backfill pattern as the PAT / user_credentials ones).

## Behavior on SQLite

Unchanged. Every routed statement was already a no-op or a swallowed error on SQLite (`DO $$`, `DROP CONSTRAINT`, `SET NOT NULL` are all unsupported there); they are now cleanly skipped instead. The full existing SQLite test suite stays green.

## Test

- `run_pg_only_skips_statements_on_sqlite` — invalid SQL is a no-op when `is_sqlite = true`.
- `run_pg_only_propagates_errors_off_sqlite` — a missing-table statement errors when forced off the SQLite path (focused test of the helper's branch; no PG harness needed).
- **Mutation check** (per CLAUDE.md claim-honesty / issue Test plan): making the helper always-ignore makes the propagate test fail; reverted after verifying.
- `cargo test -p stiglab` green (52 lib + 6 pats); `clippy`/`fmt`/`check-file-budget`/`lint-seams` clean; full workspace builds (the `run_migrations` signature change touches only the three in-tree call sites).

Closes #550

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV3FhzSwyqGkmTCtJFJAQr)_