### PR TITLE
chore: validate fixed preview-ui workflow

### DIFF
--- a/crates/onsager/src/main.rs
+++ b/crates/onsager/src/main.rs
@@ -3,6 +3,7 @@
 //! Serves the HTTP edge (dashboard API, auth, credentials; later
 //! webhooks + MCP) and hosts the scheduler as an in-process task (M1).
 //! Configuration is environment-only; see [`onsager::config::Config`].
+//! (Touch to trigger a preview build — validating the fixed preview-ui job, #659.)
 
 use std::process::ExitCode;
 


### PR DESCRIPTION
Throwaway PR to exercise the fixed `preview-ui` + `preview-environment` workflows (#660) against a real preview. Expect: a preview deploy, then an inline live-fleet screenshots comment + a working preview-environment comment. Will close after verifying.