### PR TITLE
Fix: reset stale 'online' machine rows on boot (ADR 0030 M4)

### DIFF
--- a/crates/onsager/src/fleet.rs
+++ b/crates/onsager/src/fleet.rs
@@ -319,6 +319,18 @@ async fn mark_machine_offline(pool: &PgPool, name: &str) {
     }
 }
 
+/// Boot-time machine reclaim (ADR 0030 M4): a fresh control-plane process
+/// has no machines connected, so any row still `online` is stale from a
+/// dead predecessor (a SIGKILL never runs the disconnect path). Mark them
+/// offline; each re-upserts online when it redials. `last_seen_at` is left
+/// at its last real observation, not stamped now. Returns rows reset.
+pub async fn reclaim_machines_offline(pool: &PgPool) -> anyhow::Result<u64> {
+    let r = sqlx::query("UPDATE machines SET status = 'offline' WHERE status = 'online'")
+        .execute(pool)
+        .await?;
+    Ok(r.rows_affected())
+}
+
 /// How often a worker emits a heartbeat.
 pub const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
 /// A machine silent longer than this has its lease expired (covers

--- a/crates/onsager/src/lib.rs
+++ b/crates/onsager/src/lib.rs
@@ -39,6 +39,13 @@ pub async fn serve(config: config::Config) -> anyhow::Result<()> {
         Ok(_) => {}
         Err(e) => tracing::error!("orphaned-run reclaim failed: {e:#}"),
     }
+    // No machine is connected to a fresh process; reset any stale `online`
+    // rows a SIGKILL'd predecessor left behind (ADR 0030 M4).
+    match fleet::reclaim_machines_offline(&pool).await {
+        Ok(n) if n > 0 => tracing::warn!("reset {n} stale online machine(s) to offline"),
+        Ok(_) => {}
+        Err(e) => tracing::error!("machine reclaim failed: {e:#}"),
+    }
 
     if config.dev_login_enabled() {
         auth::seed_dev_user_and_workspace(&pool)


### PR DESCRIPTION
Closes #653. The one loose end from the ADR 0030 **thorough live validation**.

## Bug
A SIGKILL'd control plane never runs the disconnect path, so `machines` rows stay `status='online'` — the operator fleet view shows a machine online when nothing's connected (forever, if it never redials).

## Fix
`fleet::reclaim_machines_offline` at boot, mirroring the run reclaim (D4): a fresh process has nothing connected, so flip every `online` row `offline`; each re-upserts `online` when it redials. `last_seen_at` is left at its last real observation.

## Verified live
migrate → seed a stale `online` row → boot → log `reset 1 stale online machine(s) to offline` and the row reads `offline`. ✓ (Plus existing units + clippy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)