### PR TITLE
feat(onsager): agent session feed — normalized session events on the run page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ In dev, the dashboard is Vite with an `/api` + `/mcp` proxy.
 
 ### Schema (11 tables, fresh migrations, `schema_migrations` ledger)
 
-`users`, `auth_sessions`, `workspaces`, `workspace_members`, `credentials` (001) · `workflows`, `runs`, `sessions`, `session_logs`*, `artifacts`, `events` (002) · `github_app_installations` (003). Migrations are immutable after merge; fixes are new migrations. (*`session_logs` is in 002 awaiting its consumer — first candidate for the ratchet if streaming logs don't land.)
+`users`, `auth_sessions`, `workspaces`, `workspace_members`, `credentials` (001) · `workflows`, `runs`, `sessions`, `artifacts`, `events` (002) · `github_app_installations` (003) · `session_events` (004 — the normalized agent feed, #632). Migrations are immutable after merge; fixes are new migrations.
 
 Key shapes:
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -25,7 +25,8 @@
     "react-router-dom": "^7.13.2",
     "shadcn": "^4.1.2",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/dashboard/src/components/runs/SessionFeed.tsx
+++ b/apps/dashboard/src/components/runs/SessionFeed.tsx
@@ -1,0 +1,196 @@
+import { useQuery } from '@tanstack/react-query'
+import Markdown from 'react-markdown'
+import { AlertTriangle, ChevronRight, Wrench } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { sessionsApi, type SessionEvent } from '@/lib/api'
+
+/**
+ * The agent session feed (#632) — what the agent said and did, as one
+ * chronological feed. Design ported from arbor's ActivityFeed: prose
+ * renders as markdown, tool_use/tool_result pairs fold into collapsible
+ * cards with running/done/error state, warnings become callouts,
+ * lifecycle events are quiet rows. Polls while the session runs.
+ */
+export function SessionFeed({ sessionId, status }: { sessionId: string; status: string }) {
+  const { data } = useQuery({
+    queryKey: ['session-events', sessionId],
+    queryFn: () => sessionsApi.events(sessionId),
+    refetchInterval: (q) => (q.state.data?.status === 'running' ? 2000 : false),
+  })
+  const events = data?.events ?? []
+  const live = (data?.status ?? status) === 'running'
+  const items = foldToolPairs(events)
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle className="text-base">Agent session</CardTitle>
+          <span className="font-mono text-xs text-muted-foreground">
+            {sessionId.slice(0, 18)}…
+          </span>
+          <Badge variant={live ? 'secondary' : 'outline'}>{data?.status ?? status}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.length === 0 && (
+          <p className="text-sm italic text-muted-foreground">
+            {live ? 'waiting for the agent…' : 'no session events recorded'}
+          </p>
+        )}
+        {items.map((item) => renderItem(item))}
+        {live && (
+          <span aria-hidden className="ml-1 inline-block animate-pulse text-primary">
+            ▍
+          </span>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+type ToolItem = {
+  kind: 'tool'
+  seq: number
+  tool: string
+  inputExcerpt: string
+  result?: { excerpt: string; isError: boolean }
+}
+type FeedItem = { kind: 'event'; event: SessionEvent } | ToolItem
+
+/** Pair each tool_use with its tool_result (by tool_use_id) into one card. */
+function foldToolPairs(events: SessionEvent[]): FeedItem[] {
+  const items: FeedItem[] = []
+  const open = new Map<string, ToolItem>()
+  for (const e of events) {
+    if (e.kind === 'agent.tool_use') {
+      const item: ToolItem = {
+        kind: 'tool',
+        seq: e.seq,
+        tool: String(e.payload.tool ?? 'unknown'),
+        inputExcerpt: String(e.payload.input_excerpt ?? ''),
+      }
+      items.push(item)
+      const id = e.payload.tool_use_id
+      if (typeof id === 'string') open.set(id, item)
+    } else if (e.kind === 'agent.tool_result') {
+      const id = e.payload.tool_use_id
+      const target = typeof id === 'string' ? open.get(id) : undefined
+      const result = {
+        excerpt: String(e.payload.result_excerpt ?? ''),
+        isError: e.payload.is_error === true,
+      }
+      if (target && !target.result) {
+        target.result = result
+        if (typeof id === 'string') open.delete(id)
+      } else {
+        // Orphan result — surfaced, never dropped (arbor convention).
+        items.push({
+          kind: 'tool',
+          seq: e.seq,
+          tool: String(e.payload.tool ?? 'unknown'),
+          inputExcerpt: '',
+          result,
+        })
+      }
+    } else {
+      items.push({ kind: 'event', event: e })
+    }
+  }
+  return items
+}
+
+function renderItem(item: FeedItem) {
+  if (item.kind === 'tool') return <ToolCard key={`t${item.seq}`} item={item} />
+  const e = item.event
+  switch (e.kind) {
+    case 'agent.text':
+      return (
+        <div key={e.seq} className="prose prose-sm max-w-none text-sm leading-relaxed dark:prose-invert">
+          <Markdown>{String(e.payload.text ?? '')}</Markdown>
+        </div>
+      )
+    case 'agent.warning':
+      return (
+        <div
+          key={e.seq}
+          className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{String(e.payload.message ?? '')}</span>
+        </div>
+      )
+    case 'agent.started':
+      return (
+        <p key={e.seq} className="text-xs italic text-muted-foreground">
+          session started{e.payload.model ? ` · ${String(e.payload.model)}` : ''}
+        </p>
+      )
+    case 'agent.completed': {
+      const bits = [
+        e.payload.turns != null ? `${String(e.payload.turns)} turns` : null,
+        e.payload.duration_ms != null
+          ? `${(Number(e.payload.duration_ms) / 1000).toFixed(1)}s`
+          : null,
+        e.payload.cost_usd != null ? `$${Number(e.payload.cost_usd).toFixed(4)}` : null,
+      ].filter(Boolean)
+      return (
+        <p key={e.seq} className="text-xs italic text-muted-foreground">
+          session completed{bits.length > 0 ? ` · ${bits.join(' · ')}` : ''}
+        </p>
+      )
+    }
+    default:
+      return null
+  }
+}
+
+function ToolCard({ item }: { item: ToolItem }) {
+  const state = item.result === undefined ? 'running' : item.result.isError ? 'error' : 'done'
+  return (
+    <details
+      className={`group overflow-hidden rounded-lg border ${
+        state === 'error' ? 'border-red-300 dark:border-red-900' : ''
+      } bg-muted/30`}
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-2.5 py-1.5 text-sm">
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+        <Wrench className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="font-mono text-xs font-semibold">{item.tool}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-[0.7rem] text-muted-foreground">
+          {item.inputExcerpt}
+        </span>
+        <span
+          className={`shrink-0 text-[0.7rem] ${
+            state === 'running'
+              ? 'text-blue-600 dark:text-blue-400'
+              : state === 'error'
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-emerald-600 dark:text-emerald-400'
+          }`}
+        >
+          {state === 'running' ? 'running…' : state}
+        </span>
+      </summary>
+      <div className="space-y-1.5 px-2.5 pb-2">
+        {item.inputExcerpt && (
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-background px-2 py-1.5 font-mono text-[0.72rem]">
+            {item.inputExcerpt}
+          </pre>
+        )}
+        {item.result?.excerpt && (
+          <pre
+            className={`overflow-x-auto whitespace-pre-wrap break-words rounded-md px-2 py-1.5 font-mono text-[0.72rem] ${
+              item.result.isError
+                ? 'bg-red-50 text-red-900 dark:bg-red-950/40 dark:text-red-200'
+                : 'bg-background'
+            }`}
+          >
+            {item.result.excerpt}
+          </pre>
+        )}
+      </div>
+    </details>
+  )
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -154,7 +154,12 @@ export const workflowsApi = {
 
 export const runsApi = {
   get: (id: string) =>
-    request<{ run: Run; timeline: RunEvent[]; artifacts: Artifact[] }>(`/runs/${id}`),
+    request<{
+      run: Run
+      timeline: RunEvent[]
+      artifacts: Artifact[]
+      sessions: { id: string; status: string }[]
+    }>(`/runs/${id}`),
 }
 
 export const artifactsApi = {
@@ -188,4 +193,23 @@ export const operateApi = {
     request<{ events: ActivityEvent[] }>(`/activity?workspace=${workspaceId}`),
   abortRun: (runId: string) =>
     request<{ ok: boolean; status: string }>(`/runs/${runId}/abort`, { method: 'POST' }),
+}
+
+// ── Session feed (#632) ──
+
+export interface SessionEvent {
+  seq: number
+  kind: string
+  payload: Record<string, unknown>
+  created_at: string
+}
+
+export interface RunSession {
+  id: string
+  status: string
+}
+
+export const sessionsApi = {
+  events: (sessionId: string) =>
+    request<{ status: string; events: SessionEvent[] }>(`/sessions/${sessionId}/events`),
 }

--- a/apps/dashboard/src/pages/RunDetailPage.tsx
+++ b/apps/dashboard/src/pages/RunDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { operateApi, runsApi } from '@/lib/api'
+import { SessionFeed } from '@/components/runs/SessionFeed'
 import { Button } from '@/components/ui/button'
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive'> = {
@@ -29,7 +30,7 @@ export function RunDetailPage() {
   })
 
   if (!data) return <p className="text-sm text-muted-foreground">Loading...</p>
-  const { run, timeline, artifacts } = data
+  const { run, timeline, artifacts, sessions } = data
 
   return (
     <>
@@ -79,6 +80,10 @@ export function RunDetailPage() {
           ))}
         </CardContent>
       </Card>
+
+      {sessions.map((s) => (
+        <SessionFeed key={s.id} sessionId={s.id} status={s.status} />
+      ))}
 
       <Card>
         <CardHeader>

--- a/crates/onsager/migrations/004_session_events.sql
+++ b/crates/onsager/migrations/004_session_events.sql
@@ -1,0 +1,17 @@
+-- v2 schema, migration 004 — normalized agent session events (#632).
+--
+-- One row per normalized `agent.*` event captured from a session's
+-- stream-json output (see `agent_events.rs` for the vocabulary).
+-- Consumed by `GET /api/sessions/:id/events` and the run page's
+-- session feed — landing together, per the ratchet.
+
+CREATE TABLE session_events (
+    id         BIGSERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions (id),
+    seq        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    payload    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (session_id, seq)
+);
+CREATE INDEX idx_session_events_session ON session_events (session_id, seq);

--- a/crates/onsager/src/agent_events.rs
+++ b/crates/onsager/src/agent_events.rs
@@ -1,0 +1,385 @@
+//! Claude stream-JSON → normalized `agent.*` session events (#632).
+//!
+//! Ported from arbor's `agent-runner/src/normalize.ts` (shapes verified
+//! there against claude 2.1.x): raw stream-json is unversioned and
+//! CLI-upgrade-volatile, so all the churn is isolated here. The
+//! normalizer is pure — `handle` maps one parsed event to zero or more
+//! `(kind, payload)` rows; persistence lives with the caller.
+//!
+//! Mapping:
+//! - `system/init`            → `agent.started` (model)
+//! - assistant `text` blocks  → `agent.text` (capped)
+//! - assistant `tool_use`     → `agent.tool_use` (tool, id, input excerpt)
+//! - user `tool_result`       → `agent.tool_result` (paired by id; orphans
+//!   keep tool "unknown", never dropped)
+//! - `result`                 → `agent.completed` (turns / cost / duration)
+//!   + warnings for error subtypes and permission denials
+//! - `system/model_fallback`  → `agent.warning`
+//! - unknown top-level types  → `agent.warning`, once per distinct type
+//! - `stream_event` partials and thinking blocks → ignored (progress noise;
+//!   token deltas return if/when live streaming lands)
+//!
+//! Not ported from arbor: the out-of-workspace path watcher (v2 has no
+//! per-run workspace root yet) and transient text deltas (polling UI).
+
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Value, json};
+
+/// Cap for assistant prose per event.
+pub const MAX_TEXT_CHARS: usize = 2000;
+/// Cap for tool inputs / results / warnings.
+pub const MAX_EXCERPT_CHARS: usize = 700;
+
+/// One normalized session event, ready to persist.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentEvent {
+    pub kind: &'static str,
+    pub payload: Value,
+}
+
+fn excerpt(s: &str, cap: usize) -> (String, bool) {
+    if s.chars().count() <= cap {
+        (s.to_string(), false)
+    } else {
+        (s.chars().take(cap).collect(), true)
+    }
+}
+
+fn s<'a>(v: &'a Value, key: &str) -> Option<&'a str> {
+    v.get(key).and_then(Value::as_str)
+}
+
+pub struct Normalizer {
+    /// tool_use id → tool name, so tool_results can be attributed.
+    pending_tools: HashMap<String, String>,
+    /// Unknown top-level types warned about — once per type.
+    warned_unknown: HashSet<String>,
+}
+
+impl Default for Normalizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Normalizer {
+    pub fn new() -> Self {
+        Self {
+            pending_tools: HashMap::new(),
+            warned_unknown: HashSet::new(),
+        }
+    }
+
+    fn warning(message: &str) -> AgentEvent {
+        let (text, _) = excerpt(message, MAX_EXCERPT_CHARS);
+        AgentEvent {
+            kind: "agent.warning",
+            payload: json!({ "message": text }),
+        }
+    }
+
+    /// Normalize one parsed stream-json event into zero or more rows.
+    pub fn handle(&mut self, event: &Value) -> Vec<AgentEvent> {
+        match s(event, "type") {
+            Some("system") => match s(event, "subtype") {
+                Some("init") => {
+                    let mut payload = json!({});
+                    if let Some(model) = s(event, "model") {
+                        payload["model"] = json!(model);
+                    }
+                    vec![AgentEvent {
+                        kind: "agent.started",
+                        payload,
+                    }]
+                }
+                Some("model_fallback") => vec![Self::warning(&format!("model fallback: {event}"))],
+                // Other system subtypes are high-frequency progress noise.
+                _ => vec![],
+            },
+            Some("assistant") => self.handle_assistant(event),
+            Some("user") => self.handle_user(event),
+            Some("result") => Self::handle_result(event),
+            // Partial messages / token deltas: progress noise for the
+            // polling UI; ignored, not warned.
+            Some("stream_event") => vec![],
+            Some(other) => {
+                if self.warned_unknown.insert(other.to_string()) {
+                    vec![Self::warning(&format!(
+                        "unknown stream event type: {other}"
+                    ))]
+                } else {
+                    vec![]
+                }
+            }
+            None => vec![],
+        }
+    }
+
+    fn content_blocks(event: &Value) -> impl Iterator<Item = &Value> {
+        event
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+    }
+
+    fn handle_assistant(&mut self, event: &Value) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        for block in Self::content_blocks(event) {
+            match s(block, "type") {
+                Some("text") => {
+                    let text = s(block, "text").unwrap_or("");
+                    if text.is_empty() {
+                        continue;
+                    }
+                    let (cut, truncated) = excerpt(text, MAX_TEXT_CHARS);
+                    let mut payload = json!({ "text": cut });
+                    if truncated {
+                        payload["truncated"] = json!(true);
+                    }
+                    out.push(AgentEvent {
+                        kind: "agent.text",
+                        payload,
+                    });
+                }
+                Some("tool_use") => {
+                    let tool = s(block, "name").unwrap_or("unknown").to_string();
+                    let id = s(block, "id").map(str::to_string);
+                    if let Some(id) = &id {
+                        self.pending_tools.insert(id.clone(), tool.clone());
+                    }
+                    let input = block.get("input").cloned().unwrap_or(json!({}));
+                    let (cut, truncated) = excerpt(&input.to_string(), MAX_EXCERPT_CHARS);
+                    let mut payload = json!({ "tool": tool, "input_excerpt": cut });
+                    if let Some(id) = id {
+                        payload["tool_use_id"] = json!(id);
+                    }
+                    if truncated {
+                        payload["truncated"] = json!(true);
+                    }
+                    out.push(AgentEvent {
+                        kind: "agent.tool_use",
+                        payload,
+                    });
+                }
+                // thinking blocks: reserved, ignored.
+                _ => {}
+            }
+        }
+        out
+    }
+
+    fn handle_user(&mut self, event: &Value) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        for block in Self::content_blocks(event) {
+            if s(block, "type") != Some("tool_result") {
+                continue;
+            }
+            let id = s(block, "tool_use_id").map(str::to_string);
+            // Orphans (unseen tool_use id) keep "unknown" — never dropped.
+            let tool = id
+                .as_ref()
+                .and_then(|i| self.pending_tools.remove(i))
+                .unwrap_or_else(|| "unknown".to_string());
+            let is_error = block.get("is_error") == Some(&json!(true));
+            let result_text = tool_result_text(block.get("content"));
+            let (cut, truncated) = excerpt(&result_text, MAX_EXCERPT_CHARS);
+            let mut payload = json!({ "tool": tool });
+            if let Some(id) = id {
+                payload["tool_use_id"] = json!(id);
+            }
+            if is_error {
+                payload["is_error"] = json!(true);
+            }
+            if !cut.is_empty() {
+                payload["result_excerpt"] = json!(cut);
+            }
+            if truncated {
+                payload["truncated"] = json!(true);
+            }
+            out.push(AgentEvent {
+                kind: "agent.tool_result",
+                payload,
+            });
+        }
+        out
+    }
+
+    fn handle_result(event: &Value) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        let mut payload = json!({});
+        if let Some(turns) = event.get("num_turns").and_then(Value::as_u64) {
+            payload["turns"] = json!(turns);
+        }
+        if let Some(cost) = event.get("total_cost_usd").and_then(Value::as_f64) {
+            payload["cost_usd"] = json!(cost);
+        }
+        if let Some(ms) = event.get("duration_ms").and_then(Value::as_u64) {
+            payload["duration_ms"] = json!(ms);
+        }
+        out.push(AgentEvent {
+            kind: "agent.completed",
+            payload,
+        });
+
+        let denials = event
+            .get("permission_denials")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        if !denials.is_empty() {
+            let tools: Vec<&str> = denials
+                .iter()
+                .map(|d| s(d, "tool_name").unwrap_or("unknown"))
+                .collect();
+            out.push(Self::warning(&format!(
+                "{} permission denial(s): {}",
+                denials.len(),
+                tools.join(", ")
+            )));
+        }
+        let subtype = s(event, "subtype");
+        if event.get("is_error") == Some(&json!(true))
+            || (subtype.is_some() && subtype != Some("success"))
+        {
+            let detail = s(event, "result").or(s(event, "error")).unwrap_or("");
+            out.push(Self::warning(&format!(
+                "claude result subtype \"{}\"{}{}",
+                subtype.unwrap_or("unknown"),
+                if detail.is_empty() { "" } else { ": " },
+                detail
+            )));
+        }
+        out
+    }
+}
+
+/// `tool_result.content` is either a string or an array of typed blocks.
+fn tool_result_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter(|b| s(b, "type") == Some("text"))
+            .filter_map(|b| s(b, "text"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fixture lines in the claude 2.1.x stream-json shapes arbor
+    /// verified (2026-06-10) — the normalizer's contract.
+    fn lines() -> Vec<Value> {
+        vec![
+            json!({"type":"system","subtype":"init","session_id":"abc","model":"claude-sonnet-4-6"}),
+            json!({"type":"assistant","message":{"content":[
+                {"type":"text","text":"I'll write the file now."},
+                {"type":"tool_use","id":"tu_1","name":"Write","input":{"file_path":"/tmp/x","content":"hi"}}
+            ]}}),
+            json!({"type":"user","message":{"content":[
+                {"type":"tool_result","tool_use_id":"tu_1","content":"File created"}
+            ]}}),
+            json!({"type":"stream_event","event":{"type":"content_block_delta"}}),
+            json!({"type":"result","subtype":"success","result":"done","num_turns":3,
+                   "total_cost_usd":0.0123,"duration_ms":4567}),
+        ]
+    }
+
+    #[test]
+    fn full_session_normalizes_in_order() {
+        let mut n = Normalizer::new();
+        let events: Vec<AgentEvent> = lines().iter().flat_map(|l| n.handle(l)).collect();
+        let kinds: Vec<&str> = events.iter().map(|e| e.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "agent.started",
+                "agent.text",
+                "agent.tool_use",
+                "agent.tool_result",
+                "agent.completed",
+            ]
+        );
+        assert_eq!(events[0].payload["model"], "claude-sonnet-4-6");
+        assert_eq!(events[2].payload["tool"], "Write");
+        assert!(
+            events[2].payload["input_excerpt"]
+                .as_str()
+                .unwrap()
+                .contains("file_path")
+        );
+        // tool_result attributed to its tool_use by id.
+        assert_eq!(events[3].payload["tool"], "Write");
+        assert_eq!(events[3].payload["result_excerpt"], "File created");
+        assert_eq!(events[4].payload["turns"], 3);
+        assert_eq!(events[4].payload["cost_usd"], 0.0123);
+    }
+
+    #[test]
+    fn orphan_tool_result_is_kept_with_unknown_tool() {
+        let mut n = Normalizer::new();
+        let events = n.handle(&json!({"type":"user","message":{"content":[
+            {"type":"tool_result","tool_use_id":"never_seen","content":"out"}
+        ]}}));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "agent.tool_result");
+        assert_eq!(events[0].payload["tool"], "unknown");
+    }
+
+    #[test]
+    fn error_result_adds_warning() {
+        let mut n = Normalizer::new();
+        let events = n.handle(
+            &json!({"type":"result","subtype":"error_max_turns","is_error":true,"result":"ran out"}),
+        );
+        let kinds: Vec<&str> = events.iter().map(|e| e.kind).collect();
+        assert_eq!(kinds, vec!["agent.completed", "agent.warning"]);
+        assert!(
+            events[1].payload["message"]
+                .as_str()
+                .unwrap()
+                .contains("error_max_turns")
+        );
+    }
+
+    #[test]
+    fn unknown_types_warn_once_per_type() {
+        let mut n = Normalizer::new();
+        assert_eq!(n.handle(&json!({"type":"mystery"})).len(), 1);
+        assert_eq!(n.handle(&json!({"type":"mystery"})).len(), 0);
+        assert_eq!(n.handle(&json!({"type":"other_mystery"})).len(), 1);
+    }
+
+    #[test]
+    fn long_text_is_capped_and_flagged() {
+        let mut n = Normalizer::new();
+        let long = "x".repeat(MAX_TEXT_CHARS + 50);
+        let events = n.handle(&json!({"type":"assistant","message":{"content":[
+            {"type":"text","text": long}
+        ]}}));
+        assert_eq!(events[0].payload["truncated"], true);
+        assert_eq!(
+            events[0].payload["text"].as_str().unwrap().chars().count(),
+            MAX_TEXT_CHARS
+        );
+    }
+
+    #[test]
+    fn tool_result_array_content_joins_text_blocks() {
+        assert_eq!(
+            tool_result_text(Some(&json!([
+                {"type":"text","text":"a"},
+                {"type":"image"},
+                {"type":"text","text":"b"}
+            ]))),
+            "a\nb"
+        );
+    }
+}

--- a/crates/onsager/src/db.rs
+++ b/crates/onsager/src/db.rs
@@ -25,6 +25,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "003_github.sql",
         include_str!("../migrations/003_github.sql"),
     ),
+    (
+        "004_session_events.sql",
+        include_str!("../migrations/004_session_events.sql"),
+    ),
 ];
 
 pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {

--- a/crates/onsager/src/http/mod.rs
+++ b/crates/onsager/src/http/mod.rs
@@ -43,6 +43,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/workflows/{id}/runs", get(workflows::list_runs))
         .route("/api/runs/{id}", get(workflows::get_run))
         .route("/api/runs/{id}/abort", post(operate::abort_run))
+        .route("/api/sessions/{id}/events", get(operate::session_events))
         .route("/api/activity", get(operate::activity))
         .route("/api/artifacts", get(workflows::list_artifacts))
         .route("/api/artifacts/{id}", get(workflows::get_artifact))

--- a/crates/onsager/src/http/operate.rs
+++ b/crates/onsager/src/http/operate.rs
@@ -13,6 +13,60 @@ use crate::http::workflows::WorkspaceQuery;
 use crate::state::AppState;
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct SessionEventRow {
+    pub seq: i32,
+    pub kind: String,
+    pub payload: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// `GET /api/sessions/:id/events` — the normalized agent feed for one
+/// session (#632). The run page polls this while the session runs.
+pub async fn session_events(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<String>,
+) -> Response {
+    let session: Option<(String, String)> =
+        match sqlx::query_as("SELECT workspace_id, status FROM sessions WHERE id = $1")
+            .bind(&id)
+            .fetch_optional(&state.pool)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("session lookup failed: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+    let Some((workspace_id, status)) = session else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "session not found" })),
+        )
+            .into_response();
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &user, &workspace_id).await {
+        return r;
+    }
+    let rows: Result<Vec<SessionEventRow>, _> = sqlx::query_as(
+        "SELECT seq, kind, payload, created_at FROM session_events          WHERE session_id = $1 ORDER BY seq",
+    )
+    .bind(&id)
+    .fetch_all(&state.pool)
+    .await;
+    match rows {
+        Ok(events) => {
+            Json(serde_json::json!({ "status": status, "events": events })).into_response()
+        }
+        Err(e) => {
+            tracing::error!("session events query failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct ActivityRow {
     pub id: i64,
     pub run_id: Option<String>,

--- a/crates/onsager/src/http/workflows.rs
+++ b/crates/onsager/src/http/workflows.rs
@@ -293,8 +293,20 @@ pub async fn get_run(
         Ok(a) => a,
         Err(e) => return internal(e, "load run artifacts"),
     };
-    Json(serde_json::json!({ "run": run, "timeline": timeline, "artifacts": artifacts }))
-        .into_response()
+    let sessions: Vec<(String, String)> =
+        sqlx::query_as("SELECT id, status FROM sessions WHERE run_id = $1 ORDER BY created_at")
+            .bind(&id)
+            .fetch_all(&state.pool)
+            .await
+            .unwrap_or_default();
+    let sessions: Vec<serde_json::Value> = sessions
+        .into_iter()
+        .map(|(id, status)| serde_json::json!({ "id": id, "status": status }))
+        .collect();
+    Json(serde_json::json!({
+        "run": run, "timeline": timeline, "artifacts": artifacts, "sessions": sessions,
+    }))
+    .into_response()
 }
 
 // ── Artifacts ──

--- a/crates/onsager/src/lib.rs
+++ b/crates/onsager/src/lib.rs
@@ -9,6 +9,7 @@
 //!   extractor (ported from legacy portal, PAT + SSO paths dropped)
 //! - [`http`] — the router and route handlers
 
+pub mod agent_events;
 pub mod auth;
 pub mod config;
 pub mod crypto;

--- a/crates/onsager/src/scheduler.rs
+++ b/crates/onsager/src/scheduler.rs
@@ -177,6 +177,7 @@ async fn run_agent_stage(
         env,
         repos,
         pgid_slot: pgid_slot.clone(),
+        pool: state.pool.clone(),
     })
     .await;
 

--- a/crates/onsager/src/sessions.rs
+++ b/crates/onsager/src/sessions.rs
@@ -115,6 +115,8 @@ pub struct SessionRequest {
     /// Written with the child's pid (== its pgid) after spawn so the
     /// abort endpoint can kill the whole process tree (M3 #625).
     pub pgid_slot: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
+    /// Sink for normalized `agent.*` session events (#632).
+    pub pool: PgPool,
 }
 
 pub struct SessionOutcome {
@@ -205,6 +207,8 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
         .ok_or_else(|| SessionError("child produced no stdout pipe".into()))?;
     let mut lines = BufReader::new(stdout).lines();
     let mut result: Option<Result<String, String>> = None;
+    let mut normalizer = crate::agent_events::Normalizer::new();
+    let mut seq: i32 = 0;
     loop {
         let line = match lines.next_line().await {
             Ok(Some(line)) => line,
@@ -214,18 +218,36 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
                 return Err(SessionError(format!("reading agent stdout: {e}")));
             }
         };
-        match serde_json::from_str::<ClaudeEvent>(&line) {
-            Ok(ClaudeEvent::Result {
-                subtype,
-                result: text,
-                error,
-            }) => {
-                result = Some(match subtype.as_str() {
-                    "success" => Ok(text.unwrap_or_default()),
-                    _ => Err(error.unwrap_or_else(|| format!("claude exited: {subtype}"))),
-                });
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        // Normalize + persist the session feed (#632). A failed insert
+        // is logged, never fatal — the feed must not fail the work.
+        for event in normalizer.handle(&value) {
+            seq += 1;
+            let inserted = sqlx::query(
+                "INSERT INTO session_events (session_id, seq, kind, payload)                  VALUES ($1, $2, $3, $4)",
+            )
+            .bind(&req.session_id)
+            .bind(seq)
+            .bind(event.kind)
+            .bind(&event.payload)
+            .execute(&req.pool)
+            .await;
+            if let Err(e) = inserted {
+                tracing::warn!(session_id = %req.session_id, "session event insert failed: {e}");
             }
-            Ok(ClaudeEvent::Other) | Err(_) => {}
+        }
+        if let Ok(ClaudeEvent::Result {
+            subtype,
+            result: text,
+            error,
+        }) = serde_json::from_value::<ClaudeEvent>(value)
+        {
+            result = Some(match subtype.as_str() {
+                "success" => Ok(text.unwrap_or_default()),
+                _ => Err(error.unwrap_or_else(|| format!("claude exited: {subtype}"))),
+            });
         }
     }
     let _ = child.wait().await;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router-dom:
         specifier: ^7.13.2
         version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -784,14 +787,29 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -806,6 +824,12 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -868,6 +892,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -977,6 +1004,9 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1035,6 +1065,9 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1046,6 +1079,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1079,6 +1124,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1169,6 +1217,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -1207,6 +1258,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -1345,6 +1399,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1385,6 +1442,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1543,6 +1603,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -1559,6 +1625,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1603,6 +1672,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -1611,8 +1683,17 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1630,6 +1711,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -1849,6 +1933,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -1872,6 +1959,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -1889,6 +2000,69 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2036,6 +2210,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -2118,6 +2295,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2149,6 +2329,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-router-dom@7.14.1:
     resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
     engines: {node: '>=20.0.0'}
@@ -2177,6 +2363,12 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2302,6 +2494,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2326,6 +2521,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -2358,6 +2556,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2421,6 +2625,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2475,6 +2685,24 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2510,6 +2738,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -2708,6 +2942,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3394,11 +3631,29 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.2':
     dependencies:
@@ -3413,6 +3668,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/statuses@2.0.6': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -3506,6 +3765,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.9.0))':
     dependencies:
@@ -3609,6 +3870,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -3674,6 +3937,8 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -3682,6 +3947,14 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3710,6 +3983,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
@@ -3777,6 +4052,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   dedent@1.7.2: {}
 
   deep-is@0.1.4: {}
@@ -3797,6 +4076,10 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff@8.0.4: {}
 
@@ -3943,6 +4226,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4023,6 +4308,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4168,6 +4455,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
@@ -4183,6 +4494,8 @@ snapshots:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4222,11 +4535,22 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -4237,6 +4561,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -4409,6 +4735,8 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -4427,6 +4755,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
@@ -4436,6 +4853,139 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -4591,6 +5141,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4658,6 +5218,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.2.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4687,6 +5249,24 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -4715,6 +5295,23 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -4900,6 +5497,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -4921,6 +5520,11 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   stringify-object@5.0.0:
     dependencies:
@@ -4947,6 +5551,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@7.2.0:
     dependencies:
@@ -4994,6 +5606,10 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -5047,6 +5663,39 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -5072,6 +5721,16 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.8(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
@@ -5211,3 +5870,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
Closes #632. User-requested; design referenced from `../arbor` (`agent-runner/src/normalize.ts` + `web/src/components/run/ActivityFeed.tsx`).

## What

The agent session stops being a black box. Three pieces, landing together per the ratchet:

- **Capture** (`agent_events.rs`, ported from arbor's normalizer): the session runner parses each stream-json line and persists typed rows — `agent.started` (model), `agent.text` (≤2000 chars), `agent.tool_use` (tool + input excerpt ≤700), `agent.tool_result` (paired by `tool_use_id`; **orphans kept, never dropped**), `agent.completed` (turns/cost/duration), `agent.warning` (error subtypes, permission denials, model fallback, unknown types once-per-type). All CLI-format churn is isolated in this one module. Inserts are non-fatal — the feed can't fail the work.
- **Storage + API**: migration 004 `session_events` (session_id, seq, kind, payload); `GET /api/sessions/:id/events` (workspace-gated); the run response lists its sessions.
- **UI** (`SessionFeed.tsx`, arbor's ActivityFeed adapted to polling): one chronological feed per session on the run page — prose as markdown (react-markdown returns with this consumer), tool_use/result pairs folded into collapsible cards with running/done/error state, warnings as callouts, lifecycle rows with model and turns · seconds · cost. Polls at 2s while the session runs.

Also fixes CLAUDE.md's stale claim that `session_logs` existed in migration 002 (it never landed — the ratchet held).

## Proof

- 6 normalizer unit tests against claude-2.1.x-shaped fixture lines (ordering, tool pairing, orphan results, error-result warnings, once-per-type unknowns, text capping).
- **Live e2e** (real claude-fable-5 session, screenshots on #632's thread): the feed renders the agent's prose, a `Bash` card with command + output, a `Write` card with content + result, the `emit_artifact` MCP call with its returned artifact id, and a genuine rate-limit warning callout — live with a typing cursor, then completed.
- cargo fmt/clippy(-D warnings)/test green (18 onsager tests); dashboard tsc/eslint/vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)