### PR TITLE
docs: record preview-ui validator in ADR 0030

### DIFF
--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -3,6 +3,7 @@
 //! Serves the HTTP edge (dashboard API, auth, credentials; later
 //! webhooks + MCP) and hosts the scheduler as an in-process task (M1).
 //! Configuration is environment-only; see [`onsager::config::Config`].
+//! (Touch to trigger a preview build for the #655 preview-ui validation.)
 
 use std::process::ExitCode;
 

--- a/docs/adr/0030-scaling-sessions-across-machines.md
+++ b/docs/adr/0030-scaling-sessions-across-machines.md
@@ -203,6 +203,9 @@ under stale wording.
       reclaim). (#648)
 - [x] M4 — `machines` table + `GET /api/fleet/machines` + Machines page
       (operator surface, not a product noun) — this PR.
+- [x] Validation: per-PR preview deploy dials a shim-worker, fires a run,
+      and posts live-fleet screenshots inline (#655/#657). Replaces the
+      one-off prod dev-login validation.
 
 ## Out of scope
 


### PR DESCRIPTION
Trivial doc line recording the #657 preview-ui validator in ADR 0030's checklist.

Also serves as the **first live exercise of the `preview-ui` workflow** (which only runs from the default branch) — this PR's preview should get inline live-fleet screenshots posted by the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)