### PR TITLE
fix(dashboard): decode inline artifact content as UTF-8

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -168,11 +168,18 @@ export const artifactsApi = {
   get: (id: string) => request<{ artifact: Artifact }>(`/artifacts/${id}`),
 }
 
-/** Decode an `inline:base64,...` content URI to text; null otherwise. */
+/**
+ * Decode an `inline:base64,...` content URI to text; null otherwise.
+ * `atob` alone yields latin-1 and mangles multi-byte UTF-8 (em-dashes
+ * became `â`), so the bytes go through TextDecoder.
+ */
 export function decodeInlineContent(uri: string | null): string | null {
   if (!uri?.startsWith('inline:base64,')) return null
   try {
-    return atob(uri.slice('inline:base64,'.length))
+    const bytes = Uint8Array.from(atob(uri.slice('inline:base64,'.length)), (c) =>
+      c.charCodeAt(0),
+    )
+    return new TextDecoder().decode(bytes)
   } catch {
     return null
   }

--- a/apps/dashboard/tests/smoke/shell.test.tsx
+++ b/apps/dashboard/tests/smoke/shell.test.tsx
@@ -62,3 +62,19 @@ describe("v2 shell (M0 #622)", () => {
     )
   })
 })
+
+import { decodeInlineContent } from "@/lib/api"
+
+describe("decodeInlineContent (utf-8)", () => {
+  it("decodes multi-byte utf-8 correctly", () => {
+    // "gears — steel" with an em-dash; btoa can't encode it directly,
+    // so build the base64 from utf-8 bytes the way the server does.
+    const utf8 = new TextEncoder().encode("gears — steel")
+    const b64 = btoa(String.fromCharCode(...utf8))
+    expect(decodeInlineContent(`inline:base64,${b64}`)).toBe("gears — steel")
+  })
+  it("rejects non-inline uris", () => {
+    expect(decodeInlineContent("https://x")).toBeNull()
+    expect(decodeInlineContent(null)).toBeNull()
+  })
+})


### PR DESCRIPTION
`decodeInlineContent` used bare `atob`, which decodes base64 to a latin-1 string — multi-byte UTF-8 got mangled (an agent's em-dash rendered as `â` on the artifact detail page; caught reviewing screenshots). The bytes now go through `TextDecoder`. Regression test included (em-dash round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)