### PR TITLE
refactor(workflow): one workflow model — the builder's definition derives the library DAG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,10 +175,10 @@ Per spec #286, the dashboard, public API field names, route segments, button cop
 
 The four canonical nouns:
 
-- **Workflow** — the automation unit (trigger + ordered stages + prompts). `/api/workflows`; spine `workflows` / `workflow_stages` (Lever D).
+- **Workflow** — the automation unit (trigger + ordered stages + prompts). `/api/workflows`; authored definition on the spine `workflows` row, executable DAG in `workflow_library` keyed by the workflow id (ADR 0028 / #602 — one model, derived at save).
 - **Run** — one execution of a workflow against an artifact. `/api/workflows/:id/runs`; has a status and a sequence of stage outcomes.
 - **Artifact** — what a run produces (issue, PR, deployment, etc.). The core noun; `/api/spine/artifacts`; spine `artifacts`.
-- **Stage** — a step within a workflow definition (gate kind + parameters). A workflow's structural unit; never a top-level nav noun.
+- **Stage** — a step within a workflow definition (gate kind + parameters), materialized as a DAG node in the executable form. A workflow's structural unit; never a top-level nav noun.
 
 **Sanctioned carve-out — "Plans" (spec plans).** ADR 0023 made the authored spec-plan graph a first-class user concept; ADR 0025 / spec #514 require a noun-surface launch path so chat isn't the sole way to run one. The dashboard carries a fifth nav noun, **Plans** (`/workspaces/:slug/spec-plans`), listing persisted spec plans with a HitlCard-routed "Run" button. A deliberate exception under the four-noun rule, not a violation: a spec **plan** (a substrate authoring artifact — a DAG of specs run in dependency order) is distinct from the internal-only dev-process **spec** (a GitHub issue) demoted below. Scoped to this one surface; new nav nouns still default to "no" and need their own ADR.
 

--- a/apps/dashboard/src/lib/api/generated/WorkflowStage.ts
+++ b/apps/dashboard/src/lib/api/generated/WorkflowStage.ts
@@ -12,6 +12,13 @@ export type WorkflowStage = { id: string, workflow_id: string,
  */
 seq: number, gate_kind: WorkflowGateKind, 
 /**
+ * Whether this stage's gate kind has a registered engine executor
+ * today (ADR 0028 / #602). `external-check` / `manual-approval`
+ * stages stay in the authored definition but are excluded from the
+ * executable DAG until their substrate executors land.
+ */
+executable: boolean, 
+/**
  * Gate-kind-specific config (e.g. agent profile, check name). Stored as
  * free-form JSON so the schema doesn't need to know every param shape.
  */

--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -411,7 +411,7 @@ pub struct RunsQuery {
 /// status derived from `artifacts.current_stage_index` and
 /// `workflow_parked_reason`.
 ///
-/// Stage IDs come from spine `workflow_stages` keyed by `(workflow_id,
+/// Stage IDs derive from the authored definition keyed by `(workflow_id,
 /// stage_order)`; the per-run stage list aligns 1:1 with that ordering so
 /// the dashboard can zip stages by index.
 pub async fn list_workflow_runs(
@@ -901,6 +901,7 @@ mod tests {
                 workflow_id: "wf_test".into(),
                 seq: i,
                 gate_kind: GateKind::AgentSession,
+                executable: true,
                 params: serde_json::json!({}),
             })
             .collect()

--- a/crates/onsager-portal/src/lib.rs
+++ b/crates/onsager-portal/src/lib.rs
@@ -61,6 +61,7 @@ pub mod substrate_library_db;
 pub mod workflow;
 pub mod workflow_activation;
 pub mod workflow_create;
+pub mod workflow_dag;
 pub mod workflow_db;
 pub mod workflow_install;
 pub mod workflow_version_db;

--- a/crates/onsager-portal/src/listeners/trigger_fired.rs
+++ b/crates/onsager-portal/src/listeners/trigger_fired.rs
@@ -12,13 +12,12 @@
 //! one run event kind; the old engine-side `trigger.fired` bridge (and
 //! its tokenless degraded mode) retired with this listener.
 //!
-//! `spec_kind` resolution (ported from the retired bridge, same
-//! precedence): an explicit `"spec_kind"` field in the trigger payload
-//! wins; otherwise the workflow row's `preset_id`; otherwise the fire
-//! is dropped with a structured warning — a webhook path cannot 4xx,
-//! so the warning (and the surviving `trigger.fired` audit row) is the
-//! operator's signal. #602 retires the string join entirely by keying
-//! the library on the workflow id.
+//! The library is keyed by the workflow id (#602): the executable DAG
+//! is registered at save time, so resolution is a direct lookup. A
+//! workflow with no executable stage has no library entry and the fire
+//! fails loudly at the engine's lookup — the surviving `trigger.fired`
+//! audit row plus a structured warning are the operator's signal (a
+//! webhook path cannot 4xx).
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -101,17 +100,9 @@ impl TriggerFired {
             .await?
             .ok_or_else(|| anyhow::anyhow!("workflow `{workflow_id}` not found"))?;
 
-        // spec_kind precedence: explicit payload field, else preset.
-        let spec_kind = payload
-            .get("spec_kind")
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .or_else(|| workflow.preset_id.clone())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no spec_kind for workflow `{workflow_id}` (no payload field, no preset)"
-                )
-            })?;
+        // ADR 0028 / #602: the library is keyed by the workflow id —
+        // the executable DAG registered at save time. No string join.
+        let spec_kind = workflow_id.clone();
 
         // Optional input artifact ids on the payload become the spec's
         // declared external inputs (compiler → `plan.entry_inputs`).

--- a/crates/onsager-portal/src/mcp/tools/workflows.rs
+++ b/crates/onsager-portal/src/mcp/tools/workflows.rs
@@ -104,6 +104,7 @@ pub async fn propose_workflow(state: &AppState, auth_user: &AuthUser, args: Valu
             workflow_id: workflow_id.clone(),
             seq: i as i32,
             gate_kind: s.gate_kind,
+            executable: crate::workflow_dag::stage_is_executable(s.gate_kind),
             params: s.params.clone().unwrap_or_else(|| serde_json::json!({})),
         })
         .collect();

--- a/crates/onsager-portal/src/workflow.rs
+++ b/crates/onsager-portal/src/workflow.rs
@@ -67,6 +67,12 @@ pub struct WorkflowStage {
     /// ascending `seq` order.
     pub seq: i32,
     pub gate_kind: GateKind,
+    /// Whether this stage's gate kind has a registered engine executor
+    /// today (ADR 0028 / #602). `external-check` / `manual-approval`
+    /// stages stay in the authored definition but are excluded from the
+    /// executable DAG until their substrate executors land.
+    #[serde(default)]
+    pub executable: bool,
     /// Gate-kind-specific config (e.g. agent profile, check name). Stored as
     /// free-form JSON so the schema doesn't need to know every param shape.
     pub params: serde_json::Value,

--- a/crates/onsager-portal/src/workflow_create.rs
+++ b/crates/onsager-portal/src/workflow_create.rs
@@ -116,6 +116,7 @@ pub fn validate_create_body(
                 workflow_id: String::new(),
                 seq: i as i32,
                 gate_kind: s.gate_kind,
+                executable: crate::workflow_dag::stage_is_executable(s.gate_kind),
                 params: s.params,
             })
             .collect()
@@ -135,6 +136,7 @@ pub fn validate_create_body(
                 workflow_id: String::new(),
                 seq: i as i32,
                 gate_kind,
+                executable: crate::workflow_dag::stage_is_executable(gate_kind),
                 params: s.params.clone().unwrap_or_else(|| serde_json::json!({})),
             });
         }

--- a/crates/onsager-portal/src/workflow_dag.rs
+++ b/crates/onsager-portal/src/workflow_dag.rs
@@ -1,0 +1,242 @@
+//! Authored workflow definition → executable library DAG
+//! (ADR 0028 / spec #602).
+//!
+//! The builder's stage list is the workflow's **authored** form
+//! (persisted as `workflows.definition_json`); this module derives the
+//! **executable** form — a substrate `Workflow` DAG — and registers it
+//! in `workflow_library` under `spec_kind = <workflow_id>`, the same
+//! logical→physical split the substrate itself uses (Spec Plan →
+//! Execution Plan, ADR 0009). The #601 trigger conversion then resolves
+//! the library by workflow id directly: no `spec_kind` string join, no
+//! preset fallback.
+//!
+//! ## Why raw JSON, not the typed `WorkflowLibrary::register`
+//!
+//! Executor impls are typetag-registered in the **engine** (ADR 0012);
+//! portal links only the substrate kernel, so it can neither construct
+//! nor deserialize an `"agent"` executor as a Rust value — and must
+//! not, per the two-process non-linking invariant (ADR 0027). Portal
+//! authors the persisted wire form (`workflow_json`) directly; the
+//! engine deserializes and kernel-validates it at load, which is the
+//! existing contract for every library row. The envelope field names
+//! are pinned by [`tests::envelope_matches_substrate_serde`] against
+//! the substrate's own serde (via a `noop` workflow round-trip), and
+//! the executor object mirrors the engine's `AgentExecutor` serde
+//! (`model`, `system_prompt`; `tools` / `credential_ref` /
+//! `runner` are `#[serde(default)]`-able or skipped).
+//!
+//! ## Executable subset (recorded on #602)
+//!
+//! Only `agent` (and `noop`) executors are registered in the engine
+//! today; `external-check` / `manual-approval` stages have had no
+//! runtime since the forge gate machine retired. They remain in the
+//! authored definition (and the builder UI) but are excluded from the
+//! derived DAG and surfaced `executable: false`; substrate executors
+//! for them are a follow-up spec.
+
+use serde_json::{Value, json};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::workflow::{GateKind, WorkflowStage};
+
+/// Derive the executable DAG (as raw `workflow_json`) from the authored
+/// stage list. Returns `None` when no stage is executable — the
+/// workflow then has no library entry, and a fire fails loudly at the
+/// engine's "no workflow registered" lookup rather than running an
+/// empty plan.
+pub fn derive_workflow_json(workflow_id: &str, stages: &[WorkflowStage]) -> Option<Value> {
+    let agents: Vec<&WorkflowStage> = stages
+        .iter()
+        .filter(|s| s.gate_kind == GateKind::AgentSession)
+        .collect();
+    if agents.is_empty() {
+        return None;
+    }
+
+    // Deterministic ids: derived from (workflow_id, position) so
+    // re-registering an unchanged definition produces an identical
+    // document (UUID v5 over a fixed namespace).
+    let ns = Uuid::new_v5(&Uuid::NAMESPACE_OID, workflow_id.as_bytes());
+    let edge_id = |i: usize| Uuid::new_v5(&ns, format!("edge:{i}").as_bytes()).to_string();
+    let node_id = |i: usize| Uuid::new_v5(&ns, format!("node:{i}").as_bytes()).to_string();
+
+    // A linear chain: edge 0 is the entry, edge i+1 carries node i's
+    // output. Artifact ids are chain-local; the compiler namespaces
+    // them per spec instance (invariant 5).
+    let mut edges = Vec::with_capacity(agents.len() + 1);
+    edges.push(json!({
+        "id": edge_id(0),
+        "artifact_id": format!("{workflow_id}:in"),
+        "requires_deterministic": false,
+    }));
+    let mut nodes = Vec::with_capacity(agents.len());
+    for (i, stage) in agents.iter().enumerate() {
+        edges.push(json!({
+            "id": edge_id(i + 1),
+            "artifact_id": format!("{workflow_id}:out:{i}"),
+            "requires_deterministic": false,
+        }));
+        let model = stage
+            .params
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let system_prompt = stage
+            .params
+            .get("system_prompt")
+            .or_else(|| stage.params.get("prompt"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        nodes.push(json!({
+            "id": node_id(i),
+            "executor": {
+                "kind": "agent",
+                "model": model,
+                "system_prompt": system_prompt,
+                "tools": [],
+                "credential_ref": null,
+            },
+            "inputs": [{ "edge_id": edge_id(i) }],
+            "outputs": [{ "edge_id": edge_id(i + 1) }],
+        }));
+    }
+
+    Some(json!({
+        "nodes": nodes,
+        "edges": edges,
+        "entry_specs": [{ "edge_id": edge_id(0) }],
+        // Agent output is non-reproducible by definition — declared
+        // provenance must match the exit path (kernel invariant 3).
+        "output_specs": [{
+            "edge_id": edge_id(agents.len()),
+            "provenance": { "kind": "uncertain", "source": "agent" },
+        }],
+    }))
+}
+
+/// Register the derived DAG under `spec_kind = workflow_id`, bumping
+/// the library version (same SQL contract as the substrate's
+/// `WorkflowLibrary::register`). No-op when the definition has no
+/// executable stage.
+pub async fn register_executable(
+    pool: &PgPool,
+    workflow_id: &str,
+    stages: &[WorkflowStage],
+) -> anyhow::Result<Option<i32>> {
+    let Some(workflow_json) = derive_workflow_json(workflow_id, stages) else {
+        return Ok(None);
+    };
+    let row_id = Uuid::new_v4().to_string();
+    let version: i32 = sqlx::query_scalar(
+        "INSERT INTO workflow_library (id, spec_kind, version, workflow_json) \
+         VALUES ($1, $2, \
+                 COALESCE((SELECT MAX(version) FROM workflow_library WHERE spec_kind = $2), 0) + 1, \
+                 $3) \
+         RETURNING version",
+    )
+    .bind(&row_id)
+    .bind(workflow_id)
+    .bind(&workflow_json)
+    .fetch_one(pool)
+    .await?;
+    Ok(Some(version))
+}
+
+/// Whether a stage's gate kind has a registered engine executor today.
+pub fn stage_is_executable(kind: GateKind) -> bool {
+    kind == GateKind::AgentSession
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stage(seq: i32, kind: GateKind, params: Value) -> WorkflowStage {
+        WorkflowStage {
+            id: format!("s{seq}"),
+            workflow_id: "wf_test".into(),
+            seq,
+            gate_kind: kind,
+            executable: stage_is_executable(kind),
+            params,
+        }
+    }
+
+    /// Pin the envelope field names against the substrate's own serde:
+    /// a `noop` workflow built through the typed API must deserialize
+    /// from a document with exactly the field layout this module
+    /// authors. (The `agent` executor body itself can only deserialize
+    /// in the engine, where the typetag impl is linked — the wave-close
+    /// e2e covers that end.)
+    #[test]
+    fn envelope_matches_substrate_serde() {
+        let mut doc = derive_workflow_json(
+            "wf_env",
+            &[stage(
+                0,
+                GateKind::AgentSession,
+                json!({"model": "sonnet", "system_prompt": "x"}),
+            )],
+        )
+        .expect("one agent stage derives");
+        // Swap the engine-only executor for the substrate-linked noop;
+        // everything else must round-trip through the typed Workflow.
+        doc["nodes"][0]["executor"] = json!({ "kind": "noop" });
+        let parsed: Result<onsager_substrate::Workflow, _> = serde_json::from_value(doc);
+        let wf = parsed.expect("envelope deserializes against substrate serde");
+        assert_eq!(wf.nodes.len(), 1);
+        assert_eq!(wf.edges.len(), 2);
+        assert_eq!(wf.entry_specs.len(), 1);
+        assert_eq!(wf.output_specs.len(), 1);
+    }
+
+    /// The derivation is deterministic: same definition → identical
+    /// document (re-saving an unchanged workflow re-registers the same
+    /// content, just bumping the version).
+    #[test]
+    fn derivation_is_deterministic() {
+        let stages = [stage(0, GateKind::AgentSession, json!({"model": "m"}))];
+        assert_eq!(
+            derive_workflow_json("wf_a", &stages),
+            derive_workflow_json("wf_a", &stages)
+        );
+        assert_ne!(
+            derive_workflow_json("wf_a", &stages),
+            derive_workflow_json("wf_b", &stages)
+        );
+    }
+
+    /// Chains chain: node i's output edge is node i+1's input edge.
+    #[test]
+    fn chain_edges_connect() {
+        let stages = [
+            stage(0, GateKind::AgentSession, json!({})),
+            stage(1, GateKind::AgentSession, json!({})),
+        ];
+        let doc = derive_workflow_json("wf_chain", &stages).unwrap();
+        let n0_out = &doc["nodes"][0]["outputs"][0]["edge_id"];
+        let n1_in = &doc["nodes"][1]["inputs"][0]["edge_id"];
+        assert_eq!(n0_out, n1_in);
+        assert_eq!(doc["edges"].as_array().unwrap().len(), 3);
+    }
+
+    /// Non-agent stages are excluded from the executable DAG; a
+    /// definition with no agent stage registers nothing.
+    #[test]
+    fn non_agent_stages_excluded() {
+        let stages = [
+            stage(0, GateKind::ExternalCheck, json!({})),
+            stage(1, GateKind::AgentSession, json!({})),
+            stage(2, GateKind::ManualApproval, json!({})),
+        ];
+        let doc = derive_workflow_json("wf_mixed", &stages).unwrap();
+        assert_eq!(doc["nodes"].as_array().unwrap().len(), 1);
+        assert!(
+            derive_workflow_json("wf_none", &[stage(0, GateKind::ExternalCheck, json!({}))])
+                .is_none()
+        );
+        assert!(stage_is_executable(GateKind::AgentSession));
+        assert!(!stage_is_executable(GateKind::ExternalCheck));
+    }
+}

--- a/crates/onsager-portal/src/workflow_db.rs
+++ b/crates/onsager-portal/src/workflow_db.rs
@@ -1,4 +1,5 @@
-//! Workflow CRUD against the spine `workflows` / `workflow_stages` tables.
+//! Workflow CRUD against the spine `workflows` table (authored
+//! definition on the row; executable DAG in `workflow_library` — ADR 0028).
 //!
 //! Spec #222 Slice 4 moved the writer surface from stiglab to portal.
 //! Portal is the only process that performs `INSERT` / `UPDATE` /
@@ -20,51 +21,9 @@
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use onsager_registry::TRIGGERS;
-use serde_json::json;
 use sqlx::{PgPool, Row};
 
 use crate::workflow::{GateKind, TriggerKind, Workflow, WorkflowStage};
-
-/// Translate the workflow's `gate_kind` + opaque `params` into the spine's
-/// `(target_state, gates)` pair. The artifact-state transitions match the
-/// "issue → PR" flow forge expects: agent-session moves Draft → InProgress,
-/// review-style gates move to UnderReview.
-fn translate_stage(
-    gate_kind: GateKind,
-    params: &serde_json::Value,
-) -> (Option<&'static str>, serde_json::Value) {
-    match gate_kind {
-        GateKind::AgentSession => {
-            let gate = json!({
-                "kind": "agent_session",
-                "shaping_intent": params.clone(),
-            });
-            (Some("in_progress"), json!([gate]))
-        }
-        GateKind::ExternalCheck => {
-            let check_name = params
-                .get("check_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("ci");
-            let gate = json!({
-                "kind": "external_check",
-                "check_name": check_name,
-            });
-            (Some("under_review"), json!([gate]))
-        }
-        GateKind::ManualApproval => {
-            let signal_kind = params
-                .get("signal_kind")
-                .and_then(|v| v.as_str())
-                .unwrap_or("dashboard_approve");
-            let gate = json!({
-                "kind": "manual_approval",
-                "signal_kind": signal_kind,
-            });
-            (Some("under_review"), json!([gate]))
-        }
-    }
-}
 
 // ── Public CRUD surface ───────────────────────────────────────────────────
 
@@ -102,11 +61,21 @@ pub async fn insert_workflow_with_stages(
     // legacy `active` pin (`false` at create → `off`). Neither reads
     // `install_id` — status is trigger-source-neutral.
 
+    let definition_json = serde_json::to_value(
+        stages
+            .iter()
+            .map(|st| {
+                serde_json::json!({ "gate_kind": st.gate_kind.to_string(), "params": st.params })
+            })
+            .collect::<Vec<_>>(),
+    )
+    .context("serialize workflow definition")?;
     sqlx::query(
         "INSERT INTO workflows (workflow_id, name, trigger_kind, trigger_config, \
                                 active, preset_id, workspace_id, install_id, \
-                                created_by, created_at, updated_at, readiness, autofire) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+                                created_by, created_at, updated_at, readiness, autofire, \
+                                definition_json) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
     )
     .bind(&workflow.id)
     .bind(&workflow.name)
@@ -121,44 +90,33 @@ pub async fn insert_workflow_with_stages(
     .bind(workflow.updated_at)
     .bind("ready")
     .bind(autofire_for_active(workflow.active))
+    .bind(&definition_json)
     .execute(&mut *tx)
     .await
     .context("insert spine workflows row")?;
 
-    // Materialize stage rows + collect snapshot inputs in one pass so
-    // the v1 `workflow_versions` row below carries the same shape
-    // migration 025's backfill produces for pre-existing workflows.
-    let mut snapshot_stages: Vec<(
+    // Snapshot input for the v1 `workflow_versions` row (spec #337):
+    // the authored definition, one tuple per stage. `target_state` /
+    // `gates` retired with the stage-chain storage (ADR 0028 / #602) —
+    // None / [] keep the snapshot shape backward-readable.
+    let snapshot_stages: Vec<(
         i32,
         String,
         Option<&'static str>,
         serde_json::Value,
         serde_json::Value,
-    )> = Vec::with_capacity(stages.len());
-    for stage in stages {
-        let (target_state, gates) = translate_stage(stage.gate_kind, &stage.params);
-        sqlx::query(
-            "INSERT INTO workflow_stages (workflow_id, stage_order, name, \
-                                          target_state, gates, params) \
-             VALUES ($1, $2, $3, $4, $5, $6)",
-        )
-        .bind(&workflow.id)
-        .bind(stage.seq)
-        .bind(stage.gate_kind.to_string())
-        .bind(target_state)
-        .bind(&gates)
-        .bind(&stage.params)
-        .execute(&mut *tx)
-        .await
-        .context("insert spine workflow_stages row")?;
-        snapshot_stages.push((
-            stage.seq,
-            stage.gate_kind.to_string(),
-            target_state,
-            gates,
-            stage.params.clone(),
-        ));
-    }
+    )> = stages
+        .iter()
+        .map(|stage| {
+            (
+                stage.seq,
+                stage.gate_kind.to_string(),
+                None,
+                serde_json::json!([]),
+                stage.params.clone(),
+            )
+        })
+        .collect();
 
     // v1 version + audit row. Spec #337: every workflow is a versioned
     // artifact, and the initial version is published with the same
@@ -215,6 +173,24 @@ pub async fn insert_workflow_with_stages(
     .context("insert initial workflow_changes row")?;
 
     tx.commit().await?;
+
+    // Register the executable DAG under spec_kind = workflow id
+    // (ADR 0028 / #602): the #601 trigger conversion resolves the
+    // library by workflow id directly. No executable stage → no entry;
+    // a fire then fails loudly at the engine's library lookup.
+    match crate::workflow_dag::register_executable(pool, &workflow.id, stages).await {
+        Ok(Some(version)) => {
+            tracing::info!(workflow_id = %workflow.id, version, "registered executable workflow DAG");
+        }
+        Ok(None) => {
+            tracing::warn!(workflow_id = %workflow.id, "workflow has no executable stage; no library entry registered");
+        }
+        Err(e) => {
+            // The authored row is committed; a registration failure is
+            // loud but not fatal to creation (re-saving re-registers).
+            tracing::error!(workflow_id = %workflow.id, "library registration failed: {e}");
+        }
+    }
     Ok(())
 }
 
@@ -401,14 +377,53 @@ pub async fn list_stages_for_workflow(
     pool: &PgPool,
     workflow_id: &str,
 ) -> anyhow::Result<Vec<WorkflowStage>> {
-    let rows = sqlx::query(
-        "SELECT workflow_id, stage_order, name, params \
-           FROM workflow_stages WHERE workflow_id = $1 ORDER BY stage_order ASC",
-    )
-    .bind(workflow_id)
-    .fetch_all(pool)
-    .await?;
-    rows.into_iter().map(row_to_stage).collect()
+    let row: Option<(serde_json::Value,)> =
+        sqlx::query_as("SELECT definition_json FROM workflows WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .fetch_optional(pool)
+            .await?;
+    let Some((definition,)) = row else {
+        return Ok(Vec::new());
+    };
+    definition_to_stages(workflow_id, &definition)
+}
+
+/// Materialize stage DTOs from the authored `definition_json` (ADR
+/// 0028 / #602). Ids stay deterministic (`<workflow_id>#<seq>`), the
+/// same contract the dashboard's per-stage anchors relied on when the
+/// rows came from the dropped `workflow_stages` table.
+pub fn definition_to_stages(
+    workflow_id: &str,
+    definition: &serde_json::Value,
+) -> anyhow::Result<Vec<WorkflowStage>> {
+    let entries = definition
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("definition_json is not an array"))?;
+    entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let seq = i as i32;
+            let name = entry
+                .get("gate_kind")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("definition entry {i} missing gate_kind"))?;
+            let gate_kind = name.parse::<GateKind>().map_err(|e| {
+                anyhow::anyhow!("definition gate_kind not a known kind ({name}): {e}")
+            })?;
+            Ok(WorkflowStage {
+                id: format!("{workflow_id}#{seq}"),
+                workflow_id: workflow_id.to_string(),
+                seq,
+                gate_kind,
+                executable: crate::workflow_dag::stage_is_executable(gate_kind),
+                params: entry
+                    .get("params")
+                    .cloned()
+                    .unwrap_or(serde_json::json!({})),
+            })
+        })
+        .collect()
 }
 
 /// Toggle the `active` flag and bump `updated_at`. The `workflow_updated`
@@ -430,8 +445,8 @@ pub async fn set_workflow_active(
     Ok(())
 }
 
-/// Delete the workflow row. `workflow_stages` is `ON DELETE CASCADE` so
-/// the stage chain goes with it — no explicit per-stage DELETE.
+/// Delete the workflow row (the authored definition lives on it; the
+/// library rows under this workflow's kind are retired separately).
 ///
 /// Artifacts that still reference this workflow are detached in the
 /// same transaction: `workflow_id`, `current_stage_index` and
@@ -451,6 +466,16 @@ pub async fn set_workflow_active(
 /// the DELETE commits, the trigger's workflow lookup then misses and
 /// it drops the trigger — no orphan stage state can leak.
 pub async fn delete_workflow(pool: &PgPool, workflow_id: &str) -> anyhow::Result<()> {
+    // Retire this workflow's executable library entries (ADR 0028 —
+    // the kind is the workflow id, so retirement is a kind-level mark).
+    sqlx::query(
+        "UPDATE workflow_library SET retired_at = NOW() \
+         WHERE spec_kind = $1 AND retired_at IS NULL",
+    )
+    .bind(workflow_id)
+    .execute(pool)
+    .await
+    .context("retire workflow library entries")?;
     let mut tx = pool.begin().await?;
     sqlx::query("SELECT workflow_id FROM workflows WHERE workflow_id = $1 FOR UPDATE")
         .bind(workflow_id)
@@ -765,27 +790,6 @@ fn row_to_workflow(row: sqlx::postgres::PgRow) -> anyhow::Result<Workflow> {
     })
 }
 
-/// Stage rows on spine don't carry an explicit `id` (PK is
-/// `(workflow_id, stage_order)`). Synthesize a stable `${workflow_id}#${seq}`
-/// string for the dashboard's per-stage anchors — the same input always
-/// produces the same id, which is the contract callers rely on.
-fn row_to_stage(row: sqlx::postgres::PgRow) -> anyhow::Result<WorkflowStage> {
-    let workflow_id: String = row.try_get("workflow_id")?;
-    let stage_order: i32 = row.try_get("stage_order")?;
-    let name: String = row.try_get("name")?;
-    let params: serde_json::Value = row.try_get("params")?;
-    let gate_kind = name
-        .parse::<GateKind>()
-        .map_err(|e| anyhow::anyhow!("workflow_stages.name not a known gate kind ({name}): {e}"))?;
-    Ok(WorkflowStage {
-        id: format!("{workflow_id}#{stage_order}"),
-        workflow_id,
-        seq: stage_order,
-        gate_kind,
-        params,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     //! Pure-function unit tests for the translation helpers. Round-trip
@@ -882,30 +886,6 @@ mod tests {
     fn autofire_mirrors_active() {
         assert_eq!(autofire_for_active(true), "active");
         assert_eq!(autofire_for_active(false), "off");
-    }
-
-    #[test]
-    fn agent_session_maps_to_in_progress() {
-        let (state, gates) =
-            translate_stage(GateKind::AgentSession, &json!({"action": "implement"}));
-        assert_eq!(state, Some("in_progress"));
-        assert_eq!(gates[0]["kind"], "agent_session");
-        assert_eq!(gates[0]["shaping_intent"]["action"], "implement");
-    }
-
-    #[test]
-    fn external_check_pulls_check_name() {
-        let (state, gates) =
-            translate_stage(GateKind::ExternalCheck, &json!({"check_name": "ci/test"}));
-        assert_eq!(state, Some("under_review"));
-        assert_eq!(gates[0]["kind"], "external_check");
-        assert_eq!(gates[0]["check_name"], "ci/test");
-    }
-
-    #[test]
-    fn manual_approval_defaults_signal_kind() {
-        let (_, gates) = translate_stage(GateKind::ManualApproval, &json!({}));
-        assert_eq!(gates[0]["signal_kind"], "dashboard_approve");
     }
 
     #[test]

--- a/crates/onsager-portal/tests/showcase_dogfood.rs
+++ b/crates/onsager-portal/tests/showcase_dogfood.rs
@@ -54,6 +54,7 @@ async fn seed_dogfood_workflow(spine: &PgPool, workspace_id: &str) -> String {
             workflow_id: workflow_id.clone(),
             seq: 0,
             gate_kind: GateKind::AgentSession,
+            executable: onsager_portal::workflow_dag::stage_is_executable(GateKind::AgentSession),
             params: serde_json::json!({}),
         },
         WorkflowStage {
@@ -61,6 +62,7 @@ async fn seed_dogfood_workflow(spine: &PgPool, workspace_id: &str) -> String {
             workflow_id: workflow_id.clone(),
             seq: 1,
             gate_kind: GateKind::ExternalCheck,
+            executable: onsager_portal::workflow_dag::stage_is_executable(GateKind::ExternalCheck),
             params: serde_json::json!({}),
         },
         WorkflowStage {
@@ -68,6 +70,7 @@ async fn seed_dogfood_workflow(spine: &PgPool, workspace_id: &str) -> String {
             workflow_id: workflow_id.clone(),
             seq: 2,
             gate_kind: GateKind::ManualApproval,
+            executable: onsager_portal::workflow_dag::stage_is_executable(GateKind::ManualApproval),
             params: serde_json::json!({}),
         },
     ];
@@ -372,7 +375,7 @@ async fn projection_exposes_only_allow_listed_fields() {
                 allow_set(STAGE_ALLOWED_KEYS),
                 "per-stage keys must be exactly the allow-list"
             );
-            // No leaked stage name from the workflow_stages table.
+            // No leaked stage name from the authored definition.
             assert!(!s.as_object().unwrap().contains_key("name"));
         }
     }

--- a/crates/onsager-portal/tests/workflow_delete.rs
+++ b/crates/onsager-portal/tests/workflow_delete.rs
@@ -46,6 +46,7 @@ async fn seed_workflow(spine: &PgPool, workspace_id: &str) -> String {
         workflow_id: wf.id.clone(),
         seq: 0,
         gate_kind: GateKind::AgentSession,
+        executable: onsager_portal::workflow_dag::stage_is_executable(GateKind::AgentSession),
         params: serde_json::json!({}),
     };
     let id = wf.id.clone();
@@ -101,14 +102,16 @@ async fn delete_workflow_with_parked_artifact_succeeds() {
         .get(0);
     assert_eq!(wf_count, 0, "workflow row should be deleted");
 
-    let stage_count: i64 =
-        sqlx::query("SELECT COUNT(*) FROM workflow_stages WHERE workflow_id = $1")
-            .bind(&workflow_id)
-            .fetch_one(&spine)
-            .await
-            .unwrap()
-            .get(0);
-    assert_eq!(stage_count, 0, "workflow_stages should cascade-delete");
+    // ADR 0028 / #602: the authored definition lives on the deleted row
+    // itself; the executable library entries are retired (not deleted).
+    let retired: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM workflow_library WHERE spec_kind = $1 AND retired_at IS NULL",
+    )
+    .bind(&workflow_id)
+    .fetch_one(&spine)
+    .await
+    .expect("count live library rows");
+    assert_eq!(retired, 0, "library entries should be retired on delete");
 
     // Artifact survives, all workflow tagging cleared.
     let row = sqlx::query(

--- a/crates/onsager-spine/migrations/010_workflow_definition.sql
+++ b/crates/onsager-spine/migrations/010_workflow_definition.sql
@@ -1,0 +1,27 @@
+-- Onsager #602 (ADR 0028) — one workflow model.
+--
+-- The authored stage list moves onto the workflows row
+-- (definition_json); the executable form lives in workflow_library
+-- keyed by the workflow id. workflow_stages — the legacy Lever D
+-- stage-chain storage the retired forge gate machine consumed — drops.
+
+ALTER TABLE workflows
+    ADD COLUMN IF NOT EXISTS definition_json JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Backfill the authored form from the legacy stage rows (gate kind +
+-- params, ordered). Idempotent: only fills rows still at the default.
+UPDATE workflows w
+   SET definition_json = sub.def
+  FROM (
+        SELECT workflow_id,
+               jsonb_agg(
+                   jsonb_build_object('gate_kind', name, 'params', params)
+                   ORDER BY stage_order
+               ) AS def
+          FROM workflow_stages
+      GROUP BY workflow_id
+       ) sub
+ WHERE sub.workflow_id = w.workflow_id
+   AND w.definition_json = '[]'::jsonb;
+
+DROP TABLE IF EXISTS workflow_stages;


### PR DESCRIPTION
Closes #602. Part of #599 (ADR 0028, sub-spec 2 of 6).

The Workflow noun now has **one authored form and one executable form with a deterministic derivation between them** — the same logical→physical split the substrate itself uses (ADR 0009):

- The builder's stage list persists as `workflows.definition_json` (spine migration 010 backfills from `workflow_stages`, then **drops the table**).
- Saving derives a linear agent-node DAG (deterministic UUIDv5 ids — unchanged definitions re-register identical content) and registers it in `workflow_library` under **`spec_kind = workflow id`**. Deleting retires the kind.
- The #601 trigger conversion now resolves the library by workflow id: the `spec_kind` string join and the preset fallback are gone end-to-end.
- Portal authors the library row as **raw `workflow_json`** rather than via the typed register: executor impls are typetag-registered in the engine (ADR 0012), and portal must not link the engine (ADR 0027). A unit test pins the envelope against the substrate's own serde via a `noop` round-trip; the engine validates + deserializes at load as it does for every library row.

**Scope decision (recorded on the issue):** only `agent` executors are registered in the engine today — `external-check` / `manual-approval` stages have had no runtime since the forge gate machine retired, so they stay in the authored definition (builder UX and templates untouched) but are excluded from the executable DAG and surfaced `executable: false` on the stage DTO. Substrate executors for both are a follow-up spec; this makes builder workflows strictly more functional than before (previously zero builder workflows executed).

Wire-shape note: the stage DTO is unchanged apart from the additive `executable` flag (generated TS updated); stage ids keep the `<workflow_id>#<seq>` anchor contract. Pre-existing dev workflows get `definition_json` backfilled by the migration but acquire a library entry on next save — pre-launch dev data, no choreography.

**Test evidence:** `cargo test --workspace` clean, `just lint` exit 0, spine vs live Postgres 82/82, dashboard vitest 43/246, new `workflow_dag` unit tests (envelope serde pin, determinism, chaining, executable subset) + mutation check (breaking the chain derivation fails 2 tests). The wave-close e2e proves builder→run with zero manual seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)