### PR TITLE
fix(portal): manual/cron activation no longer requires a GitHub App

### DIFF
--- a/crates/onsager-portal/src/handlers/workflows.rs
+++ b/crates/onsager-portal/src/handlers/workflows.rs
@@ -663,6 +663,18 @@ async fn activate_workflow(
         }
     };
 
+    // Triggers with no GitHub surface (manual / cron / spine-event) have
+    // nothing to verify or register upstream — activation is just the
+    // `active` flag flip (#614). The GitHub App requirement below is the
+    // `github_*` webhook shape only.
+    if workflow.github_repo_any().is_none() {
+        if let Err(e) = workflow_db::set_workflow_active(spine, workflow_id, true).await {
+            tracing::error!("mark workflow active: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+        return Ok(());
+    }
+
     let Some(app_cfg) = AppConfig::from_env() else {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/onsager-portal/src/workflow.rs
+++ b/crates/onsager-portal/src/workflow.rs
@@ -158,3 +158,53 @@ impl Workflow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use onsager_spine::TriggerKind;
+
+    fn workflow_with(trigger: TriggerKind) -> Workflow {
+        Workflow {
+            id: "wf_test".into(),
+            workspace_id: "ws".into(),
+            name: "t".into(),
+            trigger,
+            install_id: None,
+            preset_id: None,
+            active: false,
+            readiness: "ready".into(),
+            autofire: "off".into(),
+            created_by: "u".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    /// Activation branches on `github_repo_any()` (#614): GitHub-shaped
+    /// triggers go through App/install/webhook registration; everything
+    /// else just flips `active`. Pin which side each kind lands on.
+    #[test]
+    fn github_repo_any_discriminates_activation_shape() {
+        let none = [
+            TriggerKind::Manual { name: "go".into() },
+            TriggerKind::Cron {
+                expression: "0 0 * * *".into(),
+                timezone: None,
+            },
+        ];
+        for t in none {
+            assert!(workflow_with(t).github_repo_any().is_none());
+        }
+
+        let some = TriggerKind::GithubIssueWebhook {
+            repo: "acme/widgets".into(),
+            label: "spec".into(),
+        };
+        assert_eq!(
+            workflow_with(some).github_repo_any(),
+            Some(("acme", "widgets"))
+        );
+    }
+}


### PR DESCRIPTION
Closes #614. Part of #599 (ADR 0028 — found by the wave-close e2e).

## What

`activate_workflow` unconditionally demanded the GitHub App env, an installation, a label, and webhook registration — the `github_issue_webhook` shape. Since #578 made **Manual** the builder's default trigger, and `fire_manual` 409s on inactive workflows, a repo-less manual workflow could never be activated (503 "GitHub App not configured") in any GitHub-less environment — the default FTUE path was dead. Cron / spine-event triggers hit the same wall.

Now: triggers with no GitHub surface (`workflow.github_repo_any()` is `None`) activate by flipping the `active` flag (the owner-credentials gate in the PATCH handler still applies); the three GitHub-shaped kinds keep the full App/install/webhook path unchanged.

## Proof

- New unit test pins which trigger kinds land on which side of the `github_repo_any()` discriminator.
- Live: on the dev stack, PATCH `active=true` on a builder-created Manual workflow previously 503'd; with this build it succeeds and `fire_manual` proceeds (this is the #599 wave-close e2e path; full run evidence lands on #599).
- `cargo clippy -p onsager-portal --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)