### PR TITLE
feat(onsager): 0.5 M2 — GitHub: App webhook, issue trigger, repo access, OAuth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +279,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -460,8 +486,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -472,7 +514,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -611,6 +653,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -619,13 +678,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -774,6 +841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +861,21 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -861,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1022,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,10 +1042,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -988,6 +1098,7 @@ dependencies = [
  "base64",
  "chrono",
  "hex",
+ "onsager-github",
  "ring",
  "serde",
  "serde_json",
@@ -998,6 +1109,25 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "onsager-github"
+version = "0.5.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "chrono",
+ "hex",
+ "jsonwebtoken",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1027,6 +1157,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1093,6 +1233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1267,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1329,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1142,8 +1349,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1153,7 +1370,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1163,6 +1390,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1201,6 +1437,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,12 +1501,18 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
@@ -1254,6 +1534,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1412,7 +1693,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -1577,7 +1870,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -1616,7 +1909,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1692,6 +1985,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1731,6 +2027,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1784,6 +2111,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1847,9 +2184,11 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1925,6 +2264,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2025,6 +2370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2419,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2131,6 +2495,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/onsager"]
+members = ["crates/onsager", "crates/onsager-github"]
 
 [workspace.package]
 version = "0.5.0-alpha.1"
@@ -14,6 +14,9 @@ axum = "0.8"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
+async-trait = "0.1"
+jsonwebtoken = "9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -83,7 +83,12 @@ export interface TriggerManual {
   kind: 'manual'
   name: string
 }
-export type Trigger = TriggerManual
+export interface TriggerGithubIssue {
+  kind: 'github_issue_webhook'
+  repo: string
+  label: string
+}
+export type Trigger = TriggerManual | TriggerGithubIssue
 
 export interface Workflow {
   id: string

--- a/apps/dashboard/src/pages/WorkflowsPage.tsx
+++ b/apps/dashboard/src/pages/WorkflowsPage.tsx
@@ -27,16 +27,26 @@ export function WorkflowsPage() {
 
   const [showBuilder, setShowBuilder] = useState(false)
   const [name, setName] = useState('')
+  const [triggerKind, setTriggerKind] = useState<'manual' | 'github_issue_webhook'>('manual')
+  const [repo, setRepo] = useState('')
+  const [label, setLabel] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('')
   const [userPrompt, setUserPrompt] = useState('')
   const [error, setError] = useState<string | null>(null)
+
+  const trigger =
+    triggerKind === 'manual'
+      ? ({ kind: 'manual', name: 'run' } as const)
+      : ({ kind: 'github_issue_webhook', repo, label } as const)
+  const triggerValid =
+    triggerKind === 'manual' || (repo.includes('/') && label.trim().length > 0)
 
   const create = useMutation({
     mutationFn: () =>
       workflowsApi.create({
         workspace_id: ws.id,
         name,
-        trigger: { kind: 'manual', name: 'run' },
+        trigger,
         definition: [
           {
             kind: 'agent',
@@ -76,6 +86,39 @@ export function WorkflowsPage() {
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground">Trigger</span>
+              <Button
+                type="button"
+                variant={triggerKind === 'manual' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setTriggerKind('manual')}
+              >
+                Manual
+              </Button>
+              <Button
+                type="button"
+                variant={triggerKind === 'github_issue_webhook' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setTriggerKind('github_issue_webhook')}
+              >
+                GitHub issue label
+              </Button>
+            </div>
+            {triggerKind === 'github_issue_webhook' && (
+              <div className="flex gap-2">
+                <Input
+                  placeholder="owner/repo"
+                  value={repo}
+                  onChange={(e) => setRepo(e.target.value)}
+                />
+                <Input
+                  placeholder="label"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                />
+              </div>
+            )}
             <Textarea
               placeholder="System prompt (optional)"
               value={systemPrompt}
@@ -88,7 +131,9 @@ export function WorkflowsPage() {
             />
             {error && <p className="text-sm text-destructive">{error}</p>}
             <Button
-              disabled={create.isPending || !name.trim() || !userPrompt.trim()}
+              disabled={
+                create.isPending || !name.trim() || !userPrompt.trim() || !triggerValid
+              }
               onClick={() => create.mutate()}
             >
               Create

--- a/crates/onsager-github/Cargo.toml
+++ b/crates/onsager-github/Cargo.toml
@@ -1,25 +1,24 @@
 [package]
-name = "onsager"
-description = "Onsager — the factory, one process (ADR 0029)"
+name = "onsager-github"
+description = "Typed GitHub client + webhook verification + OAuth — the single home for GitHub HTTP"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [dependencies]
-onsager-github = { path = "../onsager-github" }
 anyhow.workspace = true
-axum.workspace = true
+async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 hex.workspace = true
+jsonwebtoken.workspace = true
+reqwest.workspace = true
 ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-sqlx.workspace = true
-tokio.workspace = true
-tower-http.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
-uuid.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/onsager-github/src/api/app.rs
+++ b/crates/onsager-github/src/api/app.rs
@@ -1,0 +1,592 @@
+//! GitHub App helpers — JWT minting, installation access tokens, and
+//! the App-scoped REST endpoints used by Phase 0 onboarding.
+//!
+//! Configured via env (resolution stays at the call site for now;
+//! credentials/installations table layer moves to portal in #220
+//! Sub-issue B):
+//!
+//! - `GITHUB_APP_ID` — numeric App ID.
+//! - `GITHUB_APP_SLUG` — App slug (used to build the install URL).
+//! - `GITHUB_APP_PRIVATE_KEY` — PEM-encoded RSA private key (may be
+//!   base64-encoded to survive env-var transport).
+//!
+//! All network paths are best-effort: a failure fetching
+//! `default_branch` or `list_repositories` never blocks onboarding.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::{Deserialize, Serialize};
+
+use crate::api::http::client;
+use crate::credential::AccountKind;
+use crate::error::GithubError;
+
+/// Config resolved from env. `None` when the App flow is not configured.
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    pub app_id: i64,
+    pub slug: String,
+    pub private_key_pem: String,
+}
+
+impl AppConfig {
+    pub fn from_env() -> Option<Self> {
+        let app_id = std::env::var("GITHUB_APP_ID").ok()?.parse::<i64>().ok()?;
+        let slug = std::env::var("GITHUB_APP_SLUG").ok()?;
+        let raw_key = std::env::var("GITHUB_APP_PRIVATE_KEY").ok()?;
+        if slug.trim().is_empty() || raw_key.trim().is_empty() {
+            return None;
+        }
+        let private_key_pem = normalize_pem(&raw_key);
+        Some(Self {
+            app_id,
+            slug,
+            private_key_pem,
+        })
+    }
+}
+
+/// Accept either a raw PEM with literal newlines or a base64-wrapped
+/// blob (commonly how Railway / dotenv files carry multiline secrets).
+/// Also tolerates escaped `\n` sequences from shell-quoted env values.
+pub fn normalize_pem(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.contains("-----BEGIN") {
+        return trimmed.replace("\\n", "\n");
+    }
+    use base64::Engine;
+    if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(trimmed.as_bytes())
+        && let Ok(s) = String::from_utf8(bytes)
+        && s.contains("-----BEGIN")
+    {
+        return s;
+    }
+    trimmed.to_string()
+}
+
+#[derive(Debug, Serialize)]
+struct AppJwtClaims {
+    iat: u64,
+    exp: u64,
+    iss: String,
+}
+
+/// Mint a short-lived App JWT (RS256, 9-minute TTL per GitHub guidance).
+pub fn mint_app_jwt(cfg: &AppConfig) -> Result<String, GithubError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| GithubError::Other(anyhow::anyhow!("system clock error: {e}")))?
+        .as_secs();
+    // Back-date iat by 60s to tolerate mild clock skew on GitHub's side.
+    let claims = AppJwtClaims {
+        iat: now.saturating_sub(60),
+        exp: now + 9 * 60,
+        iss: cfg.app_id.to_string(),
+    };
+    let key = EncodingKey::from_rsa_pem(cfg.private_key_pem.as_bytes())
+        .map_err(|e| GithubError::InvalidCredential(format!("invalid private key: {e}")))?;
+    Ok(encode(&Header::new(Algorithm::RS256), &claims, &key)?)
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationTokenResponse {
+    token: String,
+    expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstallationToken {
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Exchange an App JWT for an installation-scoped access token.
+pub async fn mint_installation_token(
+    app_jwt: &str,
+    install_id: i64,
+) -> Result<InstallationToken, GithubError> {
+    let url = format!("https://api.github.com/app/installations/{install_id}/access_tokens");
+    let resp = client()
+        .post(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    let parsed: InstallationTokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(InstallationToken {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+    })
+}
+
+/// Exchange an App JWT for a **read-scoped** installation access token,
+/// narrowed to a specific set of repositories (spec #546).
+///
+/// Unlike [`mint_installation_token`] (which yields a token carrying the
+/// App's full granted permissions across every repo in the install), this
+/// requests least-privilege: `contents:read` + `metadata:read`, scoped to
+/// `repo_names` only. It is the token an agent session gets to *clone and
+/// read* a workspace's bound repos — *writes* to origin are gated and
+/// minted separately (#548).
+///
+/// `repo_names` are the short repo names (no owner prefix), all under the
+/// install's account. An empty slice would let GitHub fall back to the
+/// install's full repo set, so callers must pass at least one name.
+pub async fn mint_read_token_for_repos(
+    app_jwt: &str,
+    install_id: i64,
+    repo_names: &[String],
+) -> Result<InstallationToken, GithubError> {
+    // Enforce least-privilege at the boundary: GitHub treats an omitted
+    // `repositories` body as "the install's full repo set", so an empty
+    // slice would silently *widen* the token rather than narrow it.
+    if repo_names.is_empty() {
+        return Err(GithubError::Other(anyhow::anyhow!(
+            "mint_read_token_for_repos requires at least one repo name; \
+             an empty set would widen the token to the install's full repo set"
+        )));
+    }
+    let url = format!("https://api.github.com/app/installations/{install_id}/access_tokens");
+    let body = serde_json::json!({
+        "repositories": repo_names,
+        "permissions": { "contents": "read", "metadata": "read" },
+    });
+    let resp = client()
+        .post(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .json(&body)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    let parsed: InstallationTokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(InstallationToken {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+    })
+}
+
+/// Exchange an App JWT for a **write-scoped** installation access token,
+/// narrowed to a single repository (spec #548, Part of #544).
+///
+/// The write counterpart of [`mint_read_token_for_repos`]: least-
+/// privilege `contents:write` + `pull_requests:write` (+ `metadata:read`),
+/// scoped to `repo_names` only. It is minted *on demand* and only for a
+/// repo bound to the requesting workspace — binding is the write-consent
+/// boundary (ADR 0027 retired the gate protocol).
+/// `metadata:read` rides along because GitHub requires it for the
+/// `contents` / `pull_requests` scopes to resolve.
+///
+/// `repo_names` are the short repo names (no owner prefix), all under the
+/// install's account. An empty slice would let GitHub fall back to the
+/// install's full repo set, so callers must pass at least one name.
+pub async fn mint_repo_write_token(
+    app_jwt: &str,
+    install_id: i64,
+    repo_names: &[String],
+) -> Result<InstallationToken, GithubError> {
+    // Least-privilege at the boundary, identical reasoning to
+    // `mint_read_token_for_repos`: an omitted `repositories` body widens
+    // the token to the install's full repo set, the opposite of intent.
+    if repo_names.is_empty() {
+        return Err(GithubError::Other(anyhow::anyhow!(
+            "mint_repo_write_token requires at least one repo name; \
+             an empty set would widen the token to the install's full repo set"
+        )));
+    }
+    let url = format!("https://api.github.com/app/installations/{install_id}/access_tokens");
+    let body = serde_json::json!({
+        "repositories": repo_names,
+        "permissions": {
+            "contents": "write",
+            "pull_requests": "write",
+            "metadata": "read",
+        },
+    });
+    let resp = client()
+        .post(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .json(&body)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    let parsed: InstallationTokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(InstallationToken {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountJson {
+    login: String,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationJson {
+    account: AccountJson,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstallationInfo {
+    pub account_login: String,
+    pub account_kind: AccountKind,
+}
+
+/// Look up public metadata for an installation (used by the OAuth
+/// callback to avoid trusting any query-string fields for account
+/// identity).
+pub async fn get_installation(
+    app_jwt: &str,
+    install_id: i64,
+) -> Result<InstallationInfo, GithubError> {
+    let url = format!("https://api.github.com/app/installations/{install_id}");
+    let resp = client()
+        .get(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    let parsed: InstallationJson = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(InstallationInfo {
+        account_login: parsed.account.login,
+        account_kind: AccountKind::from_github_str(&parsed.account.kind),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct RepoJson {
+    name: String,
+    owner: AccountJson,
+    default_branch: Option<String>,
+    private: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccessibleRepo {
+    pub owner: String,
+    pub name: String,
+    pub default_branch: Option<String>,
+    pub private: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListReposResponse {
+    repositories: Vec<RepoJson>,
+}
+
+/// List repositories this installation can access. Paginated up to 200.
+pub async fn list_installation_repos(
+    token: &InstallationToken,
+) -> Result<Vec<AccessibleRepo>, GithubError> {
+    let mut out = Vec::new();
+    for page in 1..=2 {
+        let url =
+            format!("https://api.github.com/installation/repositories?per_page=100&page={page}");
+        let resp = client()
+            .get(&url)
+            .bearer_auth(&token.token)
+            .header("Accept", "application/vnd.github+json")
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Err(GithubError::from_response(resp).await);
+        }
+        let parsed: ListReposResponse = resp
+            .json()
+            .await
+            .map_err(|e| GithubError::Decode(e.to_string()))?;
+        let count = parsed.repositories.len();
+        out.extend(parsed.repositories.into_iter().map(|r| AccessibleRepo {
+            owner: r.owner.login,
+            name: r.name,
+            default_branch: r.default_branch,
+            private: r.private,
+        }));
+        if count < 100 {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Deserialize)]
+struct LabelJson {
+    name: String,
+    color: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoLabel {
+    pub name: String,
+    pub color: Option<String>,
+    pub description: Option<String>,
+}
+
+/// List the labels defined on a repo. Paginated up to 200.
+pub async fn list_repo_labels(
+    token: &InstallationToken,
+    owner: &str,
+    repo: &str,
+) -> Result<Vec<RepoLabel>, GithubError> {
+    let mut out = Vec::new();
+    for page in 1..=2 {
+        let url =
+            format!("https://api.github.com/repos/{owner}/{repo}/labels?per_page=100&page={page}");
+        let resp = client()
+            .get(&url)
+            .bearer_auth(&token.token)
+            .header("Accept", "application/vnd.github+json")
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Err(GithubError::from_response(resp).await);
+        }
+        let parsed: Vec<LabelJson> = resp
+            .json()
+            .await
+            .map_err(|e| GithubError::Decode(e.to_string()))?;
+        let count = parsed.len();
+        out.extend(parsed.into_iter().map(|l| RepoLabel {
+            name: l.name,
+            color: l.color,
+            description: l.description,
+        }));
+        if count < 100 {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// One row from `GET /app/hook/deliveries`. Returned by GitHub's App-
+/// scoped webhook deliveries API; includes the `installation_id` so the
+/// caller can filter to a single tenant.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AppWebhookDelivery {
+    pub id: i64,
+    pub guid: String,
+    pub delivered_at: DateTime<Utc>,
+    #[serde(default)]
+    pub redelivery: bool,
+    /// HTTP status text (e.g. `"OK"`, `"Bad Request"`). Free-form per GitHub.
+    pub status: String,
+    pub status_code: i32,
+    pub event: String,
+    pub action: Option<String>,
+    pub installation_id: Option<i64>,
+}
+
+/// Fetch the most recent deliveries to the App's configured webhook URL.
+/// App-scoped (single URL across all installations); callers filter by
+/// `installation_id` to scope to a tenant. `per_page` is clamped to GitHub's
+/// max of 100. Returns one page only — pagination is the caller's problem
+/// when more history is needed.
+pub async fn list_app_webhook_deliveries(
+    app_jwt: &str,
+    per_page: u32,
+) -> Result<Vec<AppWebhookDelivery>, GithubError> {
+    let per_page = per_page.clamp(1, 100);
+    let url = format!("https://api.github.com/app/hook/deliveries?per_page={per_page}");
+    let resp = client()
+        .get(&url)
+        .bearer_auth(app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    resp.json::<Vec<AppWebhookDelivery>>()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))
+}
+
+/// Fetch a repo's default branch via the installation token.
+pub async fn get_repo_default_branch(
+    token: &InstallationToken,
+    owner: &str,
+    repo: &str,
+) -> Result<String, GithubError> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}");
+    let resp = client()
+        .get(&url)
+        .bearer_auth(&token.token)
+        .header("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let parsed: RepoJson = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    parsed.default_branch.ok_or_else(|| {
+        GithubError::Other(anyhow::anyhow!(
+            "repo {owner}/{repo} missing default_branch"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test RSA key generated with `openssl genrsa 2048` — unused
+    // outside of tests; not associated with any real GitHub App.
+    const TEST_RSA_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCu0gNSaTeR6s51
+JThsj9+CPSnoKYwCJLFDJD2wpym9eRYvWPjZY0S3oKgQPenCOe8uEVr6iOt2m4VO
+2/C3AYM/XWn0TimtdE301GWf9owTUigGMetN0RGOr8Wczs7YHxX8Nt1VTs8Bym2S
+RR0AeQ7WLDN44ab2/Hiygwbab2IFI+GVOd4y5zsTUh3sBPzDso7rCfuipufwgGHA
+K5RzF/B73XeLzygf8bSpV+j4cp/rssOJgRoxe1rx1ZVoZwfhQ5534TcPV68/6iDK
+cF+pkJHp9z7tkBLD2X2E7hpMRrcWOr06yDjrmur047c3hzJbI5eIBjL1cr++ywri
+8tjmLYlhAgMBAAECggEAAkvPy2umbTstkdVCuV4OxTFeBzKhwCrUxVNE4EjDSg3U
+v0ukldgdeEkW4QL7qqtvsVHs+UO+bjv44VwvHEu7wluk9UaIKosXraezI6GhlYzB
+ieKKpu6YM7jaPFLs7YKzw3Cx6bWVr2YOCC7yRHn6knCBXvDtjEKc2BkjiD+glK0+
+Tgp44XQJMDhI8tj1Q53Fz6UgdYzMyYm0iiGn4wPw22uM9DuT1/Gjpi/dYY9BsGGA
+zvgHAJLnuTfulihCg9GxppGWEZPWGrtTfrUN3gqNcCCcgWmYHi9Ye0CNgagTEZ+I
+lk4JrWymM7u75F03hZs2+KGA2khEUT2FZHYJ65kTQQKBgQDj1auKQQtCfSQBydZu
+dBWGTUO8IVwUrhqOr+b1KWMqf1n+10BTcUzdfTyHsAKKphTzCip+l14I+f2pjXJE
+1Z1ZXg+5oRkASGMsZB40puiv3Z18TCpK7VakYvPuUaN35hSj020liEAcyCBOSMbS
+u13Wj/fQblenvvYUHUPcCB4tQQKBgQDEbpbDHyxUjqQ0IMwET9gXCXjHyzHMegFa
+ZzXBgOhFgw0mve90h9Z4VVu9Df5+Yc2taXtAvifmsHK0L7AJxr9htoRf/EPaPzHB
+W2eWOV/HJ214YkMwZQ2ObWMM+juIz6qdKio0WJ22KqBMKFAxbiprsBBlshd3plx8
+LDAKbHi0IQKBgFHsCZNb0f2lW6Yc+jKbIQY6kAl8gUyaUchOraAnspWcVzLQGTwn
+uDjICFTN0AwkrdG6LQ95xAE8Sp6F0rm3ia2RqdvYdlHotWhH06ig/3gFGtSP2oE4
+l/fh8M4XoszA+Vjy9AMT2+G9gAhGGN+7KYG2IKhclL4nZvpSj4z1ikxBAoGAM0Vy
+UIfIeGGq9nhBCDcW/hxYzD17SBXoWIJsA4/0EIC+ZAhbgh0am9ob0eLfNHmux76q
+jyGTJKGVrvZrioG33ndXYf5kb4jjIccL6KgdGcxuxGdRhkY6HZzrp62A8JrTu6YP
+0g33TF8f7ADxvZU1uVoBTaoIehCQP1EBURczAkECgYAG6z7A4Ac1GSNLg1bp76Ys
+el5f02ypFsAcGQHRbAIRpZX/u2/7VFIVgjlR5Dx6b4Y/pf6wwL88b4Y/Sgs6PMoc
+ua1bcuTFsiOlTi/BawxRKJEbQniUm7uNpBSTysYxmVJdIooq2z1Md/vqBvtCkm53
+KHLHs4NWfuFIhN/tCfpZ/g==
+-----END PRIVATE KEY-----
+";
+
+    #[test]
+    fn normalize_pem_passes_through_raw_pem() {
+        let raw = "-----BEGIN RSA PRIVATE KEY-----\nXX\n-----END RSA PRIVATE KEY-----\n";
+        let out = normalize_pem(raw);
+        assert!(out.starts_with("-----BEGIN RSA PRIVATE KEY-----"));
+        assert!(out.ends_with("-----END RSA PRIVATE KEY-----"));
+        assert!(out.contains("XX"));
+    }
+
+    #[test]
+    fn normalize_pem_decodes_escaped_newlines() {
+        let raw = "-----BEGIN RSA PRIVATE KEY-----\\nXX\\n-----END RSA PRIVATE KEY-----";
+        let out = normalize_pem(raw);
+        assert!(out.contains("-----BEGIN"));
+        assert!(out.contains('\n'));
+    }
+
+    #[test]
+    fn normalize_pem_decodes_base64_wrapper() {
+        use base64::Engine;
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nXX\n-----END RSA PRIVATE KEY-----\n";
+        let b64 = base64::engine::general_purpose::STANDARD.encode(pem.as_bytes());
+        assert_eq!(normalize_pem(&b64), pem);
+    }
+
+    #[tokio::test]
+    async fn mint_read_token_rejects_empty_repo_set() {
+        // Least-privilege guard: an empty repo set must error *before* any
+        // network call (GitHub would otherwise issue a token for the
+        // install's full repo set). Mutation guard: drop the `is_empty()`
+        // check and this returns a network error instead of the message.
+        let err = mint_read_token_for_repos("jwt-unused", 123, &[])
+            .await
+            .expect_err("empty repo set must be rejected");
+        assert!(
+            err.to_string().contains("at least one repo name"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mint_write_token_rejects_empty_repo_set() {
+        // Least-privilege guard (spec #548): an empty repo set must error
+        // *before* any network call — GitHub would otherwise issue a
+        // write token for the install's full repo set. Mutation guard:
+        // drop the `is_empty()` check and this returns a network error
+        // instead of the message.
+        let err = mint_repo_write_token("jwt-unused", 123, &[])
+            .await
+            .expect_err("empty repo set must be rejected");
+        assert!(
+            err.to_string().contains("at least one repo name"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn mint_app_jwt_produces_three_segments() {
+        let cfg = AppConfig {
+            app_id: 42,
+            slug: "onsager".to_string(),
+            private_key_pem: TEST_RSA_PEM.to_string(),
+        };
+        let jwt = mint_app_jwt(&cfg).expect("jwt should sign");
+        assert_eq!(
+            jwt.matches('.').count(),
+            2,
+            "JWT must have 3 dot-separated segments"
+        );
+    }
+
+    #[test]
+    fn mint_app_jwt_surfaces_invalid_pem() {
+        let cfg = AppConfig {
+            app_id: 1,
+            slug: "onsager".to_string(),
+            private_key_pem: "not a pem".to_string(),
+        };
+        assert!(mint_app_jwt(&cfg).is_err());
+    }
+}

--- a/crates/onsager-github/src/api/http.rs
+++ b/crates/onsager-github/src/api/http.rs
@@ -1,0 +1,29 @@
+//! Shared HTTP client for GitHub API calls.
+//!
+//! Single process-wide `reqwest::Client` so connection pools + TLS
+//! state get reused across JWT minting, installation tokens, paginated
+//! reads, and webhook side-effects. **This is the only place in the
+//! workspace that should construct a `reqwest::Client` aimed at GitHub
+//! API endpoints** — the `xtask lint-seams` rule enforces that wall.
+
+use std::sync::OnceLock;
+
+/// Base URL for the public GitHub REST API.
+pub const GITHUB_API: &str = "https://api.github.com";
+
+/// User-Agent string sent on every API call. GitHub requires a
+/// non-empty UA; setting one here keeps the value consistent across
+/// callers (historically the subsystems had divergent UAs).
+pub const USER_AGENT: &str = "onsager-github/0.1";
+
+/// Shared GitHub HTTP client. First call builds it; subsequent calls
+/// reuse the same `Arc`-cloned handle.
+pub fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .expect("reqwest client must build")
+    })
+}

--- a/crates/onsager-github/src/api/issues.rs
+++ b/crates/onsager-github/src/api/issues.rs
@@ -1,0 +1,146 @@
+//! Issue endpoints — `GET /repos/{owner}/{repo}/issues` paginated read,
+//! plus the label toggle and issue-comment write paths used by the
+//! portal's Phase 2 surfaces today.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::api::http::{GITHUB_API, client};
+use crate::error::GithubError;
+
+/// An issue as returned by `GET /repos/{owner}/{repo}/issues`. GitHub's
+/// REST API includes pull requests in this endpoint; the
+/// `pull_request` field distinguishes them.
+///
+/// `Serialize` is implemented so the reconciliation poller can stash
+/// the full typed shape on a [`crate::NormalizedEvent`] payload and
+/// the portal scheduler can round-trip it back into this struct when
+/// it calls the shared translator.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<Label>,
+    #[serde(default)]
+    pub pull_request: Option<serde_json::Value>,
+    /// Server-reported `updated_at`. Used by the reconciliation
+    /// poller as the cursor field (#121); optional so existing
+    /// fixtures and unauthenticated calls without this field still
+    /// deserialize.
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Label {
+    pub name: String,
+}
+
+impl Issue {
+    pub fn is_pull_request(&self) -> bool {
+        self.pull_request.is_some()
+    }
+
+    pub fn has_label(&self, name: &str) -> bool {
+        self.labels.iter().any(|l| l.name == name)
+    }
+}
+
+/// Page through `GET /repos/{owner}/{repo}/issues` (which includes
+/// PRs) until `cap` items are gathered or the listing ends. Pass
+/// `token=None` for unauthenticated reads on public repos.
+pub async fn list_recent_issues(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    cap: usize,
+) -> Result<Vec<Issue>, GithubError> {
+    let mut out: Vec<Issue> = Vec::new();
+    let mut page = 1u32;
+    while out.len() < cap {
+        let per_page = std::cmp::min(100, cap - out.len()).max(1);
+        let url = format!(
+            "{GITHUB_API}/repos/{owner}/{repo}/issues?state=all&per_page={per_page}&page={page}"
+        );
+        let mut req = client().get(&url);
+        if let Some(tok) = token {
+            req = req.bearer_auth(tok);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(GithubError::from_response(resp).await);
+        }
+        let batch: Vec<Issue> = resp
+            .json()
+            .await
+            .map_err(|e| GithubError::Decode(e.to_string()))?;
+        if batch.is_empty() {
+            break;
+        }
+        out.extend(batch);
+        page += 1;
+    }
+    out.truncate(cap);
+    Ok(out)
+}
+
+/// Toggle a label on an issue. `present=true` ensures the label is
+/// set; `false` removes it.
+pub async fn set_label(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    label: &str,
+    present: bool,
+) -> Result<(), GithubError> {
+    if present {
+        let url = format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/labels");
+        let body = serde_json::json!({ "labels": [label] });
+        let mut req = client().post(&url).json(&body);
+        if let Some(tok) = token {
+            req = req.bearer_auth(tok);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(GithubError::from_response(resp).await);
+        }
+    } else {
+        let url = format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}");
+        let mut req = client().delete(&url);
+        if let Some(tok) = token {
+            req = req.bearer_auth(tok);
+        }
+        let resp = req.send().await?;
+        // 404 means the label wasn't present — that's the desired end state.
+        if !resp.status().is_success() && resp.status().as_u16() != 404 {
+            return Err(GithubError::from_response(resp).await);
+        }
+    }
+    Ok(())
+}
+
+/// Post a regular issue comment. Used for Deny-verdict rationale.
+pub async fn post_issue_comment(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    body: &str,
+) -> Result<(), GithubError> {
+    let url = format!("{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}/comments");
+    let payload = serde_json::json!({ "body": body });
+    let mut req = client().post(&url).json(&payload);
+    if let Some(tok) = token {
+        req = req.bearer_auth(tok);
+    }
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    Ok(())
+}

--- a/crates/onsager-github/src/api/mod.rs
+++ b/crates/onsager-github/src/api/mod.rs
@@ -1,0 +1,12 @@
+//! Typed REST wrappers over the GitHub API surface used by Onsager.
+//!
+//! Every outbound request goes through [`http::client`] so we have one
+//! shared `reqwest::Client` (connection pool, TLS state) for the whole
+//! workspace. New API helpers should live in a sub-module here rather
+//! than constructing a client directly.
+
+pub mod app;
+pub mod http;
+pub mod issues;
+pub mod oauth;
+pub mod pulls;

--- a/crates/onsager-github/src/api/oauth.rs
+++ b/crates/onsager-github/src/api/oauth.rs
@@ -1,0 +1,98 @@
+//! GitHub OAuth helpers.
+//!
+//! Three steps: build the authorize URL, exchange the returned code
+//! for an access token, fetch the GitHub user behind the token. The
+//! library owns the GitHub-specific exchange; the surrounding
+//! session-cookie / principal logic stays at the call site.
+
+use serde::Deserialize;
+
+use crate::api::http::client;
+use crate::error::GithubError;
+
+#[derive(Debug, Deserialize)]
+pub struct GithubTokenResponse {
+    pub access_token: String,
+}
+
+/// GitHub user identity returned by `GET /user`. Field set is what
+/// the auth flow consumes (id + login + name + avatar) —
+/// nothing extra.
+#[derive(Debug, Deserialize)]
+pub struct GithubOAuthUser {
+    pub id: i64,
+    pub login: String,
+    pub name: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+/// Build the authorize URL for the OAuth web flow. `scope` is hardcoded
+/// to `read:user` — every Onsager OAuth surface today only needs the
+/// public-profile scope.
+pub fn github_authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String {
+    let mut url = reqwest::Url::parse("https://github.com/login/oauth/authorize")
+        .expect("hardcoded GitHub OAuth authorize URL must be valid");
+    url.query_pairs_mut()
+        .append_pair("client_id", client_id)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("state", state)
+        .append_pair("scope", "read:user");
+    url.into()
+}
+
+/// Exchange an OAuth `code` for an access token.
+pub async fn exchange_code(
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+) -> Result<GithubTokenResponse, GithubError> {
+    let resp = client()
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .json(&serde_json::json!({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+        }))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    resp.json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))
+}
+
+/// Fetch the GitHub user behind an OAuth access token.
+pub async fn get_oauth_user(access_token: &str) -> Result<GithubOAuthUser, GithubError> {
+    let resp = client()
+        .get("https://api.github.com/user")
+        .bearer_auth(access_token)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+
+    resp.json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_carries_scope_and_state() {
+        let url = github_authorize_url("client123", "https://example.com/callback", "state456");
+        assert!(url.contains("client_id=client123"));
+        assert!(url.contains("state=state456"));
+        assert!(url.contains("scope=read%3Auser"));
+        assert!(url.starts_with("https://github.com/login/oauth/authorize"));
+    }
+}

--- a/crates/onsager-github/src/api/pulls.rs
+++ b/crates/onsager-github/src/api/pulls.rs
@@ -1,0 +1,216 @@
+//! Pull-request endpoints — paginated `GET /repos/{owner}/{repo}/pulls`
+//! plus the `POST /repos/.../check-runs` write path used to record
+//! gate verdicts.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::api::http::{GITHUB_API, client};
+use crate::error::GithubError;
+
+/// A pull request as returned by `GET /repos/{owner}/{repo}/pulls`.
+///
+/// `Serialize` is implemented so the reconciliation poller can stash
+/// the full typed shape on a [`crate::NormalizedEvent`] payload and
+/// the portal scheduler can round-trip it back into this struct when
+/// it calls the shared translator.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Pull {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    #[serde(default)]
+    pub merged_at: Option<String>,
+    /// Present on merged PRs; this is the commit created *in the base
+    /// branch* by the merge (as opposed to `head.sha`, which is the
+    /// tip of the PR branch itself). `None` for unmerged PRs.
+    #[serde(default)]
+    pub merge_commit_sha: Option<String>,
+    /// Server-reported `updated_at`. Used by the reconciliation
+    /// poller (#121) as the cursor field for PRs. Optional so
+    /// fixtures without this field still deserialize.
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+    pub head: PullRef,
+    pub base: PullRef,
+    pub html_url: String,
+    pub user: PullUser,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PullRef {
+    #[serde(rename = "ref")]
+    pub ref_name: String,
+    pub sha: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PullUser {
+    pub login: String,
+}
+
+/// Page through `GET /repos/{owner}/{repo}/pulls` until `cap` items
+/// are gathered or the listing ends.
+pub async fn list_recent_pulls(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    cap: usize,
+) -> Result<Vec<Pull>, GithubError> {
+    let mut out: Vec<Pull> = Vec::new();
+    let mut page = 1u32;
+    while out.len() < cap {
+        let per_page = std::cmp::min(100, cap - out.len()).max(1);
+        let url = format!(
+            "{GITHUB_API}/repos/{owner}/{repo}/pulls?state=all&per_page={per_page}&page={page}"
+        );
+        let mut req = client().get(&url);
+        if let Some(tok) = token {
+            req = req.bearer_auth(tok);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(GithubError::from_response(resp).await);
+        }
+        let batch: Vec<Pull> = resp
+            .json()
+            .await
+            .map_err(|e| GithubError::Decode(e.to_string()))?;
+        if batch.is_empty() {
+            break;
+        }
+        out.extend(batch);
+        page += 1;
+    }
+    out.truncate(cap);
+    Ok(out)
+}
+
+/// GitHub check-run conclusion variants. Mirrors the strings the API
+/// expects — kept narrow so we don't ship variants without a use site.
+#[derive(Debug, Clone, Copy)]
+pub enum CheckConclusion {
+    Success,
+    Failure,
+    ActionRequired,
+    Neutral,
+}
+
+impl CheckConclusion {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CheckConclusion::Success => "success",
+            CheckConclusion::Failure => "failure",
+            CheckConclusion::ActionRequired => "action_required",
+            CheckConclusion::Neutral => "neutral",
+        }
+    }
+}
+
+/// Create a pull request. Returns `(pr_number, html_url)`.
+pub async fn create_pull_request(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+    head: &str,
+    base: &str,
+) -> Result<(u64, String), GithubError> {
+    let url = format!("{GITHUB_API}/repos/{owner}/{repo}/pulls");
+    let payload = serde_json::json!({
+        "title": title,
+        "body": body,
+        "head": head,
+        "base": base,
+    });
+    let resp = client()
+        .post(&url)
+        .bearer_auth(token)
+        .json(&payload)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let v: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    let number = v
+        .get("number")
+        .and_then(|n| n.as_u64())
+        .ok_or_else(|| GithubError::Decode("missing pr number".into()))?;
+    let html_url = v
+        .get("html_url")
+        .and_then(|u| u.as_str())
+        .unwrap_or_default()
+        .to_string();
+    Ok((number, html_url))
+}
+
+/// Find an open pull request whose head branch matches `head`. Returns
+/// `Some((pr_number, html_url))` when one exists; `None` otherwise.
+pub async fn find_open_pr_for_branch(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    head: &str,
+) -> Result<Option<(u64, String)>, GithubError> {
+    let url = format!(
+        "{GITHUB_API}/repos/{owner}/{repo}/pulls?state=open&head={owner}:{head}&per_page=1"
+    );
+    let resp = client().get(&url).bearer_auth(token).send().await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let list: Vec<serde_json::Value> = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(list.first().and_then(|pr| {
+        let number = pr.get("number")?.as_u64()?;
+        let url = pr
+            .get("html_url")
+            .and_then(|u| u.as_str())
+            .unwrap_or_default()
+            .to_string();
+        Some((number, url))
+    }))
+}
+
+/// Post a check run on a head SHA. Returns the created check-run id.
+pub async fn create_check_run(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    head_sha: &str,
+    name: &str,
+    conclusion: CheckConclusion,
+    summary: &str,
+) -> Result<u64, GithubError> {
+    let url = format!("{GITHUB_API}/repos/{owner}/{repo}/check-runs");
+    let body = serde_json::json!({
+        "name": name,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion.as_str(),
+        "output": {
+            "title": name,
+            "summary": summary,
+        }
+    });
+    let mut req = client().post(&url).json(&body);
+    if let Some(tok) = token {
+        req = req.bearer_auth(tok);
+    }
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        return Err(GithubError::from_response(resp).await);
+    }
+    let v: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| GithubError::Decode(e.to_string()))?;
+    Ok(v.get("id").and_then(|i| i.as_u64()).unwrap_or_default())
+}

--- a/crates/onsager-github/src/credential.rs
+++ b/crates/onsager-github/src/credential.rs
@@ -1,0 +1,77 @@
+//! Credential modes for GitHub access.
+//!
+//! Two shapes today: an App installation (server-to-server, scoped to a
+//! workspace) and a personal access token. Both implement
+//! [`GithubAuth`] so call sites stay uniform.
+//!
+//! Resolution from raw config (env or DB row) lives at the call site —
+//! the library only owns the *types* and the act of producing an
+//! `Authorization` header. The intent (per #220 Sub-issue B) is to push
+//! credential persistence into the portal subsystem; the type layer here
+//! survives that move unchanged.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::GithubError;
+
+/// Account flavor returned by the App `installations/:id` endpoint.
+/// Mirrors GitHub's `User` / `Organization` distinction.
+///
+/// Callers that maintain their own enum (e.g. a legacy
+/// `core::GitHubAccountType`) map between their type and this one at
+/// the boundary — keeps the library free of subsystem domain types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AccountKind {
+    User,
+    Organization,
+}
+
+impl AccountKind {
+    /// Map GitHub's mixed-case `"User"` / `"Organization"` (anything
+    /// else collapses to `Organization`, matching the existing
+    /// pre-#583 behavior we're preserving).
+    pub fn from_github_str(s: &str) -> Self {
+        match s {
+            "User" => AccountKind::User,
+            _ => AccountKind::Organization,
+        }
+    }
+}
+
+/// How to authenticate against GitHub.
+#[derive(Debug, Clone)]
+pub enum Credential {
+    /// GitHub App installation token. Short-lived; minted from an App
+    /// JWT against a specific installation.
+    Installation { token: String },
+    /// Personal access token (classic or fine-grained). Used for
+    /// self-hosted deployments without a registered App.
+    Pat { token: String },
+}
+
+impl Credential {
+    /// The string suitable for the `Authorization: Bearer …` header.
+    pub fn bearer(&self) -> &str {
+        match self {
+            Credential::Installation { token } | Credential::Pat { token } => token,
+        }
+    }
+}
+
+/// Anything that can produce a `Credential` for the current call.
+///
+/// Most call sites today resolve a credential synchronously from a
+/// config struct, but installation tokens are minted via an async HTTP
+/// call against an App JWT — hence `async_trait`.
+#[async_trait::async_trait]
+pub trait GithubAuth: Send + Sync {
+    async fn credential(&self) -> Result<Credential, GithubError>;
+}
+
+#[async_trait::async_trait]
+impl GithubAuth for Credential {
+    async fn credential(&self) -> Result<Credential, GithubError> {
+        Ok(self.clone())
+    }
+}

--- a/crates/onsager-github/src/error.rs
+++ b/crates/onsager-github/src/error.rs
@@ -1,0 +1,49 @@
+use thiserror::Error;
+
+/// Errors returned by `onsager-github` API surfaces.
+///
+/// `NotConfigured` is the load-bearing variant — callers treat it as a
+/// feature flag (no GitHub App, no PAT, no work to do) rather than a
+/// hard error. Every other variant is an actual upstream / transport
+/// failure.
+#[derive(Debug, Error)]
+pub enum GithubError {
+    /// No credential could be resolved (no env vars, no PAT in DB).
+    /// Callers should silently skip whatever they were going to do.
+    #[error("github credentials are not configured")]
+    NotConfigured,
+
+    /// The configured credential is malformed (bad PEM, empty token).
+    #[error("github credential is invalid: {0}")]
+    InvalidCredential(String),
+
+    /// GitHub returned a non-2xx response.
+    #[error("github api error ({status}): {body}")]
+    Api { status: u16, body: String },
+
+    /// JSON / response decoding failed.
+    #[error("github response decode error: {0}")]
+    Decode(String),
+
+    /// Underlying transport failure (DNS, TLS, timeout, …).
+    #[error("github transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+
+    /// JWT signing failure (App-mode only).
+    #[error("github jwt error: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+
+    /// Anything else worth surfacing without losing context.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl GithubError {
+    /// Build an `Api` variant from a `reqwest::Response` after a
+    /// non-success status — pulls the body for the breadcrumb.
+    pub async fn from_response(resp: reqwest::Response) -> Self {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        GithubError::Api { status, body }
+    }
+}

--- a/crates/onsager-github/src/lib.rs
+++ b/crates/onsager-github/src/lib.rs
@@ -1,0 +1,18 @@
+//! # onsager-github
+//!
+//! Typed GitHub client, webhook signature verification, and OAuth —
+//! the single home for GitHub HTTP. Ported wholesale from the legacy
+//! crate (ADR 0029 / #624); `adapter` / `polling` / the `event` stub
+//! did not port (no consumer in v2).
+//!
+//! Treats GitHub as configurable infra: when no credential resolves the
+//! library returns [`GithubError::NotConfigured`] and callers no-op the
+//! feature. `just dev` boots without GitHub credentials.
+
+pub mod api;
+pub mod credential;
+pub mod error;
+pub mod webhook;
+
+pub use credential::{AccountKind, Credential, GithubAuth};
+pub use error::GithubError;

--- a/crates/onsager-github/src/webhook/mod.rs
+++ b/crates/onsager-github/src/webhook/mod.rs
@@ -1,0 +1,7 @@
+//! Webhook ingest helpers — HMAC-SHA256 signature verification
+//! (ported; the legacy `event` translator stub did not port — v2 types
+//! payloads at the receiver).
+
+pub mod signature;
+
+pub use signature::{SignatureCheck, verify_signature};

--- a/crates/onsager-github/src/webhook/signature.rs
+++ b/crates/onsager-github/src/webhook/signature.rs
@@ -1,0 +1,95 @@
+//! GitHub webhook signature verification.
+//!
+//! GitHub signs every webhook delivery with HMAC-SHA256 using the
+//! per-app installation's webhook secret. The signature arrives in the
+//! `X-Hub-Signature-256` header as `"sha256=<hex digest>"`.
+//! Constant-time comparison is mandatory to avoid leaking the secret
+//! via timing.
+
+use ring::hmac;
+
+/// Outcome of a signature check.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureCheck {
+    Valid,
+    Mismatch,
+    Malformed,
+}
+
+/// Verify a `sha256=...` signature header against the raw body using
+/// `secret`.
+pub fn verify_signature(header: &str, body: &[u8], secret: &[u8]) -> SignatureCheck {
+    let Some(sig_hex) = header.strip_prefix("sha256=") else {
+        return SignatureCheck::Malformed;
+    };
+    let Ok(sig) = hex::decode(sig_hex) else {
+        return SignatureCheck::Malformed;
+    };
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    match hmac::verify(&key, body, &sig) {
+        Ok(()) => SignatureCheck::Valid,
+        Err(_) => SignatureCheck::Mismatch,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sign(body: &[u8], secret: &[u8]) -> String {
+        let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+        let tag = hmac::sign(&key, body);
+        format!("sha256={}", hex::encode(tag.as_ref()))
+    }
+
+    #[test]
+    fn valid_signature_passes() {
+        let body = b"hello world";
+        let secret = b"shhh";
+        let header = sign(body, secret);
+        assert_eq!(
+            verify_signature(&header, body, secret),
+            SignatureCheck::Valid
+        );
+    }
+
+    #[test]
+    fn tampered_body_fails() {
+        let body = b"hello world";
+        let secret = b"shhh";
+        let header = sign(body, secret);
+        assert_eq!(
+            verify_signature(&header, b"different body", secret),
+            SignatureCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let body = b"hello world";
+        let header = sign(body, b"good secret");
+        assert_eq!(
+            verify_signature(&header, body, b"bad secret"),
+            SignatureCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn missing_prefix_is_malformed() {
+        let body = b"hello world";
+        let header = "deadbeef".to_string();
+        assert_eq!(
+            verify_signature(&header, body, b"shhh"),
+            SignatureCheck::Malformed
+        );
+    }
+
+    #[test]
+    fn bad_hex_is_malformed() {
+        let header = "sha256=zzzz";
+        assert_eq!(
+            verify_signature(header, b"x", b"shhh"),
+            SignatureCheck::Malformed
+        );
+    }
+}

--- a/crates/onsager/migrations/003_github.sql
+++ b/crates/onsager/migrations/003_github.sql
@@ -1,0 +1,14 @@
+-- v2 schema, migration 003 — GitHub App installations (M2 #624).
+--
+-- One row per App installation, maintained by the App's own webhook
+-- (`installation` created/deleted events). The run's repo-access token
+-- is minted against the installation whose account owns the trigger
+-- repo. Reference-only: GitHub owns everything else about the install.
+
+CREATE TABLE github_app_installations (
+    installation_id BIGINT PRIMARY KEY,
+    account_login   TEXT NOT NULL,
+    account_kind    TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_gh_installs_account ON github_app_installations (account_login);

--- a/crates/onsager/src/config.rs
+++ b/crates/onsager/src/config.rs
@@ -18,6 +18,13 @@ pub struct Config {
     /// Release-build opt-in for dev-login (`DEV_LOGIN_ENABLED=true`).
     /// Debug builds always allow it.
     pub dev_login_flag: bool,
+    /// HMAC secret for the GitHub App's webhook (`GITHUB_WEBHOOK_SECRET`).
+    /// Unset → the webhook route rejects everything (fail closed).
+    pub github_webhook_secret: Option<String>,
+    /// GitHub OAuth app (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`).
+    /// Unset → no GitHub login button.
+    pub github_client_id: Option<String>,
+    pub github_client_secret: Option<String>,
 }
 
 impl Config {
@@ -35,6 +42,15 @@ impl Config {
                 .ok()
                 .filter(|s| !s.is_empty()),
             dev_login_flag: std::env::var("DEV_LOGIN_ENABLED").is_ok_and(|v| v == "true"),
+            github_webhook_secret: std::env::var("GITHUB_WEBHOOK_SECRET")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            github_client_id: std::env::var("GITHUB_CLIENT_ID")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            github_client_secret: std::env::var("GITHUB_CLIENT_SECRET")
+                .ok()
+                .filter(|s| !s.is_empty()),
         })
     }
 

--- a/crates/onsager/src/db.rs
+++ b/crates/onsager/src/db.rs
@@ -21,6 +21,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "002_run_loop.sql",
         include_str!("../migrations/002_run_loop.sql"),
     ),
+    (
+        "003_github.sql",
+        include_str!("../migrations/003_github.sql"),
+    ),
 ];
 
 pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {

--- a/crates/onsager/src/domain.rs
+++ b/crates/onsager/src/domain.rs
@@ -11,6 +11,21 @@ use serde::{Deserialize, Serialize};
 pub enum TriggerKind {
     /// Fired by `POST /api/workflows/:id/fire`.
     Manual { name: String },
+    /// Fired by a GitHub `issues.labeled` webhook whose repo + label
+    /// match. `repo` is the `owner/name` slug. The App's own webhook
+    /// delivers the event (no per-repo registration, #624).
+    GithubIssueWebhook { repo: String, label: String },
+}
+
+impl TriggerKind {
+    /// The `owner/name` slug for GitHub-shaped triggers; the run's
+    /// repo-access set derives from this.
+    pub fn github_repo(&self) -> Option<&str> {
+        match self {
+            TriggerKind::GithubIssueWebhook { repo, .. } => Some(repo.as_str()),
+            TriggerKind::Manual { .. } => None,
+        }
+    }
 }
 
 /// One stage of a workflow definition. Execution is "iterate the

--- a/crates/onsager/src/github.rs
+++ b/crates/onsager/src/github.rs
@@ -1,0 +1,283 @@
+//! GitHub integration: the App webhook receiver, trigger matching, and
+//! the run's repo-access token (M2 #624).
+//!
+//! One webhook for the whole App (configured once in the App settings,
+//! verified with `GITHUB_WEBHOOK_SECRET`) — no per-repo registration,
+//! no per-install secrets (decision on #624). `installation` events
+//! maintain the installations table; `issues.labeled` events match
+//! active workflows by repo + label and fire them with the issue as
+//! trigger context.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use onsager_github::api::app::{AppConfig, mint_app_jwt, mint_repo_write_token};
+use onsager_github::webhook::{SignatureCheck, verify_signature};
+use sqlx::PgPool;
+
+use crate::domain::{StageKind, TriggerKind, Workflow};
+use crate::sessions::ClonableRepo;
+use crate::state::AppState;
+
+/// `POST /api/webhooks/github` — the App's webhook. Fails closed when
+/// the secret is unconfigured.
+pub async fn receive(State(state): State<AppState>, headers: HeaderMap, body: Bytes) -> Response {
+    let Some(secret) = state.config.github_webhook_secret.as_deref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "webhook secret not configured",
+        )
+            .into_response();
+    };
+    let signature = headers
+        .get("x-hub-signature-256")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    match verify_signature(signature, &body, secret.as_bytes()) {
+        SignatureCheck::Valid => {}
+        _ => return (StatusCode::UNAUTHORIZED, "bad signature").into_response(),
+    }
+
+    let event_type = headers
+        .get("x-github-event")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (StatusCode::BAD_REQUEST, "bad json").into_response(),
+    };
+
+    match event_type {
+        "installation" => handle_installation(&state.pool, &payload).await,
+        "issues" => handle_issues(&state, &payload).await,
+        // Anything else the App is subscribed to is acknowledged and
+        // ignored — new event types land with their consumers.
+        _ => {}
+    }
+    (StatusCode::ACCEPTED, "ok").into_response()
+}
+
+async fn handle_installation(pool: &PgPool, payload: &serde_json::Value) {
+    let action = payload["action"].as_str().unwrap_or("");
+    let install_id = payload["installation"]["id"].as_i64().unwrap_or(0);
+    if install_id == 0 {
+        return;
+    }
+    let result = match action {
+        "created" | "unsuspend" => {
+            let login = payload["installation"]["account"]["login"]
+                .as_str()
+                .unwrap_or("");
+            let kind = payload["installation"]["account"]["type"]
+                .as_str()
+                .unwrap_or("Organization");
+            sqlx::query(
+                "INSERT INTO github_app_installations (installation_id, account_login, account_kind) \
+                 VALUES ($1, $2, $3) \
+                 ON CONFLICT (installation_id) DO UPDATE SET account_login = $2, account_kind = $3",
+            )
+            .bind(install_id)
+            .bind(login)
+            .bind(kind)
+            .execute(pool)
+            .await
+        }
+        "deleted" | "suspend" => {
+            sqlx::query("DELETE FROM github_app_installations WHERE installation_id = $1")
+                .bind(install_id)
+                .execute(pool)
+                .await
+        }
+        _ => return,
+    };
+    if let Err(e) = result {
+        tracing::error!("installation webhook upsert failed: {e}");
+    } else {
+        tracing::info!(install_id, action, "github installation updated");
+    }
+}
+
+async fn handle_issues(state: &AppState, payload: &serde_json::Value) {
+    if payload["action"].as_str() != Some("labeled") {
+        return;
+    }
+    let repo = payload["repository"]["full_name"].as_str().unwrap_or("");
+    let label = payload["label"]["name"].as_str().unwrap_or("");
+    if repo.is_empty() || label.is_empty() {
+        return;
+    }
+    let workflows: Vec<Workflow> = match sqlx::query_as(
+        "SELECT id, workspace_id, name, trigger, definition, active, created_by, \
+                created_at, updated_at \
+         FROM workflows WHERE active = TRUE",
+    )
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!("webhook workflow scan failed: {e}");
+            return;
+        }
+    };
+    let context = issue_context(payload);
+    for wf in workflows {
+        if !matches_issue_trigger(&wf, repo, label) {
+            continue;
+        }
+        tracing::info!(workflow_id = %wf.id, repo, label, "issue trigger matched");
+        let fired = with_trigger_context(wf, &context);
+        if let Err(e) = crate::scheduler::fire(state, fired).await {
+            tracing::error!("webhook fire failed: {e}");
+        }
+    }
+}
+
+/// Pure trigger match — repo slug and label must both equal the
+/// workflow's `github_issue_webhook` config.
+pub fn matches_issue_trigger(workflow: &Workflow, repo: &str, label: &str) -> bool {
+    match &workflow.trigger {
+        TriggerKind::GithubIssueWebhook {
+            repo: wf_repo,
+            label: wf_label,
+        } => wf_repo.eq_ignore_ascii_case(repo) && wf_label == label,
+        TriggerKind::Manual { .. } => false,
+    }
+}
+
+/// The issue, rendered as trigger context for the agent (#624: trigger
+/// context rides the prompt until artifact inputs are a feature).
+fn issue_context(payload: &serde_json::Value) -> String {
+    let number = payload["issue"]["number"].as_u64().unwrap_or(0);
+    let title = payload["issue"]["title"].as_str().unwrap_or("");
+    let url = payload["issue"]["html_url"].as_str().unwrap_or("");
+    let body = payload["issue"]["body"].as_str().unwrap_or("");
+    format!("# Trigger: GitHub issue #{number}\n\nTitle: {title}\nURL: {url}\n\n{body}\n\n---\n\n")
+}
+
+/// Prepend the trigger context to the first agent stage's prompt.
+pub fn with_trigger_context(mut workflow: Workflow, context: &str) -> Workflow {
+    if context.is_empty() {
+        return workflow;
+    }
+    if let Some(StageKind::Agent { user_prompt, .. }) = workflow.definition.first_mut() {
+        *user_prompt = format!("{context}{user_prompt}");
+    }
+    workflow
+}
+
+/// The run's repo-access set: a write-scoped installation token for the
+/// trigger repo (binding the App is the consent — #624), shaped as
+/// [`ClonableRepo`] for the `ONSAGER_REPOS` env. Returns empty when the
+/// workflow has no GitHub surface or the App is unconfigured (the run
+/// proceeds without repo access; a private clone then fails loudly).
+pub async fn repo_access_for(pool: &PgPool, workflow: &Workflow) -> Vec<ClonableRepo> {
+    let Some(slug) = workflow.trigger.github_repo() else {
+        return Vec::new();
+    };
+    let Some((owner, name)) = slug.split_once('/') else {
+        tracing::warn!(slug, "trigger repo is not owner/name");
+        return Vec::new();
+    };
+    let Some(cfg) = AppConfig::from_env() else {
+        tracing::warn!("GitHub App unconfigured — run proceeds without repo token");
+        return vec![ClonableRepo {
+            owner: owner.into(),
+            name: name.into(),
+            default_branch: "main".into(),
+            token: None,
+        }];
+    };
+    let install: Option<(i64,)> = match sqlx::query_as(
+        "SELECT installation_id FROM github_app_installations WHERE account_login = $1",
+    )
+    .bind(owner)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::error!("installation lookup failed: {e}");
+            None
+        }
+    };
+    let token = match install {
+        Some((install_id,)) => match mint_app_jwt(&cfg) {
+            Ok(jwt) => match mint_repo_write_token(&jwt, install_id, &[name.to_string()]).await {
+                Ok(t) => Some(t.token),
+                Err(e) => {
+                    tracing::warn!("repo token mint failed: {e}");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!("app jwt mint failed: {e}");
+                None
+            }
+        },
+        None => {
+            tracing::warn!(owner, "no installation for trigger repo's account");
+            None
+        }
+    };
+    vec![ClonableRepo {
+        owner: owner.into(),
+        name: name.into(),
+        default_branch: "main".into(),
+        token,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn wf(trigger: TriggerKind) -> Workflow {
+        Workflow {
+            id: "wf_t".into(),
+            workspace_id: "ws".into(),
+            name: "t".into(),
+            trigger,
+            definition: vec![StageKind::Agent {
+                model: None,
+                system_prompt: None,
+                user_prompt: "fix the issue".into(),
+            }],
+            active: true,
+            created_by: "u".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn issue_trigger_matches_repo_and_label_only() {
+        let w = wf(TriggerKind::GithubIssueWebhook {
+            repo: "acme/widgets".into(),
+            label: "spec".into(),
+        });
+        assert!(matches_issue_trigger(&w, "acme/widgets", "spec"));
+        assert!(
+            matches_issue_trigger(&w, "ACME/widgets", "spec"),
+            "repo is case-insensitive"
+        );
+        assert!(!matches_issue_trigger(&w, "acme/widgets", "bug"));
+        assert!(!matches_issue_trigger(&w, "acme/other", "spec"));
+        assert!(!matches_issue_trigger(
+            &wf(TriggerKind::Manual { name: "go".into() }),
+            "acme/widgets",
+            "spec"
+        ));
+    }
+
+    #[test]
+    fn trigger_context_prepends_to_first_agent_stage() {
+        let w = wf(TriggerKind::Manual { name: "go".into() });
+        let fired = with_trigger_context(w, "# Trigger: issue #7\n\n");
+        let StageKind::Agent { user_prompt, .. } = &fired.definition[0];
+        assert!(user_prompt.starts_with("# Trigger: issue #7"));
+        assert!(user_prompt.ends_with("fix the issue"));
+    }
+}

--- a/crates/onsager/src/http/me.rs
+++ b/crates/onsager/src/http/me.rs
@@ -14,7 +14,8 @@ use crate::state::AppState;
 /// M2 with the GitHub port; until then only dev-login can exist.
 pub async fn auth_providers(State(state): State<AppState>) -> Response {
     Json(serde_json::json!({
-        "github": false,
+        "github": state.config.github_client_id.is_some()
+            && state.config.github_client_secret.is_some(),
         "dev": state.config.dev_login_enabled(),
     }))
     .into_response()

--- a/crates/onsager/src/http/mod.rs
+++ b/crates/onsager/src/http/mod.rs
@@ -11,6 +11,7 @@ use crate::state::AppState;
 
 mod credentials;
 mod me;
+mod oauth;
 mod workflows;
 mod workspaces;
 
@@ -43,7 +44,11 @@ pub fn router(state: AppState) -> Router {
         .route("/api/artifacts", get(workflows::list_artifacts))
         .route("/api/artifacts/{id}", get(workflows::get_artifact))
         // Agent-facing MCP output channel (session-token auth).
-        .route("/mcp/messages", post(crate::mcp::messages));
+        .route("/mcp/messages", post(crate::mcp::messages))
+        // GitHub: the App's webhook + OAuth login (M2 #624).
+        .route("/api/webhooks/github", post(crate::github::receive))
+        .route("/api/auth/github", get(oauth::start))
+        .route("/api/auth/github/callback", get(oauth::callback));
 
     if state.config.dev_login_enabled() {
         app = app.route("/api/auth/dev-login", post(auth::dev_login));

--- a/crates/onsager/src/http/oauth.rs
+++ b/crates/onsager/src/http/oauth.rs
@@ -1,0 +1,139 @@
+//! GitHub OAuth login (M2 #624). Ported from the legacy portal's auth
+//! handlers, cut to the standard dance: redirect with a CSRF state
+//! cookie → callback verifies state, exchanges the code, upserts the
+//! user, mints the same session cookie dev-login mints. The legacy
+//! cross-environment SSO machinery did not port (no consumer).
+
+use axum::extract::{Query, State};
+use axum::http::request::Parts;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Redirect, Response};
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::auth::{User, create_auth_session, parse_cookie, session_cookie, upsert_user};
+use crate::crypto::random_token;
+use crate::state::AppState;
+
+const STATE_COOKIE: &str = "onsager_oauth_state";
+
+fn callback_url(state: &AppState) -> String {
+    let origin = state
+        .config
+        .public_url
+        .clone()
+        .unwrap_or_else(|| format!("http://{}", state.config.bind));
+    format!("{origin}/api/auth/github/callback")
+}
+
+/// `GET /api/auth/github` — start the dance.
+pub async fn start(State(state): State<AppState>) -> Response {
+    let Some(client_id) = state.config.github_client_id.as_deref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub OAuth not configured",
+        )
+            .into_response();
+    };
+    let csrf = random_token();
+    let url =
+        onsager_github::api::oauth::github_authorize_url(client_id, &callback_url(&state), &csrf);
+    (
+        [(
+            header::SET_COOKIE,
+            format!("{STATE_COOKIE}={csrf}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600"),
+        )],
+        Redirect::temporary(&url),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackQuery {
+    pub code: String,
+    pub state: String,
+}
+
+/// `GET /api/auth/github/callback`.
+pub async fn callback(
+    State(state): State<AppState>,
+    parts: Parts,
+    Query(q): Query<CallbackQuery>,
+) -> Response {
+    let (Some(client_id), Some(client_secret)) = (
+        state.config.github_client_id.as_deref(),
+        state.config.github_client_secret.as_deref(),
+    ) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub OAuth not configured",
+        )
+            .into_response();
+    };
+    let cookie_state = parts
+        .headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| parse_cookie(h, STATE_COOKIE));
+    if cookie_state != Some(q.state.as_str()) {
+        return (StatusCode::UNAUTHORIZED, "oauth state mismatch").into_response();
+    }
+
+    let token =
+        match onsager_github::api::oauth::exchange_code(client_id, client_secret, &q.code).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("oauth exchange failed: {e}");
+                return (StatusCode::BAD_GATEWAY, "oauth exchange failed").into_response();
+            }
+        };
+    let gh_user = match onsager_github::api::oauth::get_oauth_user(&token.access_token).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::error!("oauth user fetch failed: {e}");
+            return (StatusCode::BAD_GATEWAY, "oauth user fetch failed").into_response();
+        }
+    };
+
+    let user = User {
+        id: Uuid::new_v4().to_string(),
+        github_id: gh_user.id,
+        github_login: gh_user.login.clone(),
+        github_name: gh_user.name.clone(),
+        github_avatar_url: gh_user.avatar_url.clone(),
+    };
+    if let Err(e) = upsert_user(&state.pool, &user).await {
+        tracing::error!("oauth user upsert failed: {e}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    // The upsert keys on github_id; re-resolve the canonical row id.
+    let user = match crate::auth::get_user_by_github_id(&state.pool, gh_user.id).await {
+        Ok(Some(u)) => u,
+        _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+
+    let session_token = random_token();
+    if let Err(e) = create_auth_session(
+        &state.pool,
+        &session_token,
+        &user.id,
+        Utc::now() + chrono::Duration::days(30),
+    )
+    .await
+    {
+        tracing::error!("oauth session mint failed: {e}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    (
+        [
+            (header::SET_COOKIE, session_cookie(&state, &session_token)),
+            (
+                header::SET_COOKIE,
+                format!("{STATE_COOKIE}=; Path=/; HttpOnly; Max-Age=0"),
+            ),
+        ],
+        Redirect::temporary("/"),
+    )
+        .into_response()
+}

--- a/crates/onsager/src/http/workflows.rs
+++ b/crates/onsager/src/http/workflows.rs
@@ -198,7 +198,16 @@ pub async fn fire_workflow(
     if let Err(r) = require_workspace_access(&state.pool, &user, &wf.workspace_id).await {
         return r;
     }
-    let TriggerKind::Manual { .. } = &wf.trigger;
+    if !matches!(&wf.trigger, TriggerKind::Manual { .. }) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "not_a_manual_trigger",
+                "detail": "this workflow fires from its GitHub trigger, not the Run button",
+            })),
+        )
+            .into_response();
+    }
     if !wf.active {
         return (
             StatusCode::CONFLICT,

--- a/crates/onsager/src/lib.rs
+++ b/crates/onsager/src/lib.rs
@@ -15,6 +15,7 @@ pub mod crypto;
 pub mod db;
 pub mod domain;
 pub mod events;
+pub mod github;
 pub mod http;
 pub mod mcp;
 pub mod scheduler;

--- a/crates/onsager/src/scheduler.rs
+++ b/crates/onsager/src/scheduler.rs
@@ -143,6 +143,10 @@ async fn run_agent_stage(
         None => Vec::new(),
     };
 
+    // Repo access (#624): a write-scoped installation token for the
+    // trigger repo, minted per run, in-memory only.
+    let repos = crate::github::repo_access_for(&state.pool, workflow).await;
+
     let outcome = run_agent_session(SessionRequest {
         session_id: session_id.clone(),
         token,
@@ -151,6 +155,7 @@ async fn run_agent_stage(
         user_prompt: user_prompt.to_string(),
         mcp_url: state.config.mcp_url(),
         env,
+        repos,
     })
     .await;
 

--- a/crates/onsager/src/sessions.rs
+++ b/crates/onsager/src/sessions.rs
@@ -20,7 +20,65 @@ use tokio::process::Command;
 /// contract, unchanged from legacy so existing agent-side docs hold.
 pub const SESSION_ID_ENV: &str = "ONSAGER_SESSION_ID";
 pub const SESSION_TOKEN_ENV: &str = "ONSAGER_SESSION_TOKEN";
+pub const REPOS_ENV: &str = "ONSAGER_REPOS";
 const CLAUDE_BIN_ENV: &str = "ONSAGER_CLAUDE_BIN";
+
+/// One repo surfaced to the agent (token already minted). Ported from
+/// legacy `onsager-agent-spawn` (#624) — the `ONSAGER_REPOS` array is
+/// the agent-facing contract and must not drift.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClonableRepo {
+    pub owner: String,
+    pub name: String,
+    pub default_branch: String,
+    pub token: Option<String>,
+}
+
+/// Build the `ONSAGER_REPOS` JSON array; `None` for an empty set so
+/// the caller injects nothing.
+pub fn repos_env_json(repos: &[ClonableRepo]) -> Option<String> {
+    if repos.is_empty() {
+        return None;
+    }
+    let entries: Vec<serde_json::Value> = repos
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "owner": r.owner,
+                "name": r.name,
+                "default_branch": r.default_branch,
+                "clone_url": clone_url(&r.owner, &r.name, r.token.as_deref()),
+            })
+        })
+        .collect();
+    serde_json::to_string(&entries).ok()
+}
+
+/// HTTPS clone URL, authenticated via the `x-access-token` convention
+/// when a token is present; the token is percent-encoded defensively.
+fn clone_url(owner: &str, name: &str, token: Option<&str>) -> String {
+    match token {
+        Some(t) => format!(
+            "https://x-access-token:{}@github.com/{owner}/{name}.git",
+            urlencode(t)
+        ),
+        None => format!("https://github.com/{owner}/{name}.git"),
+    }
+}
+
+/// Minimal percent-encoding for URL userinfo / query values (ported).
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
 
 /// Inline `--mcp-config` registering this process's MCP endpoint. The
 /// bearer token interpolates from `$ONSAGER_SESSION_TOKEN` at startup
@@ -52,6 +110,8 @@ pub struct SessionRequest {
     /// Decrypted workspace credentials injected as env vars
     /// (CLAUDE_CODE_OAUTH_TOKEN etc.).
     pub env: Vec<(String, String)>,
+    /// The run's repo-access set, surfaced as `ONSAGER_REPOS` (#624).
+    pub repos: Vec<ClonableRepo>,
 }
 
 pub struct SessionOutcome {
@@ -102,6 +162,9 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
 
     cmd.env(SESSION_ID_ENV, &req.session_id);
     cmd.env(SESSION_TOKEN_ENV, &req.token);
+    if let Some(repos) = repos_env_json(&req.repos) {
+        cmd.env(REPOS_ENV, repos);
+    }
     for (k, v) in &req.env {
         cmd.env(k, v);
     }
@@ -204,6 +267,34 @@ mod tests {
             server["headers"]["Authorization"],
             "Bearer ${ONSAGER_SESSION_TOKEN}"
         );
+    }
+
+    #[test]
+    fn repos_env_json_builds_authenticated_entries() {
+        // Ported parity tests from legacy onsager-agent-spawn (#624).
+        let repos = vec![
+            ClonableRepo {
+                owner: "acme".into(),
+                name: "widgets".into(),
+                default_branch: "main".into(),
+                token: Some("tok_a".into()),
+            },
+            ClonableRepo {
+                owner: "acme".into(),
+                name: "public".into(),
+                default_branch: "main".into(),
+                token: None,
+            },
+        ];
+        let json = repos_env_json(&repos).unwrap();
+        let arr: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 2);
+        assert_eq!(
+            arr[0]["clone_url"],
+            "https://x-access-token:tok_a@github.com/acme/widgets.git"
+        );
+        assert_eq!(arr[1]["clone_url"], "https://github.com/acme/public.git");
+        assert_eq!(repos_env_json(&[]), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #624. Part of #620 (ADR 0029 — 0.5 reset). Amendments recorded on #624 before implementation.

## What

- **`onsager-github` ported wholesale** as the second (and last) workspace crate: `api/` (App JWT, installation tokens incl. least-privilege read/write mints, issues, pulls, OAuth), webhook HMAC verification, credential types, error model — with its 13 legacy tests. Not ported (no consumer): `polling.rs`, `adapter.rs`, the `webhook/event.rs` stub.
- **One App-level webhook** (`POST /api/webhooks/github`, `GITHUB_WEBHOOK_SECRET`, fail closed): `installation` events maintain `github_app_installations` (migration 003); `issues.labeled` matches active workflows by repo+label (pure, tested matcher) and fires them with the issue prepended to the first agent stage's prompt. The legacy 1,146-line per-repo registration choreography does not return.
- **Repo access**: a write-scoped installation token minted per run for the trigger repo; `ONSAGER_REPOS` built by the ported `repos_env_json` (agent-facing contract, parity tests). The agent opens PRs itself — no portal-side PR-open listener.
- **GitHub OAuth login** ported (CSRF state cookie → exchange → upsert → same session cookie as dev-login); `/api/auth/providers` reflects configuration. SSO machinery did not port.
- **Builder**: trigger picker (Manual | GitHub issue label with repo/label inputs).

## Proof (offline e2e — no live GitHub App needed)

- Forged signature → **401**; unconfigured secret → 503 (fail closed).
- Correctly signed `issues.labeled` for `acme/widgets`+`auto` → matched the builder-created workflow → run fired and completed.
- The shim-agent's probe artifact captures exactly what reached the agent: `ONSAGER_REPOS=[{"clone_url":"https://github.com/acme/widgets.git",…}]` and a prompt beginning `# Trigger: GitHub issue #7`.
- cargo fmt/clippy(-D warnings)/test green (25 tests across both crates); dashboard tsc/eslint/vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)