### PR TITLE
Lift trigger out of the stage rail; default to no automatic trigger

### DIFF
--- a/apps/dashboard/src/components/workflows/FlowEditor.tsx
+++ b/apps/dashboard/src/components/workflows/FlowEditor.tsx
@@ -1,63 +1,46 @@
 import { useState } from "react"
-import { ChevronLeft } from "lucide-react"
+import { ChevronLeft, ListChecks } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Button } from "@/components/ui/button"
-import type { GitHubAppInstallation, WorkflowGateKind, WorkflowStage } from "@/lib/api"
+import type { WorkflowGateKind, WorkflowStage } from "@/lib/api"
 import { FlowRail } from "./FlowRail"
 import { StageEditor } from "./StageEditor"
-import { TriggerEditor } from "./TriggerEditor"
-import { isTriggerReady, makeStage, type WorkflowDocument } from "./workflow-draft"
-
-/** Which node the right-pane editor is bound to. Stages are addressed by id
- *  (not index) so the selection survives reorders and neighbour removals. */
-export type Selection = { kind: "trigger" } | { kind: "stage"; id: string }
+import { makeStage, type WorkflowDocument } from "./workflow-draft"
 
 export interface FlowEditorProps {
-  workspaceId: string
-  installations: GitHubAppInstallation[]
   draft: WorkflowDocument
   onChange: (next: WorkflowDocument) => void
 }
 
 /**
- * Master-detail workflow builder. The left {@link FlowRail} shows the whole
- * pipeline and stays visible while the right pane edits the selected node —
- * replacing the previous card-stack-plus-slide-out-sheet, which hid the flow
- * behind an overlay every time you tuned a node. On mobile the two panes
- * collapse to a list→detail push (one column, same model).
+ * Master-detail editor for a workflow's ordered stages. The left
+ * {@link FlowRail} shows the whole pipeline and stays visible while the right
+ * pane edits the selected stage. The trigger is no longer part of this
+ * surface — it's a different kind of object (how the workflow is invoked, not
+ * a step) and lives in its own always-visible section above the builder
+ * (#572). On mobile the two panes collapse to a list→detail push.
  */
-export function FlowEditor({
-  workspaceId,
-  installations,
-  draft,
-  onChange,
-}: FlowEditorProps) {
+export function FlowEditor({ draft, onChange }: FlowEditorProps) {
   const isMobile = useIsMobile()
-  const [selection, setSelection] = useState<Selection>(() => initialSelection(draft))
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => draft.stages[0]?.id ?? null,
+  )
   const [mobileDetail, setMobileDetail] = useState(false)
 
-  // Guard a stale stage selection (e.g. after a preset swap replaces every
-  // stage): fall back to the first stage, else the trigger.
-  const selectedStage =
-    selection.kind === "stage"
-      ? draft.stages.find((s) => s.id === selection.id)
-      : undefined
-  const effective: Selection =
-    selection.kind === "stage" && !selectedStage
-      ? draft.stages[0]
-        ? { kind: "stage", id: draft.stages[0].id }
-        : { kind: "trigger" }
-      : selection
+  // Guard a stale selection (e.g. after a preset swap replaces every stage):
+  // fall back to the first stage, else nothing.
+  const selectedStage = draft.stages.find((s) => s.id === selectedId)
+  const effectiveId = selectedStage ? selectedId : (draft.stages[0]?.id ?? null)
 
-  const select = (next: Selection) => {
-    setSelection(next)
+  const select = (stageId: string) => {
+    setSelectedId(stageId)
     setMobileDetail(true)
   }
 
   const addStage = (gate: WorkflowGateKind) => {
     const stage = makeStage(gate)
     onChange({ ...draft, stages: [...draft.stages, stage] })
-    select({ kind: "stage", id: stage.id })
+    select(stage.id)
   }
 
   const updateStage = (id: string, next: WorkflowStage) => {
@@ -71,41 +54,31 @@ export function FlowEditor({
     const idx = draft.stages.findIndex((s) => s.id === id)
     const stages = draft.stages.filter((s) => s.id !== id)
     onChange({ ...draft, stages })
-    if (selection.kind === "stage" && selection.id === id) {
+    if (selectedId === id) {
       const neighbour = stages[idx] ?? stages[idx - 1]
-      setSelection(neighbour ? { kind: "stage", id: neighbour.id } : { kind: "trigger" })
+      setSelectedId(neighbour?.id ?? null)
       setMobileDetail(false)
     }
   }
 
-  const editor =
-    effective.kind === "trigger" ? (
-      <TriggerEditor
-        workspaceId={workspaceId}
-        installations={installations}
-        value={draft.trigger}
-        onChange={(trigger) => onChange({ ...draft, trigger })}
-      />
-    ) : (
-      (() => {
-        const index = draft.stages.findIndex((s) => s.id === effective.id)
-        const stage = draft.stages[index]
-        if (!stage) return null
-        return (
-          <StageEditor
-            stage={stage}
-            index={index}
-            onChange={(next) => updateStage(stage.id, next)}
-            onRemove={() => removeStage(stage.id)}
-          />
-        )
-      })()
-    )
+  const index = draft.stages.findIndex((s) => s.id === effectiveId)
+  const stage = index >= 0 ? draft.stages[index] : undefined
+
+  const editor = stage ? (
+    <StageEditor
+      stage={stage}
+      index={index}
+      onChange={(next) => updateStage(stage.id, next)}
+      onRemove={() => removeStage(stage.id)}
+    />
+  ) : (
+    <EmptyDetail />
+  )
 
   const rail = (
     <FlowRail
       draft={draft}
-      selection={effective}
+      selectedStageId={effectiveId}
       onSelect={select}
       onAddStage={addStage}
     />
@@ -114,7 +87,7 @@ export function FlowEditor({
   if (isMobile) {
     return (
       <div className="rounded-lg border p-2">
-        {mobileDetail ? (
+        {mobileDetail && stage ? (
           <div className="space-y-3 p-2">
             <Button
               type="button"
@@ -136,7 +109,7 @@ export function FlowEditor({
   }
 
   return (
-    <div className="flex min-h-[22rem] overflow-hidden rounded-lg border">
+    <div className="flex min-h-[18rem] overflow-hidden rounded-lg border">
       <div className="w-64 shrink-0 overflow-y-auto border-r bg-muted/20 p-2">
         {rail}
       </div>
@@ -145,10 +118,11 @@ export function FlowEditor({
   )
 }
 
-function initialSelection(draft: WorkflowDocument): Selection {
-  // Land where setup is needed: an unconfigured trigger first, otherwise the
-  // first stage, otherwise the trigger.
-  if (!isTriggerReady(draft.trigger)) return { kind: "trigger" }
-  if (draft.stages[0]) return { kind: "stage", id: draft.stages[0].id }
-  return { kind: "trigger" }
+function EmptyDetail() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 py-8 text-center text-muted-foreground">
+      <ListChecks className="h-6 w-6" />
+      <p className="text-sm">Add a step to start building the pipeline.</p>
+    </div>
+  )
 }

--- a/apps/dashboard/src/components/workflows/FlowRail.tsx
+++ b/apps/dashboard/src/components/workflows/FlowRail.tsx
@@ -1,4 +1,4 @@
-import { Plus, Webhook, Zap } from "lucide-react"
+import { Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { WorkflowGateKind } from "@/lib/api"
 import {
@@ -8,12 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { GATE_KINDS } from "./workflow-meta"
-import {
-  triggerRepos,
-  type WorkflowDocument,
-  type WorkflowTriggerDraft,
-} from "./workflow-draft"
-import type { Selection } from "./FlowEditor"
+import { type WorkflowDocument } from "./workflow-draft"
 
 const GATE_ICON = Object.fromEntries(
   GATE_KINDS.map((g) => [g.value, g.icon]),
@@ -21,60 +16,45 @@ const GATE_ICON = Object.fromEntries(
 
 export interface FlowRailProps {
   draft: WorkflowDocument
-  selection: Selection
-  onSelect: (selection: Selection) => void
+  /** The selected stage id, or `null` when nothing is selected (no stages). */
+  selectedStageId: string | null
+  onSelect: (stageId: string) => void
   onAddStage: (gate: WorkflowGateKind) => void
 }
 
 /**
  * The left rail of the master-detail builder: a vertical pipeline "spine"
- * with the trigger node on top, one row per stage, and a typed "add step"
- * dropdown at the bottom. Selecting a row drives the right-pane editor; the
- * rail stays visible while you edit so the whole flow is never hidden behind
- * an overlay (the old card→sheet pattern it replaces).
+ * of the workflow's ordered stages plus a typed "add step" dropdown. The
+ * trigger is *not* a rail node — it's a different kind of object (how the
+ * workflow is invoked, not a step) and lives in its own always-visible
+ * section above the builder (#572). Selecting a row drives the right-pane
+ * stage editor; the rail stays visible while you edit.
  */
-export function FlowRail({ draft, selection, onSelect, onAddStage }: FlowRailProps) {
-  const trigger = summarizeTrigger(draft.trigger)
+export function FlowRail({
+  draft,
+  selectedStageId,
+  onSelect,
+  onAddStage,
+}: FlowRailProps) {
   const stageCount = draft.stages.length
 
   return (
     <nav aria-label="Workflow steps" className="flex flex-col">
-      <RailRow
-        marker={
-          draft.trigger.kind_tag === "manual" ? (
-            <Zap className="h-3.5 w-3.5" />
-          ) : (
-            <Webhook className="h-3.5 w-3.5" />
-          )
-        }
-        tone="trigger"
-        title={trigger.kindLabel}
-        subtitle={
-          <span className="truncate">
-            {trigger.repoSummary}
-            {trigger.labelSummary ? ` · ${trigger.labelSummary}` : ""}
-          </span>
-        }
-        selected={selection.kind === "trigger"}
-        onClick={() => onSelect({ kind: "trigger" })}
-        isFirst
-      />
-
       {draft.stages.map((stage, i) => {
         const Icon = GATE_ICON[stage.gate_kind]
         return (
           <RailRow
             key={stage.id}
             marker={i + 1}
-            tone="stage"
             title={
               <span className="flex min-w-0 items-center gap-1.5">
                 <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <span className="truncate">{stage.name}</span>
               </span>
             }
-            selected={selection.kind === "stage" && selection.id === stage.id}
-            onClick={() => onSelect({ kind: "stage", id: stage.id })}
+            selected={stage.id === selectedStageId}
+            onClick={() => onSelect(stage.id)}
+            isFirst={i === 0}
           />
         )
       })}
@@ -88,7 +68,7 @@ export function FlowRail({ draft, selection, onSelect, onAddStage }: FlowRailPro
             />
           }
         >
-          <RailMarker tone="add" isLast>
+          <RailMarker tone="add" isFirst={stageCount === 0} isLast>
             <Plus className="h-3.5 w-3.5" />
           </RailMarker>
           <span className="flex-1 rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground transition group-hover:bg-muted/50">
@@ -114,29 +94,25 @@ export function FlowRail({ draft, selection, onSelect, onAddStage }: FlowRailPro
 
       {stageCount === 0 && (
         <p className="px-3 pt-1 text-xs text-muted-foreground">
-          Add at least one step to run this trigger.
+          Add at least one step to run this workflow.
         </p>
       )}
     </nav>
   )
 }
 
-type Tone = "trigger" | "stage" | "add"
+type Tone = "stage" | "add"
 
 function RailRow({
   marker,
-  tone,
   title,
-  subtitle,
   selected,
   onClick,
   isFirst,
   isLast,
 }: {
   marker: React.ReactNode
-  tone: Tone
   title: React.ReactNode
-  subtitle?: React.ReactNode
   selected?: boolean
   onClick: () => void
   isFirst?: boolean
@@ -149,7 +125,7 @@ function RailRow({
       onClick={onClick}
       className="group flex w-full items-stretch gap-2 text-left"
     >
-      <RailMarker tone={tone} selected={selected} isFirst={isFirst} isLast={isLast}>
+      <RailMarker tone="stage" selected={selected} isFirst={isFirst} isLast={isLast}>
         {marker}
       </RailMarker>
       <span
@@ -159,11 +135,6 @@ function RailRow({
         )}
       >
         <span className="flex min-w-0 items-center text-sm font-medium">{title}</span>
-        {subtitle != null && (
-          <span className="flex min-w-0 items-center text-xs text-muted-foreground">
-            {subtitle}
-          </span>
-        )}
       </span>
     </button>
   )
@@ -199,46 +170,13 @@ function RailMarker({
           "absolute left-[18px] top-1/2 z-10 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border text-[11px] font-semibold",
           selected
             ? "border-primary bg-primary text-primary-foreground"
-            : tone === "trigger"
-              ? "border-primary/40 bg-primary/10 text-primary"
-              : tone === "add"
-                ? "border-dashed bg-background text-muted-foreground group-hover:border-primary/40 group-hover:text-primary"
-                : "border-border bg-background text-muted-foreground",
+            : tone === "add"
+              ? "border-dashed bg-background text-muted-foreground group-hover:border-primary/40 group-hover:text-primary"
+              : "border-border bg-background text-muted-foreground",
         )}
       >
         {children}
       </span>
     </span>
   )
-}
-
-function summarizeTrigger(t: WorkflowTriggerDraft): {
-  kindLabel: string
-  repoSummary: string
-  labelSummary: string | null
-} {
-  if (t.kind_tag === "manual") {
-    return {
-      kindLabel: t.manual_name.trim()
-        ? `Manual · ${t.manual_name.trim()}`
-        : "Manual trigger",
-      repoSummary: "Any repository in this workspace",
-      labelSummary: null,
-    }
-  }
-  const repos = triggerRepos(t)
-  const labelSummary = t.label ? `Label: ${t.label}` : "Pick a trigger label"
-  if (repos.length === 0) {
-    return {
-      kindLabel: "GitHub issue label",
-      repoSummary: "Pick one or more repositories",
-      labelSummary,
-    }
-  }
-  const primary = repos[0]
-  const repoSummary =
-    repos.length === 1
-      ? `${primary.repo_owner}/${primary.repo_name}`
-      : `${primary.repo_owner}/${primary.repo_name} +${repos.length - 1} more`
-  return { kindLabel: "GitHub issue label", repoSummary, labelSummary }
 }

--- a/apps/dashboard/src/components/workflows/TriggerEditor.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerEditor.tsx
@@ -44,7 +44,7 @@ export function TriggerEditor({
           <h3 className="text-sm font-semibold">Trigger</h3>
           <p className="text-xs text-muted-foreground">
             {isManual
-              ? "Name the manual trigger that starts the workflow."
+              ? "No automatic trigger — runs only when you fire it."
               : "Pick the repositories and label that start the workflow."}
           </p>
         </div>
@@ -59,17 +59,18 @@ export function TriggerEditor({
         <>
           <div className="space-y-1.5">
             <label htmlFor="manual-trigger-name" className="text-sm font-medium">
-              Trigger name
+              Button label{" "}
+              <span className="font-normal text-muted-foreground">(optional)</span>
             </label>
             <Input
               id="manual-trigger-name"
               value={value.manual_name}
               onChange={(e) => onChange({ ...value, manual_name: e.target.value })}
-              placeholder="e.g. Run nightly batch"
+              placeholder="Defaults to the workflow name"
             />
             <p className="text-xs text-muted-foreground">
-              The button label; fire it from the dashboard or{" "}
-              <code>onsager trigger fire</code>. No repo required.
+              Labels the run button; fire it from the dashboard or{" "}
+              <code>onsager trigger fire</code>. Defaults to the workflow name.
             </p>
           </div>
 

--- a/apps/dashboard/src/components/workflows/TriggerEditor.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerEditor.tsx
@@ -1,8 +1,7 @@
 import { Link } from "react-router-dom"
-import { FolderGit2, GitBranch, Webhook, Zap } from "lucide-react"
+import { FolderGit2, GitBranch, Zap } from "lucide-react"
 import { useOptionalActiveWorkspace } from "@/lib/workspace"
 import { type GitHubAppInstallation } from "@/lib/api"
-import { Input } from "@/components/ui/input"
 import { LabelCombobox } from "./LabelCombobox"
 import { RepoMultiCombobox } from "./RepoMultiCombobox"
 import { TriggerKindPicker } from "./TriggerKindPicker"
@@ -20,10 +19,15 @@ export interface TriggerEditorProps {
 }
 
 /**
- * Right-pane editor for the trigger node. Edits apply live to the draft via
- * `onChange` — there is no per-node "Done"; the persistent master-detail pane
- * replaces the old slide-out sheet. The form body is unchanged from the
- * previous `TriggerCard` sheet (manual vs github-webhook branches).
+ * The trigger section of the workflow builder — how a workflow is invoked.
+ * A compact kind selector (Tabs) over the kind-specific form (#574). Edits
+ * apply live to the draft via `onChange`; there is no per-section "Done".
+ *
+ * Manual is the "no automatic trigger, run it yourself" default (#572): it
+ * needs no config, so its body is just a note about workspace-scoped repos
+ * — no button-label input, since the run button derives its label from the
+ * workflow name at create time. The GitHub-webhook leg keeps the repo +
+ * label pickers.
  */
 export function TriggerEditor({
   workspaceId,
@@ -35,78 +39,45 @@ export function TriggerEditor({
   const workspace = useOptionalActiveWorkspace()
 
   return (
-    <div className="flex flex-col gap-4">
-      <header className="flex items-start gap-3">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-          {isManual ? <Zap className="h-4 w-4" /> : <Webhook className="h-4 w-4" />}
-        </div>
-        <div className="min-w-0">
-          <h3 className="text-sm font-semibold">Trigger</h3>
-          <p className="text-xs text-muted-foreground">
-            {isManual
-              ? "No automatic trigger — runs only when you fire it."
-              : "Pick the repositories and label that start the workflow."}
-          </p>
-        </div>
-      </header>
-
+    <div className="space-y-3">
       <TriggerKindPicker
         kindTag={value.kind_tag}
         onKindChange={(kind_tag) => onChange({ ...value, kind_tag })}
       />
 
       {isManual ? (
-        <>
-          <div className="space-y-1.5">
-            <label htmlFor="manual-trigger-name" className="text-sm font-medium">
-              Button label{" "}
-              <span className="font-normal text-muted-foreground">(optional)</span>
-            </label>
-            <Input
-              id="manual-trigger-name"
-              value={value.manual_name}
-              onChange={(e) => onChange({ ...value, manual_name: e.target.value })}
-              placeholder="Defaults to the workflow name"
-            />
-            <p className="text-xs text-muted-foreground">
-              Labels the run button; fire it from the dashboard or{" "}
-              <code>onsager trigger fire</code>. Defaults to the workflow name.
-            </p>
-          </div>
-
-          {/* Repo-less workflows are workspace-scoped (#553): the run is
-              handed every repo bound to the workspace and the agent clones
-              what it needs. Per-workflow repo pinning is a backend
-              follow-up (#566); for now this states the actual runtime
-              behavior rather than offering a choice we can't honor. */}
-          <div className="space-y-1.5">
-            <span className="text-sm font-medium">Repositories</span>
-            <div className="flex items-start gap-2 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-              <FolderGit2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>
-                Runs against{" "}
-                <span className="font-medium text-foreground">
-                  any repository bound to this workspace
-                </span>{" "}
-                — the agent gets the whole set and clones what it needs.
-                {workspace ? (
-                  <>
-                    {" "}
-                    <Link
-                      to={`/workspaces/${workspace.slug}/settings`}
-                      className="underline underline-offset-2 hover:text-foreground"
-                    >
-                      Manage workspace repositories
-                    </Link>
-                    .
-                  </>
-                ) : null}
-              </span>
-            </div>
-          </div>
-        </>
+        // Repo-less workflows are workspace-scoped (#553): the run is handed
+        // every repo bound to the workspace and the agent clones what it
+        // needs. Per-workflow repo pinning is a backend follow-up (#566); for
+        // now this states the actual runtime behavior rather than offering a
+        // choice we can't honor.
+        <div className="space-y-1 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          <p className="flex items-center gap-1.5 font-medium text-foreground">
+            <Zap className="h-3.5 w-3.5 shrink-0" />
+            No automatic trigger
+          </p>
+          <p>
+            Run it yourself from the dashboard or <code>onsager trigger fire</code>.
+            Runs against{" "}
+            <span className="font-medium text-foreground">
+              any repository bound to this workspace
+            </span>
+            {workspace ? (
+              <>
+                {" — "}
+                <Link
+                  to={`/workspaces/${workspace.slug}/settings`}
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  manage repositories
+                </Link>
+              </>
+            ) : null}
+            .
+          </p>
+        </div>
       ) : (
-        <>
+        <div className="space-y-3">
           <div className="space-y-1.5">
             <span className="text-sm font-medium">Repositories</span>
             <RepoMultiCombobox
@@ -158,7 +129,7 @@ export function TriggerEditor({
               </p>
             )}
           </div>
-        </>
+        </div>
       )}
     </div>
   )

--- a/apps/dashboard/src/components/workflows/TriggerKindPicker.tsx
+++ b/apps/dashboard/src/components/workflows/TriggerKindPicker.tsx
@@ -1,28 +1,17 @@
 import { useQuery } from "@tanstack/react-query"
 import { api, type TriggerManifestEntry } from "@/lib/api"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 // Kinds the builder can author today (#561). The manifest carries every
 // registry kind, but the builder only knows how to collect config for
 // these two; the rest (cron, interval, the GitHub webhook variants, …)
 // land as the per-kind forms are built out. Order here is the display
-// order in the selector.
-const SELECTABLE_KINDS = ["github_issue_webhook", "manual"] as const
+// order — Manual first, since it's the default (#572). The manifest
+// (`/api/registry/triggers`) is still queried to satisfy the API
+// contract, but the visible labels come from `humanLabel`.
+const SELECTABLE_KINDS = ["manual", "github_issue_webhook"] as const
 
 const FALLBACK: TriggerManifestEntry[] = [
-  {
-    kind_tag: "github_issue_webhook",
-    producer: "portal",
-    category: "request",
-    ui_kind: "webhook",
-    description: "Fires when a GitHub issue is labeled with the configured label.",
-  },
   {
     kind_tag: "manual",
     producer: "portal",
@@ -30,14 +19,24 @@ const FALLBACK: TriggerManifestEntry[] = [
     ui_kind: "manual",
     description: "Fires from a UI button or `onsager trigger fire` CLI command.",
   },
+  {
+    kind_tag: "github_issue_webhook",
+    producer: "portal",
+    category: "request",
+    ui_kind: "webhook",
+    description: "Fires when a GitHub issue is labeled with the configured label.",
+  },
 ]
 
 /**
- * Selector above the trigger form for the active trigger kind, sourced
- * from `/api/registry/triggers` (spec #237). Selecting a kind updates the
- * draft's `kind_tag`; the kind's manifest description stays visible below
- * the control. The builder offers the kinds it can collect config for
- * (`SELECTABLE_KINDS`); #561 adds Manual to the original webhook-only set.
+ * Segmented control for the active trigger kind, sourced from
+ * `/api/registry/triggers` (spec #237). Selecting a kind updates the
+ * draft's `kind_tag`; the kind-specific form lives below in `TriggerEditor`.
+ *
+ * Rendered as Tabs rather than a Select (#574): with only two authorable
+ * kinds, a segmented control is more compact and expressive, and it dodges
+ * the Base-UI `Select.Value` default of rendering the raw `value`
+ * (`github_issue_webhook`) instead of the human label.
  */
 export function TriggerKindPicker({
   kindTag,
@@ -62,41 +61,30 @@ export function TriggerKindPicker({
     all.find((t) => t.kind_tag === tag),
   ).filter((t): t is TriggerManifestEntry => t !== undefined)
 
-  const entry =
-    options.find((t) => t.kind_tag === kindTag) ?? options[0] ?? all[0]
-  if (!entry) return null
+  if (options.length === 0) return null
+  // Highlight a known kind; fall back to the first option for an
+  // unrecognized tag so the control never renders with nothing active.
+  const active = options.some((t) => t.kind_tag === kindTag)
+    ? kindTag
+    : options[0].kind_tag
 
   return (
-    <div className="space-y-1.5">
-      <span className="text-xs uppercase tracking-wide text-muted-foreground">
-        Trigger kind
-      </span>
-      <Select
-        value={entry.kind_tag}
-        onValueChange={(next) => {
-          if (next) onKindChange(next)
-        }}
-      >
-        <SelectTrigger className="w-full" aria-label="Trigger kind">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((t) => (
-            <SelectItem key={t.kind_tag} value={t.kind_tag}>
-              {humanLabel(t.kind_tag)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <p className="text-xs text-muted-foreground">{entry.description}</p>
-    </div>
+    <Tabs value={active} onValueChange={(v) => onKindChange(String(v))}>
+      <TabsList className="w-full" aria-label="Trigger kind">
+        {options.map((t) => (
+          <TabsTrigger key={t.kind_tag} value={t.kind_tag} className="flex-1">
+            {humanLabel(t.kind_tag)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
   )
 }
 
 function humanLabel(kindTag: string): string {
   switch (kindTag) {
     case "github_issue_webhook":
-      return "GitHub issue webhook"
+      return "GitHub issue"
     case "manual":
       return "Manual"
     default:

--- a/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { FlowEditor } from "./FlowEditor"
+import { TriggerEditor } from "./TriggerEditor"
 import { PresetPicker } from "./PresetPicker"
 import {
   documentToCreateRequest,
@@ -75,12 +76,22 @@ export function WorkflowBuilder({
 
       <PresetPicker draft={draft} onApply={setDraft} />
 
-      <FlowEditor
-        workspaceId={workspaceId}
-        installations={installations}
-        draft={draft}
-        onChange={setDraft}
-      />
+      {/* The trigger is how the workflow is invoked — a different kind of
+          object than its stages — so it gets its own always-visible section
+          rather than living as a node in the stage rail (#572). */}
+      <div className="rounded-lg border p-4">
+        <TriggerEditor
+          workspaceId={workspaceId}
+          installations={installations}
+          value={draft.trigger}
+          onChange={(trigger) => setDraft({ ...draft, trigger })}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium">Steps</span>
+        <FlowEditor draft={draft} onChange={setDraft} />
+      </div>
 
       {create.isError && (
         <p className="text-sm text-destructive">

--- a/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowBuilder.tsx
@@ -61,60 +61,70 @@ export function WorkflowBuilder({
   }
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-1.5">
-        <label htmlFor="workflow-name" className="text-sm font-medium">
-          Workflow name
-        </label>
-        <Input
-          id="workflow-name"
-          value={draft.name}
-          onChange={(e) => setDraft({ ...draft, name: e.target.value })}
-          placeholder="e.g. Issue → PR pipeline"
-        />
-      </div>
-
-      <PresetPicker draft={draft} onApply={setDraft} />
-
-      {/* The trigger is how the workflow is invoked — a different kind of
-          object than its stages — so it gets its own always-visible section
-          rather than living as a node in the stage rail (#572). */}
-      <div className="rounded-lg border p-4">
-        <TriggerEditor
-          workspaceId={workspaceId}
-          installations={installations}
-          value={draft.trigger}
-          onChange={(trigger) => setDraft({ ...draft, trigger })}
-        />
-      </div>
-
-      <div className="space-y-1.5">
-        <span className="text-sm font-medium">Steps</span>
-        <FlowEditor draft={draft} onChange={setDraft} />
-      </div>
-
-      {create.isError && (
-        <p className="text-sm text-destructive">
-          {create.error instanceof Error ? create.error.message : "Failed to save"}
-        </p>
-      )}
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <label
-          htmlFor="workflow-active"
-          className="flex items-center gap-2 text-sm font-medium"
-        >
-          <Switch
-            id="workflow-active"
-            checked={active}
-            onCheckedChange={setActive}
+    // Flex column so the action row pins to the bottom as a footer while the
+    // form scrolls (#574); the host (WorkflowBuilderSheet) gives this a
+    // bounded height.
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain pr-1">
+        <div className="space-y-1.5">
+          {/* Active is a property of the workflow as a whole, so it lives up
+              here with the name rather than in the create footer (#574). */}
+          <div className="flex items-center justify-between gap-3">
+            <label htmlFor="workflow-name" className="text-sm font-medium">
+              Workflow name
+            </label>
+            <label
+              htmlFor="workflow-active"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <Switch
+                id="workflow-active"
+                checked={active}
+                onCheckedChange={setActive}
+              />
+              Active
+            </label>
+          </div>
+          <Input
+            id="workflow-name"
+            value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            placeholder="e.g. Issue → PR pipeline"
           />
-          Active
-        </label>
+        </div>
+
+        <PresetPicker draft={draft} onApply={setDraft} />
+
+        {/* The trigger is how the workflow is invoked — a different kind of
+            object than its stages — so it gets its own always-visible section
+            rather than living as a node in the stage rail (#572). */}
+        <div className="space-y-1.5">
+          <span className="text-sm font-medium">Trigger</span>
+          <TriggerEditor
+            workspaceId={workspaceId}
+            installations={installations}
+            value={draft.trigger}
+            onChange={(trigger) => setDraft({ ...draft, trigger })}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="text-sm font-medium">Steps</span>
+          <FlowEditor draft={draft} onChange={setDraft} />
+        </div>
+
+        {create.isError && (
+          <p className="text-sm text-destructive">
+            {create.error instanceof Error ? create.error.message : "Failed to save"}
+          </p>
+        )}
+      </div>
+
+      <div className="border-t pt-4">
         <Button
           type="button"
           size="lg"
-          className="w-full sm:w-auto"
+          className="w-full"
           disabled={!canSave || create.isPending}
           onClick={() => save(active)}
         >

--- a/apps/dashboard/src/components/workflows/WorkflowBuilderSheet.tsx
+++ b/apps/dashboard/src/components/workflows/WorkflowBuilderSheet.tsx
@@ -77,9 +77,9 @@ export function WorkflowBuilderSheet({ open, onOpenChange }: WorkflowBuilderShee
               Chat out the idea, then tap cards to tune.
             </SheetDescription>
           </SheetHeader>
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-4">
-            {body}
-          </div>
+          {/* The builder owns its own scroll + pinned create footer (#574),
+              so this just gives it the bounded flex region. */}
+          <div className="min-h-0 flex-1 px-4 pb-4">{body}</div>
         </SheetContent>
       </Sheet>
     )
@@ -94,9 +94,9 @@ export function WorkflowBuilderSheet({ open, onOpenChange }: WorkflowBuilderShee
             Chat out the idea, then tap cards to tune.
           </DialogDescription>
         </DialogHeader>
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-          {body}
-        </div>
+        {/* The builder owns its own scroll + pinned create footer (#574),
+            so this just gives it the bounded flex region. */}
+        <div className="min-h-0 flex-1">{body}</div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/dashboard/src/components/workflows/workflow-draft.ts
+++ b/apps/dashboard/src/components/workflows/workflow-draft.ts
@@ -42,8 +42,8 @@ export interface WorkflowTriggerDraft {
    * Snake-case registry `kind_tag` for the selected trigger kind (e.g.
    * `'github_issue_webhook'`, `'manual'`). Drives `isTriggerReady`'s
    * per-kind readiness branch and which `TriggerKind` variant
-   * `documentToCreateRequest` emits. Defaults to `'github_issue_webhook'`
-   * (the original, GitHub-webhook-only behavior — see `emptyDocument`).
+   * `documentToCreateRequest` emits. Defaults to `'manual'` — the "no
+   * automatic trigger, run it yourself" baseline (#572); see `emptyDocument`.
    */
   kind_tag: string;
   /**
@@ -180,8 +180,13 @@ export function defaultStageName(gate: WorkflowGateKind): string {
 export function emptyDocument(): WorkflowDocument {
   return {
     name: "",
+    // A fresh workflow presumes nothing about *how* it's invoked: it defaults
+    // to Manual — the "no automatic trigger, run it yourself" baseline (#572).
+    // There is no untriggered-workflow concept in the substrate, so "no
+    // trigger" is the repo-less, workspace-scoped Manual kind. Picking GitHub
+    // webhook is a deliberate upgrade that reveals the repo + label pickers.
     trigger: {
-      kind_tag: "github_issue_webhook",
+      kind_tag: "manual",
       install_id: "",
       repo_owner: "",
       repo_name: "",
@@ -282,11 +287,13 @@ export const WORKFLOW_PRESETS: WorkflowPreset[] = [
 ];
 
 export function isTriggerReady(t: WorkflowTriggerDraft): boolean {
-  // Manual triggers (#561) are repo-less: a non-empty button name is the
-  // only requirement — no install, repo, or label. The GitHub webhook leg
-  // stays exactly as it was (#545: webhook repo is required, no regression).
+  // Manual triggers (#561) are repo-less and need nothing configured: as the
+  // "no automatic trigger" default (#572) a Manual workflow is always ready —
+  // the button label falls back to the workflow name at create time, so even
+  // `manual_name` is optional. The GitHub webhook leg stays exactly as it was
+  // (#545: webhook install + repo + label are required, no regression).
   if (t.kind_tag === "manual") {
-    return t.manual_name.trim() !== "";
+    return true;
   }
   return (
     t.install_id.trim() !== "" &&
@@ -332,9 +339,7 @@ export function documentToCreateRequest(
   }
   if (!isTriggerReady(doc.trigger)) {
     throw new ApiError(
-      doc.trigger.kind_tag === "manual"
-        ? "name the manual trigger before activating"
-        : "pick an install, repo, and label before activating",
+      "pick an install, repo, and label before activating",
       400,
     );
   }
@@ -342,14 +347,19 @@ export function documentToCreateRequest(
   // Manual triggers (#561) are repo-less: emit the `manual` variant with
   // just its button name — no `repo`, no install token-mint hint. The
   // backend's `trigger.repo` is optional (#545) and a Manual workflow
-  // resolves repos workspace-scoped at runtime (#546/#556).
+  // resolves repos workspace-scoped at runtime (#546/#556). The button label
+  // is an optional override (#572); when blank it falls back to the workflow
+  // name (the caller's `canSave` and the backend both require a non-empty
+  // workflow name), so a "no automatic trigger" workflow saves with nothing
+  // presumed about invocation.
   if (doc.trigger.kind_tag === "manual") {
+    const manualName = doc.trigger.manual_name.trim() || doc.name.trim();
     return {
       workspace_id: workspaceId,
       name: doc.name.trim(),
       trigger: {
         kind: "manual",
-        name: doc.trigger.manual_name.trim(),
+        name: manualName,
       },
       stages: doc.stages.map(stageToCreateStage),
       active: activate,

--- a/apps/dashboard/src/lib/drafts.ts
+++ b/apps/dashboard/src/lib/drafts.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowDocument,
   WorkflowDraftSource,
 } from "@/components/workflows/workflow-draft"
+import { emptyDocument } from "@/components/workflows/workflow-draft"
 import { trackActivation } from "@/lib/activation"
 
 /** Soft cap on stored drafts per user. Oldest by `updated_at` evicted. */
@@ -31,21 +32,6 @@ function newId(): string {
     return crypto.randomUUID()
   }
   return `draft_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`
-}
-
-function emptyDocument(): WorkflowDocument {
-  return {
-    name: "",
-    trigger: {
-      kind_tag: "github_issue_webhook",
-      install_id: "",
-      repo_owner: "",
-      repo_name: "",
-      label: "",
-      manual_name: "",
-    },
-    stages: [],
-  }
 }
 
 /** Build a fresh draft record. */

--- a/apps/dashboard/tests/smoke/workflow-builder-create.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-builder-create.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom"
 import type { ReactNode } from "react"
@@ -25,17 +25,37 @@ const installations: GitHubAppInstallation[] = [
   },
 ]
 
-// A fully-ready draft so `canSave` is true and the Create button is enabled.
+// A fully-ready GitHub-webhook draft so `canSave` is true and the Create
+// button is enabled.
 function readyDraft(): WorkflowDocument {
   return {
     name: "Issue → PR",
     trigger: {
+      kind_tag: "github_issue_webhook",
       install_id: "inst_one",
       repo_owner: "onsager-ai",
       repo_name: "onsager",
       label: "factory",
+      manual_name: "",
     },
-    stages: [makeStage("agent-session", "Issue", "Spec → PR")],
+    stages: [makeStage("agent-session", "Spec → PR")],
+  }
+}
+
+// A Manual ("no automatic trigger") draft with a blank button label — the
+// default shape (#572): ready with just a name + one stage.
+function manualReadyDraft(): WorkflowDocument {
+  return {
+    name: "Nightly batch",
+    trigger: {
+      kind_tag: "manual",
+      install_id: "",
+      repo_owner: "",
+      repo_name: "",
+      label: "",
+      manual_name: "",
+    },
+    stages: [makeStage("agent-session", "Run")],
   }
 }
 
@@ -136,5 +156,41 @@ describe("WorkflowBuilder create action", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create workflow" }))
     const body = await lastCreateBody()
     expect(body.active).toBe(true)
+  })
+
+  // The trigger is its own always-visible section, not a node in the stage
+  // rail (#572). Mutation guard: re-add a trigger row to FlowRail and the
+  // "not inside the rail" assertion fails.
+  it("renders the trigger as a section, not a node in the stage rail", () => {
+    mount(
+      <WorkflowBuilder
+        workspaceId="ws_1"
+        installations={installations}
+        initialDraft={manualReadyDraft()}
+      />,
+    )
+    // The trigger's framing copy is present at the top level…
+    const triggerNote = screen.getByText(/no automatic trigger/i)
+    expect(triggerNote).toBeTruthy()
+    // …but never inside the stage rail.
+    const rail = screen.getByRole("navigation", { name: /workflow steps/i })
+    expect(within(rail).queryByText(/no automatic trigger/i)).toBeNull()
+  })
+
+  // The "no automatic trigger" default (#572): a Manual workflow with a blank
+  // button label is saveable, and the wire `name` falls back to the workflow
+  // name so the run button is still labeled.
+  it("creates a Manual workflow whose button label falls back to the workflow name", async () => {
+    mount(
+      <WorkflowBuilder
+        workspaceId="ws_1"
+        installations={installations}
+        initialDraft={manualReadyDraft()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Create workflow" }))
+    const body = await lastCreateBody()
+    expect(body.trigger).toEqual({ kind: "manual", name: "Nightly batch" })
+    expect(body.active).toBe(false)
   })
 })

--- a/apps/dashboard/tests/smoke/workflow-builder-editor.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-builder-editor.test.tsx
@@ -21,9 +21,11 @@ function mount(node: ReactNode) {
   )
 }
 
-// The master-detail builder (#569) renders the node editor inline in the
-// right pane — no card→sheet click. These assertions mirror the old
-// card-editor smoke checks against the new StageEditor / TriggerEditor.
+// The master-detail builder (#569) renders the StageEditor inline in the
+// right pane — no card→sheet click. The TriggerEditor is its own
+// always-visible section above the stage rail, not a rail node (#572).
+// These assertions mirror the old card-editor smoke checks against the new
+// StageEditor / TriggerEditor.
 describe("Stage editor (master-detail right pane)", () => {
   const base: WorkflowStage = {
     id: "s1",
@@ -52,7 +54,7 @@ describe("Stage editor (master-detail right pane)", () => {
   })
 })
 
-describe("Trigger editor (master-detail right pane)", () => {
+describe("Trigger editor (always-visible section)", () => {
   const empty: WorkflowTriggerDraft = {
     kind_tag: "github_issue_webhook",
     install_id: "",

--- a/apps/dashboard/tests/smoke/workflow-builder-editor.test.tsx
+++ b/apps/dashboard/tests/smoke/workflow-builder-editor.test.tsx
@@ -83,6 +83,29 @@ describe("Trigger editor (always-visible section)", () => {
     expect(screen.queryAllByRole("textbox").length).toBe(0)
   })
 
+  it("picks the trigger kind with tabs, not a value-showing select (#574)", () => {
+    mount(
+      <TriggerEditor workspaceId="t1" installations={[]} value={empty} onChange={() => {}} />,
+    )
+    // Tabs render the human labels directly — no Base-UI `Select.Value`
+    // showing the raw `kind_tag`, and no dropdown to open. Mutation guard:
+    // revert TriggerKindPicker to a Select and these tab queries fail.
+    expect(screen.getByRole("tab", { name: "Manual" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /GitHub issue/i })).toBeInTheDocument()
+    // The raw snake-case kind_tag must never be the visible label.
+    expect(screen.queryByText("github_issue_webhook")).not.toBeInTheDocument()
+  })
+
+  it("a Manual trigger has no button-label input — it derives from the workflow name (#574)", () => {
+    mount(
+      <TriggerEditor workspaceId="t1" installations={[]} value={manual} onChange={() => {}} />,
+    )
+    // The manual button label was useless busywork (it falls back to the
+    // workflow name at create time), so the input is gone. Mutation guard:
+    // re-add the button-label <Input> and this fails.
+    expect(screen.queryAllByRole("textbox").length).toBe(0)
+  })
+
   it("tells a repo-less (manual) trigger it runs workspace-scoped (#553)", () => {
     mount(
       <TriggerEditor workspaceId="t1" installations={[]} value={manual} onChange={() => {}} />,

--- a/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
+++ b/apps/dashboard/tests/smoke/workflow-create-contract.test.ts
@@ -93,8 +93,24 @@ describe("documentToCreateRequest", () => {
     );
   });
 
-  it("throws when the trigger isn't ready (missing label)", () => {
-    const d = emptyDocument();
+  it("throws when a GitHub trigger isn't ready (missing label)", () => {
+    // `emptyDocument()` now defaults to Manual (always ready, #572), so build
+    // an explicit half-filled GitHub-webhook trigger to exercise the gate.
+    const d: WorkflowDocument = {
+      ...emptyDocument(),
+      name: "Issue → PR",
+      trigger: {
+        kind_tag: "github_issue_webhook",
+        install_id: "inst_abc",
+        repo_owner: "onsager-ai",
+        repo_name: "onsager",
+        label: "",
+        manual_name: "",
+      },
+      stages: [
+        { id: "s1", name: "Spec → PR", gate_kind: "agent-session", config: {} },
+      ],
+    };
     expect(() =>
       documentToCreateRequest(d, [installation], "t_1", true),
     ).toThrow(/install, repo, and label/);

--- a/apps/dashboard/tests/unit/workflow-draft-manual-trigger.test.ts
+++ b/apps/dashboard/tests/unit/workflow-draft-manual-trigger.test.ts
@@ -9,10 +9,12 @@ import {
   type WorkflowTriggerDraft,
 } from "@/components/workflows/workflow-draft"
 
-// Manual repo-less trigger kind in the workflow builder (spec #561).
-// The backend is unchanged — these exercise the dashboard's draft-side
-// branch on `kind_tag`: Manual needs only a name; GitHub keeps requiring
-// install + repo + label (#545 — no regression).
+// Manual repo-less trigger kind in the workflow builder (spec #561, amended
+// by #572). The backend is unchanged — these exercise the dashboard's
+// draft-side branch on `kind_tag`: Manual is the "no automatic trigger"
+// default and is always ready (the button label is optional, falling back to
+// the workflow name); GitHub keeps requiring install + repo + label
+// (#545 — no regression).
 
 function githubTrigger(
   over: Partial<WorkflowTriggerDraft> = {},
@@ -53,17 +55,27 @@ const INSTALLATIONS: GitHubAppInstallation[] = [
   },
 ]
 
-describe("isTriggerReady — per-kind branch (#561)", () => {
-  it("Manual is ready with only a non-empty name", () => {
-    expect(isTriggerReady(manualTrigger())).toBe(true)
+describe("emptyDocument default trigger (#572)", () => {
+  it("defaults a fresh workflow to Manual — no automatic trigger presumed", () => {
+    const doc = emptyDocument()
+    expect(doc.trigger.kind_tag).toBe("manual")
+    // …and that default is immediately ready, so the only thing left to make
+    // it saveable is a name + at least one stage.
+    expect(isTriggerReady(doc.trigger)).toBe(true)
   })
+})
 
-  it("Manual with a blank name is not ready", () => {
-    expect(isTriggerReady(manualTrigger({ manual_name: "   " }))).toBe(false)
+describe("isTriggerReady — per-kind branch (#561, amended #572)", () => {
+  it("Manual is always ready, even with a blank button label (#572)", () => {
+    // The "no automatic trigger" default: nothing to configure. The button
+    // label is optional and falls back to the workflow name at create time.
+    expect(isTriggerReady(manualTrigger())).toBe(true)
+    expect(isTriggerReady(manualTrigger({ manual_name: "" }))).toBe(true)
+    expect(isTriggerReady(manualTrigger({ manual_name: "   " }))).toBe(true)
   })
 
   it("Manual ignores install/repo/label entirely", () => {
-    // No install, no repo, no label — still ready as long as it has a name.
+    // No install, no repo, no label — still ready; Manual needs nothing.
     expect(
       isTriggerReady(
         manualTrigger({
@@ -102,13 +114,13 @@ describe("isTriggerReady — per-kind branch (#561)", () => {
   })
 })
 
-describe("documentToCreateRequest — Manual variant (#561)", () => {
+describe("documentToCreateRequest — Manual variant (#561, amended #572)", () => {
   function manualDoc(): WorkflowDocument {
     return {
       ...emptyDocument(),
       name: "Nightly batch",
       trigger: manualTrigger(),
-      stages: [makeStage("agent-session", "Issue", "Agent session")],
+      stages: [makeStage("agent-session", "Agent session")],
     }
   }
 
@@ -137,10 +149,13 @@ describe("documentToCreateRequest — Manual variant (#561)", () => {
     expect(body.trigger).toEqual({ kind: "manual", name: "spaced" })
   })
 
-  it("throws when the Manual name is blank", () => {
+  it("falls back to the workflow name when the button label is blank (#572)", () => {
+    // No automatic trigger needs no button label; the wire `name` derives
+    // from the workflow name so the run button is still meaningfully labeled.
     const doc = manualDoc()
     doc.trigger = manualTrigger({ manual_name: "" })
-    expect(() => documentToCreateRequest(doc, [], "ws_1", false)).toThrow()
+    const body = documentToCreateRequest(doc, [], "ws_1", false)
+    expect(body.trigger).toEqual({ kind: "manual", name: "Nightly batch" })
   })
 })
 
@@ -150,7 +165,7 @@ describe("documentToCreateRequest — GitHub variant unchanged (#561)", () => {
       ...emptyDocument(),
       name: "Issue to PR",
       trigger: githubTrigger(),
-      stages: [makeStage("agent-session", "Issue", "Agent session")],
+      stages: [makeStage("agent-session", "Agent session")],
     }
   }
 


### PR DESCRIPTION
Closes #572.

## Why
The master-detail workflow builder (#569) modeled the trigger as the top node of the stage rail. Three UX costs followed, all from one root — the trigger is a different kind of object than a stage (how a workflow is *invoked*, not a step), and burying it as a rail node hides its config:

1. Selecting a rail row to edit the trigger reads as "step 0".
2. `emptyDocument()` defaulted the trigger to `github_issue_webhook`, silently presuming a GitHub-webhook automation.
3. The repo picker lived inside the trigger node — no obvious place to configure repositories.

## What
- **Trigger is its own always-visible section** in `WorkflowBuilder`, above the stage flow. `FlowRail` / `FlowEditor` are now **stages-only** (the `Selection` `trigger` arm is gone; the right pane is a `StageEditor` or an empty-state prompt).
- **Default to "no automatic trigger" = Manual.** There is no untriggered-workflow concept in the substrate, so the repo-less, workspace-scoped Manual kind *is* "no trigger". The kind picker sits at Manual with GitHub webhook one explicit click away; repo + label pickers appear only on the webhook leg.
- **Manual button label is now optional (amends #561).** `isTriggerReady(manual)` is always true; the wire `name` falls back to the workflow name in `documentToCreateRequest`. A workflow now saves with just a name + one stage — nothing presumed about invocation. The backend already accepts an empty manual name (`validate_create_body` only gates the workflow name + GitHub repo slugs), so this is frontend-only.

Backend-honest: repos stay trigger-level on the wire (the github webhook `TriggerKind` carries `repo`; Manual is workspace-scoped). No workflow-level repo concept is invented ahead of #566.

## Incidental cleanup
- De-duplicated the drifted private `emptyDocument` in `drafts.ts` (it was already missing `repos: []`) — now imports the canonical one.
- Fixed pre-existing stale 3-arg `makeStage(gate, "Issue", name)` calls in tests (the middle `artifactKind` arg was removed in #568; vitest runs through esbuild so the dead arg never type-failed).

## Tests
- `isTriggerReady(manual)` is always true regardless of `manual_name`; GitHub leg still requires install + repo + label (no regression).
- `emptyDocument()` defaults to Manual and is immediately ready.
- Manual create falls back to the workflow name for the button label (mutation-checked: breaking the fallback fails two tests).
- The trigger framing renders at the top level but **not** inside the stage rail nav.
- `pnpm tsc -b`, `pnpm eslint .`, full vitest (259) all green; `check-file-budget` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-on (this push): compact the create dialog — Closes #574**
- Trigger-kind picker is now a `Tabs` segmented control (Manual | GitHub issue), not a value-showing `Select`.
- Dropped the trigger section header and the useless Manual button-label input.
- Create button pinned in the dialog footer; `Active` toggle moved up next to the workflow name.
- Trigger/Steps render as parallel labeled sections (no heavy bordered box).
