### PR TITLE
fix(ci): match Railway pr-<N> env name + construct preview app URL (#659)

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -35,12 +35,13 @@ jobs:
     # error — so the `railway-preview` check_run is published on red as
     # well as green (#295). The smoke-test + sticky-comment steps below
     # stay gated on `state == 'success'` so a failed deploy isn't reported
-    # as healthy. Railway names its PR environments `pr-<N>`; anything
-    # else is prod or a non-PR env and we ignore it here.
+    # as healthy. Railway names the deploy environment
+    # "Onsager / onsager-pr-<N>", so match `pr-` anywhere; anything else
+    # (e.g. "Onsager / production") is ignored.
     if: >-
       github.event_name == 'deployment_status' &&
       contains(fromJSON('["success", "failure", "error"]'), github.event.deployment_status.state) &&
-      startsWith(github.event.deployment.environment, 'pr-')
+      contains(github.event.deployment.environment, 'pr-')
     runs-on: ubuntu-latest
     steps:
       - name: Extract PR number from environment name
@@ -48,31 +49,28 @@ jobs:
         env:
           ENV_NAME: ${{ github.event.deployment.environment }}
         run: |
-          # Railway uses `pr-<N>` (sometimes `pr-<N>-<slug>`). Pull the first
-          # numeric segment; bail cleanly if the convention ever changes.
-          pr_num=$(printf '%s' "$ENV_NAME" | sed -nE 's/^pr-([0-9]+).*/\1/p')
+          # Environment is "Onsager / onsager-pr-<N>" — pull the PR number
+          # from anywhere; bail cleanly if the convention ever changes.
+          pr_num=$(printf '%s' "$ENV_NAME" | sed -nE 's/.*pr-([0-9]+).*/\1/p')
           if [ -z "$pr_num" ]; then
             echo "::warning::Could not extract PR number from deployment environment '$ENV_NAME'"
             exit 0
           fi
           echo "number=$pr_num" >> "$GITHUB_OUTPUT"
 
-      - name: Pick preview URL from event payload
+      - name: Build preview URL from PR number
         id: url
         env:
-          ENV_URL: ${{ github.event.deployment_status.environment_url }}
-          TARGET_URL: ${{ github.event.deployment_status.target_url }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
         run: |
-          # `environment_url` is what Railway sets for PR envs; `target_url`
-          # is the fallback (links to the deploy page) when no environment
-          # URL is provided.
-          url="$ENV_URL"
-          [ -n "$url" ] || url="$TARGET_URL"
-          if [ -z "$url" ]; then
-            echo "::warning::deployment_status event had no URL"
+          # The deployment_status URL fields point at the Railway dashboard,
+          # not the app. Construct the preview app host from the PR number
+          # (Railway default domain: <project>-<service>-pr-<N>.up.railway.app).
+          if [ -z "$PR_NUM" ]; then
+            echo "::warning::no PR number — cannot build preview URL"
             exit 0
           fi
-          echo "value=$url" >> "$GITHUB_OUTPUT"
+          echo "value=https://onsager-onsager-pr-${PR_NUM}.up.railway.app" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test /api/health
         # Only smoke-test on successful deploys — a failed build has nothing

--- a/.github/workflows/preview-ui.yml
+++ b/.github/workflows/preview-ui.yml
@@ -23,9 +23,11 @@ permissions:
 
 jobs:
   screenshots:
+    # Railway names the deploy environment "Onsager / onsager-pr-<N>", so
+    # match `pr-` anywhere (not startsWith). "production" has no "pr-".
     if: >-
       github.event.deployment_status.state == 'success' &&
-      startsWith(github.event.deployment.environment, 'pr-')
+      contains(github.event.deployment.environment, 'pr-')
     runs-on: ubuntu-latest
     env:
       MACHINE_TOKEN: preview-fleet-ci # must match railway.toml preview vars
@@ -34,18 +36,20 @@ jobs:
         id: ctx
         env:
           ENV_NAME: ${{ github.event.deployment.environment }}
-          ENV_URL: ${{ github.event.deployment_status.environment_url }}
-          TARGET_URL: ${{ github.event.deployment_status.target_url }}
         run: |
-          pr=$(printf '%s' "$ENV_NAME" | sed -nE 's/^pr-([0-9]+).*/\1/p')
-          url="${ENV_URL:-$TARGET_URL}"
-          if [ -z "$pr" ] || [ -z "$url" ]; then
-            echo "::warning::missing PR number or URL ($ENV_NAME / $url)"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          # Environment is "Onsager / onsager-pr-<N>" — pull the PR number
+          # from anywhere in the string.
+          pr=$(printf '%s' "$ENV_NAME" | sed -nE 's/.*pr-([0-9]+).*/\1/p')
+          if [ -z "$pr" ]; then
+            echo "::warning::no PR number in env '$ENV_NAME'"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          url="${url%/}"
+          # The deployment_status URL fields point at the Railway dashboard,
+          # not the app. Construct the preview app host from the PR number
+          # (Railway default domain: <project>-<service>-pr-<N>.up.railway.app).
+          host="onsager-onsager-pr-${pr}.up.railway.app"
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "host=$(printf '%s' "$url" | sed -E 's#^https?://##')" >> "$GITHUB_OUTPUT"
+          echo "host=$host" >> "$GITHUB_OUTPUT"
+          echo "url=https://$host" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         if: steps.ctx.outputs.skip != '1'


### PR DESCRIPTION
Closes #659. The first live `preview-ui` run (and, it turns out, the preexisting `preview-environment.yml`) never matched Railway's actual env name.

- Railway's `deployment.environment` is `Onsager / onsager-pr-<N>` → `startsWith(env,'pr-')` was always false. Fixed to `contains(env,'pr-')` in both workflows (`production` has no `pr-`).
- PR-number parse `^pr-` → `.*pr-([0-9]+)`.
- `deployment_status` URL fields are the Railway **dashboard** link, not the app — both workflows now construct `onsager-onsager-pr-<N>.up.railway.app` (the health-wait gates it, so a wrong host fails loudly rather than silently).

Can't self-validate (deployment_status workflows run from the default branch); I'll confirm with a throwaway watched-path PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)