### PR TITLE
feat(dashboard): expose Manual repo-less trigger in workflow builder

### DIFF
--- a/apps/dashboard/src/components/workflows/CardStackEditor.tsx
+++ b/apps/dashboard/src/components/workflows/CardStackEditor.tsx
@@ -54,7 +54,11 @@ export function CardStackEditor({
             Flow
           </div>
           <ArtifactFlowOverview
-            triggerLabel={draft.trigger.label}
+            triggerLabel={
+              draft.trigger.kind_tag === "manual"
+                ? draft.trigger.manual_name
+                : draft.trigger.label
+            }
             stages={draft.stages}
             currentStageIndex={currentStageIndex}
           />

--- a/apps/dashboard/src/components/workflows/TriggerCard.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerCard.tsx
@@ -4,6 +4,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { type GitHubAppInstallation } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
 import {
   Sheet,
   SheetContent,
@@ -76,7 +77,9 @@ export function TriggerCard({
           <SheetHeader>
             <SheetTitle>Edit trigger</SheetTitle>
             <SheetDescription>
-              Pick the repo and label that starts the workflow.
+              {value.kind_tag === "manual"
+                ? "Name the manual trigger that starts the workflow."
+                : "Pick the repo and label that starts the workflow."}
             </SheetDescription>
           </SheetHeader>
           <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain px-4">
@@ -109,53 +112,78 @@ function TriggerForm({
   value: WorkflowTriggerDraft
   onChange: (next: WorkflowTriggerDraft) => void
 }) {
+  const isManual = value.kind_tag === "manual"
+
   return (
     <>
-      <TriggerKindPicker kindTag="github_issue_webhook" />
+      <TriggerKindPicker
+        kindTag={value.kind_tag}
+        onKindChange={(kind_tag) => onChange({ ...value, kind_tag })}
+      />
 
-      <div className="space-y-1.5">
-        <span className="text-sm font-medium">Repository</span>
-        <RepoCombobox
-          workspaceId={workspaceId}
-          installations={installations}
-          installId={value.install_id}
-          repoOwner={value.repo_owner}
-          repoName={value.repo_name}
-          onChange={(next) =>
-            onChange({
-              ...value,
-              install_id: next.install_id,
-              repo_owner: next.repo_owner,
-              repo_name: next.repo_name,
-              label:
-                next.install_id === value.install_id &&
-                next.repo_owner === value.repo_owner &&
-                next.repo_name === value.repo_name
-                  ? value.label
-                  : "",
-            })
-          }
-        />
-      </div>
-
-      <div className="space-y-1.5">
-        <span className="text-sm font-medium">Trigger label</span>
-        {value.install_id && value.repo_owner && value.repo_name ? (
-          <LabelCombobox
-            workspaceId={workspaceId}
-            installId={value.install_id}
-            repoOwner={value.repo_owner}
-            repoName={value.repo_name}
-            value={value.label || null}
-            onChange={(label) => onChange({ ...value, label })}
+      {isManual ? (
+        <div className="space-y-1.5">
+          <label htmlFor="manual-trigger-name" className="text-sm font-medium">
+            Trigger name
+          </label>
+          <Input
+            id="manual-trigger-name"
+            value={value.manual_name}
+            onChange={(e) => onChange({ ...value, manual_name: e.target.value })}
+            placeholder="e.g. Run nightly batch"
           />
-        ) : (
-          <p className="flex items-center gap-2 text-xs text-muted-foreground">
-            <GitBranch className="h-3.5 w-3.5" />
-            Pick a repository above.
+          <p className="text-xs text-muted-foreground">
+            The button label; fire it from the dashboard or{" "}
+            <code>onsager trigger fire</code>. No repo required.
           </p>
-        )}
-      </div>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1.5">
+            <span className="text-sm font-medium">Repository</span>
+            <RepoCombobox
+              workspaceId={workspaceId}
+              installations={installations}
+              installId={value.install_id}
+              repoOwner={value.repo_owner}
+              repoName={value.repo_name}
+              onChange={(next) =>
+                onChange({
+                  ...value,
+                  install_id: next.install_id,
+                  repo_owner: next.repo_owner,
+                  repo_name: next.repo_name,
+                  label:
+                    next.install_id === value.install_id &&
+                    next.repo_owner === value.repo_owner &&
+                    next.repo_name === value.repo_name
+                      ? value.label
+                      : "",
+                })
+              }
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <span className="text-sm font-medium">Trigger label</span>
+            {value.install_id && value.repo_owner && value.repo_name ? (
+              <LabelCombobox
+                workspaceId={workspaceId}
+                installId={value.install_id}
+                repoOwner={value.repo_owner}
+                repoName={value.repo_name}
+                value={value.label || null}
+                onChange={(label) => onChange({ ...value, label })}
+              />
+            ) : (
+              <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                <GitBranch className="h-3.5 w-3.5" />
+                Pick a repository above.
+              </p>
+            )}
+          </div>
+        </>
+      )}
     </>
   )
 }
@@ -164,6 +192,12 @@ function summarizeTrigger(t: WorkflowTriggerDraft): {
   title: string
   detail: string
 } {
+  if (t.kind_tag === "manual") {
+    return {
+      title: t.manual_name.trim() || "Name the trigger",
+      detail: "Fires manually — no repo required",
+    }
+  }
   if (!t.install_id || !t.repo_owner || !t.repo_name) {
     return {
       title: "Pick a repository",

--- a/apps/dashboard/src/components/workflows/TriggerKindPicker.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerKindPicker.tsx
@@ -1,27 +1,50 @@
 import { useQuery } from "@tanstack/react-query"
 import { api, type TriggerManifestEntry } from "@/lib/api"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+// Kinds the builder can author today (#561). The manifest carries every
+// registry kind, but the builder only knows how to collect config for
+// these two; the rest (cron, interval, the GitHub webhook variants, …)
+// land as the per-kind forms are built out. Order here is the display
+// order in the selector.
+const SELECTABLE_KINDS = ["github_issue_webhook", "manual"] as const
 
 const FALLBACK: TriggerManifestEntry[] = [
   {
     kind_tag: "github_issue_webhook",
-    producer: "stiglab",
-    category: "event",
+    producer: "portal",
+    category: "request",
     ui_kind: "webhook",
     description: "Fires when a GitHub issue is labeled with the configured label.",
+  },
+  {
+    kind_tag: "manual",
+    producer: "portal",
+    category: "manual",
+    ui_kind: "manual",
+    description: "Fires from a UI button or `onsager trigger fire` CLI command.",
   },
 ]
 
 /**
- * Read-only badge above the trigger form that names the active kind and
- * its description, sourced from `/api/registry/triggers` (spec #237). The
- * dashboard renders one picker today because the registry has one row;
- * future kinds (cron, interval, …) will append manifest rows and the
- * picker will become a real selector.
+ * Selector above the trigger form for the active trigger kind, sourced
+ * from `/api/registry/triggers` (spec #237). Selecting a kind updates the
+ * draft's `kind_tag`; the kind's manifest description stays visible below
+ * the control. The builder offers the kinds it can collect config for
+ * (`SELECTABLE_KINDS`); #561 adds Manual to the original webhook-only set.
  */
 export function TriggerKindPicker({
   kindTag,
+  onKindChange,
 }: {
   kindTag: string
+  onKindChange: (kindTag: string) => void
 }) {
   const { data } = useQuery({
     queryKey: ["registry", "triggers"],
@@ -31,17 +54,41 @@ export function TriggerKindPicker({
     staleTime: Infinity,
   })
 
-  const triggers = data?.triggers ?? FALLBACK
-  const entry = triggers.find((t) => t.kind_tag === kindTag) ?? triggers[0]
+  const all = data?.triggers ?? FALLBACK
+  // Keep only the kinds the builder can author, in `SELECTABLE_KINDS`
+  // order. Falls back to any single matching row when the manifest is
+  // missing one (defensive — both rows exist server-side).
+  const options = SELECTABLE_KINDS.map((tag) =>
+    all.find((t) => t.kind_tag === tag),
+  ).filter((t): t is TriggerManifestEntry => t !== undefined)
+
+  const entry =
+    options.find((t) => t.kind_tag === kindTag) ?? options[0] ?? all[0]
   if (!entry) return null
 
   return (
-    <div className="rounded-md border bg-muted/30 px-3 py-2">
-      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+    <div className="space-y-1.5">
+      <span className="text-xs uppercase tracking-wide text-muted-foreground">
         Trigger kind
-      </div>
-      <div className="text-sm font-medium">{humanLabel(entry.kind_tag)}</div>
-      <div className="text-xs text-muted-foreground">{entry.description}</div>
+      </span>
+      <Select
+        value={entry.kind_tag}
+        onValueChange={(next) => {
+          if (next) onKindChange(next)
+        }}
+      >
+        <SelectTrigger className="w-full" aria-label="Trigger kind">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((t) => (
+            <SelectItem key={t.kind_tag} value={t.kind_tag}>
+              {humanLabel(t.kind_tag)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">{entry.description}</p>
     </div>
   )
 }
@@ -50,6 +97,8 @@ function humanLabel(kindTag: string): string {
   switch (kindTag) {
     case "github_issue_webhook":
       return "GitHub issue webhook"
+    case "manual":
+      return "Manual"
     default:
       return kindTag
   }

--- a/apps/dashboard/src/components/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/workflows/workflow-draft.ts
@@ -26,10 +26,23 @@ export interface WorkflowDocument {
 }
 
 export interface WorkflowTriggerDraft {
+  /**
+   * Snake-case registry `kind_tag` for the selected trigger kind (e.g.
+   * `'github_issue_webhook'`, `'manual'`). Drives `isTriggerReady`'s
+   * per-kind readiness branch and which `TriggerKind` variant
+   * `documentToCreateRequest` emits. Defaults to `'github_issue_webhook'`
+   * (the original, GitHub-webhook-only behavior — see `emptyDocument`).
+   */
+  kind_tag: string;
   install_id: string;
   repo_owner: string;
   repo_name: string;
   label: string;
+  /**
+   * Manual-trigger button name; used only when `kind_tag === 'manual'`.
+   * Empty for every other kind.
+   */
+  manual_name: string;
 }
 
 /**
@@ -103,7 +116,14 @@ export function defaultStageName(gate: WorkflowGateKind): string {
 export function emptyDocument(): WorkflowDocument {
   return {
     name: "",
-    trigger: { install_id: "", repo_owner: "", repo_name: "", label: "" },
+    trigger: {
+      kind_tag: "github_issue_webhook",
+      install_id: "",
+      repo_owner: "",
+      repo_name: "",
+      label: "",
+      manual_name: "",
+    },
     stages: [],
   };
 }
@@ -197,6 +217,12 @@ export const WORKFLOW_PRESETS: WorkflowPreset[] = [
 ];
 
 export function isTriggerReady(t: WorkflowTriggerDraft): boolean {
+  // Manual triggers (#561) are repo-less: a non-empty button name is the
+  // only requirement — no install, repo, or label. The GitHub webhook leg
+  // stays exactly as it was (#545: webhook repo is required, no regression).
+  if (t.kind_tag === "manual") {
+    return t.manual_name.trim() !== "";
+  }
   return (
     t.install_id.trim() !== "" &&
     t.repo_owner.trim() !== "" &&
@@ -214,8 +240,8 @@ export function draftToRequestTrigger(
     repo_owner: t.repo_owner,
     repo_name: t.repo_name,
     label: t.label,
-    kind_tag: "github_issue_webhook",
-    manual_name: "",
+    kind_tag: t.kind_tag,
+    manual_name: t.kind_tag === "manual" ? t.manual_name : "",
   };
 }
 
@@ -241,10 +267,30 @@ export function documentToCreateRequest(
   }
   if (!isTriggerReady(doc.trigger)) {
     throw new ApiError(
-      "pick an install, repo, and label before activating",
+      doc.trigger.kind_tag === "manual"
+        ? "name the manual trigger before activating"
+        : "pick an install, repo, and label before activating",
       400,
     );
   }
+
+  // Manual triggers (#561) are repo-less: emit the `manual` variant with
+  // just its button name — no `repo`, no install token-mint hint. The
+  // backend's `trigger.repo` is optional (#545) and a Manual workflow
+  // resolves repos workspace-scoped at runtime (#546/#556).
+  if (doc.trigger.kind_tag === "manual") {
+    return {
+      workspace_id: workspaceId,
+      name: doc.name.trim(),
+      trigger: {
+        kind: "manual",
+        name: doc.trigger.manual_name.trim(),
+      },
+      stages: doc.stages.map(stageToCreateStage),
+      active: activate,
+    };
+  }
+
   const install = installations.find((i) => i.id === doc.trigger.install_id);
   if (!install) {
     throw new ApiError(
@@ -255,9 +301,8 @@ export function documentToCreateRequest(
   return {
     workspace_id: workspaceId,
     name: doc.name.trim(),
-    // Structured trigger (ADR 0024 / spec #509). The UI draft is
-    // GitHub-only today, so we assemble the `github_issue_webhook`
-    // variant; the wire contract accepts any registry trigger kind.
+    // Structured trigger (ADR 0024 / spec #509). The GitHub-webhook leg is
+    // unchanged from before #561 — `github_issue_webhook` with a `repo`.
     trigger: {
       kind: "github_issue_webhook",
       repo: `${doc.trigger.repo_owner}/${doc.trigger.repo_name}`,

--- a/apps/dashboard/src/lib/drafts.ts
+++ b/apps/dashboard/src/lib/drafts.ts
@@ -36,7 +36,14 @@ function newId(): string {
 function emptyDocument(): WorkflowDocument {
   return {
     name: "",
-    trigger: { install_id: "", repo_owner: "", repo_name: "", label: "" },
+    trigger: {
+      kind_tag: "github_issue_webhook",
+      install_id: "",
+      repo_owner: "",
+      repo_name: "",
+      label: "",
+      manual_name: "",
+    },
     stages: [],
   }
 }

--- a/apps/dashboard/src/lib/templates/index.ts
+++ b/apps/dashboard/src/lib/templates/index.ts
@@ -52,10 +52,12 @@ export function templateToDocument(template: FtueTemplate): WorkflowDocument {
   return {
     name: template.name,
     trigger: {
+      kind_tag: "github_issue_webhook",
       install_id: "",
       repo_owner: "",
       repo_name: "",
       label: template.trigger_label,
+      manual_name: "",
     },
     stages: template.stages.map((s) =>
       makeStage(s.gate_kind, s.artifact_kind, s.name),

--- a/apps/dashboard/src/lib/workflow-yaml.ts
+++ b/apps/dashboard/src/lib/workflow-yaml.ts
@@ -30,10 +30,12 @@ export function workflowDocumentToYaml(doc: WorkflowDocument): string {
     {
       name: doc.name,
       trigger: {
+        kind_tag: doc.trigger.kind_tag,
         install_id: doc.trigger.install_id,
         repo_owner: doc.trigger.repo_owner,
         repo_name: doc.trigger.repo_name,
         label: doc.trigger.label,
+        manual_name: doc.trigger.manual_name,
       },
       stages: doc.stages.map((s) => ({
         id: s.id,
@@ -83,11 +85,16 @@ function parseTrigger(raw: unknown): WorkflowTriggerDraft {
   if (!isObject(raw)) {
     throw new WorkflowYamlError("`trigger` must be a mapping")
   }
+  // `kind_tag` / `manual_name` are read optionally so YAML authored before
+  // the Manual trigger kind (#561) still round-trips: an absent `kind_tag`
+  // defaults to the original `github_issue_webhook` behavior.
   return {
+    kind_tag: optionalString(raw, "kind_tag", "trigger") || "github_issue_webhook",
     install_id: requireString(raw, "install_id", "trigger"),
     repo_owner: requireString(raw, "repo_owner", "trigger"),
     repo_name: requireString(raw, "repo_name", "trigger"),
     label: requireString(raw, "label", "trigger"),
+    manual_name: optionalString(raw, "manual_name", "trigger"),
   }
 }
 
@@ -126,6 +133,18 @@ function parseStages(raw: unknown): WorkflowStage[] {
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v != null && !Array.isArray(v)
+}
+
+// Like `requireString` but a missing key yields `""` rather than throwing.
+// Used for fields added after the original YAML shape (e.g. the Manual
+// trigger's `kind_tag` / `manual_name`, #561) so older drafts still parse.
+function optionalString(
+  obj: Record<string, unknown>,
+  key: string,
+  ctx: string,
+): string {
+  if (!(key in obj)) return ""
+  return requireString(obj, key, ctx)
 }
 
 function requireString(

--- a/apps/dashboard/src/pages/ChatPage.tsx
+++ b/apps/dashboard/src/pages/ChatPage.tsx
@@ -228,10 +228,16 @@ function extractWorkflowDocument(
     return {
       name,
       trigger: {
+        kind_tag:
+          typeof trigger.kind_tag === "string" && trigger.kind_tag
+            ? trigger.kind_tag
+            : "github_issue_webhook",
         install_id: String(trigger.install_id ?? ""),
         repo_owner: typeof trigger.repo_owner === "string" ? trigger.repo_owner : "",
         repo_name: typeof trigger.repo_name === "string" ? trigger.repo_name : "",
         label: typeof trigger.label === "string" ? trigger.label : "",
+        manual_name:
+          typeof trigger.manual_name === "string" ? trigger.manual_name : "",
       },
       stages,
     }

--- a/apps/dashboard/src/pages/WorkflowStartPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowStartPage.tsx
@@ -207,10 +207,12 @@ function RepoRow({
     // explicit 400 on the backend). The draft here is only used to
     // compute a nice default name.
     const draft = githubIssueToPrPreset({
+      kind_tag: "github_issue_webhook",
       install_id: installId,
       repo_owner: repo.owner,
       repo_name: repo.name,
       label,
+      manual_name: "",
     });
     create.mutate({
       workspace_id: workspaceId,

--- a/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
@@ -56,16 +56,18 @@ describe("Stage card editor", () => {
 
 describe("Trigger card editor", () => {
   const empty: WorkflowTriggerDraft = {
+    kind_tag: "github_issue_webhook",
     install_id: "",
     repo_owner: "",
     repo_name: "",
     label: "",
+    manual_name: "",
   }
 
   it("has no free-text inputs for the linkable fields (install/repo/label)", () => {
     mount(
       <TriggerCard
-        tenantId="t1"
+        workspaceId="t1"
         installations={[]}
         value={empty}
         onChange={() => {}}
@@ -82,10 +84,12 @@ describe("Trigger card editor", () => {
 describe("workflow-draft serialization", () => {
   it("only produces structured trigger values on the wire", () => {
     const t: WorkflowTriggerDraft = {
+      kind_tag: "github_issue_webhook",
       install_id: "inst_1",
       repo_owner: "onsager-ai",
       repo_name: "onsager",
       label: "factory",
+      manual_name: "",
     }
     expect(isTriggerReady(t)).toBe(true)
     const wire = draftToRequestTrigger(t)
@@ -103,18 +107,22 @@ describe("workflow-draft serialization", () => {
   it("rejects drafts with empty linkable fields", () => {
     expect(
       isTriggerReady({
+        kind_tag: "github_issue_webhook",
         install_id: "inst_1",
         repo_owner: "onsager-ai",
         repo_name: "onsager",
         label: "",
+        manual_name: "",
       }),
     ).toBe(false)
     expect(
       isTriggerReady({
+        kind_tag: "github_issue_webhook",
         install_id: "",
         repo_owner: "a",
         repo_name: "b",
         label: "c",
+        manual_name: "",
       }),
     ).toBe(false)
   })

--- a/apps/dashboard/tests/unit/workflow-draft-manual-trigger.test.ts
+++ b/apps/dashboard/tests/unit/workflow-draft-manual-trigger.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest"
+import type { GitHubAppInstallation } from "@/lib/api"
+import {
+  documentToCreateRequest,
+  emptyDocument,
+  isTriggerReady,
+  makeStage,
+  type WorkflowDocument,
+  type WorkflowTriggerDraft,
+} from "@/components/workflows/workflow-draft"
+
+// Manual repo-less trigger kind in the workflow builder (spec #561).
+// The backend is unchanged — these exercise the dashboard's draft-side
+// branch on `kind_tag`: Manual needs only a name; GitHub keeps requiring
+// install + repo + label (#545 — no regression).
+
+function githubTrigger(
+  over: Partial<WorkflowTriggerDraft> = {},
+): WorkflowTriggerDraft {
+  return {
+    kind_tag: "github_issue_webhook",
+    install_id: "inst_1",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    label: "ai",
+    manual_name: "",
+    ...over,
+  }
+}
+
+function manualTrigger(
+  over: Partial<WorkflowTriggerDraft> = {},
+): WorkflowTriggerDraft {
+  return {
+    kind_tag: "manual",
+    install_id: "",
+    repo_owner: "",
+    repo_name: "",
+    label: "",
+    manual_name: "Run nightly batch",
+    ...over,
+  }
+}
+
+const INSTALLATIONS: GitHubAppInstallation[] = [
+  {
+    id: "inst_1",
+    workspace_id: "ws_1",
+    install_id: 4242,
+    account_login: "acme",
+    account_type: "Organization",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+]
+
+describe("isTriggerReady — per-kind branch (#561)", () => {
+  it("Manual is ready with only a non-empty name", () => {
+    expect(isTriggerReady(manualTrigger())).toBe(true)
+  })
+
+  it("Manual with a blank name is not ready", () => {
+    expect(isTriggerReady(manualTrigger({ manual_name: "   " }))).toBe(false)
+  })
+
+  it("Manual ignores install/repo/label entirely", () => {
+    // No install, no repo, no label — still ready as long as it has a name.
+    expect(
+      isTriggerReady(
+        manualTrigger({
+          install_id: "",
+          repo_owner: "",
+          repo_name: "",
+          label: "",
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("GitHub still requires install + repo + label (no regression)", () => {
+    expect(isTriggerReady(githubTrigger())).toBe(true)
+    expect(isTriggerReady(githubTrigger({ install_id: "" }))).toBe(false)
+    expect(isTriggerReady(githubTrigger({ repo_owner: "" }))).toBe(false)
+    expect(isTriggerReady(githubTrigger({ repo_name: "" }))).toBe(false)
+    expect(isTriggerReady(githubTrigger({ label: "" }))).toBe(false)
+  })
+
+  it("a GitHub trigger with a name set is NOT treated as ready (kind decides)", () => {
+    // Mutation guard: if the Manual branch keyed off `manual_name` instead
+    // of `kind_tag`, this github trigger (missing repo/label) would falsely
+    // pass. It must stay false because the kind is github_issue_webhook.
+    expect(
+      isTriggerReady(
+        githubTrigger({
+          install_id: "",
+          repo_owner: "",
+          repo_name: "",
+          label: "",
+          manual_name: "Run nightly batch",
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("documentToCreateRequest — Manual variant (#561)", () => {
+  function manualDoc(): WorkflowDocument {
+    return {
+      ...emptyDocument(),
+      name: "Nightly batch",
+      trigger: manualTrigger(),
+      stages: [makeStage("agent-session", "Issue", "Agent session")],
+    }
+  }
+
+  it("emits a repo-less manual trigger with no install_id hint", () => {
+    const body = documentToCreateRequest(manualDoc(), [], "ws_1", false)
+    expect(body.trigger).toEqual({ kind: "manual", name: "Run nightly batch" })
+    // Repo-less: no install token-mint hint, no repo on the trigger.
+    expect(body.install_id).toBeUndefined()
+    expect("repo" in body.trigger).toBe(false)
+    expect(body.workspace_id).toBe("ws_1")
+    expect(body.active).toBe(false)
+  })
+
+  it("succeeds for a Manual workflow with NO repo selected", () => {
+    // The "repo unpinned" leg (deferred from #547 / #553): a Manual
+    // workflow created with no install/repo must not throw.
+    expect(() =>
+      documentToCreateRequest(manualDoc(), [], "ws_1", true),
+    ).not.toThrow()
+  })
+
+  it("trims the manual name on the wire", () => {
+    const doc = manualDoc()
+    doc.trigger = manualTrigger({ manual_name: "  spaced  " })
+    const body = documentToCreateRequest(doc, [], "ws_1", false)
+    expect(body.trigger).toEqual({ kind: "manual", name: "spaced" })
+  })
+
+  it("throws when the Manual name is blank", () => {
+    const doc = manualDoc()
+    doc.trigger = manualTrigger({ manual_name: "" })
+    expect(() => documentToCreateRequest(doc, [], "ws_1", false)).toThrow()
+  })
+})
+
+describe("documentToCreateRequest — GitHub variant unchanged (#561)", () => {
+  function githubDoc(): WorkflowDocument {
+    return {
+      ...emptyDocument(),
+      name: "Issue to PR",
+      trigger: githubTrigger(),
+      stages: [makeStage("agent-session", "Issue", "Agent session")],
+    }
+  }
+
+  it("emits the github_issue_webhook variant with repo + numeric install id", () => {
+    const body = documentToCreateRequest(githubDoc(), INSTALLATIONS, "ws_1", true)
+    expect(body.trigger).toEqual({
+      kind: "github_issue_webhook",
+      repo: "acme/widgets",
+      label: "ai",
+    })
+    expect(body.install_id).toBe(4242)
+    expect(body.active).toBe(true)
+  })
+
+  it("still requires the selected install to exist in the workspace", () => {
+    expect(() =>
+      documentToCreateRequest(githubDoc(), [], "ws_1", false),
+    ).toThrow()
+  })
+})


### PR DESCRIPTION
Closes #561
Part of #544

Stacked on #560 (base = `claude/spec-560-workflow-builder-ui`); will be rebased onto `main` after #560 merges. **Unblocks #553.**

## Delivers
Exposes a Manual (repo-less) trigger kind in the workflow builder — dashboard-only, no backend change (the `manual` row already exists in the registry manifest; `trigger.repo` already optional per #545):
- [x] `TriggerKindPicker`: read-only badge → real Select over `/api/registry/triggers` (github_issue_webhook + manual)
- [x] `isTriggerReady` branches on kind: Manual needs only a name; GitHub unchanged (install+repo+label)
- [x] `documentToCreateRequest` emits the repo-less `{kind:"manual", name}` variant — wire shape verified against the Rust SSOT (`onsager-spine` TriggerKind); GitHub path untouched
- [x] `TriggerCard`/`CardStackEditor`: repo+label hidden for Manual, trigger-name field shown

## Tests
- `isTriggerReady` branch tests (manual name-only ready; GitHub still needs install+repo+label), mutation-checked
- `documentToCreateRequest` emits repo-less manual vs github variant
- full dashboard test suite green

The two inherently-local Test items (fire via `onsager trigger fire`, in-app create-with-no-repo) are covered by the unit/contract tests; full CLI→Runs e2e needs a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)