### PR TITLE
docs(adr): flip ADR 0028 to enforced — 0.4 simplification complete

### DIFF
--- a/crates/onsager-github/src/adapter.rs
+++ b/crates/onsager-github/src/adapter.rs
@@ -1,99 +1,11 @@
-//! Boot-time registration into the spine `artifact_adapters` catalog.
+//! GitHub adapter identity constants.
 //!
-//! Migration 004 created the `artifact_adapters` table but left it
-//! empty — that's the "producer with no consumer" drift this spec
-//! closes. Every Onsager binary that links `onsager-github` should
-//! call [`register`] once at startup to upsert the GitHub adapter row.
-//!
-//! The capability set is encoded in `config` (a JSONB column) so
-//! consumers can discover what kinds + intents this adapter speaks
-//! without hard-coding the answer. Format is intentionally loose
-//! pending #150's registry manifest, which will own the schema.
-
-use serde_json::json;
-use sqlx::{AnyPool, PgPool};
+//! The 0.1 boot-time registration into the `artifact_adapters` catalog
+//! retired with the registry diet (ADR 0028 / #603 dropped the table;
+//! the registration fns were deleted at the adoption flip). What
+//! remains is the adapter's stable identity, still stamped on
+//! `external_ref.adapter` for GitHub-sourced artifact refs.
 
 /// Stable adapter identifier. Matches the `external_ref.adapter` field
 /// already in use on artifact rows for GitHub-sourced refs.
 pub const ADAPTER_ID: &str = "github";
-
-/// Current revision of the adapter capability set. Bump on every
-/// schema-meaningful change to `config`; downstream consumers can
-/// `WHERE revision >= N` to opt into newer fields.
-pub const ADAPTER_REVISION: i32 = 1;
-
-fn config_blob() -> serde_json::Value {
-    json!({
-        "kinds": ["pull_request", "issue", "check_run"],
-        "intents": [],
-        "version": ADAPTER_REVISION,
-    })
-}
-
-/// Upsert the GitHub adapter row using a `PgPool`. Idempotent —
-/// safe to call on every boot. The `'default'` workspace covers
-/// single-tenant deployments that haven't migrated to per-workspace
-/// rows yet.
-///
-/// Takes a `&PgPool` rather than the spine `EventStore` because the
-/// store doesn't expose its pool publicly today; the underlying
-/// schema lives in the spine migrations regardless.
-pub async fn register(pool: &PgPool, workspace_id: &str) -> sqlx::Result<()> {
-    let config = config_blob();
-    sqlx::query(
-        r#"
-        INSERT INTO artifact_adapters (adapter_id, workspace_id, revision, status, config)
-        VALUES ($1, $2, $3, 'approved', $4)
-        ON CONFLICT (workspace_id, adapter_id) DO UPDATE
-            SET revision = EXCLUDED.revision,
-                config   = EXCLUDED.config,
-                updated_at = NOW()
-        "#,
-    )
-    .bind(ADAPTER_ID)
-    .bind(workspace_id)
-    .bind(ADAPTER_REVISION)
-    .bind(&config)
-    .execute(pool)
-    .await?;
-
-    log_registered(workspace_id);
-    Ok(())
-}
-
-/// Same as [`register`] for an `AnyPool`. Some callers use sqlx's runtime-
-/// polymorphic pool so it gets its own entry point; the SQL is
-/// identical (postgres-style placeholders work under `Any` driver).
-/// `Any` doesn't accept `JSONB` directly, so the config is passed as
-/// a JSON string and cast in SQL.
-pub async fn register_any(pool: &AnyPool, workspace_id: &str) -> sqlx::Result<()> {
-    let config = config_blob().to_string();
-    sqlx::query(
-        r#"
-        INSERT INTO artifact_adapters (adapter_id, workspace_id, revision, status, config)
-        VALUES ($1, $2, $3, 'approved', CAST($4 AS JSONB))
-        ON CONFLICT (workspace_id, adapter_id) DO UPDATE
-            SET revision = EXCLUDED.revision,
-                config   = EXCLUDED.config,
-                updated_at = NOW()
-        "#,
-    )
-    .bind(ADAPTER_ID)
-    .bind(workspace_id)
-    .bind(ADAPTER_REVISION)
-    .bind(config)
-    .execute(pool)
-    .await?;
-
-    log_registered(workspace_id);
-    Ok(())
-}
-
-fn log_registered(workspace_id: &str) {
-    tracing::info!(
-        adapter = ADAPTER_ID,
-        workspace_id = workspace_id,
-        revision = ADAPTER_REVISION,
-        "registered github adapter"
-    );
-}

--- a/crates/onsager-portal/src/server.rs
+++ b/crates/onsager-portal/src/server.rs
@@ -30,12 +30,6 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let pool = crate::db::connect(&config.database_url).await?;
     crate::migrate::run(&pool).await?;
     let spine = onsager_spine::EventStore::connect(&config.database_url).await?;
-    // Register the GitHub adapter into the spine catalog. Best-effort:
-    // a missing `artifact_adapters` table (older migration set) shouldn't
-    // block portal boot. See `onsager_github::adapter::register`.
-    if let Err(e) = onsager_github::adapter::register(&pool, "default").await {
-        tracing::warn!(error = %e, "github adapter registration skipped");
-    }
 
     // Seed the dev user / workspace when dev-login is active (always in
     // debug builds, or release builds with DEV_LOGIN_ENABLED=true).

--- a/docs/adr/0028-one-workflow-model-one-run-path.md
+++ b/docs/adr/0028-one-workflow-model-one-run-path.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-06-11
 - **Identity impact**: no
-- **Adoption**: ongoing
+- **Adoption**: enforced (2026-06-12 — all six sub-specs landed; wave-close e2e green, evidence on #599)
 - **Tracking issues**: #599 (umbrella; sub-specs listed there)
 - **Supersedes**: the Lever D legacy workflow storage model (ADR 0004's
   `workflows`/`workflow_stages` stage-chain as the authored form); the
@@ -99,20 +99,27 @@ live structure, not dead code:
 
 ## Adoption checklist
 
-- [ ] Decision recorded; index updated. (this PR)
-- [ ] Run-path unification landed (portal converts fires; bridge
+- [x] Decision recorded; index updated. (PR #600)
+- [x] Run-path unification landed (portal converts fires; bridge
       retired; #594 closed by re-pointing FTUE to the run-terminal
-      signal).
-- [ ] One workflow model landed (builder edits the DAG; stage-chain
+      signal). (#601 / PR #607)
+- [x] One workflow model landed (builder edits the DAG; stage-chain
       storage retired; e2e: a builder-authored workflow runs with no
-      manual library registration).
-- [ ] Registry diet landed (dead evaluators/registry machinery gone).
-- [ ] Spine vocabulary sweep landed (legacy gate protocol types,
-      `forge` stream namespace).
-- [ ] Dev-env consolidation landed (slot system deleted).
-- [ ] CI + lint diet 2 landed (filter matrix collapsed; lint set
-      re-judged; stale architecture doc removed).
-- [ ] Flip `Adoption` to `enforced`; e2e on the unified model.
+      manual library registration). (#602 / PR #608; follow-up fixes
+      #613, #614, #616)
+- [x] Registry diet landed (dead evaluators/registry machinery gone).
+      (#603 / PR #609; the orphaned `adapter::register` boot write
+      removed at this flip)
+- [x] Spine vocabulary sweep landed (legacy gate protocol types,
+      `forge` stream namespace). (#604 / PR #610)
+- [x] Dev-env consolidation landed (slot system deleted). (#605 /
+      PR #611)
+- [x] CI + lint diet 2 landed (filter matrix collapsed; lint set
+      re-judged; stale architecture doc removed). (#606 / PR #612)
+- [x] Flip `Adoption` to `enforced`; e2e on the unified model. (this
+      PR; e2e evidence on #599 — builder-created manual workflow →
+      fire → tokenized plan run → live agent session → MCP
+      `emit_artifact` → `plan.run_completed`, zero manual seeding)
 
 ## Out of scope
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,7 @@ see [`../architecture.md`](../architecture.md).
 | [0025](0025-chat-as-design-and-maintenance-surface.md) | Chat as design + maintenance surface | Accepted (2026-05-29, adoption ongoing) — `Identity impact: no` — amends ADR 0020 |
 | [0026](0026-nav-ia-sidebar-and-mobile-drawer.md) | Nav IA: desktop sidebar + mobile drawer | Accepted (2026-05-31) — `Identity impact: no` — supersedes ADR 0019's top-bar chrome |
 | [0027](0027-two-process-consolidation.md) | 0.3 consolidation: two-process factory (portal + engine) | Accepted (2026-06-11, **enforced**) — `Identity impact: yes` — supersedes ADR 0013 |
-| [0028](0028-one-workflow-model-one-run-path.md) | 0.4 simplification: one workflow model, one run path | Accepted (2026-06-11, adoption ongoing) — `Identity impact: no` |
+| [0028](0028-one-workflow-model-one-run-path.md) | 0.4 simplification: one workflow model, one run path | Accepted (2026-06-11, enforced 2026-06-12) — `Identity impact: no` |
 
 ## How to add an ADR
 

--- a/justfile
+++ b/justfile
@@ -242,7 +242,11 @@ dev: dev-infra
         cargo run -p onsager-portal -- serve &
 
     echo "==> Starting onsager-scheduler (substrate scheduler)..."
+    # Agent sessions need the portal MCP endpoint to get tools
+    # (emit_artifact etc.) — without it every run parks at the
+    # liveness gate. Default to this stack's portal; allow override.
     DATABASE_URL="$DATABASE_URL" \
+    ONSAGER_MCP_URL="${ONSAGER_MCP_URL:-http://localhost:${PORTAL_PORT}/mcp/messages}" \
         cargo run -p onsager-engine --bin onsager-scheduler -- serve &
 
     echo "==> Starting dashboard on :${DASHBOARD_PORT}..."
@@ -284,6 +288,7 @@ dev-portal port="3002":
 
 dev-scheduler:
     DATABASE_URL="${DATABASE_URL:-postgres://onsager:onsager@localhost:5432/onsager}" \
+    ONSAGER_MCP_URL="${ONSAGER_MCP_URL:-http://localhost:3002/mcp/messages}" \
         cargo run -p onsager-engine --bin onsager-scheduler -- serve
 
 # ── DB ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #599 (closes it once merged — umbrella checklist ticked separately).

## What

- **ADR 0028 → `Adoption: enforced`**, all eight checklist items ticked with their landing PRs (#600, #607–#612, this PR). ADR index updated.
- **Removes the orphaned `onsager_github::adapter::register` boot write** — a #603 leftover: it upserted into `artifact_adapters`, which migration 011 dropped, so every portal boot logged a 'registration skipped' warning into a void. `ADAPTER_ID` (still stamped on `external_ref`) survives; the dead `register`/`register_any`/config blob and the `server.rs` call are gone.

## Wave-close e2e (zero manual seeding)

On the dev stack at current main: dashboard-API-created workflow (`manual` trigger + one `agent-session` stage with system+user prompt) → `PATCH active=true` (no GitHub App, per #614) → `POST .../triggers/manual/go` → event chain `trigger.fired → plan.run_requested (tokenized) → node.started → agent.session_started → artifact.emitted → agent.session_completed → node.completed → plan.run_completed` — a live Claude session emitted an artifact whose content decodes to exactly `WAVE04-OK`. Full evidence (event ids, library row, fixes found en route) on #599.

## Proof

- `just lint` exit 0; `xtask check-adr-adoption` no longer flags 0028; portal+github tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)