### PR TITLE
Fleet M4: machine registry persistence + Machines dashboard (ADR 0030)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,14 @@ One binary (`onsager`) serves everything:
 - **HTTP edge** — dashboard API, auth (dev-login + GitHub OAuth), credentials CRUD, the GitHub App webhook, and the agent-facing MCP endpoint (`POST /mcp/messages`).
 - **Scheduler** — in-process: a fire is a function call that inserts a `runs` row and spawns a supervised tokio task which iterates the workflow's stage list. Abort = abort the task + SIGKILL the session's process group.
 - **Agent sessions** — one spawn path (`sessions.rs`): the `claude` CLI with `--mcp-config` pointing back at the control plane. Sessions deliver via the MCP `emit_artifact` tool (writes an `artifacts` row) or `declare_no_output`; a session that does neither fails its run (liveness, plain).
-- **Fleet** (`fleet.rs`, ADR 0030) — agent sessions run either in-process or on a **worker machine** that dials in over a WebSocket (`/api/fleet/connect`, machine-token, fail closed) and subscribes to work. `scheduler::fire` → `dispatch()`: a connected machine runs the `claude` CLI and forwards `session_events` back for the control plane to persist; with none connected, sessions run in-process (unchanged). Workers (`onsager worker`) hold no database, heartbeat, and reconnect with backoff; a control-plane lease reaper + boot-time reclaim fail sessions of a silent/crashed machine (at-most-once, never re-queue). M1–M3 landed; the dashboard fleet view (M4) is pending.
+- **Fleet** (`fleet.rs`, ADR 0030) — agent sessions run either in-process or on a **worker machine** that dials in over a WebSocket (`/api/fleet/connect`, machine-token, fail closed) and subscribes to work. `scheduler::fire` → `dispatch()`: a connected machine runs the `claude` CLI and forwards `session_events` back for the control plane to persist; with none connected, sessions run in-process (unchanged). Workers (`onsager worker`) hold no database, heartbeat, and reconnect with backoff; a control-plane lease reaper + boot-time reclaim fail sessions of a silent/crashed machine (at-most-once, never re-queue). The `machines` table + `GET /api/fleet/machines` back a **Machines** operator page (alongside Activity/Credentials — not a product noun). M1–M4 landed; the ladder is complete.
 - **Static dashboard** — in production the same process serves the built Vite app (`ONSAGER_STATIC_DIR`); one container, no edge dispatcher.
 
 In dev, the dashboard is Vite with an `/api` + `/mcp` proxy.
 
-### Schema (11 tables, fresh migrations, `schema_migrations` ledger)
+### Schema (12 tables, fresh migrations, `schema_migrations` ledger)
 
-`users`, `auth_sessions`, `workspaces`, `workspace_members`, `credentials` (001) · `workflows`, `runs`, `sessions`, `artifacts`, `events` (002) · `github_app_installations` (003) · `session_events` (004 — the normalized agent feed, #632). Migrations are immutable after merge; fixes are new migrations.
+`users`, `auth_sessions`, `workspaces`, `workspace_members`, `credentials` (001) · `workflows`, `runs`, `sessions`, `artifacts`, `events` (002) · `github_app_installations` (003) · `session_events` (004 — the normalized agent feed, #632) · `machines` (005 — the fleet registry, ADR 0030 M4). Migrations are immutable after merge; fixes are new migrations.
 
 Key shapes:
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { RunDetailPage } from '@/pages/RunDetailPage'
 import { ArtifactDetailPage, ArtifactsPage } from '@/pages/ArtifactsPage'
 import { ActivityPage } from '@/pages/ActivityPage'
 import { CredentialsPage } from '@/pages/CredentialsPage'
+import { MachinesPage } from '@/pages/MachinesPage'
 
 const queryClient = new QueryClient()
 
@@ -47,6 +48,7 @@ export default function App() {
                         <Route path="/artifacts" element={<ArtifactsPage />} />
                         <Route path="/artifacts/:id" element={<ArtifactDetailPage />} />
                         <Route path="/activity" element={<ActivityPage />} />
+                        <Route path="/machines" element={<MachinesPage />} />
                         <Route path="/credentials" element={<CredentialsPage />} />
                       </Routes>
                     </Shell>

--- a/apps/dashboard/src/components/layout/Shell.tsx
+++ b/apps/dashboard/src/components/layout/Shell.tsx
@@ -9,6 +9,7 @@ const NAV = [
   { to: '/workflows', label: 'Workflows' },
   { to: '/artifacts', label: 'Artifacts' },
   { to: '/activity', label: 'Activity' },
+  { to: '/machines', label: 'Machines' },
   { to: '/credentials', label: 'Credentials' },
 ]
 

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -220,3 +220,17 @@ export const sessionsApi = {
   events: (sessionId: string) =>
     request<{ status: string; events: SessionEvent[] }>(`/sessions/${sessionId}/events`),
 }
+
+// ── Fleet (ADR 0030 M4) ──
+
+export interface Machine {
+  name: string
+  status: string
+  connected_at: string | null
+  last_seen_at: string
+  in_flight: number
+}
+
+export const fleetApi = {
+  listMachines: () => request<{ machines: Machine[] }>('/fleet/machines'),
+}

--- a/apps/dashboard/src/pages/MachinesPage.tsx
+++ b/apps/dashboard/src/pages/MachinesPage.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'
+import { Badge } from '@/components/ui/badge'
+import { fleetApi } from '@/lib/api'
+
+/** The fleet view (ADR 0030 M4): worker machines + live in-flight work.
+ *  Operator surface — not workspace-scoped (machines are infra). */
+export function MachinesPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['fleet-machines'],
+    queryFn: () => fleetApi.listMachines(),
+    refetchInterval: 3000,
+  })
+  return (
+    <>
+      <h1 className="text-xl font-bold tracking-tight">Machines</h1>
+      <p className="text-sm text-muted-foreground">
+        Worker machines that dial in to run agent sessions (ADR 0030). With none
+        connected, sessions run in the control plane itself.
+      </p>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading...</p>}
+      <div className="space-y-1">
+        {data?.machines.map((m) => (
+          <div
+            key={m.name}
+            className="flex items-baseline gap-3 rounded-md px-2 py-1.5 text-sm hover:bg-muted/40"
+          >
+            <Badge variant={m.status === 'online' ? 'default' : 'outline'}>{m.status}</Badge>
+            <span className="font-medium">{m.name}</span>
+            <span className="text-xs text-muted-foreground">
+              {m.in_flight} in flight
+            </span>
+            <span className="ml-auto text-xs text-muted-foreground">
+              last seen {new Date(m.last_seen_at).toLocaleString()}
+            </span>
+          </div>
+        ))}
+      </div>
+      {data && data.machines.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No machines have connected. Run one with{' '}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">onsager worker</code>.
+        </p>
+      )}
+    </>
+  )
+}

--- a/crates/onsager/migrations/005_machines.sql
+++ b/crates/onsager/migrations/005_machines.sql
@@ -1,0 +1,13 @@
+-- v2 schema, migration 005 — fleet machine registry (ADR 0030 M4).
+--
+-- Durable record of worker machines that have dialed in: a connection
+-- upserts the row online, a disconnect/lease-expiry marks it offline.
+-- Consumed by `GET /api/fleet/machines` and the dashboard Machines
+-- (operator) surface — landing together, per the ratchet.
+
+CREATE TABLE machines (
+    name         TEXT PRIMARY KEY,
+    status       TEXT NOT NULL DEFAULT 'offline',
+    connected_at TIMESTAMPTZ,
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/onsager/src/fleet.rs
+++ b/crates/onsager/src/fleet.rs
@@ -12,16 +12,21 @@
 //! the session in-process — the degenerate "local machine = default
 //! machine" case, byte-compatible with ADR 0029.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use axum::Json;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use tokio::sync::{mpsc, oneshot};
 
+use crate::auth::AuthUser;
 use crate::sessions::{
     ClonableRepo, SessionError, SessionOutcome, SessionRequest, SessionSink, run_agent_session,
 };
@@ -163,6 +168,7 @@ async fn handle_machine(socket: WebSocket, state: AppState, name: String) {
             last_seen: last_seen.clone(),
         },
     );
+    mark_machine_online(&state.pool, &name).await;
     tracing::info!(machine = %name, "machine connected");
 
     // Outgoing pump: serialize control frames to the socket.
@@ -255,14 +261,15 @@ async fn handle_machine(socket: WebSocket, state: AppState, name: String) {
     // Teardown: deregister and fail anything still in flight on this
     // machine so its run resolves instead of hanging forever.
     writer.abort();
-    fail_machine(&state, &name, "disconnected mid-session");
+    fail_machine(&state, &name, "disconnected mid-session").await;
     tracing::info!(machine = %name, "machine disconnected");
 }
 
-/// Deregister a machine and fail its in-flight sessions at-most-once
-/// (ADR 0030 D4 — sessions aren't idempotent, so we never re-queue).
-/// Used by clean disconnect and by the lease reaper.
-fn fail_machine(state: &AppState, name: &str, why: &str) {
+/// Deregister a machine, mark it offline in the registry table, and fail
+/// its in-flight sessions at-most-once (ADR 0030 D4 — sessions aren't
+/// idempotent, so we never re-queue). Used by clean disconnect and the
+/// lease reaper.
+async fn fail_machine(state: &AppState, name: &str, why: &str) {
     state.machines.lock().expect("machines lock").remove(name);
     let orphaned: Vec<String> = {
         let mut rs = state.remote_sessions.lock().expect("remote_sessions lock");
@@ -280,6 +287,35 @@ fn fail_machine(state: &AppState, name: &str, why: &str) {
         if let Some(done) = state.pending.lock().expect("pending lock").remove(&id) {
             let _ = done.send(Err(format!("machine {name} {why}")));
         }
+    }
+    mark_machine_offline(&state.pool, name).await;
+}
+
+/// Upsert a machine as online in the registry table (ADR 0030 M4).
+async fn mark_machine_online(pool: &PgPool, name: &str) {
+    let r = sqlx::query(
+        "INSERT INTO machines (name, status, connected_at, last_seen_at) \
+         VALUES ($1, 'online', NOW(), NOW()) \
+         ON CONFLICT (name) DO UPDATE \
+           SET status = 'online', connected_at = NOW(), last_seen_at = NOW()",
+    )
+    .bind(name)
+    .execute(pool)
+    .await;
+    if let Err(e) = r {
+        tracing::warn!(machine = name, "machine online upsert failed: {e}");
+    }
+}
+
+/// Mark a machine offline in the registry table (ADR 0030 M4).
+async fn mark_machine_offline(pool: &PgPool, name: &str) {
+    let r =
+        sqlx::query("UPDATE machines SET status = 'offline', last_seen_at = NOW() WHERE name = $1")
+            .bind(name)
+            .execute(pool)
+            .await;
+    if let Err(e) = r {
+        tracing::warn!(machine = name, "machine offline update failed: {e}");
     }
 }
 
@@ -313,7 +349,7 @@ pub async fn reap_stale_machines(state: AppState) {
             .collect();
         for name in stale {
             tracing::warn!(machine = %name, "lease expired (no heartbeat) — failing sessions");
-            fail_machine(&state, &name, "lease expired (no heartbeat)");
+            fail_machine(&state, &name, "lease expired (no heartbeat)").await;
         }
     }
 }
@@ -423,6 +459,48 @@ pub fn abort_remote_session(state: &AppState, session_id: &str) {
             session_id: session_id.to_string(),
         });
     }
+}
+
+/// One machine in the fleet view (ADR 0030 M4): the durable registry row
+/// plus the live in-flight session count from the in-memory registry.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct MachineRow {
+    pub name: String,
+    pub status: String,
+    pub connected_at: Option<DateTime<Utc>>,
+    pub last_seen_at: DateTime<Utc>,
+    #[sqlx(default)]
+    pub in_flight: i64,
+}
+
+/// `GET /api/fleet/machines` — the operator fleet view. Any authenticated
+/// user (machines are infra, not workspace-scoped).
+pub async fn list_machines(State(state): State<AppState>, _user: AuthUser) -> Response {
+    let rows: Result<Vec<MachineRow>, _> = sqlx::query_as(
+        "SELECT name, status, connected_at, last_seen_at FROM machines ORDER BY name",
+    )
+    .fetch_all(&state.pool)
+    .await;
+    let mut rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("list machines failed: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    // Overlay live in-flight session counts (in-memory; not persisted).
+    let counts: HashMap<String, i64> = {
+        let rs = state.remote_sessions.lock().expect("remote_sessions lock");
+        let mut m: HashMap<String, i64> = HashMap::new();
+        for machine in rs.values() {
+            *m.entry(machine.clone()).or_insert(0) += 1;
+        }
+        m
+    };
+    for row in &mut rows {
+        row.in_flight = counts.get(&row.name).copied().unwrap_or(0);
+    }
+    Json(serde_json::json!({ "machines": rows })).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/onsager/src/http/mod.rs
+++ b/crates/onsager/src/http/mod.rs
@@ -56,6 +56,8 @@ pub fn router(state: AppState) -> Router {
         // Fleet: a machine dials in to subscribe to work (ADR 0030,
         // machine-token auth, fail closed).
         .route("/api/fleet/connect", get(crate::fleet::connect))
+        // Fleet view: the operator machine list (ADR 0030 M4).
+        .route("/api/fleet/machines", get(crate::fleet::list_machines))
         // GitHub: the App's webhook + OAuth login (M2 #624).
         .route("/api/webhooks/github", post(crate::github::receive))
         .route("/api/auth/github", get(oauth::start))

--- a/docs/adr/0030-scaling-sessions-across-machines.md
+++ b/docs/adr/0030-scaling-sessions-across-machines.md
@@ -141,8 +141,14 @@ silent.
   left `running`). A disconnect/crash **fails** the run (never re-queue —
   sessions aren't idempotent, D4). Registry stays in-memory; durable
   machine-registry persistence folds into M4.
-- **M4 — dashboard fleet view.** A "Machines" surface (new nav noun → its own
-  ADR note, the 4-noun vocab is identity) + machine registry persistence.
+- **M4 — dashboard fleet view.** *(Done.)* A `machines` table (migration 005;
+  the 12th table) upserted online on connect / offline on disconnect+reap; a
+  `GET /api/fleet/machines` operator endpoint overlaying live in-flight counts;
+  a **Machines** dashboard page. **Nav-noun decision:** Machines is an
+  *operator/infrastructure* surface, sitting alongside the existing Activity
+  and Credentials operator nav items — **not** a fifth user-facing product
+  noun. The 4-noun product vocabulary (Workflow/Run/Artifact/Stage) is
+  unchanged, so M4 needs no separate identity ADR.
 
 Per-workspace credentials (D3) already satisfy the quota axis and need no
 milestone.
@@ -194,8 +200,9 @@ under stale wording.
 - [x] M1 — bounded concurrency cap on `scheduler::fire`. (#644)
 - [x] M2 — transport + dispatch + event inversion + abort routing. (#646)
 - [x] M3 — at-most-once lease + reclaim (heartbeat, reaper, reconnect, boot
-      reclaim) — this PR.
-- [ ] M4 — dashboard fleet view + machine-registry persistence.
+      reclaim). (#648)
+- [x] M4 — `machines` table + `GET /api/fleet/machines` + Machines page
+      (operator surface, not a product noun) — this PR.
 
 ## Out of scope
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,7 +40,7 @@ see [`../architecture.md`](../architecture.md).
 | [0027](0027-two-process-consolidation.md) | 0.3 consolidation: two-process factory (portal + engine) | Accepted (2026-06-11, **enforced**) — `Identity impact: yes` — supersedes ADR 0013 |
 | [0028](0028-one-workflow-model-one-run-path.md) | 0.4 simplification: one workflow model, one run path | Accepted (2026-06-11, enforced 2026-06-12) — `Identity impact: no` |
 | [0029](0029-one-process-progressive-rebuild.md) | 0.5 reset: one factory process, events as record, progressive rebuild | Accepted (2026-06-12, enforced same day) — `Identity impact: yes` |
-| [0030](0030-scaling-sessions-across-machines.md) | Scaling agent sessions across machines | Accepted (2026-06-15, building — owner override of the defer; M1–M3 landed) — `Identity impact: yes` — amends ADR 0029's one-process commitment |
+| [0030](0030-scaling-sessions-across-machines.md) | Scaling agent sessions across machines | Accepted (2026-06-15, building — owner override of the defer; M1–M4 landed) — `Identity impact: yes` — amends ADR 0029's one-process commitment |
 
 ## How to add an ADR
 


### PR DESCRIPTION
Closes #649. ADR 0030 **M4 — the final rung**: a durable fleet registry + an operator Machines view. M1–M4 now complete the ladder.

## What lands
- **Migration 005 `machines`** (the 12th table): upserted `online` on connect, `offline` on disconnect / lease expiry.
- **`GET /api/fleet/machines`** (authed): registry rows + live in-flight session counts overlaid from the in-memory map.
- **Dashboard**: a `Machines` page (status, in-flight, last-seen; polls) + nav item + `fleetApi` client.

## Nav-noun decision (identity)
Machines is an **operator/infrastructure** surface, alongside the existing Activity/Credentials nav items — **not** a 5th user-facing product noun. The 4-noun product vocab (Workflow/Run/Artifact/Stage) is unchanged, so no separate identity ADR (recorded in ADR 0030 M4).

## Tests
- Rust: fleet/state/config units pass, clippy clean.
- Dashboard: `tsc -b` + `vite build` clean, eslint clean, vitest passes.

## Verification status
Live behavior — a connected worker showing online with in-flight counts and flipping offline on disconnect — is **NOT in CI** (needs DB + worker + browser). The UI is **not visually verified**; L2 web-testing + manual e2e tracked on #649. (Same honest contract as M2/M3.)

## Ladder complete
M1 cap (#644) · M2 transport+dispatch (#646) · M3 lease+reclaim (#648) · M4 registry+view (this). Remaining for production trust: run the live e2e across the milestones (DB + `onsager worker` + CLI shim), and use `wss://` (the dial carries credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)