### PR TITLE
fix(spine): make migration 010 re-applicable after workflow_stages drops

### DIFF
--- a/crates/onsager-spine/migrations/010_workflow_definition.sql
+++ b/crates/onsager-spine/migrations/010_workflow_definition.sql
@@ -9,19 +9,29 @@ ALTER TABLE workflows
     ADD COLUMN IF NOT EXISTS definition_json JSONB NOT NULL DEFAULT '[]'::jsonb;
 
 -- Backfill the authored form from the legacy stage rows (gate kind +
--- params, ordered). Idempotent: only fills rows still at the default.
-UPDATE workflows w
-   SET definition_json = sub.def
-  FROM (
-        SELECT workflow_id,
-               jsonb_agg(
-                   jsonb_build_object('gate_kind', name, 'params', params)
-                   ORDER BY stage_order
-               ) AS def
-          FROM workflow_stages
-      GROUP BY workflow_id
-       ) sub
- WHERE sub.workflow_id = w.workflow_id
-   AND w.definition_json = '[]'::jsonb;
+-- params, ordered). Guarded so re-applies stay idempotent after the
+-- DROP below has removed the source table (migrations re-run on every
+-- `just db-migrate`).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'workflow_stages'
+    ) THEN
+        UPDATE workflows w
+           SET definition_json = sub.def
+          FROM (
+                SELECT workflow_id,
+                       jsonb_agg(
+                           jsonb_build_object('gate_kind', name, 'params', params)
+                           ORDER BY stage_order
+                       ) AS def
+                  FROM workflow_stages
+              GROUP BY workflow_id
+               ) sub
+         WHERE sub.workflow_id = w.workflow_id
+           AND w.definition_json = '[]'::jsonb;
+    END IF;
+END $$;
 
 DROP TABLE IF EXISTS workflow_stages;


### PR DESCRIPTION
Migration 010's backfill UPDATE referenced `workflow_stages` unconditionally; since `just db-migrate` re-applies every file on each run and 010 itself drops that table, the second run failed at the UPDATE. Wraps the backfill in a `DO` block guarded by a table-existence check. First-run behavior is unchanged (verified by applying to a dev DB that still had the table, then re-applying).

Found while bringing up the dev stack for the #599 wave-close e2e. Part of #602 (ADR 0028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)