### PR TITLE
feat(dashboard): state workspace-scoped repos for repo-less triggers

### DIFF
--- a/apps/dashboard/src/components/workflows/TriggerCard.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerCard.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react"
-import { ChevronRight, GitBranch, Tag } from "lucide-react"
+import { Link } from "react-router-dom"
+import { ChevronRight, FolderGit2, GitBranch, Tag } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useOptionalActiveWorkspace } from "@/lib/workspace"
 import { type GitHubAppInstallation } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -113,6 +115,7 @@ function TriggerForm({
   onChange: (next: WorkflowTriggerDraft) => void
 }) {
   const isManual = value.kind_tag === "manual"
+  const workspace = useOptionalActiveWorkspace()
 
   return (
     <>
@@ -122,21 +125,56 @@ function TriggerForm({
       />
 
       {isManual ? (
-        <div className="space-y-1.5">
-          <label htmlFor="manual-trigger-name" className="text-sm font-medium">
-            Trigger name
-          </label>
-          <Input
-            id="manual-trigger-name"
-            value={value.manual_name}
-            onChange={(e) => onChange({ ...value, manual_name: e.target.value })}
-            placeholder="e.g. Run nightly batch"
-          />
-          <p className="text-xs text-muted-foreground">
-            The button label; fire it from the dashboard or{" "}
-            <code>onsager trigger fire</code>. No repo required.
-          </p>
-        </div>
+        <>
+          <div className="space-y-1.5">
+            <label htmlFor="manual-trigger-name" className="text-sm font-medium">
+              Trigger name
+            </label>
+            <Input
+              id="manual-trigger-name"
+              value={value.manual_name}
+              onChange={(e) =>
+                onChange({ ...value, manual_name: e.target.value })
+              }
+              placeholder="e.g. Run nightly batch"
+            />
+            <p className="text-xs text-muted-foreground">
+              The button label; fire it from the dashboard or{" "}
+              <code>onsager trigger fire</code>. No repo required.
+            </p>
+          </div>
+
+          {/* Repo-less workflows are workspace-scoped (#553): the run is
+              handed every repo bound to the workspace and the agent clones
+              what it needs. Per-workflow repo pinning is a backend
+              follow-up (#566); for now this states the actual runtime
+              behavior rather than offering a choice we can't honor. */}
+          <div className="space-y-1.5">
+            <span className="text-sm font-medium">Repositories</span>
+            <div className="flex items-start gap-2 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              <FolderGit2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                Runs against{" "}
+                <span className="font-medium text-foreground">
+                  any repository bound to this workspace
+                </span>
+                {" "}— the agent gets the whole set and clones what it needs.
+                {workspace ? (
+                  <>
+                    {" "}
+                    <Link
+                      to={`/workspaces/${workspace.slug}/settings`}
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      Manage workspace repositories
+                    </Link>
+                    .
+                  </>
+                ) : null}
+              </span>
+            </div>
+          </div>
+        </>
       ) : (
         <>
           <div className="space-y-1.5">

--- a/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-card-editor.test.tsx
@@ -64,6 +64,15 @@ describe("Trigger card editor", () => {
     manual_name: "",
   }
 
+  const manual: WorkflowTriggerDraft = {
+    kind_tag: "manual",
+    install_id: "",
+    repo_owner: "",
+    repo_name: "",
+    label: "",
+    manual_name: "Run nightly batch",
+  }
+
   it("has no free-text inputs for the linkable fields (install/repo/label)", () => {
     mount(
       <TriggerCard
@@ -78,6 +87,41 @@ describe("Trigger card editor", () => {
     // should contain zero native `<input type="text">` fields.
     const textboxes = screen.queryAllByRole("textbox")
     expect(textboxes.length).toBe(0)
+  })
+
+  it("tells a repo-less (manual) trigger it runs workspace-scoped (#553)", () => {
+    mount(
+      <TriggerCard
+        workspaceId="t1"
+        installations={[]}
+        value={manual}
+        onChange={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Edit trigger/i }))
+    // A repo-less workflow defaults to "any bound repo" — the form states
+    // that runtime behavior rather than pinning a repo. Mutation guard:
+    // delete the Repositories note from the manual branch and this fails.
+    expect(
+      screen.getByText(/any repository bound to this workspace/i),
+    ).toBeInTheDocument()
+  })
+
+  it("does not show the workspace-scoped note for a GitHub webhook trigger", () => {
+    mount(
+      <TriggerCard
+        workspaceId="t1"
+        installations={[]}
+        value={empty}
+        onChange={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Edit trigger/i }))
+    // GitHub webhook triggers pin exactly one repo via the webhook itself,
+    // so the workspace-scoped note must not appear (no regression).
+    expect(
+      screen.queryByText(/any repository bound to this workspace/i),
+    ).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
Closes #553. Part of #544.

## Delivers

A repo-less (Manual) workflow runs **workspace-scoped** — the #546 handoff (`build_workspace_repo_access(state, workspace_id)`) hands the agent every repo bound to the workspace. The builder hid the repo entirely for Manual triggers (post-#563), so an author had no idea what the run operates on. This states it:

- The repo-less trigger card now shows a read-only **Repositories** note: *"Runs against any repository bound to this workspace — the agent gets the whole set and clones what it needs"*, with a link to manage workspace repos in Settings.
- GitHub webhook triggers are unchanged (they pin one repo via the webhook itself — no note).

## Scope decision (see [#553 comment](https://github.com/onsager-ai/onsager/issues/553#issuecomment-4630569734))

#553 assumed an "any bound repo vs **pin one**" selector. Discovery: pin-one is **not representable** in the current backend — no per-workflow repo field, and the runtime never narrows the repo set by workflow. So this PR ships the dashboard-only half (default to "any bound repo", make it legible) and splits per-workflow pinning into backend follow-up **#566**.

Plan as delivered:
- [x] Repo-less trigger exposed (Manual) — #561/#563
- [x] Repo-less workflows state "any bound repo (workspace-scoped)"; pinning deferred to #566
- [x] GitHub webhook triggers keep their required repo — no regression

## Tests

- `workflow-card-editor.test.tsx`: Manual trigger renders the workspace-scoped note (mutation-checked); GitHub webhook trigger does **not** (no regression).
- Full dashboard suite green (271 tests); `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)