### PR TITLE
fix(just): build synodic with postgres feature in dev recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -196,7 +196,7 @@ dev: dev-infra
         cargo run -p stiglab -- server &
 
     echo "==> Starting synodic on :3001..."
-    PORT=3001 cargo run -p synodic -- serve &
+    PORT=3001 cargo run -p synodic --features postgres -- serve &
 
     echo "==> Starting onsager-scheduler (substrate scheduler)..."
     DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
@@ -248,7 +248,7 @@ dev-stiglab:
     cargo run -p stiglab -- server
 
 dev-synodic port="3001":
-    PORT={{port}} cargo run -p synodic -- serve
+    PORT={{port}} cargo run -p synodic --features postgres -- serve
 
 # ── DB ───────────────────────────────────────────────────────────────
 db-migrate:


### PR DESCRIPTION
The justfile has `set dotenv-load := true`, so `.env`'s `DATABASE_URL=postgres://…` is loaded into every recipe. But synodic's crate defaults to the `sqlite` feature (`default = ["sqlite"]`), so `just dev` and `just dev-synodic` crashed at startup with:

```
Error: PostgreSQL support not compiled in — enable the `postgres` feature
```

Fix: pass `--features postgres` to both synodic invocations (the `dev` aggregate recipe and the standalone `dev-synodic`).

Verified locally: `just`-launched synodic now connects to the postgres spine and serves on :3001.

Trivial: two-line dev-tooling fix, no product behavior change, no spec needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)