### PR TITLE
feat(onsager): 0.5 M3 — operate: activity feed, run abort, credentials UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "base64",
  "chrono",
  "hex",
+ "libc",
  "onsager-github",
  "ring",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
 async-trait = "0.1"
 jsonwebtoken = "9"
+libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 ring = "0.17"
 serde = { version = "1", features = ["derive"] }

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -8,6 +8,8 @@ import { WorkflowsPage } from '@/pages/WorkflowsPage'
 import { WorkflowDetailPage } from '@/pages/WorkflowDetailPage'
 import { RunDetailPage } from '@/pages/RunDetailPage'
 import { ArtifactDetailPage, ArtifactsPage } from '@/pages/ArtifactsPage'
+import { ActivityPage } from '@/pages/ActivityPage'
+import { CredentialsPage } from '@/pages/CredentialsPage'
 
 const queryClient = new QueryClient()
 
@@ -44,6 +46,8 @@ export default function App() {
                         <Route path="/runs/:id" element={<RunDetailPage />} />
                         <Route path="/artifacts" element={<ArtifactsPage />} />
                         <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
+                        <Route path="/activity" element={<ActivityPage />} />
+                        <Route path="/credentials" element={<CredentialsPage />} />
                       </Routes>
                     </Shell>
                   </WorkspaceProvider>

--- a/apps/dashboard/src/components/layout/Shell.tsx
+++ b/apps/dashboard/src/components/layout/Shell.tsx
@@ -8,6 +8,8 @@ import { useAuth } from '@/lib/auth'
 const NAV = [
   { to: '/workflows', label: 'Workflows' },
   { to: '/artifacts', label: 'Artifacts' },
+  { to: '/activity', label: 'Activity' },
+  { to: '/credentials', label: 'Credentials' },
 ]
 
 /** The v2 app frame: top bar + nav. */

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -172,3 +172,20 @@ export function decodeInlineContent(uri: string | null): string | null {
     return null
   }
 }
+
+// ── M3: activity / abort / credentials ──
+
+export interface ActivityEvent {
+  id: number
+  run_id: string | null
+  kind: string
+  payload: Record<string, unknown>
+  created_at: string
+}
+
+export const operateApi = {
+  activity: (workspaceId: string) =>
+    request<{ events: ActivityEvent[] }>(`/activity?workspace=${workspaceId}`),
+  abortRun: (runId: string) =>
+    request<{ ok: boolean; status: string }>(`/runs/${runId}/abort`, { method: 'POST' }),
+}

--- a/apps/dashboard/src/pages/ActivityPage.tsx
+++ b/apps/dashboard/src/pages/ActivityPage.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { Badge } from '@/components/ui/badge'
+import { operateApi } from '@/lib/api'
+import { useWorkspace } from '@/lib/workspace'
+
+/** The workspace audit feed (polls; rows deep-link to their run). */
+export function ActivityPage() {
+  const ws = useWorkspace()
+  const { data, isLoading } = useQuery({
+    queryKey: ['activity', ws.id],
+    queryFn: () => operateApi.activity(ws.id),
+    refetchInterval: 3000,
+  })
+  return (
+    <>
+      <h1 className="text-xl font-bold tracking-tight">Activity</h1>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading...</p>}
+      <div className="space-y-1">
+        {data?.events.map((e) => {
+          const row = (
+            <div className="flex items-baseline gap-3 rounded-md px-2 py-1.5 text-sm hover:bg-muted/40">
+              <span className="w-40 shrink-0 text-xs text-muted-foreground">
+                {new Date(e.created_at).toLocaleString()}
+              </span>
+              <Badge variant="outline">{e.kind}</Badge>
+              <span className="truncate text-xs text-muted-foreground">
+                {summary(e.kind, e.payload)}
+              </span>
+            </div>
+          )
+          return e.run_id ? (
+            <Link key={e.id} to={`/runs/${e.run_id}`} className="block">
+              {row}
+            </Link>
+          ) : (
+            <div key={e.id}>{row}</div>
+          )
+        })}
+      </div>
+      {data && data.events.length === 0 && (
+        <p className="text-sm text-muted-foreground">Nothing has happened yet.</p>
+      )}
+    </>
+  )
+}
+
+function summary(kind: string, payload: Record<string, unknown>): string {
+  if (kind === 'run.started') return String(payload.workflow_name ?? '')
+  if (kind === 'artifact.emitted') return String(payload.name ?? '')
+  if (kind === 'run.failed') return String(payload.error ?? '')
+  if (kind === 'run.aborted') return `by ${String(payload.by ?? '?')}`
+  return ''
+}

--- a/apps/dashboard/src/pages/CredentialsPage.tsx
+++ b/apps/dashboard/src/pages/CredentialsPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { api } from '@/lib/api'
+import { useWorkspace } from '@/lib/workspace'
+
+/**
+ * Workspace credentials (encrypted at rest, injected into agent
+ * sessions as env vars). Add CLAUDE_CODE_OAUTH_TOKEN here to run
+ * agents.
+ */
+export function CredentialsPage() {
+  const ws = useWorkspace()
+  const qc = useQueryClient()
+  const { data } = useQuery({
+    queryKey: ['credentials', ws.id],
+    queryFn: () => api.listCredentials(ws.id),
+  })
+  const [name, setName] = useState('CLAUDE_CODE_OAUTH_TOKEN')
+  const [value, setValue] = useState('')
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['credentials', ws.id] })
+  const save = useMutation({
+    mutationFn: () => api.setCredential(ws.id, name.trim(), value),
+    onSuccess: () => {
+      setValue('')
+      invalidate()
+    },
+  })
+  const remove = useMutation({
+    mutationFn: (credName: string) => api.deleteCredential(ws.id, credName),
+    onSuccess: invalidate,
+  })
+
+  return (
+    <>
+      <h1 className="text-xl font-bold tracking-tight">Credentials</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Add credential</CardTitle>
+          <CardDescription>
+            Encrypted at rest; handed to agent sessions as an env var. Values are never
+            shown again.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-2">
+          <Input
+            placeholder="NAME"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="max-w-xs font-mono"
+          />
+          <Input
+            placeholder="value"
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <Button
+            disabled={save.isPending || !name.trim() || !value}
+            onClick={() => save.mutate()}
+          >
+            Save
+          </Button>
+        </CardContent>
+      </Card>
+      <div className="space-y-2">
+        {data?.credentials.map((c) => (
+          <div
+            key={c.name}
+            className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+          >
+            <span className="font-mono">{c.name}</span>
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-muted-foreground">
+                updated {new Date(c.updated_at).toLocaleString()}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={`Delete ${c.name}`}
+                onClick={() => remove.mutate(c.name)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        ))}
+        {data && data.credentials.length === 0 && (
+          <p className="text-sm text-muted-foreground">No credentials yet.</p>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/dashboard/src/pages/RunDetailPage.tsx
+++ b/apps/dashboard/src/pages/RunDetailPage.tsx
@@ -1,23 +1,31 @@
 import { Link, useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { runsApi } from '@/lib/api'
+import { operateApi, runsApi } from '@/lib/api'
+import { Button } from '@/components/ui/button'
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive'> = {
   completed: 'default',
   running: 'secondary',
   failed: 'destructive',
+  aborted: 'destructive',
 }
 
 export function RunDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const qc = useQueryClient()
   const { data } = useQuery({
     queryKey: ['run', id],
     queryFn: () => runsApi.get(id!),
     enabled: !!id,
     refetchInterval: (q) => (q.state.data?.run.status === 'running' ? 2000 : false),
+  })
+
+  const abort = useMutation({
+    mutationFn: () => operateApi.abortRun(id!),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['run', id] }),
   })
 
   if (!data) return <p className="text-sm text-muted-foreground">Loading...</p>
@@ -33,7 +41,19 @@ export function RunDetailPage() {
       </Link>
       <div className="flex items-center justify-between">
         <h1 className="font-mono text-lg font-bold tracking-tight">{run.id}</h1>
-        <Badge variant={STATUS_VARIANT[run.status] ?? 'secondary'}>{run.status}</Badge>
+        <div className="flex items-center gap-2">
+          {run.status === 'running' && (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={abort.isPending}
+              onClick={() => abort.mutate()}
+            >
+              Abort
+            </Button>
+          )}
+          <Badge variant={STATUS_VARIANT[run.status] ?? 'secondary'}>{run.status}</Badge>
+        </div>
       </div>
       {run.error && (
         <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">

--- a/crates/onsager/Cargo.toml
+++ b/crates/onsager/Cargo.toml
@@ -13,6 +13,7 @@ axum.workspace = true
 base64.workspace = true
 chrono.workspace = true
 hex.workspace = true
+libc.workspace = true
 ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/onsager/src/http/mod.rs
+++ b/crates/onsager/src/http/mod.rs
@@ -12,6 +12,7 @@ use crate::state::AppState;
 mod credentials;
 mod me;
 mod oauth;
+mod operate;
 mod workflows;
 mod workspaces;
 
@@ -41,6 +42,8 @@ pub fn router(state: AppState) -> Router {
         .route("/api/workflows/{id}/fire", post(workflows::fire_workflow))
         .route("/api/workflows/{id}/runs", get(workflows::list_runs))
         .route("/api/runs/{id}", get(workflows::get_run))
+        .route("/api/runs/{id}/abort", post(operate::abort_run))
+        .route("/api/activity", get(operate::activity))
         .route("/api/artifacts", get(workflows::list_artifacts))
         .route("/api/artifacts/{id}", get(workflows::get_artifact))
         // Agent-facing MCP output channel (session-token auth).

--- a/crates/onsager/src/http/operate.rs
+++ b/crates/onsager/src/http/operate.rs
@@ -1,0 +1,136 @@
+//! Operator surfaces (M3 #625): the activity feed and run abort.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::auth::{AuthUser, require_workspace_access};
+use crate::events::record;
+use crate::http::workflows::WorkspaceQuery;
+use crate::state::AppState;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ActivityRow {
+    pub id: i64,
+    pub run_id: Option<String>,
+    pub kind: String,
+    pub payload: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// `GET /api/activity?workspace=` — the workspace's audit feed, newest
+/// first. The dashboard polls this; rows deep-link via `run_id`.
+pub async fn activity(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Query(q): Query<WorkspaceQuery>,
+) -> Response {
+    if let Err(r) = require_workspace_access(&state.pool, &user, &q.workspace).await {
+        return r;
+    }
+    let rows: Result<Vec<ActivityRow>, _> = sqlx::query_as(
+        "SELECT id, run_id, kind, payload, created_at FROM events \
+         WHERE workspace_id = $1 ORDER BY id DESC LIMIT 100",
+    )
+    .bind(&q.workspace)
+    .fetch_all(&state.pool)
+    .await;
+    match rows {
+        Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),
+        Err(e) => {
+            tracing::error!("activity query failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// `POST /api/runs/:id/abort` — abort an in-flight run. The scheduler
+/// task is aborted (its agent child dies via `kill_on_drop`); this
+/// handler then settles the rows the dead task can no longer settle.
+pub async fn abort_run(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<String>,
+) -> Response {
+    let run: Option<(String, String)> =
+        match sqlx::query_as("SELECT workspace_id, status FROM runs WHERE id = $1")
+            .bind(&id)
+            .fetch_optional(&state.pool)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("abort run lookup failed: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+    let Some((workspace_id, status)) = run else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "run not found" })),
+        )
+            .into_response();
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &user, &workspace_id).await {
+        return r;
+    }
+    if status != "running" {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": format!("run is {status}, not running") })),
+        )
+            .into_response();
+    }
+
+    let handle = state.running.lock().expect("registry lock").remove(&id);
+    let was_live = handle.is_some();
+    if let Some(handle) = handle {
+        handle.abort.abort();
+        // kill_on_drop reaches the direct child; the session's process
+        // GROUP catches the tree the agent spawned under it.
+        let pgid = *handle.pgid.lock().expect("pgid lock");
+        if let Some(pgid) = pgid
+            && pgid > 1
+        {
+            // SAFETY: plain syscall; negative pid addresses the group.
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+
+    // Settle the rows the aborted task can no longer settle.
+    if let Err(e) = sqlx::query(
+        "UPDATE runs SET status = 'aborted', error = $2, finished_at = NOW() WHERE id = $1",
+    )
+    .bind(&id)
+    .bind(format!("aborted by {}", user.github_login))
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("abort run update failed: {e}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    if let Err(e) = sqlx::query(
+        "UPDATE sessions SET status = 'failed', error = 'run aborted', finished_at = NOW() \
+         WHERE run_id = $1 AND status = 'running'",
+    )
+    .bind(&id)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("abort session settle failed: {e}");
+    }
+    record(
+        &state.pool,
+        &workspace_id,
+        Some(&id),
+        "run.aborted",
+        serde_json::json!({ "by": user.github_login, "task_was_live": was_live }),
+    )
+    .await;
+    Json(serde_json::json!({ "ok": true, "run_id": id, "status": "aborted" })).into_response()
+}

--- a/crates/onsager/src/scheduler.rs
+++ b/crates/onsager/src/scheduler.rs
@@ -34,11 +34,15 @@ pub async fn fire(state: &AppState, workflow: Workflow) -> anyhow::Result<String
     )
     .await;
 
-    let state = state.clone();
+    let pgid_slot = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let task_state = state.clone();
+    let task_pgid = pgid_slot.clone();
     let id = run_id.clone();
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
+        let state = task_state;
+        let pgid_slot = task_pgid;
         let workspace_id = workflow.workspace_id.clone();
-        match execute(&state, &workflow, &id).await {
+        match execute(&state, &workflow, &id, &pgid_slot).await {
             Ok(()) => {
                 finish(&state.pool, &id, "completed", None).await;
                 record(
@@ -64,7 +68,15 @@ pub async fn fire(state: &AppState, workflow: Workflow) -> anyhow::Result<String
                 .await;
             }
         }
+        state.running.lock().expect("registry lock").remove(&id);
     });
+    state.running.lock().expect("registry lock").insert(
+        run_id.clone(),
+        crate::state::RunHandle {
+            abort: handle.abort_handle(),
+            pgid: pgid_slot,
+        },
+    );
     Ok(run_id)
 }
 
@@ -82,7 +94,12 @@ async fn finish(pool: &PgPool, run_id: &str, status: &str, error: Option<&str>) 
 }
 
 /// Iterate the stage list. The first failing stage fails the run.
-async fn execute(state: &AppState, workflow: &Workflow, run_id: &str) -> anyhow::Result<()> {
+async fn execute(
+    state: &AppState,
+    workflow: &Workflow,
+    run_id: &str,
+    pgid_slot: &std::sync::Arc<std::sync::Mutex<Option<i32>>>,
+) -> anyhow::Result<()> {
     for (index, stage) in workflow.definition.iter().enumerate() {
         match stage {
             StageKind::Agent {
@@ -98,6 +115,7 @@ async fn execute(state: &AppState, workflow: &Workflow, run_id: &str) -> anyhow:
                     model.clone(),
                     system_prompt.clone(),
                     user_prompt,
+                    pgid_slot,
                 )
                 .await?;
             }
@@ -106,6 +124,7 @@ async fn execute(state: &AppState, workflow: &Workflow, run_id: &str) -> anyhow:
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_agent_stage(
     state: &AppState,
     workflow: &Workflow,
@@ -114,6 +133,7 @@ async fn run_agent_stage(
     model: Option<String>,
     system_prompt: Option<String>,
     user_prompt: &str,
+    pgid_slot: &std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 ) -> anyhow::Result<()> {
     let session_id = format!("sess_{}", Uuid::new_v4());
     let token = random_token();
@@ -156,6 +176,7 @@ async fn run_agent_stage(
         mcp_url: state.config.mcp_url(),
         env,
         repos,
+        pgid_slot: pgid_slot.clone(),
     })
     .await;
 

--- a/crates/onsager/src/sessions.rs
+++ b/crates/onsager/src/sessions.rs
@@ -112,6 +112,9 @@ pub struct SessionRequest {
     pub env: Vec<(String, String)>,
     /// The run's repo-access set, surfaced as `ONSAGER_REPOS` (#624).
     pub repos: Vec<ClonableRepo>,
+    /// Written with the child's pid (== its pgid) after spawn so the
+    /// abort endpoint can kill the whole process tree (M3 #625).
+    pub pgid_slot: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 }
 
 pub struct SessionOutcome {
@@ -170,11 +173,19 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
     }
     cmd.stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .stdin(Stdio::null());
+        .stdin(Stdio::null())
+        // Abort (#625) drops this future; the child must die with it.
+        // The child leads its own process group so abort can SIGKILL
+        // the whole tree (claude spawns subprocess trees).
+        .kill_on_drop(true)
+        .process_group(0);
 
     let mut child = cmd
         .spawn()
         .map_err(|e| SessionError(format!("spawning `{command}`: {e}")))?;
+    if let Some(pid) = child.id() {
+        *req.pgid_slot.lock().expect("pgid slot lock") = Some(pid as i32);
+    }
 
     // Drain stderr to tracing — a CLI usage error must surface, not
     // fill the pipe buffer (#601).

--- a/crates/onsager/src/state.rs
+++ b/crates/onsager/src/state.rs
@@ -1,17 +1,39 @@
 //! Shared application state handed to every handler.
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 use sqlx::PgPool;
+use tokio::task::AbortHandle;
 
 use crate::config::Config;
+
+/// What the abort endpoint needs to stop a run: the task's abort
+/// handle plus the live session's process-group id. `kill_on_drop`
+/// only reaches the direct child; real agent sessions spawn process
+/// trees, so abort also SIGKILLs the negative pgid (M3 #625).
+#[derive(Clone)]
+pub struct RunHandle {
+    pub abort: AbortHandle,
+    pub pgid: Arc<Mutex<Option<i32>>>,
+}
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: PgPool,
     pub config: Config,
+    /// In-flight runs (M3 #625). The scheduler registers on fire and
+    /// deregisters on finish; the abort endpoint aborts the task and
+    /// kills the session's process group.
+    pub running: Arc<Mutex<HashMap<String, RunHandle>>>,
 }
 
 impl AppState {
     pub fn new(pool: PgPool, config: Config) -> Self {
-        Self { pool, config }
+        Self {
+            pool,
+            config,
+            running: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 }


### PR DESCRIPTION
Closes #625. Part of #620 (ADR 0029 — 0.5 reset). Amendment on #625: live updates ship as polling; pg_notify/SSE returns when polling measurably hurts.

## What

- **Activity**: `GET /api/activity?workspace=` reads the audit events table newest-first; the Activity page polls at 3s with run deep-links.
- **Abort**: `POST /api/runs/:id/abort`. The run registry (`AppState.running`) holds each in-flight run's task `AbortHandle` plus its session's **process-group id**; abort drops the task (agent children spawn with `kill_on_drop` + `process_group(0)`) and SIGKILLs the negative pgid, then settles the run/session rows and records `run.aborted`.
- **UI**: Abort button on a running run; `aborted` status; Credentials settings page (add/delete, write-only values); Activity in the nav.

## Proof (live, slow-shim agent)

- The first e2e **caught a real bug**: `kill_on_drop` killed the direct child but orphaned its `sleep 60` grandchild — exactly what a real claude session's bash children would do. The process-group kill fixes it: re-run shows the run in Activity while live, abort returns `{status: aborted}`, the timeline records `run.aborted`, and **both the shim and its grandchild are verified dead**.
- cargo fmt/clippy(-D warnings)/test green; dashboard tsc/eslint/vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)