### PR TITLE
feat(infra): host-run just dev — auto ports + Traefik self-registration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,10 @@
 export REPO=onsager
 export WORKTREE=$(basename "$PWD" | tr '/_.' '-')
 export COMPOSE_PROJECT_NAME="${REPO}-${WORKTREE}"
-export DEV_HOST="${WORKTREE}.${REPO}.localhost"
+# Main checkout (dir name == repo) sits at the apex; worktrees are
+# subdomains: onsager.localhost vs feat-x.onsager.localhost.
+if [ "$WORKTREE" = "$REPO" ]; then
+    export DEV_HOST="${REPO}.localhost"
+else
+    export DEV_HOST="${WORKTREE}.${REPO}.localhost"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,7 +362,18 @@ curl -s -H "Host: $DEV_HOST" localhost:8000
 ```
 
 Manage worktrees with `wt new <branch>` / `wt rm <branch>` / `wt ls`
-(see `~/bin/wt`). Note: the root compose no longer publishes Postgres
-on host :5432; for host-run `cargo` against a containerized db, either
-use the slot system or add a local (gitignored) `compose.override.yml`
-re-adding the port.
+(see `~/bin/wt`).
+
+**Host-run mode (#579, the fast loop).** `just dev` is also a devproxy
+citizen: it allocates free ports per service (canonical 3000–3002/5173
+first, random fallback so parallel worktree stacks never collide),
+derives `DATABASE_URL` from the db's OS-assigned loopback port
+(`docker compose port db 5432` — the compose publishes `127.0.0.1::5432`,
+no override needed), and self-registers `Host($DEV_HOST)` with Traefik
+by writing `~/dev-proxy/dynamic/$COMPOSE_PROJECT_NAME.yml` (removed on
+exit). The host stack is then reachable at the same
+`http://$DEV_HOST:8000`, HMR included. One-time machine setup: the
+`~/dev-proxy` Traefik needs `--providers.file.directory=/dynamic
+--providers.file.watch=true`, a `./dynamic:/dynamic:ro` mount, and
+`extra_hosts: [host.docker.internal:host-gateway]`. Without that dir
+(or outside direnv) `just dev` skips registration and behaves as before.

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -11,6 +11,12 @@ const hmrClientPort = process.env.VITE_HMR_CLIENT_PORT
   ? Number(process.env.VITE_HMR_CLIENT_PORT)
   : undefined
 
+// Host-run `just dev` may start the backends on non-canonical ports when
+// the canonical ones are busy (parallel worktrees, #579); it exports the
+// chosen ports so the dev proxy follows. Defaults match the fixed ports.
+const portalPort = process.env.PORTAL_PORT ?? '3002'
+const stiglabPort = process.env.STIGLAB_PORT ?? '3000'
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -29,15 +35,15 @@ export default defineConfig({
     proxy: {
       // After #222 Slice 6, portal (3002) owns all /api/* routes;
       // stiglab (3000) keeps only /agent/ws for agent binary connections.
-      '/api': 'http://localhost:3002',
+      '/api': `http://localhost:${portalPort}`,
       // Portal also hosts the MCP server at POST /mcp/messages (ADR 0007 /
       // spec #288). The dashboard chat and the Spec Plans page are
       // same-origin MCP clients, so dev needs the same forward Caddy's
       // `/mcp/*` block gives production — without it `/mcp/messages` hits
       // the Vite dev server and 404s (breaking Plans + chat).
-      '/mcp': 'http://localhost:3002',
+      '/mcp': `http://localhost:${portalPort}`,
       '/agent': {
-        target: 'ws://localhost:3000',
+        target: `ws://localhost:${stiglabPort}`,
         ws: true,
       },
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,11 @@ services:
       POSTGRES_USER: onsager
       POSTGRES_PASSWORD: onsager
       POSTGRES_DB: onsager
+    # OS-assigned loopback port so host-run `cargo` (just dev) reaches the
+    # db without a hand-rolled override, conflict-free across parallel
+    # worktrees. `just dev` reads it back via `docker compose port db 5432`.
+    ports:
+      - "127.0.0.1::5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # per-slot flow, nothing publishes a host port: the caddy `edge` service
 # joins the shared `devproxy` network and Traefik (in ~/dev-proxy)
 # routes Host(`$DEV_HOST`) → edge. Browser/agent access:
-#   http://<worktree>.onsager.localhost:8000
+#   http://<worktree>.onsager.localhost:8000  (main checkout: http://onsager.localhost:8000)
 #
 # Usage:
 #   just dev-infra          # start Postgres + run migrations

--- a/justfile
+++ b/justfile
@@ -194,35 +194,87 @@ measure-tokens FILE:
 dev: dev-infra
     #!/usr/bin/env bash
     set -euo pipefail
-    trap 'pids=$(jobs -p); [ -n "$pids" ] && kill $pids 2>/dev/null || true' EXIT
 
-    echo "==> Starting portal on :3002..."
-    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
-    PORTAL_BIND="0.0.0.0:3002" \
+    # The committed compose publishes db on an OS-assigned loopback port
+    # (a local override may add a fixed one) — read back what we got.
+    DB_PORT=$(docker compose port db 5432 | head -1 | awk -F: '{print $NF}')
+    DATABASE_URL="postgres://onsager:onsager@localhost:${DB_PORT}/onsager"
+
+    # Canonical-first port picker (#579): keep muscle-memory ports when
+    # free; fall back to a random free port so parallel worktree stacks
+    # never collide.
+    pick_port() {
+        local p=$1
+        while (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; do
+            p=$(( (RANDOM % 20000) + 20000 ))
+        done
+        echo "$p"
+    }
+    PORTAL_PORT=$(pick_port 3002)
+    STIGLAB_PORT=$(pick_port 3000)
+    SYNODIC_PORT=$(pick_port 3001)
+    DASHBOARD_PORT=$(pick_port 5173)
+    export PORTAL_PORT STIGLAB_PORT  # vite.config.ts proxy targets
+
+    # Self-register with the machine Traefik (worktree devproxy) when its
+    # file-provider dir exists: Host($DEV_HOST) → host-run Vite. Vite
+    # fronts /api, /mcp and /agent same-origin, so one route suffices;
+    # HMR must aim at the proxy port when reached through it. (#579)
+    DEVPROXY_DYNAMIC_DIR="${DEVPROXY_DYNAMIC_DIR:-$HOME/dev-proxy/dynamic}"
+    route_file=""
+    if [ -n "${DEV_HOST:-}" ] && [ -d "$DEVPROXY_DYNAMIC_DIR" ]; then
+        route_file="$DEVPROXY_DYNAMIC_DIR/${COMPOSE_PROJECT_NAME:-onsager}.yml"
+        cat > "$route_file" <<ROUTE
+    http:
+      routers:
+        ${COMPOSE_PROJECT_NAME:-onsager}:
+          rule: Host(\`${DEV_HOST}\`)
+          service: ${COMPOSE_PROJECT_NAME:-onsager}
+      services:
+        ${COMPOSE_PROJECT_NAME:-onsager}:
+          loadBalancer:
+            servers:
+              - url: http://host.docker.internal:${DASHBOARD_PORT}
+    ROUTE
+        export VITE_HMR_CLIENT_PORT="${VITE_HMR_CLIENT_PORT:-8000}"
+    else
+        echo "==> devproxy registration skipped (need DEV_HOST + $DEVPROXY_DYNAMIC_DIR)"
+    fi
+
+    trap 'pids=$(jobs -p); [ -n "$pids" ] && kill $pids 2>/dev/null || true; [ -n "$route_file" ] && rm -f "$route_file"' EXIT
+
+    echo "==> Starting portal on :${PORTAL_PORT}..."
+    DATABASE_URL="$DATABASE_URL" \
+    PORTAL_BIND="0.0.0.0:${PORTAL_PORT}" \
+    SYNODIC_URL="http://localhost:${SYNODIC_PORT}" \
+    STIGLAB_INTERNAL_WS_URL="ws://localhost:${STIGLAB_PORT}/agent/ws-internal" \
         cargo run -p onsager-portal -- serve &
 
-    echo "==> Starting stiglab on :3000..."
-    ONSAGER_DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+    echo "==> Starting stiglab on :${STIGLAB_PORT}..."
+    ONSAGER_DATABASE_URL="$DATABASE_URL" \
+    STIGLAB_PORT="$STIGLAB_PORT" \
         cargo run -p stiglab -- server &
 
-    echo "==> Starting synodic on :3001..."
-    PORT=3001 cargo run -p synodic --features postgres -- serve &
+    echo "==> Starting synodic on :${SYNODIC_PORT}..."
+    DATABASE_URL="$DATABASE_URL" \
+    PORT=$SYNODIC_PORT cargo run -p synodic --features postgres -- serve &
 
     echo "==> Starting onsager-scheduler (substrate scheduler)..."
-    DATABASE_URL="postgres://onsager:onsager@localhost:5432/onsager" \
+    DATABASE_URL="$DATABASE_URL" \
         cargo run -p onsager-scheduler -- serve &
 
-    echo "==> Starting dashboard on :5173..."
-    pnpm --filter dashboard dev -- --strictPort &
+    echo "==> Starting dashboard on :${DASHBOARD_PORT}..."
+    pnpm --filter dashboard dev -- --port "$DASHBOARD_PORT" --strictPort &
 
     echo ""
     echo "=== Onsager dev stack running ==="
-    echo "  Dashboard:  http://localhost:5173"
-    echo "  Stiglab:    http://localhost:3000"
-    echo "  Synodic:    http://localhost:3001"
-    echo "  Portal:     http://localhost:3002"
+    [ -n "$route_file" ] && echo "  Devproxy:   http://${DEV_HOST}:8000"
+    echo "  Dashboard:  http://localhost:${DASHBOARD_PORT}"
+    echo "  Stiglab:    http://localhost:${STIGLAB_PORT}"
+    echo "  Synodic:    http://localhost:${SYNODIC_PORT}"
+    echo "  Portal:     http://localhost:${PORTAL_PORT}"
     echo "  Scheduler:  spine listener (no HTTP port)"
-    echo "  Postgres:   postgres://onsager:onsager@localhost:5432/onsager"
+    echo "  Postgres:   postgres://onsager:onsager@localhost:${DB_PORT}/onsager"
     echo ""
     echo "Press Ctrl+C to stop all services."
     wait


### PR DESCRIPTION
Closes #579

Makes the host-run `just dev` loop a first-class devproxy citizen, per the spec:

- **Port allocation (canonical-first):** the recipe tries 3002/3000/3001/5173 and falls back to a random free port per service, so parallel worktree stacks never collide. Chosen ports flow to the services via their existing env knobs and to Vite's dev proxy via new `PORTAL_PORT` / `STIGLAB_PORT` reads in `vite.config.ts` (defaults unchanged). Portal's `SYNODIC_URL` / `STIGLAB_INTERNAL_WS_URL` follow the chosen ports too.
- **Postgres:** the committed compose now publishes `127.0.0.1::5432` (OS-assigned, conflict-free); `just dev` derives `DATABASE_URL` from `docker compose port db 5432`. The hand-rolled gitignored override is no longer needed (but still merges cleanly if present).
- **Traefik registration:** when `DEV_HOST` is set and `~/dev-proxy/dynamic` exists, the recipe writes a file-provider route `Host($DEV_HOST) → host.docker.internal:<vite port>` and removes it in the EXIT trap, setting `VITE_HMR_CLIENT_PORT=8000` so HMR works through the proxy. Without the dir, `just dev` behaves exactly as before (skip notice).
- **Docs:** CLAUDE.md worktree section documents the host-run mode and the one-time machine-side Traefik setup (file provider + `host.docker.internal:host-gateway`).

**Verified on the dev VM** (machine Traefik updated accordingly):
- All services up on canonical ports; `Host: onsager.onsager.localhost` through Traefik :8000 serves the Vite dev page and proxies `/api` to portal (401 from auth, proving the chain).
- Port picker returns random free ports when canonical ones are busy, keeps free ones.
- Killing the recipe removes the dynamic route file.
- `eslint vite.config.ts` clean.

**Not yet exercised:** a full second-stack run from a cold worktree (spec Test item 2) — the collision fallback and registration halves are each verified above, but the end-to-end two-worktree run still needs a cold-cargo build to confirm. Browser-side HMR through :8000 (Test item 5) verified only as far as the dev page loading react-refresh through the proxy; a human click-through confirming live HMR is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)