### PR TITLE
Preview-env live-fleet UI screenshots (#655)

### DIFF
--- a/.github/workflows/preview-ui.yml
+++ b/.github/workflows/preview-ui.yml
@@ -1,0 +1,187 @@
+name: preview-ui
+
+# Live-fleet UI screenshots on each PR preview (ADR 0030 / #655).
+#
+# When Railway reports a healthy pr-<N> preview, this job: builds the
+# `onsager` binary, dials a shim-worker into the preview's control plane
+# (the preview carries DEV_LOGIN_ENABLED + ONSAGER_MACHINE_TOKEN from
+# railway.toml, and PR #656 lets it hand the worker a reachable MCP URL),
+# fires a workflow so a run dispatches to that worker and an artifact
+# lands, then screenshots the dashboard (Machines online, the run, the
+# artifact) at desktop + mobile and posts them inline on the PR.
+
+on:
+  deployment_status:
+
+concurrency:
+  group: preview-ui-${{ github.event.deployment.environment }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write # push screenshots to the ci-screenshots branch
+  pull-requests: write # sticky evidence comment
+
+jobs:
+  screenshots:
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      startsWith(github.event.deployment.environment, 'pr-')
+    runs-on: ubuntu-latest
+    env:
+      MACHINE_TOKEN: preview-fleet-ci # must match railway.toml preview vars
+    steps:
+      - name: Resolve PR number + preview URL
+        id: ctx
+        env:
+          ENV_NAME: ${{ github.event.deployment.environment }}
+          ENV_URL: ${{ github.event.deployment_status.environment_url }}
+          TARGET_URL: ${{ github.event.deployment_status.target_url }}
+        run: |
+          pr=$(printf '%s' "$ENV_NAME" | sed -nE 's/^pr-([0-9]+).*/\1/p')
+          url="${ENV_URL:-$TARGET_URL}"
+          if [ -z "$pr" ] || [ -z "$url" ]; then
+            echo "::warning::missing PR number or URL ($ENV_NAME / $url)"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          url="${url%/}"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "host=$(printf '%s' "$url" | sed -E 's#^https?://##')" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        if: steps.ctx.outputs.skip != '1'
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - name: Install Rust toolchain
+        if: steps.ctx.outputs.skip != '1'
+        run: rustup show active-toolchain
+      - uses: Swatinem/rust-cache@v2
+        if: steps.ctx.outputs.skip != '1'
+      - name: Build onsager binary (for the worker)
+        if: steps.ctx.outputs.skip != '1'
+        run: cargo build -p onsager --bin onsager
+
+      - uses: pnpm/action-setup@v4
+        if: steps.ctx.outputs.skip != '1'
+      - uses: actions/setup-node@v4
+        if: steps.ctx.outputs.skip != '1'
+        with:
+          node-version: 20
+      - name: Install dashboard deps + chromium
+        if: steps.ctx.outputs.skip != '1'
+        run: |
+          pnpm install
+          pnpm --filter dashboard exec playwright install --with-deps chromium
+
+      - name: Wait for preview health
+        if: steps.ctx.outputs.skip != '1'
+        env:
+          URL: ${{ steps.ctx.outputs.url }}
+        run: |
+          for i in $(seq 1 20); do
+            [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL/api/health")" = "200" ] && exit 0
+            sleep 5
+          done
+          echo "::error::preview never became healthy"; exit 1
+
+      - name: Dial shim-worker into the preview
+        if: steps.ctx.outputs.skip != '1'
+        env:
+          HOST: ${{ steps.ctx.outputs.host }}
+          URL: ${{ steps.ctx.outputs.url }}
+        run: |
+          cat > /tmp/shim.sh <<'SHIM'
+          #!/usr/bin/env bash
+          curl -s -X POST "$ONSAGER_MCP_URL" -H "Authorization: Bearer $ONSAGER_SESSION_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"emit_artifact","arguments":{"kind":"document","summary":"preview smoke artifact","content":"Preview fleet validation — this artifact was produced by a worker dialed into the pr preview."}}}' >/dev/null 2>&1
+          echo '{"type":"result","subtype":"success","result":"preview smoke ok"}'
+          SHIM
+          chmod +x /tmp/shim.sh
+          ONSAGER_CONTROL_URL="wss://$HOST" \
+          ONSAGER_MACHINE_TOKEN="$MACHINE_TOKEN" \
+          ONSAGER_MACHINE_NAME="ci-preview-worker" \
+          ONSAGER_MCP_URL="$URL/mcp/messages" \
+          ONSAGER_CLAUDE_BIN=/tmp/shim.sh \
+          RUST_LOG=info ./target/debug/onsager worker > /tmp/worker.log 2>&1 &
+          echo $! > /tmp/worker.pid
+          for i in $(seq 1 15); do grep -q "registered; awaiting work" /tmp/worker.log && break; sleep 1; done
+          cat /tmp/worker.log
+
+      - name: Seed a run through the fleet
+        if: steps.ctx.outputs.skip != '1'
+        id: seed
+        env:
+          URL: ${{ steps.ctx.outputs.url }}
+        run: |
+          J=/tmp/cj
+          curl -s -c $J -X POST "$URL/api/auth/dev-login" >/dev/null
+          WS=$(curl -s -b $J "$URL/api/workspaces" | sed -n 's/.*"id":"\([0-9a-f-]*\)".*/\1/p' | head -1)
+          WF=$(curl -s -b $J -X POST "$URL/api/workflows" -H 'Content-Type: application/json' \
+            -d "{\"workspace_id\":\"$WS\",\"name\":\"preview-fleet-smoketest\",\"trigger\":{\"kind\":\"manual\",\"name\":\"smoke\"},\"definition\":[{\"kind\":\"agent\",\"user_prompt\":\"preview smoke\"}]}")
+          WFID=$(echo "$WF" | sed -n 's/.*"id":"\(wf_[^"]*\)".*/\1/p' | head -1)
+          curl -s -b $J -X PATCH "$URL/api/workflows/$WFID" -H 'Content-Type: application/json' -d '{"active":true}' >/dev/null
+          RUN=$(curl -s -b $J -X POST "$URL/api/workflows/$WFID/fire" | sed -n 's/.*"run_id":"\(run_[^"]*\)".*/\1/p')
+          echo "fired $RUN"
+          for i in $(seq 1 24); do
+            S=$(curl -s -b $J "$URL/api/runs/$RUN" | sed -n 's/.*"status":"\([a-z]*\)".*/\1/p' | head -1)
+            echo "[$i] $S"; case "$S" in completed|failed|aborted) break;; esac; sleep 5
+          done
+          echo "run_id=$RUN" >> "$GITHUB_OUTPUT"
+
+      - name: Capture screenshots
+        if: steps.ctx.outputs.skip != '1'
+        env:
+          PREVIEW_URL: ${{ steps.ctx.outputs.url }}
+          RUN_ID: ${{ steps.seed.outputs.run_id }}
+          OUT_DIR: ${{ github.workspace }}/shots
+        run: pnpm --filter dashboard preview-shots
+
+      - name: Publish screenshots + comment
+        if: steps.ctx.outputs.skip != '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.ctx.outputs.pr }}
+          SHA: ${{ github.event.deployment.sha }}
+        run: |
+          set -e
+          tmp=$(mktemp -d); cd "$tmp"
+          git init -q
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch -q --depth 1 origin ci-screenshots && git checkout -q ci-screenshots || git checkout -q --orphan ci-screenshots
+          rm -rf "pr-$PR"; mkdir -p "pr-$PR"
+          cp "$GITHUB_WORKSPACE"/shots/*.png "pr-$PR"/
+          git add -A
+          git -c user.email="github-actions[bot]@users.noreply.github.com" -c user.name="github-actions[bot]" \
+            commit -q -m "preview-ui screenshots: PR #$PR @ ${SHA:0:7}"
+          git push -q origin HEAD:ci-screenshots
+          base="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/ci-screenshots/pr-$PR"
+          {
+            echo '<!-- onsager-ui -->'
+            echo "### Preview UI evidence — live fleet (\`${SHA:0:7}\`)"
+            echo
+            echo "A shim-worker dialed into the preview, a run dispatched to it, and an artifact landed. Pages below are the live preview at desktop + mobile."
+            for name in machines run artifacts workflows activity; do
+              dk="$base/desktop-$name.png"; mb="$base/mobile-$name.png"
+              if [ -f "$GITHUB_WORKSPACE/shots/desktop-$name.png" ]; then
+                echo; echo "<details><summary><b>$name</b></summary>"; echo
+                echo "| desktop | mobile |"; echo "|---|---|"
+                echo "| <img src=\"$dk\" width=\"420\"> | <img src=\"$mb\" width=\"200\"> |"
+                echo; echo "</details>"
+              fi
+            done
+          } > /tmp/body.md
+          # Upsert by marker so we never clobber the preview-environment comment.
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.body|startswith("<!-- onsager-ui -->"))][0].id')
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" -F body=@/tmp/body.md >/dev/null
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -F body=@/tmp/body.md >/dev/null
+          fi
+
+      - name: Stop worker
+        if: always() && steps.ctx.outputs.skip != '1'
+        run: |
+          [ -f /tmp/worker.pid ] && kill "$(cat /tmp/worker.pid)" 2>/dev/null || true
+          echo "--- worker log ---"; cat /tmp/worker.log 2>/dev/null || true

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest --config vitest.config.ts",
-    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "preview-shots": "node scripts/preview-shots.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -43,6 +44,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",
+    "playwright": "^1.48.0",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/apps/dashboard/scripts/preview-shots.mjs
+++ b/apps/dashboard/scripts/preview-shots.mjs
@@ -1,0 +1,78 @@
+// Preview-env UI screenshots (ADR 0030 / #655). Drives the live preview
+// deploy with a dev-login cookie and captures the fleet evidence pages at
+// desktop + mobile. The CI job seeds a connected machine + a completed run
+// first, then runs this; output PNGs are published inline on the PR.
+//
+// Env:
+//   PREVIEW_URL  — the pr-<N> base URL (required)
+//   RUN_ID       — a completed run to screenshot (optional; skipped if unset)
+//   OUT_DIR      — output directory (default: ./shots)
+import { chromium } from 'playwright'
+import { mkdir } from 'node:fs/promises'
+
+const BASE = process.env.PREVIEW_URL
+const RUN_ID = process.env.RUN_ID || ''
+const OUT = process.env.OUT_DIR || 'shots'
+if (!BASE) {
+  console.error('PREVIEW_URL is required')
+  process.exit(1)
+}
+
+// Dev-login (previews enable it) and lift the session cookie for the browser.
+const res = await fetch(`${BASE}/api/auth/dev-login`, { method: 'POST' })
+if (!res.ok) {
+  console.error(`dev-login failed: ${res.status}`)
+  process.exit(1)
+}
+const setCookie = res.headers.get('set-cookie') || ''
+const m = setCookie.match(/onsager_session=([^;]+)/)
+if (!m) {
+  console.error('no onsager_session cookie in dev-login response')
+  process.exit(1)
+}
+const sessionValue = m[1]
+const host = new URL(BASE).hostname
+
+const pages = [
+  ['workflows', '/workflows'],
+  ['machines', '/machines'],
+  ['artifacts', '/artifacts'],
+  ['activity', '/activity'],
+]
+if (RUN_ID) pages.push(['run', `/runs/${RUN_ID}`])
+
+const viewports = [
+  ['desktop', 1280, 800],
+  ['mobile', 390, 844],
+]
+
+await mkdir(OUT, { recursive: true })
+const browser = await chromium.launch()
+try {
+  for (const [label, width, height] of viewports) {
+    const ctx = await browser.newContext({ viewport: { width, height } })
+    await ctx.addCookies([
+      {
+        name: 'onsager_session',
+        value: sessionValue,
+        domain: host,
+        path: '/',
+        httpOnly: true,
+        secure: BASE.startsWith('https'),
+        sameSite: 'Lax',
+      },
+    ])
+    const page = await ctx.newPage()
+    for (const [name, path] of pages) {
+      await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle', timeout: 30000 })
+      // Let react-query settle (lists poll on an interval).
+      await page.waitForTimeout(2000)
+      const file = `${OUT}/${label}-${name}.png`
+      await page.screenshot({ path: file, fullPage: true })
+      console.log(`captured ${file}`)
+    }
+    await ctx.close()
+  }
+} finally {
+  await browser.close()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
+      playwright:
+        specifier: ^1.48.0
+        version: 1.61.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -1521,6 +1524,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2266,6 +2274,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -4389,6 +4407,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5187,6 +5208,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/railway.toml
+++ b/railway.toml
@@ -40,3 +40,10 @@ numReplicas = 1
 
 [environments.preview.variables]
 DEV_LOGIN_ENABLED = "true"
+# Preview-only fleet token (ADR 0030 / #655): lets the preview-ui CI job
+# dial a worker into the ephemeral pr-<N> control plane to capture live
+# fleet screenshots. Low-value by construction — it only grants
+# /api/fleet/connect on throwaway preview envs (which already expose
+# dev-login); production sets its own token via the Railway dashboard,
+# never from this file.
+ONSAGER_MACHINE_TOKEN = "preview-fleet-ci"


### PR DESCRIPTION
Closes #655. The validation mechanism you asked for: every PR preview gets **live-fleet screenshots** posted inline as evidence.

## How it works
On a healthy `pr-<N>` deploy, the new `preview-ui` workflow:
1. builds the `onsager` binary and dials a **shim-worker** into the preview's control plane — the preview carries `DEV_LOGIN_ENABLED` + a committed preview-only `ONSAGER_MACHINE_TOKEN` (railway.toml), and #656 gives it a reachable MCP URL;
2. fires a workflow → a run **dispatches to that worker**, the shim emits an artifact (no real LLM/secrets);
3. Playwright screenshots the dashboard — **Machines (online), the run, the artifact** — at desktop + mobile;
4. posts them inline on the PR (committed to a `ci-screenshots` orphan branch, embedded via raw URLs — public repo, so they render).

## Pieces
- `railway.toml`: preview-only `ONSAGER_MACHINE_TOKEN` (low-value; preview envs only, prod sets its own).
- `apps/dashboard`: `playwright` devDep + `scripts/preview-shots.mjs`.
- `.github/workflows/preview-ui.yml`: the job.

## Validation note (important)
`deployment_status`-triggered workflows run from the **default branch**, so this job can't run on its own PR. It activates after merge; I'll then open a tiny test PR to confirm the job runs and the screenshots land. Static checks (rust/frontend/deploy-ready) are unaffected by this PR.

Retires the prod dev-login hack as a validation mechanism (and I should revert the prod machine-token/MCP vars I set earlier — noted separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)