### PR TITLE
fix(engine): authored user_prompt reaches the agent session

### DIFF
--- a/crates/onsager-engine/src/nodes/agent.rs
+++ b/crates/onsager-engine/src/nodes/agent.rs
@@ -58,6 +58,11 @@ use crate::nodes::spine::{EmittedArtifact, SessionManifest};
 pub struct AgentExecutor {
     pub model: String,
     pub system_prompt: String,
+    /// Authored user-side task body (the builder stage's `user_prompt`
+    /// param, #616). Rendered ahead of the upstream-input sections;
+    /// optional so pre-#616 library rows still parse.
+    #[serde(default)]
+    pub user_prompt: Option<String>,
     #[serde(default)]
     pub tools: Vec<String>,
     #[serde(default)]
@@ -78,10 +83,17 @@ impl AgentExecutor {
         Self {
             model: model.into(),
             system_prompt: system_prompt.into(),
+            user_prompt: None,
             tools: Vec::new(),
             credential_ref: None,
             runner: default_runner(),
         }
+    }
+
+    /// Set the authored user-side task body (#616).
+    pub fn with_user_prompt(mut self, user_prompt: impl Into<String>) -> Self {
+        self.user_prompt = Some(user_prompt.into());
+        self
     }
 
     /// Replace the runtime runner. Required before `execute` does
@@ -349,7 +361,7 @@ impl Executor for AgentExecutor {
             system_prompt: effective.system_prompt.clone(),
             tools: effective.tools.clone(),
             credential_ref: effective.credential_ref.clone(),
-            user_prompt: render_user_prompt(&ctx),
+            user_prompt: render_user_prompt(self.user_prompt.as_deref(), &ctx),
             session_id: session_id.clone(),
             // Plan-scoped token (#536) flows context → request so the
             // runner injects it as ONSAGER_SESSION_TOKEN. The scheduler
@@ -504,8 +516,12 @@ async fn emit_event<T: serde::Serialize>(ctx: &ExecutorContext, kind: &str, payl
 /// Render upstream artifacts into a single user-side prompt body. The
 /// v1 form is one section per input artifact id; the scheduler
 /// (RUN-01) replaces this with the full templating story.
-fn render_user_prompt(ctx: &ExecutorContext) -> String {
+fn render_user_prompt(authored: Option<&str>, ctx: &ExecutorContext) -> String {
     let mut out = String::new();
+    if let Some(body) = authored.map(str::trim).filter(|b| !b.is_empty()) {
+        out.push_str(body);
+        out.push('\n');
+    }
     for (id, _art) in &ctx.inputs {
         out.push_str("# input ");
         out.push_str(id.as_str());
@@ -630,6 +646,18 @@ mod tests {
     fn agent_with_stub(output: &str) -> AgentExecutor {
         AgentExecutor::new("claude-sonnet-4-6", "you are helpful")
             .with_runner(Arc::new(StubAgentRunner::new(output)))
+    }
+
+    /// #616: the authored user_prompt leads the rendered body, so an
+    /// entry node with no upstream inputs still hands the runner a
+    /// non-empty prompt. Without an authored prompt the empty-input
+    /// body stays empty (pre-#616 behavior).
+    #[test]
+    fn authored_user_prompt_leads_rendered_body() {
+        let ctx = empty_ctx();
+        assert_eq!(render_user_prompt(Some("do the task"), &ctx), "do the task\n");
+        assert_eq!(render_user_prompt(Some("  "), &ctx), "");
+        assert_eq!(render_user_prompt(None, &ctx), "");
     }
 
     /// A manifest carrying a single emitted output — the "agent

--- a/crates/onsager-engine/src/nodes/agent.rs
+++ b/crates/onsager-engine/src/nodes/agent.rs
@@ -669,7 +669,10 @@ mod tests {
     #[test]
     fn authored_user_prompt_leads_rendered_body() {
         let ctx = empty_ctx();
-        assert_eq!(render_user_prompt(Some("do the task"), &ctx), "do the task\n");
+        assert_eq!(
+            render_user_prompt(Some("do the task"), &ctx),
+            "do the task\n"
+        );
         assert_eq!(render_user_prompt(Some("  "), &ctx), "");
         assert_eq!(render_user_prompt(None, &ctx), "");
     }

--- a/crates/onsager-engine/src/nodes/agent.rs
+++ b/crates/onsager-engine/src/nodes/agent.rs
@@ -312,6 +312,7 @@ impl SubstrateExecutor for AgentExecutor {
         Some(AgentConfig {
             model: self.model.clone(),
             system_prompt: self.system_prompt.clone(),
+            user_prompt: self.user_prompt.clone(),
             tools: self.tools.clone(),
             credential_ref: self.credential_ref.clone(),
         })
@@ -352,6 +353,7 @@ impl Executor for AgentExecutor {
         let effective = ctx.agent_config.clone().unwrap_or_else(|| AgentConfig {
             model: self.model.clone(),
             system_prompt: self.system_prompt.clone(),
+            user_prompt: self.user_prompt.clone(),
             tools: self.tools.clone(),
             credential_ref: self.credential_ref.clone(),
         });
@@ -361,7 +363,7 @@ impl Executor for AgentExecutor {
             system_prompt: effective.system_prompt.clone(),
             tools: effective.tools.clone(),
             credential_ref: effective.credential_ref.clone(),
-            user_prompt: render_user_prompt(self.user_prompt.as_deref(), &ctx),
+            user_prompt: render_user_prompt(effective.user_prompt.as_deref(), &ctx),
             session_id: session_id.clone(),
             // Plan-scoped token (#536) flows context → request so the
             // runner injects it as ONSAGER_SESSION_TOKEN. The scheduler
@@ -646,6 +648,18 @@ mod tests {
     fn agent_with_stub(output: &str) -> AgentExecutor {
         AgentExecutor::new("claude-sonnet-4-6", "you are helpful")
             .with_runner(Arc::new(StubAgentRunner::new(output)))
+    }
+
+    /// #616 runtime path: the shared registered instance executes with
+    /// per-node config from `ctx.agent_config` — `agent_config()` must
+    /// carry the authored user_prompt or it dies at the singleton hop.
+    #[test]
+    fn agent_config_carries_user_prompt() {
+        let exec = AgentExecutor::new("m", "s").with_user_prompt("do the task");
+        assert_eq!(
+            exec.agent_config().unwrap().user_prompt.as_deref(),
+            Some("do the task")
+        );
     }
 
     /// #616: the authored user_prompt leads the rendered body, so an

--- a/crates/onsager-portal/src/workflow_dag.rs
+++ b/crates/onsager-portal/src/workflow_dag.rs
@@ -212,7 +212,11 @@ mod tests {
 
         let doc = derive_workflow_json(
             "wf_up",
-            &[stage(0, GateKind::AgentSession, json!({"system_prompt": "s"}))],
+            &[stage(
+                0,
+                GateKind::AgentSession,
+                json!({"system_prompt": "s"}),
+            )],
         )
         .expect("derives");
         assert!(doc["nodes"][0]["executor"]["user_prompt"].is_null());

--- a/crates/onsager-portal/src/workflow_dag.rs
+++ b/crates/onsager-portal/src/workflow_dag.rs
@@ -88,12 +88,16 @@ pub fn derive_workflow_json(workflow_id: &str, stages: &[WorkflowStage]) -> Opti
             .or_else(|| stage.params.get("prompt"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        // Authored user-side task body (#616). `null` when absent —
+        // the executor field is `Option` with serde(default).
+        let user_prompt = stage.params.get("user_prompt").and_then(|v| v.as_str());
         nodes.push(json!({
             "id": node_id(i),
             "executor": {
                 "kind": "agent",
                 "model": model,
                 "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
                 "tools": [],
                 "credential_ref": null,
             },
@@ -189,6 +193,29 @@ mod tests {
         assert_eq!(wf.edges.len(), 2);
         assert_eq!(wf.entry_specs.len(), 1);
         assert_eq!(wf.output_specs.len(), 1);
+    }
+
+    /// #616: the stage's authored `user_prompt` param rides into the
+    /// executor object (and `null`s cleanly when absent).
+    #[test]
+    fn user_prompt_param_reaches_executor() {
+        let doc = derive_workflow_json(
+            "wf_up",
+            &[stage(
+                0,
+                GateKind::AgentSession,
+                json!({"system_prompt": "s", "user_prompt": "do it"}),
+            )],
+        )
+        .expect("derives");
+        assert_eq!(doc["nodes"][0]["executor"]["user_prompt"], "do it");
+
+        let doc = derive_workflow_json(
+            "wf_up",
+            &[stage(0, GateKind::AgentSession, json!({"system_prompt": "s"}))],
+        )
+        .expect("derives");
+        assert!(doc["nodes"][0]["executor"]["user_prompt"].is_null());
     }
 
     /// The derivation is deterministic: same definition → identical

--- a/crates/onsager-substrate/src/executor.rs
+++ b/crates/onsager-substrate/src/executor.rs
@@ -113,6 +113,10 @@ pub trait Executor: std::fmt::Debug + Send + Sync {
 pub struct AgentConfig {
     pub model: String,
     pub system_prompt: String,
+    /// Authored user-side task body (#616). Optional — pre-#616
+    /// payloads parse with `None`.
+    #[serde(default)]
+    pub user_prompt: Option<String>,
     #[serde(default)]
     pub tools: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
Closes #616. Part of #599 (ADR 0028 — found by the wave-close e2e).

## What

The builder's `agent-session` stage has a `user_prompt` param the UI exposes, but the #602 derivation mapped only `model` + `system_prompt` into the executor and `AgentExecutor` had no authored user-side prompt concept — `render_user_prompt` rendered upstream-input sections only. An entry node with no inputs handed the claude CLI an **empty prompt**: `Error: Input must be provided either through stdin or as a prompt argument` (visible thanks to #601's stderr drain). The 0.3 e2e missed it because spec-plan runs always carried input artifacts.

- `AgentExecutor` gains `user_prompt: Option<String>` with `#[serde(default)]` — additive; pre-#616 `workflow_library` rows still deserialize.
- `render_user_prompt` leads with the authored body (trimmed; empty → omitted), then the input sections.
- `workflow_dag::derive_workflow_json` maps the stage's `user_prompt` param into the executor object (`null` when absent).

## Proof

- New tests: `user_prompt_param_reaches_executor` (portal derivation, both present + absent), `authored_user_prompt_leads_rendered_body` (engine render, incl. whitespace-only → empty).
- `cargo test --workspace` 39/39 binaries clean; clippy `-D warnings` clean.
- Live wave-close e2e run evidence lands on #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)