### PR TITLE
feat(dashboard): dialog builder, preset dropdown, create+active toggle

### DIFF
--- a/apps/dashboard/src/components/ui/switch.tsx
+++ b/apps/dashboard/src/components/ui/switch.tsx
@@ -1,0 +1,25 @@
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0.5 dark:data-checked:bg-primary-foreground dark:data-unchecked:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/dashboard/src/components/workflows/PresetPicker.tsx
+++ b/apps/dashboard/src/components/workflows/PresetPicker.tsx
@@ -1,6 +1,10 @@
-import { Sparkles } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   WORKFLOW_PRESETS,
   type WorkflowDocument,
@@ -12,9 +16,11 @@ export interface PresetPickerProps {
   onApply: (next: WorkflowDocument) => void
 }
 
-// Preset picker shown above the chat builder. Applying a preset fills the
+// Preset picker shown above the card stack. Applying a preset fills the
 // stage list while keeping the trigger (install/repo/label) intact so the
-// user doesn't have to re-pick a repo they already chose.
+// user doesn't have to re-pick a repo they already chose. De-emphasized to
+// one compact line — the name + card stack are the focus, presets are a
+// shortcut.
 export function PresetPicker({ draft, onApply }: PresetPickerProps) {
   const apply = (preset: WorkflowPreset) => {
     const next = preset.build(draft.trigger)
@@ -26,30 +32,29 @@ export function PresetPicker({ draft, onApply }: PresetPickerProps) {
     })
   }
 
+  const onValueChange = (id: string | null) => {
+    const preset = WORKFLOW_PRESETS.find((p) => p.id === id)
+    if (preset) apply(preset)
+  }
+
   return (
-    <Card>
-      <CardContent className="flex flex-col gap-3 p-4">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Sparkles className="h-3.5 w-3.5" />
-          Start from a preset, or build from scratch below.
-        </div>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <span className="shrink-0">Start from a preset</span>
+      <Select value="" onValueChange={onValueChange}>
+        <SelectTrigger size="sm" className="w-full" aria-label="Start from a preset">
+          <SelectValue placeholder="Choose a preset…" />
+        </SelectTrigger>
+        <SelectContent>
           {WORKFLOW_PRESETS.map((p) => (
-            <Button
-              key={p.id}
-              type="button"
-              variant="outline"
-              className="h-auto flex-col items-start gap-1 whitespace-normal p-3 text-left"
-              onClick={() => apply(p)}
-            >
-              <span className="text-sm font-medium">{p.label}</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                {p.description}
+            <SelectItem key={p.id} value={p.id}>
+              <span className="flex flex-col">
+                <span className="text-sm font-medium text-foreground">{p.label}</span>
+                <span className="text-xs text-muted-foreground">{p.description}</span>
               </span>
-            </Button>
+            </SelectItem>
           ))}
-        </div>
-      </CardContent>
-    </Card>
+        </SelectContent>
+      </Select>
+    </div>
   )
 }

--- a/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
@@ -5,6 +5,7 @@ import { api, type CreateWorkflowRequest, type GitHubAppInstallation } from "@/l
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
 import { CardStackEditor } from "./CardStackEditor"
 import { PresetPicker } from "./PresetPicker"
 import {
@@ -28,6 +29,9 @@ export function WorkflowBuilder({
   onCreated,
 }: WorkflowBuilderProps) {
   const [draft, setDraft] = useState<WorkflowDocument>(initialDraft ?? emptyDocument())
+  // Creation and activation are distinct acts; default OFF preserves today's
+  // draft-by-default behavior (the old "Save as draft" path).
+  const [active, setActive] = useState(false)
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const activeWorkspace = useOptionalActiveWorkspace()
@@ -84,25 +88,26 @@ export function WorkflowBuilder({
         </p>
       )}
 
-      <div className="flex flex-col gap-2 sm:flex-row">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label
+          htmlFor="workflow-active"
+          className="flex items-center gap-2 text-sm font-medium"
+        >
+          <Switch
+            id="workflow-active"
+            checked={active}
+            onCheckedChange={setActive}
+          />
+          Active
+        </label>
         <Button
           type="button"
-          variant="outline"
           size="lg"
-          className="w-full sm:flex-1"
+          className="w-full sm:w-auto"
           disabled={!canSave || create.isPending}
-          onClick={() => save(false)}
+          onClick={() => save(active)}
         >
-          Save as draft
-        </Button>
-        <Button
-          type="button"
-          size="lg"
-          className="w-full sm:flex-1"
-          disabled={!canSave || create.isPending}
-          onClick={() => save(true)}
-        >
-          {create.isPending ? "Saving…" : "Activate workflow"}
+          {create.isPending ? "Creating…" : "Create workflow"}
         </Button>
       </div>
     </div>

--- a/apps/dashboard/src/components/workflows/WorkflowBuilderSheet.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowBuilderSheet.tsx
@@ -4,6 +4,13 @@ import { api } from "@/lib/api"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -19,7 +26,10 @@ export interface WorkflowBuilderSheetProps {
 
 /**
  * Thin wrapper that loads the active workspace's installations and mounts
- * WorkflowBuilder inside a shadcn Sheet. Closes itself on successful create.
+ * WorkflowBuilder. On desktop it renders inside a centered modal Dialog; on
+ * mobile it falls back to a bottom Sheet (a centered modal is wrong on small
+ * screens per the dashboard-ui mobile-chrome rules). Closes itself on a
+ * successful create.
  */
 export function WorkflowBuilderSheet({ open, onOpenChange }: WorkflowBuilderSheetProps) {
   const isMobile = useIsMobile()
@@ -45,36 +55,49 @@ export function WorkflowBuilderSheet({ open, onOpenChange }: WorkflowBuilderShee
   })
   const installations = useMemo(() => installsData?.installations ?? [], [installsData])
 
+  const body = workspaceId ? (
+    <WorkflowBuilder
+      workspaceId={workspaceId}
+      installations={installations}
+      onCreated={() => onOpenChange(false)}
+    />
+  ) : (
+    <p className="py-6 text-sm text-muted-foreground">
+      Create a workspace first — workflows live inside a workspace.
+    </p>
+  )
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="bottom" className="h-[90dvh] rounded-t-xl">
+          <SheetHeader>
+            <SheetTitle>Create workflow</SheetTitle>
+            <SheetDescription>
+              Chat out the idea, then tap cards to tune.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-4">
+            {body}
+          </div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side={isMobile ? "bottom" : "right"}
-        className={
-          isMobile
-            ? "h-[90dvh] rounded-t-xl"
-            : "sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl"
-        }
-      >
-        <SheetHeader>
-          <SheetTitle>Create workflow</SheetTitle>
-          <SheetDescription>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85dvh] flex-col gap-4 sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Create workflow</DialogTitle>
+          <DialogDescription>
             Chat out the idea, then tap cards to tune.
-          </SheetDescription>
-        </SheetHeader>
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-4">
-          {workspaceId ? (
-            <WorkflowBuilder
-              workspaceId={workspaceId}
-              installations={installations}
-              onCreated={() => onOpenChange(false)}
-            />
-          ) : (
-            <p className="py-6 text-sm text-muted-foreground">
-              Create a workspace first — workflows live inside a workspace.
-            </p>
-          )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          {body}
         </div>
-      </SheetContent>
-    </Sheet>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/dashboard/tests/smoke/workflow-builder-create.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-builder-create.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import type { ReactNode } from "react"
+
+import { WorkflowBuilder } from "@/components/workflows/WorkflowBuilder"
+import {
+  makeStage,
+  type WorkflowDocument,
+} from "@/components/workflows/workflow-draft"
+import type {
+  CreateWorkflowRequest,
+  GitHubAppInstallation,
+} from "@/lib/api"
+
+const installations: GitHubAppInstallation[] = [
+  {
+    id: "inst_one",
+    workspace_id: "ws_1",
+    install_id: 1001,
+    account_login: "onsager-ai",
+    account_type: "organization",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+]
+
+// A fully-ready draft so `canSave` is true and the Create button is enabled.
+function readyDraft(): WorkflowDocument {
+  return {
+    name: "Issue → PR",
+    trigger: {
+      install_id: "inst_one",
+      repo_owner: "onsager-ai",
+      repo_name: "onsager",
+      label: "factory",
+    },
+    stages: [makeStage("agent-session", "Issue", "Spec → PR")],
+  }
+}
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<object>("@/lib/api")
+  return {
+    ...actual,
+    api: {
+      createWorkflow: vi.fn(),
+    },
+  }
+})
+
+async function primeApi() {
+  const { api } = await import("@/lib/api")
+  vi.mocked(api.createWorkflow).mockResolvedValue({
+    workflow: {
+      id: "wf_1",
+      workspace_id: "ws_1",
+      name: "Issue → PR",
+      preset: null,
+      status: "draft",
+      trigger: {
+        kind: "github-label",
+        install_id: "1001",
+        repo_owner: "onsager-ai",
+        repo_name: "onsager",
+        label: "factory",
+        kind_tag: "github_issue_webhook",
+        manual_name: "",
+      },
+      stages: [],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  })
+}
+
+function mount(node: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+async function lastCreateBody(): Promise<CreateWorkflowRequest> {
+  const { api } = await import("@/lib/api")
+  const mock = vi.mocked(api.createWorkflow)
+  await waitFor(() => expect(mock).toHaveBeenCalledTimes(1))
+  return mock.mock.calls[0][0]
+}
+
+describe("WorkflowBuilder create action", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await primeApi()
+  })
+
+  it("renders one Create workflow button and an Active toggle (no draft/activate split)", () => {
+    mount(
+      <WorkflowBuilder
+        workspaceId="ws_1"
+        installations={installations}
+        initialDraft={readyDraft()}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Create workflow" })).toBeTruthy()
+    expect(screen.getByRole("switch", { name: "Active" })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: /Save as draft/i })).toBeNull()
+    expect(screen.queryByRole("button", { name: /Activate workflow/i })).toBeNull()
+  })
+
+  it("defaults the Active toggle off — Create yields an inactive workflow", async () => {
+    mount(
+      <WorkflowBuilder
+        workspaceId="ws_1"
+        installations={installations}
+        initialDraft={readyDraft()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Create workflow" }))
+    const body = await lastCreateBody()
+    expect(body.active).toBe(false)
+  })
+
+  it("threads the Active toggle through to the create request's active boolean", async () => {
+    mount(
+      <WorkflowBuilder
+        workspaceId="ws_1"
+        installations={installations}
+        initialDraft={readyDraft()}
+      />,
+    )
+    // Flip the toggle on, then create.
+    fireEvent.click(screen.getByRole("switch", { name: "Active" }))
+    fireEvent.click(screen.getByRole("button", { name: "Create workflow" }))
+    const body = await lastCreateBody()
+    expect(body.active).toBe(true)
+  })
+})

--- a/apps/dashboard/tests/smoke/workflow-builder-sheet-responsive.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-builder-sheet-responsive.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import type { ReactNode } from "react"
+
+import { WorkflowBuilderSheet } from "@/components/workflows/WorkflowBuilderSheet"
+
+// The builder mounts inside a centered Dialog on desktop and a bottom Sheet
+// on mobile (spec #560). Both wrap the same base-ui dialog primitive, so the
+// branch is observable only via the distinct content `data-slot`s. Mock the
+// breakpoint hook so the test pins the branch rather than the viewport.
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: vi.fn(),
+}))
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<{ api: Record<string, unknown> }>(
+    "@/lib/api",
+  )
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+      listWorkspaceInstallations: vi
+        .fn()
+        .mockResolvedValue({ installations: [] }),
+    },
+  }
+})
+
+async function setMobile(value: boolean) {
+  const { useIsMobile } = await import("@/hooks/use-mobile")
+  vi.mocked(useIsMobile).mockReturnValue(value)
+}
+
+function mount(node: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("WorkflowBuilderSheet responsive container", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders a centered Dialog (not a Sheet) on desktop", async () => {
+    await setMobile(false)
+    mount(<WorkflowBuilderSheet open onOpenChange={() => {}} />)
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-slot="dialog-content"]'),
+      ).not.toBeNull(),
+    )
+    expect(document.querySelector('[data-slot="sheet-content"]')).toBeNull()
+  })
+
+  it("renders a bottom Sheet (not a Dialog) on mobile", async () => {
+    await setMobile(true)
+    mount(<WorkflowBuilderSheet open onOpenChange={() => {}} />)
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-slot="sheet-content"]'),
+      ).not.toBeNull(),
+    )
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull()
+  })
+})

--- a/apps/dashboard/tests/smoke/workflow-preset-picker.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-preset-picker.test.tsx
@@ -7,15 +7,35 @@ import {
   type WorkflowDocument,
 } from "@/components/workflows/workflow-draft"
 
+// Open the preset dropdown and choose the option whose label matches.
+function choosePreset(label: string) {
+  fireEvent.click(screen.getByRole("combobox", { name: "Start from a preset" }))
+  fireEvent.click(screen.getByText(label))
+}
+
 describe("PresetPicker", () => {
-  it("renders one button per preset", () => {
+  it("renders a single compact preset dropdown, not a button grid", () => {
     render(<PresetPicker draft={emptyDocument()} onApply={() => {}} />)
+    // One de-emphasized control: the Select trigger, labeled for a11y.
+    expect(
+      screen.getByRole("combobox", { name: "Start from a preset" }),
+    ).toBeTruthy()
+    // The old per-preset buttons are gone.
     for (const p of WORKFLOW_PRESETS) {
-      expect(screen.getByRole("button", { name: new RegExp(p.label) })).toBeTruthy()
+      expect(screen.queryByRole("button", { name: new RegExp(p.label) })).toBeNull()
     }
   })
 
-  it("applying a preset fills stages but preserves the existing trigger", () => {
+  it("lists every preset (label + description) inside the dropdown", () => {
+    render(<PresetPicker draft={emptyDocument()} onApply={() => {}} />)
+    fireEvent.click(screen.getByRole("combobox", { name: "Start from a preset" }))
+    for (const p of WORKFLOW_PRESETS) {
+      expect(screen.getByText(p.label)).toBeTruthy()
+      expect(screen.getByText(p.description)).toBeTruthy()
+    }
+  })
+
+  it("choosing a preset fills stages but preserves the existing trigger", () => {
     const onApply = vi.fn()
     const draft: WorkflowDocument = {
       name: "",
@@ -28,7 +48,7 @@ describe("PresetPicker", () => {
       stages: [],
     }
     render(<PresetPicker draft={draft} onApply={onApply} />)
-    fireEvent.click(screen.getByRole("button", { name: /Issue → PR/ }))
+    choosePreset("Issue → PR")
     const next = onApply.mock.calls[0][0] as WorkflowDocument
     expect(next.trigger).toEqual(draft.trigger)
     expect(next.stages.length).toBeGreaterThan(0)
@@ -41,7 +61,7 @@ describe("PresetPicker", () => {
       name: "My custom workflow",
     }
     render(<PresetPicker draft={draft} onApply={onApply} />)
-    fireEvent.click(screen.getByRole("button", { name: /Issue → PR/ }))
+    choosePreset("Issue → PR")
     const next = onApply.mock.calls[0][0] as WorkflowDocument
     expect(next.name).toBe("My custom workflow")
   })
@@ -49,7 +69,7 @@ describe("PresetPicker", () => {
   it("falls back to the preset-generated name when the draft name is blank", () => {
     const onApply = vi.fn()
     render(<PresetPicker draft={emptyDocument()} onApply={onApply} />)
-    fireEvent.click(screen.getByRole("button", { name: /Issue → PR/ }))
+    choosePreset("Issue → PR")
     const next = onApply.mock.calls[0][0] as WorkflowDocument
     expect(next.name.length).toBeGreaterThan(0)
   })


### PR DESCRIPTION
Closes #560

## Delivers
Workflow-builder UI polish — presentation only, no trigger-contract change:
- [x] `WorkflowBuilderSheet`: centered Dialog on desktop, bottom Sheet on mobile (branched on `useIsMobile()`)
- [x] `PresetPicker`: 5-button grid → one compact "Start from a preset" Select
- [x] `WorkflowBuilder`: single **Create workflow** button + an **Active** toggle (defaults off), wired through the existing `save(active)`
- [x] No change to `documentToCreateRequest` / trigger contract

Adds the shadcn `Switch` primitive built on `@base-ui/react` to match the repo's other ui/* primitives (no new dependency).

## Tests
- responsive branch (Dialog vs bottom Sheet) asserted via `data-slot`, mutation-checked
- preset dropdown fills stages + preserves a typed name
- Active toggle threads through to `active` (off→false, on→true), mutation-checked

Open question resolved: **Active defaults off** (creation ≠ activation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)