### PR TITLE
fix(onsager): env-gated one-shot schema reset to deploy v2 over a legacy DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@
 
 # Vite binds all interfaces for remote-dev boxes.
 # VITE_HOST=0.0.0.0
+
+# One-shot destructive schema reset (#637): set to "true" to DROP and
+# recreate the public schema at boot before migrating. Use to bring v2
+# up over a database that still carries an older schema; REMOVE after
+# the deploy. Off by default.
+# ONSAGER_RESET_SCHEMA=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ just dev                 # Postgres + the onsager process + Vite
 
 Then dev-login in the dashboard and add `CLAUDE_CODE_OAUTH_TOKEN` under Credentials — agent sessions read workspace credentials as env vars. The server applies migrations at boot.
 
-Useful env: `ONSAGER_BIND` (default `127.0.0.1:3002`), `ONSAGER_CLAUDE_BIN` (shim the agent CLI in tests), `ONSAGER_MCP_URL` (defaults to the bind address), `GITHUB_APP_ID/SLUG/PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_CLIENT_ID/SECRET`.
+Useful env: `ONSAGER_BIND` (default `127.0.0.1:3002`), `ONSAGER_CLAUDE_BIN` (shim the agent CLI in tests), `ONSAGER_MCP_URL` (defaults to the bind address), `GITHUB_APP_ID/SLUG/PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_CLIENT_ID/SECRET`, `ONSAGER_RESET_SCHEMA` (one-shot: drop+recreate the public schema at boot before migrating — #637; remove after use).
 
 ### Parallel dev environments (per-worktree)
 

--- a/crates/onsager/src/db.rs
+++ b/crates/onsager/src/db.rs
@@ -38,7 +38,41 @@ pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
         .await?)
 }
 
+/// One-shot, opt-in destructive schema reset (#637). When
+/// `ONSAGER_RESET_SCHEMA=true`, drop and recreate the `public` schema
+/// before migrating. The 0.5 reset (ADR 0029) ships a fresh schema with
+/// no v1→v2 migration, so a database that still carries the v1 schema
+/// (e.g. the persistent production DB) makes migration 001 collide
+/// (`relation "users" already exists`). This is the operator's escape
+/// hatch: set the flag once, deploy (drops → migrates → boots clean),
+/// then remove the flag. Off by default; loud when it fires.
+///
+/// Pre-launch affordance — also resets preview/staging DBs. Tightening
+/// or removing it is part of the launch posture flip.
+pub async fn reset_schema_if_requested(pool: &PgPool) -> anyhow::Result<()> {
+    if std::env::var("ONSAGER_RESET_SCHEMA").as_deref() != Ok("true") {
+        return Ok(());
+    }
+    tracing::warn!(
+        "ONSAGER_RESET_SCHEMA=true — DROPPING and recreating the public \
+         schema before migrating. All existing data is destroyed. Remove \
+         the flag after this deploy."
+    );
+    sqlx::raw_sql(
+        "DROP SCHEMA public CASCADE; \
+         CREATE SCHEMA public; \
+         GRANT ALL ON SCHEMA public TO CURRENT_USER; \
+         GRANT ALL ON SCHEMA public TO public;",
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| anyhow::anyhow!("schema reset failed: {e}"))?;
+    tracing::warn!("public schema reset complete");
+    Ok(())
+}
+
 pub async fn migrate(pool: &PgPool) -> anyhow::Result<()> {
+    reset_schema_if_requested(pool).await?;
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS schema_migrations (
              filename   TEXT PRIMARY KEY,


### PR DESCRIPTION
Closes #637.

## Why
Production has failed to deploy on every commit since the 0.5 reset (M0) — at **boot**, not build: the persistent production DB still carries the v1 schema, and v2 migration 001 (`CREATE TABLE users`, no IF NOT EXISTS by design) collides → `relation "users" already exists` → the binary exits → healthcheck fails. Previews pass (fresh forked Postgres each); production has the persistent one. app.onsager.ai stayed up on the **last successful = pre-reset 0.4** build. The DB can't be reset externally (this environment reaches the Railway proxy's TCP connect but not a sustained psql session), so the reset runs inside Railway.

## What
`ONSAGER_RESET_SCHEMA=true` → `db::migrate` runs `DROP SCHEMA public CASCADE; CREATE SCHEMA public` (re-granted) before migrating, warn-logged. Off by default. Pre-launch operational tool (also resets preview/staging). Procedure: set the var on production → redeploy (drops → migrates → boots clean) → **remove the var**.

## Proof
Booted the build against the dev `onsager` DB — a faithful mirror with the **same v1 schema production has** (46 tables incl. `governance_events`). Logs: `DROPPING…` → `public schema reset complete` → all four v2 migrations applied → `listening`. The DB is now the clean 13-table v2 schema. cargo fmt/clippy(-D warnings)/test green.

## Note
A flag-gated DROP SCHEMA is a pre-launch affordance; tightening/removing it belongs to the launch posture flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)