### PR TITLE
chore: load .env in just recipes, gitignore local stiglab db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 /.dev-slots.json
 /worktrees/
 **/.env.slot
+
+# Local runtime data. Stiglab defaults its DB to sqlite://./data/stiglab.db
+# (see .env.example); the file is per-machine dev state, never committed.
+/data/

--- a/justfile
+++ b/justfile
@@ -1,6 +1,11 @@
 # Onsager monorepo task runner.
 # Rust + TS workspaces coexist; this file is just a command registry.
 
+# Load .env into every recipe's environment. Lets `just dev` (which runs
+# cargo directly, not via docker-compose) pick up credential keys and other
+# config from .env — e.g. ONSAGER_CREDENTIAL_KEY / STIGLAB_CREDENTIAL_KEY.
+set dotenv-load := true
+
 default:
     @just --list
 


### PR DESCRIPTION
Two dev-tooling fixes, unrelated to any feature spec (hence `trivial`):

- **justfile**: `set dotenv-load := true` so `just dev` (which runs cargo directly, not via docker-compose) picks up `.env` keys like `ONSAGER_CREDENTIAL_KEY` / `STIGLAB_CREDENTIAL_KEY`.
- **.gitignore**: add `/data/` — stiglab defaults its DB to `sqlite://./data/stiglab.db` (per `.env.example`); that file is per-machine dev state and was showing up as untracked.

No code/behavior change to any crate; the DB file itself is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)