### PR TITLE
Fix: embed migration 005 (machines) + guard test

### DIFF
--- a/crates/onsager/src/db.rs
+++ b/crates/onsager/src/db.rs
@@ -29,6 +29,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "004_session_events.sql",
         include_str!("../migrations/004_session_events.sql"),
     ),
+    (
+        "005_machines.sql",
+        include_str!("../migrations/005_machines.sql"),
+    ),
 ];
 
 pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
@@ -104,4 +108,30 @@ pub async fn migrate(pool: &PgPool) -> anyhow::Result<()> {
         tracing::info!(migration = filename, "applied");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MIGRATIONS;
+
+    /// Every `NNN_*.sql` file under migrations/ must be wired into the
+    /// embedded `MIGRATIONS` list — otherwise the file ships but never
+    /// runs (the M4 `005_machines.sql` bug, caught by the fleet e2e, not
+    /// CI). This guard fails the build if a file is added but not embedded.
+    #[test]
+    fn every_migration_file_is_embedded() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
+        let mut files: Vec<String> = std::fs::read_dir(dir)
+            .expect("read migrations dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".sql"))
+            .collect();
+        files.sort();
+        let embedded: Vec<String> = MIGRATIONS.iter().map(|(n, _)| n.to_string()).collect();
+        assert_eq!(
+            files, embedded,
+            "migrations/ files must exactly match the embedded MIGRATIONS list"
+        );
+    }
 }


### PR DESCRIPTION
Closes #651, Part of #649. A real bug in M4 (#650) found by the **ADR 0030 live e2e**.

## Bug
`005_machines.sql` was added as a file but never wired into the embedded `MIGRATIONS` list in `db.rs` — so the `machines` table is never created, and `GET /api/fleet/machines` + the online/offline upserts fail at runtime. CI passed because no DB-backed test exercises the embedded list (the contiguity pre-commit checks files, not the list).

## Fix
- Add the `005_machines.sql` entry to `MIGRATIONS`.
- Add guard test `every_migration_file_is_embedded`: `migrations/` files must exactly match the embedded list — closes the CI blind spot so this can't recur.

## Verification (the live e2e that found it)
With the fix, I ran the full fleet e2e locally (control plane + `onsager worker` + a `claude` shim, real Postgres):
- boots, applies migrations **001–005**;
- worker dials in, `GET /api/fleet/machines` → `e2e-worker` **online** (persisted);
- fired run → **dispatched to the worker**, shim ran *on the worker*, emitted an artifact via MCP → run **completed**, 1 artifact, session events forwarded + persisted;
- kill worker → machine flips **offline**;
- fire with no worker → runs **in-process** (byte-compatible fallback).

So M1–M4 are now proven live, not just merged. Remaining unverified (acceptable): the 45s lease-reaper timeout, abort-over-socket, reconnect/backoff, and the dashboard UI render (its API is verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)