### PR TITLE
feat(onsager): live session streaming (SSE + text deltas) + rate-limit warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2133,6 +2134,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "macros",
 ] }
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/dashboard/src/components/runs/SessionFeed.tsx
+++ b/apps/dashboard/src/components/runs/SessionFeed.tsx
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import Markdown from 'react-markdown'
 import { AlertTriangle, ChevronRight, Wrench } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
@@ -13,14 +14,60 @@ import { sessionsApi, type SessionEvent } from '@/lib/api'
  * lifecycle events are quiet rows. Polls while the session runs.
  */
 export function SessionFeed({ sessionId, status }: { sessionId: string; status: string }) {
+  const qc = useQueryClient()
+  // Pending token-streamed prose (#634): accumulates from SSE deltas,
+  // cleared when its durable agent.text row arrives.
+  const [pending, setPending] = useState('')
+  const [sseDown, setSseDown] = useState(false)
+  const pendingRef = useRef('')
+
   const { data } = useQuery({
     queryKey: ['session-events', sessionId],
     queryFn: () => sessionsApi.events(sessionId),
-    refetchInterval: (q) => (q.state.data?.status === 'running' ? 2000 : false),
+    // SSE drives live updates; polling is the fallback (and the slow
+    // reconciliation pass while streaming works).
+    refetchInterval: (q) =>
+      q.state.data?.status === 'running' ? (sseDown ? 2000 : 5000) : false,
   })
   const events = data?.events ?? []
   const live = (data?.status ?? status) === 'running'
   const items = foldToolPairs(events)
+
+  useEffect(() => {
+    if (!live) return
+    const source = new EventSource(`/api/sessions/${sessionId}/events/stream`)
+    source.onmessage = (msg) => {
+      let parsed: { kind?: string; payload?: { text?: string } }
+      try {
+        parsed = JSON.parse(msg.data)
+      } catch {
+        return
+      }
+      if (parsed.kind === 'agent.text_delta') {
+        pendingRef.current += parsed.payload?.text ?? ''
+        setPending(pendingRef.current)
+      } else {
+        // A durable event landed: the full message supersedes the
+        // accumulating draft; pull the persisted rows.
+        if (parsed.kind === 'agent.text') {
+          pendingRef.current = ''
+          setPending('')
+        }
+        qc.invalidateQueries({ queryKey: ['session-events', sessionId] })
+        if (parsed.kind === 'agent.completed') {
+          qc.invalidateQueries({ queryKey: ['run'] })
+        }
+      }
+    }
+    source.onerror = () => {
+      // Stream closed: either the session ended (normal) or SSE is
+      // unavailable — polling covers both.
+      setSseDown(true)
+      source.close()
+      qc.invalidateQueries({ queryKey: ['session-events', sessionId] })
+    }
+    return () => source.close()
+  }, [live, sessionId, qc])
 
   return (
     <Card>
@@ -40,6 +87,11 @@ export function SessionFeed({ sessionId, status }: { sessionId: string; status: 
           </p>
         )}
         {items.map((item) => renderItem(item))}
+        {live && pending && (
+          <div className="prose prose-sm max-w-none text-sm leading-relaxed dark:prose-invert">
+            <Markdown>{pending}</Markdown>
+          </div>
+        )}
         {live && (
           <span aria-hidden className="ml-1 inline-block animate-pulse text-primary">
             ▍

--- a/crates/onsager/Cargo.toml
+++ b/crates/onsager/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/onsager/src/agent_events.rs
+++ b/crates/onsager/src/agent_events.rs
@@ -16,8 +16,11 @@
 //!   + warnings for error subtypes and permission denials
 //! - `system/model_fallback`  → `agent.warning`
 //! - unknown top-level types  → `agent.warning`, once per distinct type
-//! - `stream_event` partials and thinking blocks → ignored (progress noise;
-//!   token deltas return if/when live streaming lands)
+//! - `rate_limit_event`        → `agent.warning` when degraded or using
+//!   overage; healthy `allowed` is silent
+//! - `stream_event` text deltas → transient drafts via [`text_delta`]
+//!   (never persisted; the SSE live feed forwards them, #634); other
+//!   partials and thinking blocks are ignored progress noise
 //!
 //! Not ported from arbor: the out-of-workspace path watcher (v2 has no
 //! per-run workspace root yet) and transient text deltas (polling UI).
@@ -100,9 +103,29 @@ impl Normalizer {
             Some("assistant") => self.handle_assistant(event),
             Some("user") => self.handle_user(event),
             Some("result") => Self::handle_result(event),
-            // Partial messages / token deltas: progress noise for the
-            // polling UI; ignored, not warned.
+            // Partial messages: token deltas flow to the transient
+            // delta path (`text_delta`, #634); other stream_event
+            // subtypes are progress noise — ignored, not warned.
             Some("stream_event") => vec![],
+            Some("rate_limit_event") => {
+                // "allowed" arrives on every healthy run — only
+                // degradations warrant a warning (arbor parity, #634).
+                let info = event.get("rate_limit_info");
+                let status = info.and_then(|i| i.get("status")).and_then(Value::as_str);
+                if let Some(status) = status
+                    && status != "allowed"
+                {
+                    let kind = info
+                        .and_then(|i| i.get("rateLimitType"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    return vec![Self::warning(&format!("rate limit {status} ({kind})"))];
+                }
+                if info.and_then(|i| i.get("isUsingOverage")) == Some(&json!(true)) {
+                    return vec![Self::warning("rate limit: consuming overage")];
+                }
+                vec![]
+            }
             Some(other) => {
                 if self.warned_unknown.insert(other.to_string()) {
                     vec![Self::warning(&format!(
@@ -256,6 +279,25 @@ impl Normalizer {
     }
 }
 
+/// Extract the text from a `stream_event` token delta, if this event is
+/// one (#634). Transient: forwarded to live SSE subscribers, never
+/// persisted — the durable `agent.text` row arrives with the full
+/// message.
+pub fn text_delta(event: &Value) -> Option<&str> {
+    if s(event, "type") != Some("stream_event") {
+        return None;
+    }
+    let inner = event.get("event")?;
+    if s(inner, "type") != Some("content_block_delta") {
+        return None;
+    }
+    let delta = inner.get("delta")?;
+    if s(delta, "type") != Some("text_delta") {
+        return None;
+    }
+    s(delta, "text").filter(|t| !t.is_empty())
+}
+
 /// `tool_result.content` is either a string or an array of typed blocks.
 fn tool_result_text(content: Option<&Value>) -> String {
     match content {
@@ -369,6 +411,50 @@ mod tests {
             events[0].payload["text"].as_str().unwrap().chars().count(),
             MAX_TEXT_CHARS
         );
+    }
+
+    #[test]
+    fn rate_limit_allowed_is_silent_degraded_warns() {
+        let mut n = Normalizer::new();
+        assert!(
+            n.handle(&json!({"type":"rate_limit_event",
+                "rate_limit_info":{"status":"allowed"}}))
+                .is_empty()
+        );
+        let warned = n.handle(&json!({"type":"rate_limit_event",
+            "rate_limit_info":{"status":"rejected","rateLimitType":"five_hour"}}));
+        assert_eq!(warned[0].kind, "agent.warning");
+        assert_eq!(
+            warned[0].payload["message"],
+            "rate limit rejected (five_hour)"
+        );
+        let overage = n.handle(&json!({"type":"rate_limit_event",
+            "rate_limit_info":{"status":"allowed","isUsingOverage":true}}));
+        assert_eq!(
+            overage[0].payload["message"],
+            "rate limit: consuming overage"
+        );
+        // and it no longer trips the unknown-type warning
+        assert!(
+            n.handle(&json!({"type":"rate_limit_event",
+                "rate_limit_info":{"status":"allowed"}}))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn text_delta_extracts_only_token_deltas() {
+        assert_eq!(
+            text_delta(&json!({"type":"stream_event","event":{
+                "type":"content_block_delta","delta":{"type":"text_delta","text":"hel"}}})),
+            Some("hel")
+        );
+        assert_eq!(
+            text_delta(&json!({"type":"stream_event","event":{
+                "type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{"}}})),
+            None
+        );
+        assert_eq!(text_delta(&json!({"type":"assistant"})), None);
     }
 
     #[test]

--- a/crates/onsager/src/http/mod.rs
+++ b/crates/onsager/src/http/mod.rs
@@ -44,6 +44,10 @@ pub fn router(state: AppState) -> Router {
         .route("/api/runs/{id}", get(workflows::get_run))
         .route("/api/runs/{id}/abort", post(operate::abort_run))
         .route("/api/sessions/{id}/events", get(operate::session_events))
+        .route(
+            "/api/sessions/{id}/events/stream",
+            get(operate::session_events_stream),
+        )
         .route("/api/activity", get(operate::activity))
         .route("/api/artifacts", get(workflows::list_artifacts))
         .route("/api/artifacts/{id}", get(workflows::get_artifact))

--- a/crates/onsager/src/http/operate.rs
+++ b/crates/onsager/src/http/operate.rs
@@ -66,6 +66,72 @@ pub async fn session_events(
     }
 }
 
+/// `GET /api/sessions/:id/events/stream` — the live feed (#634).
+/// Server-sent events: one JSON message per durable `agent.*` event
+/// plus transient `agent.text_delta` drafts. The stream ends when the
+/// session does (the scheduler drops the channel). A session that has
+/// already ended gets an immediately-closing stream — the client's
+/// initial fetch already has the durable rows.
+pub async fn session_events_stream(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<String>,
+) -> Response {
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use tokio_stream::StreamExt;
+    use tokio_stream::wrappers::BroadcastStream;
+
+    let session: Option<(String,)> =
+        match sqlx::query_as("SELECT workspace_id FROM sessions WHERE id = $1")
+            .bind(&id)
+            .fetch_optional(&state.pool)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("session lookup failed: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+    let Some((workspace_id,)) = session else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "session not found" })),
+        )
+            .into_response();
+    };
+    if let Err(r) = require_workspace_access(&state.pool, &user, &workspace_id).await {
+        return r;
+    }
+
+    let receiver = state
+        .feeds
+        .lock()
+        .expect("feeds lock")
+        .get(&id)
+        .map(|sender| sender.subscribe());
+    let live = BroadcastStream::new(match receiver {
+        Some(r) => r,
+        None => {
+            // Session already ended: empty channel whose sender drops
+            // here, closing the stream immediately.
+            let (sender, receiver) = tokio::sync::broadcast::channel(1);
+            drop(sender);
+            receiver
+        }
+    });
+    let stream = live.filter_map(|item| match item {
+        Ok(value) => Some(Ok::<Event, std::convert::Infallible>(
+            Event::default().data(value.to_string()),
+        )),
+        // Lagged subscriber: skip — the durable rows are the truth.
+        Err(_) => None,
+    });
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct ActivityRow {
     pub id: i64,

--- a/crates/onsager/src/scheduler.rs
+++ b/crates/onsager/src/scheduler.rs
@@ -167,6 +167,15 @@ async fn run_agent_stage(
     // trigger repo, minted per run, in-memory only.
     let repos = crate::github::repo_access_for(&state.pool, workflow).await;
 
+    // Live feed (#634): registered for the session's lifetime; removing
+    // it at the end drops the sender, which closes every SSE stream.
+    let (feed, _) = tokio::sync::broadcast::channel(256);
+    state
+        .feeds
+        .lock()
+        .expect("feeds lock")
+        .insert(session_id.clone(), feed.clone());
+
     let outcome = run_agent_session(SessionRequest {
         session_id: session_id.clone(),
         token,
@@ -178,8 +187,10 @@ async fn run_agent_stage(
         repos,
         pgid_slot: pgid_slot.clone(),
         pool: state.pool.clone(),
+        feed,
     })
     .await;
+    state.feeds.lock().expect("feeds lock").remove(&session_id);
 
     match outcome {
         Ok(out) => {

--- a/crates/onsager/src/sessions.rs
+++ b/crates/onsager/src/sessions.rs
@@ -117,6 +117,10 @@ pub struct SessionRequest {
     pub pgid_slot: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
     /// Sink for normalized `agent.*` session events (#632).
     pub pool: PgPool,
+    /// Live feed for SSE subscribers (#634): durable events plus
+    /// transient text deltas. Dropped (closing all streams) when the
+    /// session ends.
+    pub feed: tokio::sync::broadcast::Sender<serde_json::Value>,
 }
 
 pub struct SessionOutcome {
@@ -151,7 +155,13 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
         .unwrap_or_else(|| "claude".to_string());
     let mut cmd = Command::new(&command);
 
-    cmd.args(["--output-format", "stream-json", "--verbose"]);
+    cmd.args([
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        // Token deltas for the live feed (#634).
+        "--include-partial-messages",
+    ]);
     // Headless: no human at the TTY.
     cmd.args(["--permission-mode", "bypassPermissions"]);
     if let Some(model) = req.model.as_deref().filter(|m| !m.is_empty()) {
@@ -221,6 +231,15 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
         };
+        // Transient token deltas (#634): straight to live subscribers,
+        // never persisted — the durable agent.text row carries the
+        // full message.
+        if let Some(delta) = crate::agent_events::text_delta(&value) {
+            let _ = req.feed.send(serde_json::json!({
+                "kind": "agent.text_delta",
+                "payload": { "text": delta },
+            }));
+        }
         // Normalize + persist the session feed (#632). A failed insert
         // is logged, never fatal — the feed must not fail the work.
         for event in normalizer.handle(&value) {
@@ -237,6 +256,11 @@ pub async fn run_agent_session(req: SessionRequest) -> Result<SessionOutcome, Se
             if let Err(e) = inserted {
                 tracing::warn!(session_id = %req.session_id, "session event insert failed: {e}");
             }
+            let _ = req.feed.send(serde_json::json!({
+                "kind": event.kind,
+                "payload": event.payload,
+                "seq": seq,
+            }));
         }
         if let Ok(ClaudeEvent::Result {
             subtype,

--- a/crates/onsager/src/state.rs
+++ b/crates/onsager/src/state.rs
@@ -26,6 +26,11 @@ pub struct AppState {
     /// deregisters on finish; the abort endpoint aborts the task and
     /// kills the session's process group.
     pub running: Arc<Mutex<HashMap<String, RunHandle>>>,
+    /// Live session feeds (#634): one broadcast channel per running
+    /// session, carrying durable `agent.*` events and transient
+    /// `agent.text_delta` drafts to SSE subscribers. In-process only —
+    /// one process is the whole factory (ADR 0029), so no pg_notify.
+    pub feeds: Arc<Mutex<HashMap<String, tokio::sync::broadcast::Sender<serde_json::Value>>>>,
 }
 
 impl AppState {
@@ -34,6 +39,7 @@ impl AppState {
             pool,
             config,
             running: Arc::new(Mutex::new(HashMap::new())),
+            feeds: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }


### PR DESCRIPTION
Closes #634 — both follow-ups from the session feed (#633), arbor parity.

## What

1. **Dedicated `rate_limit_event` handling** (normalizer arm + 2 tests): degraded status → `agent.warning` (`rate limit <status> (<type>)`), `isUsingOverage` → warning, healthy `allowed` → silent. Replaces the generic unknown-type warning it used to trip.
2. **Live token streaming.** The runner spawns claude with `--include-partial-messages` and forwards `text_delta`s (transient, never persisted) plus durable `agent.*` events over a **per-session in-process broadcast channel** — one process is the whole factory (ADR 0029), so this narrows rather than reverses the M3 "no pg_notify" amendment. Exposed as `GET /api/sessions/:id/events/stream` (axum SSE, workspace-gated, keep-alive; the channel drops when the session ends, closing every stream — an already-ended session gets an immediately-closing stream). `SessionFeed` renders the accumulating draft with the typing cursor, clears it when the durable `agent.text` row lands, slows its poll to 5s while SSE is healthy, and falls back to 2s polling on EventSource error.

## Proof

- Unit: rate-limit arms (allowed silent / rejected warns / overage warns, and no more unknown-type trip) + `text_delta` extraction (token deltas only). 21 onsager tests total.
- **Live e2e** (screenshots on #634): the agent's prose captured mid-stream growing token-by-token with the cursor — before anything was emitted — then the settled feed identical to the polled result.
- cargo fmt/clippy(-D warnings)/test green; dashboard tsc/eslint/vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)